### PR TITLE
Replace radix select with react select 

### DIFF
--- a/apps/documentation/components/ProjectSwitcher.tsx
+++ b/apps/documentation/components/ProjectSwitcher.tsx
@@ -1,20 +1,19 @@
 'use client';
 
-import {
-  Heading,
-  Paragraph,
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-} from '@codaco/ui';
-import { useRouter } from '~/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
-import { type LocalesEnum, type ProjectsEnum, projects } from '~/app/types';
-import { forwardRef } from 'react';
-import { cn } from '~/lib/utils';
+import React from 'react';
+import { projects, type LocalesEnum, type ProjectsEnum } from '~/app/types';
+import { useRouter } from '~/navigation';
+import SelectProject from './SelectProject';
+import z from 'zod';
+
+export const OptionsSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+  description: z.string(),
+  image: z.custom<React.ReactNode>((value) => React.isValidElement(value)),
+});
 
 const getImageForProject = (project: ProjectsEnum) => {
   if (project === 'desktop') {
@@ -30,68 +29,37 @@ const getImageForProject = (project: ProjectsEnum) => {
   }
 };
 
-const ProjectValue = forwardRef<
-  HTMLDivElement,
-  {
-    project: ProjectsEnum;
-    showDescription?: boolean;
-  }
->(({ project, showDescription }, ref) => {
-  const t = useTranslations('ProjectSwitcher');
-  return (
-    <div className="flex flex-1 items-center" ref={ref}>
-      <div
-        className={cn(
-          'mr-2 flex items-center justify-start',
-          showDescription && 'min-w-[75px]',
-        )}
-      >
-        {getImageForProject(project)}
-      </div>
-      <div className="flex flex-col">
-        <Heading variant="h4" margin={showDescription ? 'default' : 'none'}>
-          {t(`${project}.label`)}
-        </Heading>
-        {showDescription && (
-          <Paragraph
-            className="max-w-[20rem] max-[450px]:max-w-[12rem] sm:max-w-full"
-            variant="smallText"
-          >
-            {t(`${project}.description`)}
-          </Paragraph>
-        )}
-      </div>
-    </div>
-  );
-});
-
-ProjectValue.displayName = 'ProjectValue';
-
 export default function ProjectSwitcher() {
+  const t = useTranslations('ProjectSwitcher');
   const router = useRouter();
   const pathname = usePathname();
   const project = pathname.split('/')[2]! as ProjectsEnum;
   const locale = useLocale() as LocalesEnum;
 
+  const defaultOption = {
+    value: project,
+    label: t(`${project}.label`),
+    description: t(`${project}.description`),
+    image: getImageForProject(project),
+  };
+
+  const options = projects.map((p) => ({
+    value: p,
+    label: t(`${p}.label`),
+    description: t(`${p}.description`),
+    image: getImageForProject(p),
+  }));
+
   return (
-    <Select
-      value={project}
-      onValueChange={(val) => {
-        router.push(`/${val}`, { locale });
+    <SelectProject
+      className="mt-4"
+      value={defaultOption}
+      onChange={(selectedOption) => {
+        const parsedOption = OptionsSchema.safeParse(selectedOption);
+        if (!parsedOption.success) return;
+        router.push(`/${parsedOption.data.value}`, { locale });
       }}
-    >
-      <SelectTrigger className="my-4 h-16">
-        <ProjectValue project={project} />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectGroup>
-          {projects.map((p) => (
-            <SelectItem key={p} value={p} className="sm:w-[30rem]">
-              <ProjectValue project={p} showDescription />
-            </SelectItem>
-          ))}
-        </SelectGroup>
-      </SelectContent>
-    </Select>
+      options={options}
+    />
   );
 }

--- a/apps/documentation/components/SelectProject.tsx
+++ b/apps/documentation/components/SelectProject.tsx
@@ -1,0 +1,70 @@
+import { Heading, Paragraph } from '@codaco/ui';
+import ReactSelect, {
+  components,
+  type ControlProps,
+  type OptionProps,
+  type Props as SelectProps,
+} from 'react-select';
+import { cn } from '~/lib/utils';
+import { OptionsSchema } from './ProjectSwitcher';
+
+// custom Control component
+const CustomControl = ({ children, ...props }: ControlProps) => {
+  const selectedOption = props.getValue()[0];
+  const parsedOption = OptionsSchema.safeParse(selectedOption);
+
+  return (
+    <components.Control {...props}>
+      {parsedOption.success && parsedOption.data.image} {children}
+    </components.Control>
+  );
+};
+
+// custom Option component
+const CustomOption = (props: OptionProps) => {
+  const { data } = props;
+  const parsedOption = OptionsSchema.safeParse(data);
+
+  if (!parsedOption.success) return null;
+
+  return (
+    <components.Option {...props}>
+      <div className="flex flex-1 items-center">
+        <div className={'mr-2 flex min-w-[75px] items-center justify-start'}>
+          {parsedOption.data.image}
+        </div>
+        <div className="flex flex-col">
+          <Heading variant="h4" margin={'default'}>
+            {parsedOption.data.label}
+          </Heading>
+          <Paragraph
+            className="max-w-[20rem] max-[450px]:max-w-[12rem] sm:max-w-full"
+            variant="smallText"
+          >
+            {parsedOption.data.description}
+          </Paragraph>
+        </div>
+      </div>
+    </components.Option>
+  );
+};
+
+// custom React Select component
+const SelectProject = ({
+  options,
+  value,
+  onChange,
+  className,
+}: SelectProps) => (
+  <ReactSelect
+    isSearchable={false}
+    className={cn('react-select-container', className)}
+    classNamePrefix="react-select"
+    value={value}
+    onChange={onChange}
+    options={options}
+    components={{ Control: CustomControl, Option: CustomOption }}
+  />
+);
+
+export default SelectProject;

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -29,7 +29,8 @@
     "next-intl": "3.9.1",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-select": "^5.8.0"
   },
   "devDependencies": {
     "@codaco/eslint-config": "workspace:*",

--- a/apps/documentation/styles/globals.css
+++ b/apps/documentation/styles/globals.css
@@ -15,7 +15,9 @@
     --secondary-foreground: var(--white);
 
     --muted: var(--platinum);
-    --muted-foreground: var(--cyber-grape-hue) calc(var(--cyber-grape-saturation) - 10%) calc(var(--cyber-grape-lightness) - 10%);
+    --muted-foreground: var(--cyber-grape-hue)
+      calc(var(--cyber-grape-saturation) - 10%)
+      calc(var(--cyber-grape-lightness) - 10%);
 
     --accent: var(--slate-blue);
     --accent-foreground: var(--white);
@@ -48,7 +50,6 @@
 
     --popover: var(--white);
     --popover-foreground: var(--foreground);
-
   }
 
   html.dark {
@@ -63,7 +64,9 @@
     --secondary-foreground: var(--white);
 
     --muted: var(--platinum);
-    --muted-foreground: var(--cyber-grape-hue) calc(var(--cyber-grape-saturation) - 10%) calc(var(--cyber-grape-lightness) - 10%);
+    --muted-foreground: var(--cyber-grape-hue)
+      calc(var(--cyber-grape-saturation) - 10%)
+      calc(var(--cyber-grape-lightness) - 10%);
 
     --accent: var(--slate-blue);
     --accent-foreground: var(--white);
@@ -97,8 +100,6 @@
     --popover: var(--cyber-grape);
     --popover-foreground: var(--foreground);
   }
-
-
 }
 
 @layer base {
@@ -123,7 +124,6 @@
     @apply focus-visible:outline-mustard;
   }
 }
