### PR TITLE
fix(architect-web): disable preview when stage is invalid

### DIFF
--- a/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
+++ b/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
@@ -12,7 +12,13 @@ export default function Tooltip({ content, children, side = "top" }: TooltipProp
 
 	return (
 		<BaseTooltip.Root>
-			<BaseTooltip.Trigger render={<span className="inline-flex">{children}</span>} />
+			<BaseTooltip.Trigger
+				render={
+					<span className="inline-flex" tabIndex={0}>
+						{children}
+					</span>
+				}
+			/>
 			<BaseTooltip.Portal>
 				<BaseTooltip.Positioner side={side} sideOffset={8}>
 					<BaseTooltip.Popup className="max-w-sm rounded-md bg-surface-accent px-3 py-2 text-sm text-surface-accent-foreground shadow-lg">

--- a/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
+++ b/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
@@ -2,14 +2,12 @@ import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import type { ReactNode } from "react";
 
 type TooltipProps = {
-	content?: ReactNode;
+	content: ReactNode;
 	children: ReactNode;
 	side?: "top" | "bottom" | "left" | "right";
 };
 
 export default function Tooltip({ content, children, side = "top" }: TooltipProps) {
-	if (content == null) return <>{children}</>;
-
 	return (
 		<BaseTooltip.Root>
 			<BaseTooltip.Trigger

--- a/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
+++ b/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
@@ -1,0 +1,25 @@
+import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
+import type { ReactNode } from "react";
+
+type TooltipProps = {
+	content: ReactNode;
+	children: ReactNode;
+	side?: "top" | "bottom" | "left" | "right";
+};
+
+export default function Tooltip({ content, children, side = "top" }: TooltipProps) {
+	if (!content) return <>{children}</>;
+
+	return (
+		<BaseTooltip.Root>
+			<BaseTooltip.Trigger render={<span className="inline-flex">{children}</span>} />
+			<BaseTooltip.Portal>
+				<BaseTooltip.Positioner side={side} sideOffset={8}>
+					<BaseTooltip.Popup className="max-w-sm rounded-md bg-surface-accent px-3 py-2 text-sm text-surface-accent-foreground shadow-lg">
+						{content}
+					</BaseTooltip.Popup>
+				</BaseTooltip.Positioner>
+			</BaseTooltip.Portal>
+		</BaseTooltip.Root>
+	);
+}

--- a/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
+++ b/apps/architect-vite/src/components/NewComponents/Tooltip.tsx
@@ -2,13 +2,13 @@ import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import type { ReactNode } from "react";
 
 type TooltipProps = {
-	content: ReactNode;
+	content?: ReactNode;
 	children: ReactNode;
 	side?: "top" | "bottom" | "left" | "right";
 };
 
 export default function Tooltip({ content, children, side = "top" }: TooltipProps) {
-	if (!content) return <>{children}</>;
+	if (content == null) return <>{children}</>;
 
 	return (
 		<BaseTooltip.Root>

--- a/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
@@ -2,13 +2,14 @@ import { type CurrentProtocol, type Stage, type StageType, validateProtocol } fr
 import { omit } from "es-toolkit/compat";
 import { useCallback, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
-import { getFormValues, isDirty as isFormDirty } from "redux-form";
+import { getFormValues, isDirty as isFormDirty, isInvalid } from "redux-form";
 import { v1 as uuid } from "uuid";
 import { useLocation } from "wouter";
 import ControlBar from "~/components/ControlBar";
 import Editor from "~/components/Editor";
 import ExternalLink from "~/components/ExternalLink";
 import Issues from "~/components/Issues";
+import Tooltip from "~/components/NewComponents/Tooltip";
 import { useAppDispatch } from "~/ducks/hooks";
 import { actionCreators as dialogActions } from "~/ducks/modules/dialogs";
 import { actionCreators as stageActions } from "~/ducks/modules/protocol/stages";
@@ -72,6 +73,7 @@ const StageEditor = (props: StageEditorProps) => {
 	// Get form state
 	const hasUnsavedChanges = useSelector((state: RootState) => isFormDirty(formName)(state));
 	const formValues = useSelector((state: RootState) => getFormValues(formName)(state)) as Stage | undefined;
+	const isStageInvalid = useSelector((state: RootState) => isInvalid(formName)(state));
 
 	// Preview state
 	const [isUploadingPreview, setIsUploadingPreview] = useState(false);
@@ -205,9 +207,18 @@ const StageEditor = (props: StageEditorProps) => {
 						</Button>,
 					]}
 					buttons={[
-						<Button key="preview" onClick={handlePreview} color="barbie-pink" disabled={isUploadingPreview}>
-							{isUploadingPreview ? getProgressText(uploadProgress) : "Preview"}
-						</Button>,
+						<Tooltip
+							key="preview"
+							content={
+								isStageInvalid
+									? "Previewing this stage requires valid stage configuration. Fix the errors on this stage to enable previewing."
+									: null
+							}
+						>
+							<Button onClick={handlePreview} color="barbie-pink" disabled={isUploadingPreview || isStageInvalid}>
+								{isUploadingPreview ? getProgressText(uploadProgress) : "Preview"}
+							</Button>
+						</Tooltip>,
 						...(hasUnsavedChanges
 							? [
 									<Button key="submit" type="submit" color="sea-green" iconPosition="right" icon="arrow-right">

--- a/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-vite/src/components/StageEditor/StageEditor.tsx
@@ -192,6 +192,12 @@ const StageEditor = (props: StageEditorProps) => {
 			return <SectionComponent key={sectionKey} form={formName} stagePath={stagePath} interfaceType={interfaceType} />;
 		});
 
+	const previewButton = (
+		<Button key="preview" onClick={handlePreview} color="barbie-pink" disabled={isUploadingPreview || isStageInvalid}>
+			{isUploadingPreview ? getProgressText(uploadProgress) : "Preview"}
+		</Button>
+	);
+
 	return (
 		<Editor initialValues={initialValues} onSubmit={onSubmit} form={formName}>
 			<div className="relative flex flex-col h-dvh">
@@ -207,18 +213,16 @@ const StageEditor = (props: StageEditorProps) => {
 						</Button>,
 					]}
 					buttons={[
-						<Tooltip
-							key="preview"
-							content={
-								isStageInvalid
-									? "Previewing this stage requires valid stage configuration. Fix the errors on this stage to enable previewing."
-									: null
-							}
-						>
-							<Button onClick={handlePreview} color="barbie-pink" disabled={isUploadingPreview || isStageInvalid}>
-								{isUploadingPreview ? getProgressText(uploadProgress) : "Preview"}
-							</Button>
-						</Tooltip>,
+						isStageInvalid ? (
+							<Tooltip
+								key="preview"
+								content="Previewing this stage requires valid stage configuration. Fix the errors on this stage to enable previewing."
+							>
+								{previewButton}
+							</Tooltip>
+						) : (
+							previewButton
+						),
 						...(hasUnsavedChanges
 							? [
 									<Button key="submit" type="submit" color="sea-green" iconPosition="right" icon="arrow-right">


### PR DESCRIPTION
Disables the Stage Editor “Preview” action when the current stage form is invalid, and introduces a small Base UI-backed tooltip wrapper to explain disabled state (matching the Architect desktop UX).

Changes:

- Add a minimal Tooltip component wrapping @base-ui/react/tooltip.
- Use redux-form’s isInvalid selector in StageEditor to disable the Preview button when the stage form is invalid.
- Wrap the Preview button in the new tooltip to explain why Preview is disabled.