### PR TITLE
Fix(architect-web): Correct node shape in codebook and summary

### DIFF
--- a/apps/architect-vite/src/components/Codebook/EntityType.tsx
+++ b/apps/architect-vite/src/components/Codebook/EntityType.tsx
@@ -1,6 +1,7 @@
 import { compose, withHandlers } from "react-recompose";
 import { connect } from "react-redux";
 import { Link } from "wouter";
+import type { NodeShape } from "~/components/Node/Node";
 import { actionCreators as dialogActionCreators } from "~/ducks/modules/dialogs";
 import { deleteTypeAsync } from "~/ducks/modules/protocol/codebook";
 import type { RootState } from "~/ducks/store";
@@ -38,6 +39,7 @@ type EntityTypeProps = {
 	type: string;
 	name: string;
 	color: string;
+	shape?: NodeShape;
 	usage: UsageItem[];
 	inUse?: boolean;
 	handleDelete?: () => void;
@@ -48,6 +50,7 @@ type EntityTypeProps = {
 const EntityType = ({
 	name,
 	color,
+	shape,
 	inUse = true,
 	usage,
 	entity,
@@ -79,7 +82,7 @@ const EntityType = ({
 		<div className="codebook__entity">
 			<div className="codebook__entity-detail">
 				<div className="codebook__entity-icon">
-					<EntityIcon color={color} entity={entity} />
+					<EntityIcon color={color} entity={entity} shape={shape} />
 				</div>
 				<div className="codebook__entity-name">
 					<h2>{name}</h2>

--- a/apps/architect-vite/src/components/Codebook/helpers.ts
+++ b/apps/architect-vite/src/components/Codebook/helpers.ts
@@ -8,6 +8,7 @@ import type {
 } from "@codaco/protocol-validation";
 import { createSelector } from "@reduxjs/toolkit";
 import { compact, get, reduce, uniq } from "es-toolkit/compat";
+import type { NodeShape } from "~/components/Node/Node";
 import type { RootState } from "~/ducks/store";
 import { getAllVariablesByUUID, getType } from "~/selectors/codebook";
 import { makeGetIsUsed } from "~/selectors/codebook/isUsed";
@@ -171,6 +172,7 @@ type VariableWithUsage = Variable & {
 type EntityProperties = {
 	name: string;
 	color?: string;
+	shape?: NodeShape;
 	variables: Record<string, VariableWithUsage>;
 };
 
@@ -207,6 +209,7 @@ export const getEntityProperties = (
 
 	const name = hasNameAndColor(entityType) ? entityType.name : "Ego";
 	const color = hasNameAndColor(entityType) ? entityType.color : undefined;
+	const shape = entity === "node" && "shape" in entityType ? entityType.shape?.default : undefined;
 
 	const variableIndex = getVariableIndex(state) as Record<string, string>;
 	const variableMeta = getVariableMetaByIndex(state);
@@ -246,6 +249,7 @@ export const getEntityProperties = (
 	return {
 		name,
 		color,
+		shape,
 		variables: variablesWithUsage,
 	};
 };

--- a/apps/architect-vite/src/lib/ProtocolSummary/components/EntityBadge.tsx
+++ b/apps/architect-vite/src/lib/ProtocolSummary/components/EntityBadge.tsx
@@ -19,11 +19,12 @@ const EntityBadge = ({ type, entity, link = false, small = false, tiny = false }
 
 	const color = get(codebook, [entity, type, "color"]);
 	const name = get(codebook, [entity, type, "name"]);
+	const shape = get(codebook, [entity, type, "shape", "default"]);
 
 	const size = tiny ? "tiny" : small ? "small" : "default";
 	const label = small || tiny ? name : <h2>{name}</h2>;
 
-	const badge = <EntityIcon color={color} entity={entity} label={label} size={size} />;
+	const badge = <EntityIcon color={color} entity={entity} shape={shape} label={label} size={size} />;
 
 	if (!link) {
 		return badge;


### PR DESCRIPTION
Show configured node shape in codebook and protocol summary


<img width="1333" height="205" alt="Screenshot 2026-05-05 at 8 59 42 AM" src="https://github.com/user-attachments/assets/e0e8add1-3a7d-4bce-8d6e-e0da4651c535" />

<img width="273" height="333" alt="Screenshot 2026-05-05 at 8 59 50 AM" src="https://github.com/user-attachments/assets/ff8bfb6a-e347-4b28-b26c-19c63ffbba8a" />