-
 
 .DocSearch-Button {
   --docsearch-primary-color: hsl(var(--primary));
@@ -156,12 +156,15 @@
   --docsearch-hit-shadow: 0 1px 3px 0 rgb(212, 217, 225);
 
   /* key */
-  --docsearch-key-gradient: linear-gradient(-225deg,
-      rgb(213, 219, 228) 0%,
-      rgb(248, 248, 248) 100%);
+  --docsearch-key-gradient: linear-gradient(
+    -225deg,
+    rgb(213, 219, 228) 0%,
+    rgb(248, 248, 248) 100%
+  );
   --docsearch-key-shadow: inset 0 -2px 0 0 rgb(205, 205, 230),
     inset 0 0 1px 1px #fff, 0 1px 2px 1px rgba(30, 35, 90, 0.4);
-  --docsearch-key-pressed-shadow: inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff, 0 1px 1px 0 rgba(30, 35, 90, 0.4);
+  --docsearch-key-pressed-shadow: inset 0 -2px 0 0 #cdcde6,
+    inset 0 0 1px 1px #fff, 0 1px 1px 0 rgba(30, 35, 90, 0.4);
   /* footer */
   --docsearch-footer-height: 44px;
   --docsearch-footer-background: #fff;
@@ -184,6 +187,34 @@
     @apply px-3 !important;
     @apply text-sm !important;
   }
+}
 
