### PR TITLE
ci(interview-e2e): scope id-token/pages perms to deploy job

### DIFF
--- a/.github/workflows/interview-e2e.yml
+++ b/.github/workflows/interview-e2e.yml
@@ -2,8 +2,6 @@ name: Interview E2E
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   pull-requests: write
 
 on:
@@ -80,6 +78,11 @@ jobs:
     if: ${{ !cancelled() && needs.e2e.result != 'cancelled' }}
     needs: e2e
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      pull-requests: write
     concurrency:
       group: interview-e2e-pages-deploy
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Remove `id-token: write` and `pages: write` from the workflow-level `permissions` block in `interview-e2e.yml`
- Add a job-level `permissions` block on the `deploy-report` job — the only job that actually needs `pages: write` + `id-token: write` (for `actions/deploy-pages`)
- The `e2e` job (Playwright) inherits the reduced workflow-level perms only

## Context

This is Task 2 of the [CI supply-chain hardening plan](./docs/superpowers/plans/2026-05-12-ci-supply-chain-hardening.md), deferred from PR #506 because `interview-e2e.yml` lives only on this feature branch (not on \`main\`).

Targets \`feat/interview-package\` as base so it lands together with the rest of that branch's work.

## Test plan

- [ ] CI on this PR runs green (the `interview-e2e` workflow must complete with the same outcome as before — Playwright runs, deploy-report deploys, PR comment lands). If \`deploy-pages\` fails with a permissions error, the job-level permissions block is missing one of \`pages: write\` or \`id-token: write\`.