### PR TITLE
Fix(architect-web): use section disabled prop to prevent prompt creation

### DIFF
--- a/apps/architect-vite/src/components/EditorLayout/Section.tsx
+++ b/apps/architect-vite/src/components/EditorLayout/Section.tsx
@@ -89,7 +89,8 @@ const Section = ({
 							title="Turn this feature on or off"
 							checked={isOpen}
 							onCheckedChange={changeToggleState}
-							className="shrink-0 grow-0"
+							disabled={disabled}
+							className={cn("shrink-0 grow-0", disabled && "opacity-50 cursor-not-allowed")}
 						/>
 					)}
 				</legend>

--- a/apps/architect-vite/src/components/EditorLayout/Section.tsx
+++ b/apps/architect-vite/src/components/EditorLayout/Section.tsx
@@ -12,6 +12,7 @@ type SectionProps = {
 	title: string;
 	summary?: React.ReactNode;
 	disabled?: boolean;
+	disabledMessage?: string;
 	group?: boolean;
 	children: React.ReactNode;
 	className?: string;
@@ -25,7 +26,8 @@ const Section = ({
 	id = null,
 	title,
 	summary = null,
-	disabled: _disabled = false,
+	disabled = false,
+	disabledMessage = "Complete the required options above to enable this section.",
 	group: _group = false,
 	children,
 	className = "",
@@ -94,11 +96,25 @@ const Section = ({
 				<div className="text-current/70">{summary}</div>
 			</div>
 			<fieldset className={classes}>
-				{isOpen && children}
-				{toggleable && !isOpen && layout !== "vertical" && (
-					<div className="absolute inset-0 flex justify-center items-center w-full h-full bg-border/75 text-foreground/70 font-semibold italic">
-						Click the toggle to enable this feature...
-					</div>
+				{disabled ? (
+					layout === "horizontal" ? (
+						<div className="absolute inset-0 flex justify-center items-center w-full h-full bg-border/75 text-foreground/70 font-semibold italic rounded">
+							{disabledMessage}
+						</div>
+					) : (
+						<div className="flex items-center justify-center p-8 bg-border/75 text-foreground/70 font-semibold italic text-center rounded">
+							{disabledMessage}
+						</div>
+					)
+				) : (
+					<>
+						{isOpen && children}
+						{toggleable && !isOpen && layout !== "vertical" && (
+							<div className="absolute inset-0 flex justify-center items-center w-full h-full bg-border/75 text-foreground/70 font-semibold italic">
+								Click the toggle to enable this feature...
+							</div>
+						)}
+					</>
 				)}
 				{id && <IssueAnchor fieldName={id} description={title} />}
 			</fieldset>

--- a/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
+++ b/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
@@ -8,14 +8,14 @@ type PropsWithSubject = {
 type InjectedProps = { disabled: boolean; disabledMessage?: string };
 
 const withDisabledSubjectRequired = withProps<InjectedProps, PropsWithSubject>(({ interfaceType, type }) => {
-	if (interfaceType === "EgoForm") {
+	if (interfaceType === "EgoForm" || type) {
 		return { disabled: false };
 	}
 
 	const entityLabel = interfaceType === "AlterEdgeForm" ? "an edge" : "a node";
 
 	return {
-		disabled: !type,
+		disabled: true,
 		disabledMessage: `Select ${entityLabel} type above to configure this section.`,
 	};
 });

--- a/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
+++ b/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
@@ -12,9 +12,11 @@ const withDisabledSubjectRequired = withProps<InjectedProps, PropsWithSubject>((
 		return { disabled: false };
 	}
 
+	const entityLabel = interfaceType === "AlterEdgeForm" ? "an edge" : "a node";
+
 	return {
 		disabled: !type,
-		disabledMessage: "Select a node type above to configure this section.",
+		disabledMessage: `Select ${entityLabel} type above to configure this section.`,
 	};
 });
 

--- a/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
+++ b/apps/architect-vite/src/components/enhancers/withDisabledSubjectRequired.tsx
@@ -5,12 +5,17 @@ type PropsWithSubject = {
 	type?: string;
 };
 
-const withDisabledSubjectRequired = withProps<{ disabled: boolean }, PropsWithSubject>(({ interfaceType, type }) => {
+type InjectedProps = { disabled: boolean; disabledMessage?: string };
+
+const withDisabledSubjectRequired = withProps<InjectedProps, PropsWithSubject>(({ interfaceType, type }) => {
 	if (interfaceType === "EgoForm") {
 		return { disabled: false };
 	}
 
-	return { disabled: !type };
+	return {
+		disabled: !type,
+		disabledMessage: "Select a node type above to configure this section.",
+	};
 });
 
 export default withDisabledSubjectRequired;

--- a/apps/architect-vite/src/components/sections/CategoricalBinPrompts/CategoricalBinPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/CategoricalBinPrompts/CategoricalBinPrompts.tsx
@@ -15,6 +15,7 @@ type CategoricalBinPromptsProps = StageEditorSectionProps & {
 	type?: string | null;
 	form: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
 const CategoricalBinPrompts = ({
@@ -23,9 +24,11 @@ const CategoricalBinPrompts = ({
 	type = null,
 	form,
 	disabled,
+	disabledMessage,
 }: CategoricalBinPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/DyadCensusPrompts/DyadCensusPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/DyadCensusPrompts/DyadCensusPrompts.tsx
@@ -11,11 +11,13 @@ type DyadCensusPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
-const DyadCensusPrompts = ({ form, entity, type, disabled }: DyadCensusPromptsProps) => (
+const DyadCensusPrompts = ({ form, entity, type, disabled, disabledMessage }: DyadCensusPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/Form/Form.tsx
+++ b/apps/architect-vite/src/components/sections/Form/Form.tsx
@@ -15,6 +15,7 @@ import withFormHandlers from "./withFormHandlers";
 type FormProps = StageEditorSectionProps & {
 	handleChangeFields: (fields: Array<Record<string, unknown>>) => void;
 	disabled?: boolean;
+	disabledMessage?: string;
 	disableFormTitle?: boolean;
 	type?: string | null;
 	entity?: string | null;
@@ -24,12 +25,14 @@ const Form = ({
 	handleChangeFields,
 	form,
 	disabled = false,
+	disabledMessage,
 	type = null,
 	entity = null,
 	disableFormTitle = false,
 }: FormProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		group
 		title="Form"
 		summary={

--- a/apps/architect-vite/src/components/sections/GeospatialPrompts/GeospatialPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/GeospatialPrompts/GeospatialPrompts.tsx
@@ -13,11 +13,13 @@ type GeospatialPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
-const GeospatialPrompts = ({ form, entity, type, disabled }: GeospatialPromptsProps) => (
+const GeospatialPrompts = ({ form, entity, type, disabled, disabledMessage }: GeospatialPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/NameGeneratorPrompts/NameGeneratorPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/NameGeneratorPrompts/NameGeneratorPrompts.tsx
@@ -11,11 +11,13 @@ type NameGeneratorPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
-const NameGeneratorPrompts = ({ disabled, entity, type, ...rest }: NameGeneratorPromptsProps) => (
+const NameGeneratorPrompts = ({ disabled, disabledMessage, entity, type, ...rest }: NameGeneratorPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/NameGeneratorRosterPrompts/NameGeneratorRosterPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/NameGeneratorRosterPrompts/NameGeneratorRosterPrompts.tsx
@@ -13,12 +13,21 @@ type NameGeneratorRosterPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 	dataSource?: string;
 };
 
-const NameGeneratorRosterPrompts = ({ form, entity, type, disabled, dataSource }: NameGeneratorRosterPromptsProps) => (
+const NameGeneratorRosterPrompts = ({
+	form,
+	entity,
+	type,
+	disabled,
+	disabledMessage,
+	dataSource,
+}: NameGeneratorRosterPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/NarrativePresets/NarrativePresets.tsx
+++ b/apps/architect-vite/src/components/sections/NarrativePresets/NarrativePresets.tsx
@@ -28,11 +28,13 @@ type NarrativePresetsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
-const NarrativePresets = ({ form, entity, type, disabled }: NarrativePresetsProps) => (
+const NarrativePresets = ({ form, entity, type, disabled, disabledMessage }: NarrativePresetsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more &quot;presets&quot; below, to create different visualizations that you can switch between within

--- a/apps/architect-vite/src/components/sections/OneToManyDyadCensus/OneToManyDyadCensusPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/OneToManyDyadCensus/OneToManyDyadCensusPrompts.tsx
@@ -11,11 +11,19 @@ type OneToManyDyadCensusPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
-const OneToManyDyadCensusPrompts = ({ form, entity, type, disabled }: OneToManyDyadCensusPromptsProps) => (
+const OneToManyDyadCensusPrompts = ({
+	form,
+	entity,
+	type,
+	disabled,
+	disabledMessage,
+}: OneToManyDyadCensusPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/OrdinalBinPrompts/OrdinalBinPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/OrdinalBinPrompts/OrdinalBinPrompts.tsx
@@ -16,6 +16,7 @@ type OrdinalBinPromptsProps = StageEditorSectionProps & {
 	entity?: string | null;
 	type?: string | null;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
 const OrdinalBinPrompts = ({
@@ -24,9 +25,11 @@ const OrdinalBinPrompts = ({
 	type = null,
 	form,
 	disabled,
+	disabledMessage,
 }: OrdinalBinPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/SociogramPrompts/SociogramPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/SociogramPrompts/SociogramPrompts.tsx
@@ -14,12 +14,21 @@ type SociogramPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 	usedVariableIndex?: Record<string, unknown>;
 };
 
-const SociogramPrompts = ({ form, entity, type, disabled, usedVariableIndex }: SociogramPromptsProps) => (
+const SociogramPrompts = ({
+	form,
+	entity,
+	type,
+	disabled,
+	disabledMessage,
+	usedVariableIndex,
+}: SociogramPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable

--- a/apps/architect-vite/src/components/sections/TieStrengthCensusPrompts/TieStrengthCensusPrompts.tsx
+++ b/apps/architect-vite/src/components/sections/TieStrengthCensusPrompts/TieStrengthCensusPrompts.tsx
@@ -14,6 +14,7 @@ type TieStrengthCensusPromptsProps = StageEditorSectionProps & {
 	entity?: string;
 	type?: string;
 	disabled?: boolean;
+	disabledMessage?: string;
 };
 
 const TieStrengthCensusPrompts = ({
@@ -22,9 +23,11 @@ const TieStrengthCensusPrompts = ({
 	entity,
 	type,
 	disabled,
+	disabledMessage,
 }: TieStrengthCensusPromptsProps) => (
 	<Section
 		disabled={disabled}
+		disabledMessage={disabledMessage}
 		summary={
 			<p>
 				Add one or more prompts below to frame the task for the user. You can reorder the prompts using the draggable


### PR DESCRIPTION
Section's disabled prop was ignored, so users could create a prompt with no subject. This led to unwanted behavior:
- variables for that prompt were created on the ego (due to it being the withSubject default)
- When a subject was selected, the created prompt/variables disappeared for the user 

Fix includes using the disabled prop to grey out the disabled section so that it cannot be configured until not disabled. In this case, prompts then cannot be configured until a subject is selected. This is in alignment with behavior in Architect desktop.

Also enhanced the UI/UX with a disabledMessage so that the greyed out area message is more clear ("Select a node type above to configure this section."


<img width="1448" height="695" alt="Screenshot 2026-04-21 at 3 02 52 PM" src="https://github.com/user-attachments/assets/85700683-11dc-4504-95f1-9abcf77a49f9" />
)

