### PR TITLE
Potential fixes for workflow permissions

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -10,6 +10,8 @@ jobs:
   # Setup job that all other jobs depend on
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       node-modules-cache-hit: ${{ steps.cache-node-modules.outputs.cache-hit }}
     steps:
@@ -63,6 +65,8 @@ jobs:
   lint-and-format:
     needs: setup
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js

--- a/.github/workflows/development-protocol-release.yml
+++ b/.github/workflows/development-protocol-release.yml
@@ -7,6 +7,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation-check-links.yml
+++ b/.github/workflows/documentation-check-links.yml
@@ -1,5 +1,8 @@
 name: Documentation Check for Broken Links
 
+permissions:
+  contents: read
+
 on:
   deployment_status
 


### PR DESCRIPTION
Potential fix for [https://github.com/complexdatacollective/network-canvas-monorepo/security/code-scanning/29](https://github.com/complexdatacollective/network-canvas-monorepo/security/code-scanning/29)

To fix the issue, we will add an explicit `permissions` block to the `setup` and `lint-and-format` jobs. These jobs primarily involve installing dependencies, caching, and running build or linting commands, so they only require `contents: read` permissions. This change ensures that these jobs do not inherit unnecessary write permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
