### PR TITLE
Fix/ Changeset action linting

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,6 +30,8 @@ jobs:
     - name: Create Release Pull Request
       uses: changesets/action@v1
       with:
+        # command used to version packages. allows for fixing formatting issues caused by versioning
+        version: pnpm run version-packages
         # builds packages and runs changesets publish. versioning is done by changesets action
         publish: pnpm run publish-packages
         createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"test": "turbo run test",
 		"test:watch": "turbo run test:watch",
 		"publish-packages": "turbo run format-and-lint:fix build && pnpm changeset publish",
+		"version-packages": "pnpm changeset version pnpm run format-and-lint:fix",
 		"format-and-lint": "biome check .",
 		"format-and-lint:fix": "biome check . --write"
 	},


### PR DESCRIPTION
The changeset action breaks formatting in files it changes when versioning packages. This PR updates the [version script ](https://github.com/changesets/action?tab=readme-ov-file#with-version-script) in the action to format and fix biome issues after versioning to automatically fix these.
