### PR TITLE
fix(architect): break render loop in useVariablesFromExternalData

### DIFF
--- a/apps/architect-vite/src/hooks/useVariablesFromExternalData.ts
+++ b/apps/architect-vite/src/hooks/useVariablesFromExternalData.ts
@@ -1,7 +1,8 @@
+import { get } from "es-toolkit/compat";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import type { RootState } from "~/ducks/modules/root";
-import { makeGetGeoJsonAssetVariables, makeGetNetworkAssetVariables } from "~/selectors/assets";
+import { getAssetManifest } from "~/selectors/protocol";
+import { getGeoJsonVariables, getNetworkVariables } from "~/utils/protocols/assetTools";
 
 type VariableOption = { label: string; value: string };
 
@@ -20,6 +21,8 @@ const initialState: VariablesState = {
 	variablesError: null,
 };
 
+const toOptions = (variables: string[]): VariableOption[] => variables.map((v) => ({ label: v, value: v }));
+
 function useVariablesFromExternalData(
 	dataSource: string | undefined,
 	asOptions: true,
@@ -36,8 +39,7 @@ function useVariablesFromExternalData(
 	type = "network",
 ): VariablesState {
 	const [state, setState] = useState<VariablesState>(initialState);
-
-	const rootState = useSelector((s: RootState) => s);
+	const assetManifest = useSelector(getAssetManifest);
 
 	useEffect(() => {
 		if (!dataSource) {
@@ -46,12 +48,25 @@ function useVariablesFromExternalData(
 
 		setState({ isVariablesLoading: true, variables: [], variablesError: null });
 
-		const getVariablesFn =
-			type === "geojson" ? makeGetGeoJsonAssetVariables(rootState) : makeGetNetworkAssetVariables(rootState);
+		if (!get(assetManifest, dataSource)) {
+			setState((s) => ({ ...s, isVariablesLoading: false, variables: [] }));
+			return;
+		}
 
-		getVariablesFn(dataSource, asOptions)
+		const fetchVariables = async (): Promise<string[]> => {
+			if (type === "geojson") {
+				return getGeoJsonVariables(dataSource);
+			}
+			return (await getNetworkVariables(dataSource)) ?? [];
+		};
+
+		fetchVariables()
 			.then((variables) => {
-				setState((s) => ({ ...s, isVariablesLoading: false, variables: variables ?? [] }));
+				setState((s) => ({
+					...s,
+					isVariablesLoading: false,
+					variables: asOptions ? toOptions(variables) : variables,
+				}));
 			})
 			.catch((e: Error) => {
 				setState((s) => ({
@@ -60,7 +75,7 @@ function useVariablesFromExternalData(
 					variablesError: e.toString(),
 				}));
 			});
-	}, [dataSource, type, asOptions, rootState]);
+	}, [dataSource, type, asOptions, assetManifest]);
 
 	return state;
 }

--- a/apps/architect-vite/src/hooks/useVariablesFromExternalData.ts
+++ b/apps/architect-vite/src/hooks/useVariablesFromExternalData.ts
@@ -1,6 +1,7 @@
 import { get } from "es-toolkit/compat";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import type { RootState } from "~/ducks/modules/root";
 import { getAssetManifest } from "~/selectors/protocol";
 import { getGeoJsonVariables, getNetworkVariables } from "~/utils/protocols/assetTools";
 
@@ -39,7 +40,7 @@ function useVariablesFromExternalData(
 	type = "network",
 ): VariablesState {
 	const [state, setState] = useState<VariablesState>(initialState);
-	const assetManifest = useSelector(getAssetManifest);
+	const asset = useSelector((s: RootState) => (dataSource ? get(getAssetManifest(s), dataSource) : undefined));
 
 	useEffect(() => {
 		if (!dataSource) {
@@ -48,7 +49,7 @@ function useVariablesFromExternalData(
 
 		setState({ isVariablesLoading: true, variables: [], variablesError: null });
 
-		if (!get(assetManifest, dataSource)) {
+		if (!asset) {
 			setState((s) => ({ ...s, isVariablesLoading: false, variables: [] }));
 			return;
 		}
@@ -75,7 +76,7 @@ function useVariablesFromExternalData(
 					variablesError: e.toString(),
 				}));
 			});
-	}, [dataSource, type, asOptions, assetManifest]);
+	}, [dataSource, type, asOptions, asset]);
 
 	return state;
 }

--- a/apps/architect-vite/src/selectors/assets.ts
+++ b/apps/architect-vite/src/selectors/assets.ts
@@ -1,6 +1,6 @@
 import { get } from "es-toolkit/compat";
 import type { RootState } from "~/ducks/modules/root";
-import { getGeoJsonVariables, getNetworkVariables } from "~/utils/protocols/assetTools";
+import { getNetworkVariables } from "~/utils/protocols/assetTools";
 import { getAssetManifest } from "./protocol";
 
 export const getAssetPath = (state: RootState, dataSource: string) => {
@@ -45,21 +45,3 @@ export const makeGetNetworkAssetVariables =
 
 		return variables;
 	};
-
-export const makeGetGeoJsonAssetVariables = (state: RootState) => async (dataSource: string) => {
-	const assetManifest = getAssetManifest(state);
-	const asset = get(assetManifest, dataSource);
-
-	if (!asset) {
-		return null;
-	}
-
-	const variables = await getGeoJsonVariables(dataSource);
-
-	const variableOptions = variables.map((attribute: string) => ({
-		label: attribute,
-		value: attribute,
-	}));
-
-	return variableOptions;
-};


### PR DESCRIPTION
This PR fixes regressions related to the JS-> TS refactor of the `useVariablesFromExternalData` hook in af34c31d

The hook subscribed to the entire root state via `useSelector(s => s)` and put it in a useEffect dependency array, causing the effect to rerun on every redux dispatch. redux-form `REGISTER_FIELD` / `UNREGISTER_FIELD` actions on conditionally rendered fields then produced an infinite loop causing visual regressions:
- Roster card display options were not visible
- Geospatial map selection property selection was not visible

Fix: subscribe only to the specific asset, call the underlying `getGeoJsonVariables` / `getNetworkVariables` utils directly, and bypass factory selectors that required full state.