### PR TITLE
Fix development protocol and create .netcanvas file

### DIFF
--- a/packages/development-protocol/.gitignore
+++ b/packages/development-protocol/.gitignore
@@ -1,0 +1,1 @@
+Development.netcanvas

--- a/packages/development-protocol/build.js
+++ b/packages/development-protocol/build.js
@@ -1,0 +1,5 @@
+import { execSync } from "node:child_process";
+
+execSync("zip -r -0 Development.netcanvas protocol.json assets nodeLabelWorker.js", {
+	stdio: "inherit",
+});

--- a/packages/development-protocol/package.json
+++ b/packages/development-protocol/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@codaco/development-protocol",
+	"version": "1.0.0",
+	"description": "",
+	"main": "protocol.json",
+	"files": ["protocol.json", "Development.netcanvas", "assets"],
+	"scripts": {
+		"build": "node build.js",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "",
+	"license": "GPL-3.0-only"
+}

--- a/packages/development-protocol/protocol.json
+++ b/packages/development-protocol/protocol.json
@@ -205,7 +205,7 @@
             "join": "OR",
             "rules": [
               {
-                "type": "alter",
+                "type": "node",
                 "id": "15218241538622",
                 "options": {
                   "type": "person_node_type",
@@ -395,7 +395,7 @@
         "join": "AND",
         "rules": [
           {
-            "type": "alter",
+            "type": "node",
             "options": {
               "type": "person_node_type",
               "operator": "EXACTLY",
@@ -679,7 +679,7 @@
         "join": "AND",
         "rules": [
           {
-            "type": "alter",
+            "type": "node",
             "options": {
               "type": "person_node_type",
               "operator": "NOT",
@@ -689,7 +689,7 @@
             "id": "6091efec-3ef1-4680-810f-d68f69441384"
           },
           {
-            "type": "alter",
+            "type": "node",
             "options": {
               "type": "person_node_type",
               "operator": "NOT",
@@ -882,7 +882,7 @@
         "join": "AND",
         "rules": [
           {
-            "type": "alter",
+            "type": "node",
             "options": {
               "type": "person_node_type",
               "operator": "NOT",
@@ -941,7 +941,7 @@
           "join": "AND",
           "rules": [
             {
-              "type": "alter",
+              "type": "node",
               "options": {
                 "type": "person_node_type",
                 "operator": "INCLUDES",
@@ -995,7 +995,7 @@
             "id": "3a6fad4a-f175-492f-87d7-0747a4e4ffca"
           },
           {
-            "type": "alter",
+            "type": "node",
             "options": {
               "type": "person_node_type",
               "operator": "EXCLUDES",
@@ -1150,7 +1150,7 @@
           "join": "OR",
           "rules": [
             {
-              "type": "alter",
+              "type": "node",
               "id": "15218241538622",
               "options": {
                 "type": "person_node_type",


### PR DESCRIPTION
- Updates protocol to use correct filter rule type (`node` instead of `alter`) from https://github.com/complexdatacollective/network-canvas-monorepo/pull/195

- Implements a build step for creating .netcanvas file. Will allow for easier use in architect-web.