### PR TITLE
Fix/migration schema 8

### DIFF
--- a/packages/protocol-validation/src/__tests__/test-protocols.test.ts
+++ b/packages/protocol-validation/src/__tests__/test-protocols.test.ts
@@ -28,8 +28,6 @@ describe("Test protocols", () => {
 	// Use a single test with detailed logging for each protocol
 	it("should validate each protocol individually with detailed logging", async () => {
 		const totalCount = protocols.length;
-		let nInvalid = 0;
-		let invalidMigrations = [];
 
 		for (let i = 0; i < protocols.length; i++) {
 			// biome-ignore lint/style/noNonNullAssertion: duh
@@ -61,15 +59,11 @@ describe("Test protocols", () => {
 
 			// Migrate and validate protocols with schema version < 8
 			if (protocol.schemaVersion < 8) {
-				const migratedProtocol = migrateProtocol(protocol, 8);
+				const migratedProtocol = migrateProtocol(protocol, 8) as Protocol;
 				const migrationResult = await validateProtocol(migratedProtocol);
 
 				console.log(`Migration result: ${migrationResult.isValid ? "✅ Valid" : "❌ Invalid"}`);
 
-				if (!migrationResult.isValid) {
-					nInvalid++;
-					invalidMigrations.push(filename);
-				}
 				if (migrationResult.schemaErrors.length > 0) {
 					console.log(`Schema errors: ${JSON.stringify(migrationResult.schemaErrors, null, 2)}`);
 				}
@@ -77,13 +71,11 @@ describe("Test protocols", () => {
 				if (migrationResult.logicErrors.length > 0) {
 					console.log(`Logic errors: ${JSON.stringify(migrationResult.logicErrors, null, 2)}`);
 				}
-			// expect.soft(migrationResult.isValid).toBe(true);
-			// expect.soft(migrationResult.schemaErrors).toEqual([]);
-			// expect.soft(migrationResult.logicErrors).toEqual([]);
+				expect.soft(migrationResult.isValid).toBe(true);
+				expect.soft(migrationResult.schemaErrors).toEqual([]);
+				expect.soft(migrationResult.logicErrors).toEqual([]);
 			}
 		}
-		console.log('❌ Number of Invalid Protocols:', nInvalid, 'Invalid Protocols:', invalidMigrations);
-
 	});
 
 	// // Keep the original test as a summary test

--- a/packages/protocol-validation/src/migrations/migrations/8.js
+++ b/packages/protocol-validation/src/migrations/migrations/8.js
@@ -4,14 +4,10 @@
 
 const migration = (protocol) => {
 	// Iterate node and edge types in codebook, and remove 'displayVariable' property
-	for (const type of ["nodes", "edges"]) {
-		if (protocol.codebook[type]) {
-			for (const node of protocol.codebook[type]) {
-				if (node.displayVariable) {
-					// biome-ignore lint/performance/noDelete: performance hit acceptable, as this is a one-time operation
-					delete node.displayVariable;
-				}
-			}
+	for (const type of ["node", "edge"]) {
+		for (const entityDefinition of Object.values(protocol.codebook[type])) {
+			// biome-ignore lint/performance/noDelete: performance hit acceptable, as this is a one-time operation
+			delete entityDefinition.displayVariable;
 		}
 	}
 	return protocol;

--- a/packages/protocol-validation/src/migrations/migrations/8.js
+++ b/packages/protocol-validation/src/migrations/migrations/8.js
@@ -12,6 +12,18 @@ const migration = (protocol) => {
 			}
 		}
 	}
+	// Remove options from Toggle variables
+	for (const type of ["ego", "node", "edge"]) {
+		const variables = protocol.codebook[type]?.variables;
+		if (!variables) continue;
+
+		for (const [, variable] of Object.entries(variables)) {
+			if (variable.type === "boolean" && variable.component === "Toggle") {
+				// biome-ignore lint/performance/noDelete: performance hit acceptable, as this is a one-time operation
+				delete variable.options;
+			}
+		}
+	}
 	return protocol;
 };
 

--- a/packages/protocol-validation/src/migrations/migrations/8.js
+++ b/packages/protocol-validation/src/migrations/migrations/8.js
@@ -5,9 +5,11 @@
 const migration = (protocol) => {
 	// Iterate node and edge types in codebook, and remove 'displayVariable' property
 	for (const type of ["node", "edge"]) {
-		for (const entityDefinition of Object.values(protocol.codebook[type])) {
-			// biome-ignore lint/performance/noDelete: performance hit acceptable, as this is a one-time operation
-			delete entityDefinition.displayVariable;
+		if (protocol.codebook[type]) {
+			for (const entityDefinition of Object.values(protocol.codebook[type])) {
+				// biome-ignore lint/performance/noDelete: performance hit acceptable, as this is a one-time operation
+				delete entityDefinition.displayVariable;
+			}
 		}
 	}
 	return protocol;

--- a/packages/protocol-validation/src/migrations/migrations/8.js
+++ b/packages/protocol-validation/src/migrations/migrations/8.js
@@ -14,6 +14,7 @@ const migration = (protocol) => {
 			}
 		}
 	}
+	return protocol;
 };
 
 // Markdown format


### PR DESCRIPTION
### Add protocol-validation schema migration tests and fix schema 8 migrations to make them pass

Key changes include adding a migration test and updating schema 8 migration logic to fix `displayVariable` removal and handle an additional edge case.

### Test Suite Enhancements:
* Implemented migration logic in the test suite to migrate protocols to schema 8 and and validate them.

### Schema Migration Updates:
* Updated migration logic in `migrations/8.js` to:
  * Correctly iterate over `node` and `edge` types instead of `nodes` and `edges` in the protocol codebook.
  * Correctly access and remove the `displayVariable` property from entity definitions.
  * Delete `options` from `Toggle` variables of type `boolean`. Addresses edge case where old protocol versions contained variables with `Toggle` component and `options`, when `options` is only allowed on `Boolean` (Boolean Choice) components.