### PR TITLE
Add bodyFormat to preview mode presigned url return

### DIFF
--- a/apps/architect-vite/src/utils/preview/types.ts
+++ b/apps/architect-vite/src/utils/preview/types.ts
@@ -39,6 +39,13 @@ type PresignedUrlWithAssetId = {
 	url: string;
 	/** Headers the client must include on the upload PUT request. */
 	headers: Record<string, string>;
+	/**
+	 * How to wrap the file bytes when PUTting to `url`:
+	 * - `raw`: PUT the file as the request body (S3 presigned URLs).
+	 * - `formdata`: wrap the file in a `FormData` with field name `file`
+	 *   (UploadThing ingest endpoint requires multipart/form-data).
+	 */
+	bodyFormat: "raw" | "formdata";
 };
 
 type JobCreatedResponse = {

--- a/apps/architect-vite/src/utils/preview/uploadPreview.ts
+++ b/apps/architect-vite/src/utils/preview/uploadPreview.ts
@@ -109,6 +109,7 @@ async function uploadAsset(
 	fileBlob: Blob,
 	fileName: string,
 	headers: Record<string, string>,
+	bodyFormat: "raw" | "formdata",
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
@@ -173,11 +174,18 @@ async function uploadAsset(
 			xhr.setRequestHeader(key, value);
 		}
 
-		if (!Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
-			xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+		if (bodyFormat === "formdata") {
+			// XHR auto-sets Content-Type (with the multipart boundary) for FormData.
+			// Manually setting Content-Type here would break the boundary.
+			const formData = new FormData();
+			formData.append("file", fileBlob, fileName);
+			xhr.send(formData);
+		} else {
+			if (!Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
+				xhr.setRequestHeader("Content-Type", fileBlob.type || "application/octet-stream");
+			}
+			xhr.send(fileBlob);
 		}
-
-		xhr.send(fileBlob);
 	});
 }
 
@@ -361,7 +369,7 @@ export async function uploadProtocolForPreview(
 		if (!presignedUrl) {
 			throw new Error(`Missing presigned URL at index ${i}`);
 		}
-		const { assetId, url, headers = {} } = presignedUrl;
+		const { assetId, url, headers = {}, bodyFormat } = presignedUrl;
 		const localAsset = fileAssetsMap.get(assetId);
 
 		if (!localAsset) {
@@ -375,7 +383,7 @@ export async function uploadProtocolForPreview(
 		});
 
 		try {
-			await uploadAsset(url, localAsset.data, localAsset.name, headers);
+			await uploadAsset(url, localAsset.data, localAsset.name, headers, bodyFormat);
 		} catch (uploadError) {
 			// If upload fails, abort the preview job
 			await sendPreviewRequest<AbortResponse>(frescoUrl, apiToken, {


### PR DESCRIPTION
Refactoring Fresco to use direct presigned urls instead of proxy to uploadthing due to file size limits for Netlify functions. Requires specifying bodyFormat in consumer so that file is correctly uploaded to uploadthing.