### PR TITLE
fix(architect-web): stack issues panel above control bar

### DIFF
--- a/apps/architect-vite/src/components/Editor.tsx
+++ b/apps/architect-vite/src/components/Editor.tsx
@@ -38,9 +38,8 @@ export const useFormContext = () => {
 };
 
 /**
- * A thin wrapper over redux form's Form component that handles displaying issues
- * when the form is submitted and there are validation errors.
- *
+ * A thin wrapper over redux form's Form component that exposes form
+ * state via FormContext for descendants to consume.
  */
 const Editor = (props: EditorProps) => {
 	const {

--- a/apps/architect-vite/src/components/Editor.tsx
+++ b/apps/architect-vite/src/components/Editor.tsx
@@ -1,11 +1,10 @@
 import { merge } from "es-toolkit/compat";
-import React, { createContext, useContext, useState } from "react";
+import { createContext, type ReactNode, useContext } from "react";
 import { type ConfigProps, Form, type InjectedFormProps, reduxForm } from "redux-form";
-import Issues from "./Issues";
 
 type EditorOwnProps = Partial<ConfigProps<Record<string, unknown>, EditorOwnProps>> & {
 	form: string; // Make this required, so that consumers must specify a form name.
-	children?: React.ReactNode;
+	children?: ReactNode;
 };
 
 type EditorProps = EditorOwnProps &
@@ -57,18 +56,6 @@ const Editor = (props: EditorProps) => {
 		children,
 		values,
 	} = props;
-	const [isIssuesVisible, setIsIssuesVisible] = useState(false);
-
-	const hideIssues = () => {
-		setIsIssuesVisible(false);
-	};
-
-	// Show issues when submit fails
-	React.useEffect(() => {
-		if (submitFailed) {
-			setIsIssuesVisible(true);
-		}
-	}, [submitFailed]);
 
 	// Create context value with useful form information
 	const contextValue: FormContextType = {
@@ -88,7 +75,6 @@ const Editor = (props: EditorProps) => {
 			<Form onSubmit={handleSubmit} className="flex-1 h-full w-full">
 				{children}
 			</Form>
-			<Issues show={isIssuesVisible} hideIssues={hideIssues} />
 		</FormContext.Provider>
 	);
 };

--- a/apps/architect-vite/src/components/Issues.tsx
+++ b/apps/architect-vite/src/components/Issues.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from "motion/react";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { getFormSyncErrors } from "redux-form";
+import { getFormSyncErrors, hasSubmitFailed } from "redux-form";
 import { Icon } from "~/lib/legacy-ui/components";
 import { flattenIssues, getFieldId } from "../utils/issues";
 import scrollTo from "../utils/scrollTo";
@@ -20,14 +20,11 @@ const variants = {
 	},
 };
 
-type IssuesProps = {
-	show?: boolean;
-	hideIssues: () => void;
-};
-
-const Issues = ({ show = true, hideIssues }: IssuesProps) => {
+const Issues = () => {
 	const formErrors = useSelector(getFormSyncErrors(formName));
+	const submitFailed = useSelector(hasSubmitFailed(formName));
 	const issues = formErrors as Record<string, unknown>;
+	const [show, setShow] = useState(false);
 	const [open, setOpen] = useState(true);
 	const flatIssues = flattenIssues(issues);
 	const issueRefs = useRef<Record<string, HTMLElement | null>>({});
@@ -35,10 +32,16 @@ const Issues = ({ show = true, hideIssues }: IssuesProps) => {
 	const hasOutstandingIssues = Object.keys(issues).length !== 0;
 
 	useEffect(() => {
-		if (!hasOutstandingIssues) {
-			hideIssues();
+		if (submitFailed) {
+			setShow(true);
 		}
-	}, [hasOutstandingIssues, hideIssues]);
+	}, [submitFailed]);
+
+	useEffect(() => {
+		if (!hasOutstandingIssues) {
+			setShow(false);
+		}
+	}, [hasOutstandingIssues]);
 
 	const setIssueRef = (el: HTMLElement | null, fieldId: string) => {
 		issueRefs.current[fieldId] = el;
@@ -133,7 +136,7 @@ const Issues = ({ show = true, hideIssues }: IssuesProps) => {
 							aria-expanded={open}
 						>
 							<div className="issues__title-bar-icon">
-								<Icon name="info" color="white" />
+								<Icon name="info" />
 							</div>
 							<div className="issues__title-bar-text">Issues ({flatIssues.length})</div>
 							<motion.div className="issues__title-bar-toggle" animate={{ rotate: isVisible ? 180 : 0 }}>

--- a/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
@@ -8,6 +8,7 @@ import { useLocation } from "wouter";
 import ControlBar from "~/components/ControlBar";
 import Editor from "~/components/Editor";
 import ExternalLink from "~/components/ExternalLink";
+import Issues from "~/components/Issues";
 import { useAppDispatch } from "~/ducks/hooks";
 import { actionCreators as dialogActions } from "~/ducks/modules/dialogs";
 import { actionCreators as stageActions } from "~/ducks/modules/protocol/stages";
@@ -196,6 +197,7 @@ const StageEditor = (props: StageEditorProps) => {
 					<StageHeading />
 					<div className="flex flex-col gap-10 mb-32">{renderSections(sections)}</div>
 				</div>
+				<Issues />
 				<ControlBar
 					secondaryButtons={[
 						<Button key="cancel" onClick={handleCancel} color="platinum">

--- a/apps/architect-vite/src/components/__tests__/Issues.test.tsx
+++ b/apps/architect-vite/src/components/__tests__/Issues.test.tsx
@@ -1,7 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { getFormSyncErrors } from "redux-form";
+import { getFormSyncErrors, hasSubmitFailed } from "redux-form";
 import { describe, expect, it, type Mock, vi } from "vitest";
 import Issues from "../Issues";
 
@@ -17,11 +17,6 @@ const mockIssues = {
 	],
 };
 
-const mockProps = {
-	show: true,
-	hideIssues: () => {},
-};
-
 const mockStore = configureStore({
 	reducer: {
 		form: () => ({}),
@@ -31,10 +26,11 @@ const mockStore = configureStore({
 describe("<Issues />", () => {
 	it("will render", () => {
 		(getFormSyncErrors as Mock).mockReturnValue(() => ({}));
+		(hasSubmitFailed as Mock).mockReturnValue(() => false);
 
 		const { container } = render(
 			<Provider store={mockStore}>
-				<Issues {...mockProps} />
+				<Issues />
 			</Provider>,
 		);
 
@@ -43,10 +39,11 @@ describe("<Issues />", () => {
 
 	it("renders issues from object", () => {
 		(getFormSyncErrors as Mock).mockReturnValue(() => mockIssues);
+		(hasSubmitFailed as Mock).mockReturnValue(() => true);
 
 		const { container } = render(
 			<Provider store={mockStore}>
-				<Issues {...mockProps} show />
+				<Issues />
 			</Provider>,
 		);
 

--- a/apps/architect-vite/src/styles/components/issues.css
+++ b/apps/architect-vite/src/styles/components/issues.css
@@ -5,7 +5,6 @@
 	transform-origin: 0 100%;
 	overflow: hidden;
 	color: var(--color-primary-foreground);
-	max-height: auto;
 }
 
 .issues__title-bar {

--- a/apps/architect-vite/src/styles/components/issues.css
+++ b/apps/architect-vite/src/styles/components/issues.css
@@ -1,16 +1,15 @@
 .issues {
-	position: sticky;
-	bottom: 0;
 	width: 100%;
+	flex-shrink: 0;
 	background-color: var(--color-sea-serpent);
 	transform-origin: 0 100%;
 	overflow: hidden;
 	color: var(--color-primary-foreground);
-	z-index: var(--z-default);
 	max-height: auto;
 }
 
 .issues__title-bar {
+	width: 100%;
 	background-color: var(--color-sea-serpent-dark);
 	padding: var(--space-sm) var(--space-md);
 	cursor: pointer;
@@ -18,6 +17,7 @@
 	flex-direction: row;
 	align-items: center;
 	justify-content: flex-start;
+	text-align: left;
 }
 
 .issues__title-bar-icon .icon {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,8 +455,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
       es-toolkit:
-        specifier: ^1.46.0
-        version: 1.46.0
+        specifier: ^1.46.1
+        version: 1.46.1
       fuse.js:
         specifier: ^3.6.1
         version: 3.6.1
@@ -7692,9 +7692,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  es-toolkit@1.46.0:
-    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
@@ -19660,8 +19657,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  es-toolkit@1.46.0: {}
 
   es-toolkit@1.46.1: {}
 


### PR DESCRIPTION
This PR adjusts the Architect stage editor layout so the validation “Issues” panel sits above the control bar, and refactors the issues panel’s visibility logic to be driven directly by redux-form submission state rather than Editor props.

Changes:

- Move <Issues /> rendering into StageEditor so it can be positioned directly above the ControlBar.
- Refactor Issues to manage its own show state based on hasSubmitFailed(formName) and hide itself when issues are resolved.
- Update issues panel styling (remove sticky positioning, adjust title bar layout) and update tests accordingly.