### PR TITLE
update articles to use v4 of sample protocol

### DIFF
--- a/apps/documentation/docs/desktop/tutorials/building-a-protocol.en.mdx
+++ b/apps/documentation/docs/desktop/tutorials/building-a-protocol.en.mdx
@@ -12,7 +12,7 @@ Network Canvas protocol using Architect. We will be rebuilding the sample
 protocol that is available to install within Interviewer, which was discussed
 extensively in the tutorial on [using Interviewer](/en/desktop/tutorials/using-interviewer). If
 you would like to download and open the finished protocol, you can do so [from
-here](</protocols/Sample Protocol v2.netcanvas>).
+here](</protocols/Sample Protocol v4.netcanvas>).
 
 </SummarySection>
 <PrerequisitesSection>

--- a/apps/documentation/docs/desktop/tutorials/using-interviewer.en.mdx
+++ b/apps/documentation/docs/desktop/tutorials/using-interviewer.en.mdx
@@ -94,7 +94,7 @@ provider to distribute protocol files to multiple devices.
 
 ### Import the Sample Protocol
 
-For the purposes of this tutorial, we will proceed using the built-in sample protocol. To follow along on your own device, **click the "install sample protocol" button in the welcome section of the app** to install the protocol that we will be using. Alternatively, [click here](</protocols/Sample Protocol v2.netcanvas>) to download the file, and then import it into Interviewer using the import from file method described above.
+For the purposes of this tutorial, we will proceed using the built-in sample protocol. To follow along on your own device, **click the "install sample protocol" button in the welcome section of the app** to install the protocol that we will be using. Alternatively, [click here](</protocols/Sample Protocol v4.netcanvas>) to download the file, and then import it into Interviewer using the import from file method described above.
 
 Once a protocol has been imported, a new section will appear on the start screen: the **new interview section**. Inside this section will be a protocol card, representing the protocol you imported.
 


### PR DESCRIPTION
Updates two articles that were pointing to the old v2 version of the sample protocol.