### PR TITLE
feature: warn when imported csv contains duplicate rows

### DIFF
--- a/apps/architect-vite/src/ducks/modules/protocol/__tests__/assetManifest.test.ts
+++ b/apps/architect-vite/src/ducks/modules/protocol/__tests__/assetManifest.test.ts
@@ -1,6 +1,35 @@
+import { configureStore } from "@reduxjs/toolkit";
 import { v4 as uuid } from "uuid";
-import { describe, expect, it } from "vitest";
-import reducer, { test } from "../assetManifest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import dialogsReducer from "~/ducks/modules/dialogs";
+import reducer, { importAssetAsync, test } from "../assetManifest";
+
+vi.mock("~/utils/protocols/assetTools", () => ({
+	validateAsset: vi.fn(),
+}));
+
+vi.mock("~/utils/protocols/importAsset", () => ({
+	getSupportedAssetType: vi.fn(() => "network"),
+}));
+
+vi.mock("~/utils/assetUtils", () => ({
+	saveAssetToDb: vi.fn(() => Promise.resolve()),
+}));
+
+const { validateAsset } = await import("~/utils/protocols/assetTools");
+const mockedValidateAsset = vi.mocked(validateAsset);
+
+const createTestStore = () =>
+	configureStore({
+		reducer: {
+			assetManifest: reducer,
+			dialogs: dialogsReducer,
+		},
+		middleware: (getDefaultMiddleware) =>
+			getDefaultMiddleware({
+				serializableCheck: false,
+			}),
+	});
 
 describe("protocol/assetManifest", () => {
 	describe("reducer", () => {
@@ -36,6 +65,39 @@ describe("protocol/assetManifest", () => {
 			};
 			const result = reducer(state, test.deleteAsset(assetId));
 			expect(result).toEqual({});
+		});
+	});
+
+	describe("importAssetAsync", () => {
+		let store: ReturnType<typeof createTestStore>;
+
+		beforeEach(() => {
+			store = createTestStore();
+			vi.clearAllMocks();
+		});
+
+		it("dispatches duplicate rows warning dialog when duplicateCount > 0", async () => {
+			mockedValidateAsset.mockResolvedValue({ duplicateCount: 3 });
+
+			const file = new File(["test"], "roster.csv", { type: "text/csv" });
+			await store.dispatch(importAssetAsync(file));
+
+			const dialogs = store.getState().dialogs.dialogs;
+			expect(dialogs).toHaveLength(1);
+			expect(dialogs[0]).toMatchObject({
+				type: "Warning",
+				title: "Warning: roster.csv contains duplicate rows",
+			});
+		});
+
+		it("does not dispatch duplicate rows warning dialog when duplicateCount is 0", async () => {
+			mockedValidateAsset.mockResolvedValue({ duplicateCount: 0 });
+
+			const file = new File(["test"], "roster.csv", { type: "text/csv" });
+			await store.dispatch(importAssetAsync(file));
+
+			const dialogs = store.getState().dialogs.dialogs;
+			expect(dialogs).toHaveLength(0);
 		});
 	});
 

--- a/apps/architect-vite/src/ducks/modules/protocol/assetManifest.ts
+++ b/apps/architect-vite/src/ducks/modules/protocol/assetManifest.ts
@@ -2,7 +2,11 @@ import type { ExtractedAsset } from "@codaco/protocol-validation";
 import { createAsyncThunk, createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { omit } from "es-toolkit/compat";
 import { v4 as uuid } from "uuid";
-import { importAssetErrorDialog, invalidAssetErrorDialog } from "~/ducks/modules/protocol/utils/dialogs";
+import {
+	duplicateRowsWarningDialog,
+	importAssetErrorDialog,
+	invalidAssetErrorDialog,
+} from "~/ducks/modules/protocol/utils/dialogs";
 import { saveAssetToDb } from "~/utils/assetUtils";
 import { validateAsset } from "~/utils/protocols/assetTools";
 import { getSupportedAssetType } from "~/utils/protocols/importAsset";
@@ -49,10 +53,14 @@ export const importAssetAsync = createAsyncThunk(
 
 		try {
 			// Validate asset
-			await validateAsset(file).catch((error) => {
+			const validationResult = await validateAsset(file).catch((error) => {
 				dispatch(invalidAssetErrorDialog(error, name));
 				throw error;
 			});
+
+			if (validationResult.duplicateCount > 0) {
+				dispatch(duplicateRowsWarningDialog(name, validationResult.duplicateCount));
+			}
 
 			// Convert File to Blob and create ExtractedAsset
 			const blob = new Blob([file], { type: file.type });

--- a/apps/architect-vite/src/ducks/modules/protocol/utils/dialogs.tsx
+++ b/apps/architect-vite/src/ducks/modules/protocol/utils/dialogs.tsx
@@ -70,6 +70,22 @@ export const invalidAssetErrorDialog = (e: AssetError, filePath: string) => {
 	});
 };
 
+export const duplicateRowsWarningDialog = (filePath: string, count: number) => {
+	return dialogActions.openDialog({
+		type: "Warning",
+		title: `Warning: ${basename(filePath)} contains duplicate rows`,
+		message: (
+			<>
+				<p>
+					The file contains {count} duplicate {count === 1 ? "row" : "rows"}. Duplicate rows will be removed when this
+					roster is used in Fresco.
+				</p>
+				<p>Consider removing duplicates from your CSV file before importing.</p>
+			</>
+		),
+	});
+};
+
 export const importAssetErrorDialog = (e: AssetError, filePath: string) => {
 	e.friendlyMessage = (
 		<>

--- a/apps/architect-vite/src/utils/protocols/assetTools.ts
+++ b/apps/architect-vite/src/utils/protocols/assetTools.ts
@@ -90,10 +90,29 @@ export const getNetworkVariables = async (assetId: string) => {
 	return getVariableNamesFromNetwork(network);
 };
 
-const validateNetwork = async (file: File) => {
+export type ValidationResult = {
+	duplicateCount: number;
+};
+
+const countDuplicateRows = (rows: Record<string, unknown>[]): number => {
+	const seen = new Set<string>();
+	let count = 0;
+	for (const row of rows) {
+		const key = JSON.stringify(row);
+		if (seen.has(key)) {
+			count++;
+		} else {
+			seen.add(key);
+		}
+	}
+	return count;
+};
+
+const validateNetwork = async (file: File): Promise<ValidationResult> => {
 	const extension = file.name.split(".").pop()?.toLowerCase() || "";
 
 	let network: Network | undefined;
+	let duplicateCount = 0;
 
 	if (extension === "json") {
 		const text = await file.text();
@@ -104,6 +123,7 @@ const validateNetwork = async (file: File) => {
 		let nodes: Network["nodes"];
 		try {
 			const rows = await csvModule.default({ checkColumn: true }).fromString(text);
+			duplicateCount = countDuplicateRows(rows);
 			nodes = rows.map((attributes) => ({ attributes })) as Network["nodes"];
 		} catch (e: unknown) {
 			const error = e as CodedError;
@@ -129,10 +149,10 @@ const validateNetwork = async (file: File) => {
 		throw error;
 	}
 
-	return true;
+	return { duplicateCount };
 };
 
-export const validateAsset = async (file: File) => {
+export const validateAsset = async (file: File): Promise<ValidationResult> => {
 	const assetType = getSupportedAssetType(file.name);
 
 	if (!assetType) {
@@ -140,10 +160,10 @@ export const validateAsset = async (file: File) => {
 	}
 
 	if (assetType === "network") {
-		await validateNetwork(file);
+		return await validateNetwork(file);
 	}
 
-	return true;
+	return { duplicateCount: 0 };
 };
 
 export const getGeoJsonVariables = async (assetId: string) => {


### PR DESCRIPTION
This pull request adds a user-facing warning when a CSV asset being imported contains duplicate rows, and includes the duplicate count in the warning dialog. It also introduces supporting infrastructure for this warning, including logic to detect duplicates and new tests to verify the behavior.

**User-facing improvements:**

* Show a warning dialog if a CSV asset contains duplicate rows when importing, including the file name and number of duplicates. This helps users be aware of data quality issues before using the asset. [[1]](diffhunk://#diff-1ecb0aa20b28e5ba8ae10e5e836fa8fb40799961d4ba2ea5d99b830cd2b4467aL52-R64) [[2]](diffhunk://#diff-a8c897679e7a488898e2810722daeab5e47e5446947235640791816995ce7b0aR73-R88)

**Validation logic updates:**

* Add a `countDuplicateRows` helper and update `validateNetwork` in `assetTools.ts` to count duplicate rows in CSV files; the validation result now includes `duplicateCount`. [[1]](diffhunk://#diff-cb04285ade61cf93ae6930e0d719ff572b593c5ac914870ae1a3a56de6a665feL93-R115) [[2]](diffhunk://#diff-cb04285ade61cf93ae6930e0d719ff572b593c5ac914870ae1a3a56de6a665feR126) [[3]](diffhunk://#diff-cb04285ade61cf93ae6930e0d719ff572b593c5ac914870ae1a3a56de6a665feL132-R166)

**Testing improvements:**

* Add tests for the new duplicate row warning behavior in `assetManifest.test.ts`, including both the presence and absence of duplicates. Mocks are added for relevant utility functions. [[1]](diffhunk://#diff-41d42f7bb3533c96a4200dea3bd30a19125086d515a06144d00a134c95369e78R1-R32) [[2]](diffhunk://#diff-41d42f7bb3533c96a4200dea3bd30a19125086d515a06144d00a134c95369e78R71-R103)

**Dialog infrastructure:**

* Add a new `duplicateRowsWarningDialog` action creator in `dialogs.tsx` for consistent warning dialog display.

**Imports and type updates:**

* Update imports and types to support the new validation result and dialog action.