+@layer components {
+  .react-select-container .react-select__control {
+    @apply cursor-pointer rounded-xl border border-border bg-input p-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:bg-input;
+  }
 
+  .react-select-container .react-select__single-value {
+    @apply text-foreground dark:text-foreground;
+  }
+
+  .react-select-container .react-select__menu {
+    @apply p-1.5 dark:bg-background lg:w-[30rem];
+  }
+
+  .react-select-container .react-select__menu-list {
+    @apply p-0;
+  }
+
+  .react-select-container .react-select__option {
+    @apply text-foreground dark:text-foreground;
+  }
+
+  .react-select-container .react-select__option--is-focused {
+    @apply text-cyber-grape dark:text-cyber-grape;
+  }
+
+  .react-select-container .react-select__option--is-selected {
+    @apply bg-accent text-platinum dark:text-platinum;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      react-select:
+        specifier: ^5.8.0
+        version: 5.8.0(@types/react@18.2.64)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@codaco/eslint-config':
         specifier: workspace:*
@@ -1289,6 +1292,36 @@ packages:
       superjson: 2.2.1
     dev: true
 
+  /@emotion/babel-plugin@11.11.0:
+    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/runtime': 7.24.0
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/serialize': 1.1.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/cache@11.11.0:
+    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+      '@emotion/sheet': 1.2.2
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/hash@0.9.1:
+    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+    dev: false
+
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
     requiresBuild: true
@@ -1302,6 +1335,65 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@emotion/memoize@0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+    dev: false
+
+  /@emotion/react@11.11.4(@types/react@18.2.64)(react@18.2.0):
+    resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.1.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      '@types/react': 18.2.64
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+    dev: false
+
+  /@emotion/serialize@1.1.3:
+    resolution: {integrity: sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==}
+    dependencies:
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/unitless': 0.8.1
+      '@emotion/utils': 1.2.1
+      csstype: 3.1.3
+    dev: false
+
+  /@emotion/sheet@1.2.2:
+    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+    dev: false
+
+  /@emotion/unitless@0.8.1:
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+    dev: false
+
+  /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0):
+    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@emotion/utils@1.2.1:
+    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
+    dev: false
+
+  /@emotion/weak-memoize@0.3.1:
+    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
+    dev: false
 
   /@esbuild-kit/core-utils@3.3.2:
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -3598,6 +3690,10 @@ packages:
       '@types/node': 20.11.25
     dev: true
 
+  /@types/parse-json@4.0.2:
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+    dev: false
+
   /@types/pg@8.6.6:
     resolution: {integrity: sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==}
     dependencies:
@@ -3621,6 +3717,12 @@ packages:
     resolution: {integrity: sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==}
     dependencies:
       '@types/react': 18.2.64
+
+  /@types/react-transition-group@4.4.10:
+    resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
+    dependencies:
+      '@types/react': 18.2.64
+    dev: false
 
   /@types/react@18.2.64:
     resolution: {integrity: sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==}
@@ -4201,6 +4303,15 @@ packages:
       dequal: 2.0.3
     dev: false
 
+  /babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+    dependencies:
+      '@babel/runtime': 7.24.0
+      cosmiconfig: 7.1.0
+      resolve: 1.22.8
+    dev: false
+
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
     dev: true
@@ -4520,6 +4631,10 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: false
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -4544,6 +4659,17 @@ packages:
     resolution: {integrity: sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==}
     requiresBuild: true
     dev: true
+
+  /cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+    dev: false
 
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -4803,6 +4929,13 @@ packages:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
 
+  /dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.24.0
+      csstype: 3.1.3
+    dev: false
+
   /dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
@@ -4985,7 +5118,6 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
-    dev: true
 
   /es-abstract@1.22.5:
     resolution: {integrity: sha512-oW69R+4q2wG+Hc3KZePPZxOiisRIqfKBVo/HLx94QcJeWGU/8sZhCvc829rd1kS366vlJbzBfXf9yWwf0+Ko7w==}
@@ -5615,6 +5747,10 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -6091,6 +6227,12 @@ packages:
     engines: {node: '>=12.0.0'}
     dev: true
 
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
+
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
@@ -6272,7 +6414,6 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-    dev: true
 
   /is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
@@ -6582,7 +6723,6 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: true
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -7027,6 +7167,10 @@ packages:
     dependencies:
       '@types/mdast': 4.0.3
     dev: true
+
+  /memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+    dev: false
 
   /memoizee@0.4.15:
     resolution: {integrity: sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==}
@@ -7861,7 +8005,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: true
 
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
@@ -8301,6 +8444,27 @@ packages:
       use-sidecar: 1.1.2(@types/react@18.2.64)(react@18.2.0)
     dev: false
 
+  /react-select@5.8.0(@types/react@18.2.64)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.4(@types/react@18.2.64)(react@18.2.0)
+      '@floating-ui/dom': 1.6.3
+      '@types/react-transition-group': 4.4.10
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.64)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /react-style-singleton@2.2.1(@types/react@18.2.64)(react@18.2.0):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
@@ -8316,6 +8480,20 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.2
+    dev: false
+
+  /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.24.0
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:
@@ -8790,6 +8968,11 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -9005,6 +9188,10 @@ packages:
       '@babel/core': 7.24.0
       client-only: 0.0.1
       react: 18.2.0
+
+  /stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+    dev: false
 
   /sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -9597,6 +9784,19 @@ packages:
       react: 18.2.0
     dev: false
 
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.64)(react@18.2.0):
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.64
+      react: 18.2.0
+    dev: false
+
   /use-sidecar@1.1.2(@types/react@18.2.64)(react@18.2.0):
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -10026,6 +10226,11 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /yaml@2.4.1:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}


### PR DESCRIPTION
This PR intends to replace the Radix select component with the React select

Issues with `@radix-ui/react-select`:
- When an option is selected from the options menu via touch (on mobile devices or touch screens), any buttons or links beneath the options menu overlay are also activated simultaneously.

I customized the Select component style via TailwindCSS in the global.css file based on the suggestion [here](https://stackoverflow.com/questions/63212723/using-dark-mode-in-react-select)

Please let me know if I need to make any changes to the implementation or styling.