### PR TITLE
fix(preview-upload): use headers in response

### DIFF
--- a/apps/architect-vite/src/utils/preview/types.ts
+++ b/apps/architect-vite/src/utils/preview/types.ts
@@ -39,8 +39,6 @@ type PresignedUrlWithAssetId = {
 	url: string;
 	/** Whether the client must attach its Bearer token to the upload PUT request. */
 	requiresAuth: boolean;
-	/** How to encode the file in the request body. */
-	bodyFormat: "raw" | "formdata";
 };
 
 type JobCreatedResponse = {

--- a/apps/architect-vite/src/utils/preview/types.ts
+++ b/apps/architect-vite/src/utils/preview/types.ts
@@ -37,8 +37,8 @@ export type PreviewRequest = InitializePreviewRequest | CompletePreviewRequest |
 type PresignedUrlWithAssetId = {
 	assetId: string;
 	url: string;
-	/** Whether the client must attach its Bearer token to the upload PUT request. */
-	requiresAuth: boolean;
+	/** Headers the client must include on the upload PUT request. */
+	headers: Record<string, string>;
 };
 
 type JobCreatedResponse = {

--- a/apps/architect-vite/src/utils/preview/types.ts
+++ b/apps/architect-vite/src/utils/preview/types.ts
@@ -37,6 +37,10 @@ export type PreviewRequest = InitializePreviewRequest | CompletePreviewRequest |
 type PresignedUrlWithAssetId = {
 	assetId: string;
 	url: string;
+	/** Whether the client must attach its Bearer token to the upload PUT request. */
+	requiresAuth: boolean;
+	/** How to encode the file in the request body. */
+	bodyFormat: "raw" | "formdata";
 };
 
 type JobCreatedResponse = {

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -110,6 +110,12 @@ async function uploadAsset(
 	fileName: string,
 	options: { requiresAuth: boolean; apiToken?: string },
 ): Promise<void> {
+	if (options.requiresAuth && !options.apiToken) {
+		throw new Error(
+			"Upload requires authentication but no API token is configured. Set VITE_FRESCO_PREVIEW_API_TOKEN in your environment.",
+		);
+	}
+
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
 		let settled = false;

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -173,7 +173,10 @@ async function uploadAsset(
 			xhr.setRequestHeader(key, value);
 		}
 
-		xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+		if (!Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
+			xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+		}
+
 		xhr.send(fileBlob);
 	});
 }
@@ -358,7 +361,7 @@ export async function uploadProtocolForPreview(
 		if (!presignedUrl) {
 			throw new Error(`Missing presigned URL at index ${i}`);
 		}
-		const { assetId, url, headers } = presignedUrl;
+		const { assetId, url, headers = {} } = presignedUrl;
 		const localAsset = fileAssetsMap.get(assetId);
 
 		if (!localAsset) {

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -108,14 +108,8 @@ async function uploadAsset(
 	uploadUrl: string,
 	fileBlob: Blob,
 	fileName: string,
-	options: { requiresAuth: boolean; apiToken?: string },
+	headers: Record<string, string>,
 ): Promise<void> {
-	if (options.requiresAuth && !options.apiToken) {
-		throw new Error(
-			"Upload requires authentication but no API token is configured. Set VITE_FRESCO_PREVIEW_API_TOKEN in your environment.",
-		);
-	}
-
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
 		let settled = false;
@@ -174,8 +168,9 @@ async function uploadAsset(
 
 		xhr.open("PUT", uploadUrl);
 
-		if (options.requiresAuth && options.apiToken) {
-			xhr.setRequestHeader("Authorization", `Bearer ${options.apiToken}`);
+		// Apply server-provided headers
+		for (const [key, value] of Object.entries(headers)) {
+			xhr.setRequestHeader(key, value);
 		}
 
 		xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
@@ -363,7 +358,7 @@ export async function uploadProtocolForPreview(
 		if (!presignedUrl) {
 			throw new Error(`Missing presigned URL at index ${i}`);
 		}
-		const { assetId, url, requiresAuth } = presignedUrl;
+		const { assetId, url, headers } = presignedUrl;
 		const localAsset = fileAssetsMap.get(assetId);
 
 		if (!localAsset) {
@@ -377,7 +372,7 @@ export async function uploadProtocolForPreview(
 		});
 
 		try {
-			await uploadAsset(url, localAsset.data, localAsset.name, { requiresAuth, apiToken });
+			await uploadAsset(url, localAsset.data, localAsset.name, headers);
 		} catch (uploadError) {
 			// If upload fails, abort the preview job
 			await sendPreviewRequest<AbortResponse>(frescoUrl, apiToken, {

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -108,7 +108,7 @@ async function uploadAsset(
 	uploadUrl: string,
 	fileBlob: Blob,
 	fileName: string,
-	options: { requiresAuth: boolean; bodyFormat: "raw" | "formdata"; apiToken?: string },
+	options: { requiresAuth: boolean; apiToken?: string },
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
@@ -172,14 +172,8 @@ async function uploadAsset(
 			xhr.setRequestHeader("Authorization", `Bearer ${options.apiToken}`);
 		}
 
-		if (options.bodyFormat === "raw") {
-			xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
-			xhr.send(fileBlob);
-		} else {
-			const formData = new FormData();
-			formData.append("file", fileBlob, fileName);
-			xhr.send(formData);
-		}
+		xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+		xhr.send(fileBlob);
 	});
 }
 
@@ -363,7 +357,7 @@ export async function uploadProtocolForPreview(
 		if (!presignedUrl) {
 			throw new Error(`Missing presigned URL at index ${i}`);
 		}
-		const { assetId, url, requiresAuth, bodyFormat } = presignedUrl;
+		const { assetId, url, requiresAuth } = presignedUrl;
 		const localAsset = fileAssetsMap.get(assetId);
 
 		if (!localAsset) {
@@ -377,7 +371,7 @@ export async function uploadProtocolForPreview(
 		});
 
 		try {
-			await uploadAsset(url, localAsset.data, localAsset.name, { requiresAuth, bodyFormat, apiToken });
+			await uploadAsset(url, localAsset.data, localAsset.name, { requiresAuth, apiToken });
 		} catch (uploadError) {
 			// If upload fails, abort the preview job
 			await sendPreviewRequest<AbortResponse>(frescoUrl, apiToken, {

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -98,12 +98,18 @@ async function handleFetchError(response: Response): Promise<never> {
 }
 
 /**
- * Upload an asset directly to UploadThing using the presigned URL
+ * Upload an asset using server-provided upload instructions.
  *
- * Uses XHR because UploadThing doesn't always send a response for presigned URLs,
- * so we resolve when the upload completes rather than waiting for a response.
+ * Uses XHR because some providers (UploadThing) don't always send a response
+ * for presigned URLs, so we resolve when the upload completes rather than
+ * waiting for a response.
  */
-async function uploadAssetToPresignedUrl(uploadUrl: string, fileBlob: Blob, fileName: string): Promise<void> {
+async function uploadAsset(
+	uploadUrl: string,
+	fileBlob: Blob,
+	fileName: string,
+	options: { requiresAuth: boolean; bodyFormat: "raw" | "formdata"; apiToken?: string },
+): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
 		let settled = false;
@@ -118,7 +124,7 @@ async function uploadAssetToPresignedUrl(uploadUrl: string, fileBlob: Blob, file
 		// Set timeout to prevent hanging forever
 		xhr.timeout = ASSET_UPLOAD_TIMEOUT_MS;
 
-		// UploadThing may not send a response for presigned URL uploads.
+		// Some providers don't send a response for presigned URL uploads.
 		// After the upload body is fully sent, start a grace period waiting for the
 		// HTTP response. If the main XHR "load" event fires first (response received),
 		// it clears this timer and handles success/failure. The fallback only resolves
@@ -160,11 +166,20 @@ async function uploadAssetToPresignedUrl(uploadUrl: string, fileBlob: Blob, file
 			settle(() => reject(new Error(`Asset upload timed out for ${fileName}`)));
 		});
 
-		const formData = new FormData();
-		formData.append("file", fileBlob, fileName);
-
 		xhr.open("PUT", uploadUrl);
-		xhr.send(formData);
+
+		if (options.requiresAuth && options.apiToken) {
+			xhr.setRequestHeader("Authorization", `Bearer ${options.apiToken}`);
+		}
+
+		if (options.bodyFormat === "raw") {
+			xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+			xhr.send(fileBlob);
+		} else {
+			const formData = new FormData();
+			formData.append("file", fileBlob, fileName);
+			xhr.send(formData);
+		}
 	});
 }
 
@@ -348,7 +363,7 @@ export async function uploadProtocolForPreview(
 		if (!presignedUrl) {
 			throw new Error(`Missing presigned URL at index ${i}`);
 		}
-		const { assetId, url } = presignedUrl;
+		const { assetId, url, requiresAuth, bodyFormat } = presignedUrl;
 		const localAsset = fileAssetsMap.get(assetId);
 
 		if (!localAsset) {
@@ -362,7 +377,7 @@ export async function uploadProtocolForPreview(
 		});
 
 		try {
-			await uploadAssetToPresignedUrl(url, localAsset.data, localAsset.name);
+			await uploadAsset(url, localAsset.data, localAsset.name, { requiresAuth, bodyFormat, apiToken });
 		} catch (uploadError) {
 			// If upload fails, abort the preview job
 			await sendPreviewRequest<AbortResponse>(frescoUrl, apiToken, {


### PR DESCRIPTION
This pull request updates the asset upload flow to support custom headers when uploading assets to presigned URLs, improving compatibility with a wider range of storage providers. The main changes include updating the asset upload utility to accept and apply server-provided headers, modifying the type definitions to include these headers, and updating the upload logic to use the new interface.

**Asset upload enhancements:**

* The `uploadAsset` function now accepts a `headers` parameter and applies these headers to the XHR request, ensuring server-required headers (such as `Content-Type` or authentication) are correctly set. The function also defaults the `Content-Type` header if not provided. (`apps/architect-vite/src/utils/preview/uploadPreview.ts`, [[1]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L101-R112) [[2]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L163-R180)
* The upload logic in `uploadProtocolForPreview` is updated to extract and pass the `headers` from the presigned URL object to the upload function, ensuring each asset upload uses the correct headers. (`apps/architect-vite/src/utils/preview/uploadPreview.ts`, [[1]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L351-R364) [[2]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L365-R378)

**Type definition updates:**

* The `PresignedUrlWithAssetId` type now includes a `headers` field, documenting and enabling server-provided headers for asset uploads. (`apps/architect-vite/src/utils/preview/types.ts`, [apps/architect-vite/src/utils/preview/types.tsR40-R41](diffhunk://#diff-c8276be56d6286c17d1a144480013c81dfd24eb0a7d64404c676adf3265ee339R40-R41))

**Documentation and comments:**

* Updated function and inline comments to clarify the new upload behavior and rationale for using XHR and handling headers. (`apps/architect-vite/src/utils/preview/uploadPreview.ts`, [[1]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L101-R112) [[2]](diffhunk://#diff-dfda902f8d6709a86cea8ff0e1434d0136c6c19fbea4da8a8fa6f8a63c998d52L121-R127)