### PR TITLE
ci: optional hardening — test --ignore-scripts + persist-credentials

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -154,6 +154,11 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      with:
+        # Don't leave GITHUB_TOKEN in the local git config after checkout.
+        # changesets/action reads GITHUB_TOKEN from its env block at line ~189;
+        # nothing else in this job needs the token in git config.
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
     - name: Set up Node.js

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -110,7 +110,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts: defense-in-depth alongside the release job. The
+        # test job exposes PROTOCOL_ENCRYPTION_KEY/IV and TEST_PROTOCOL_TOKEN
+        # via env; preventing lifecycle scripts from running here removes a
+        # path where a compromised transitive dep could read those secrets.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Download shared-consts build
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4


### PR DESCRIPTION
## Summary

Two follow-up hardening changes surfaced during the final review of #506. Stacked on top of #506 because Change 2 modifies a line that #506 SHA-pinned.

**Change 1 (`5319c0d3`) — \`--ignore-scripts\` on the test job's install.** The test job exposes \`PROTOCOL_ENCRYPTION_KEY\`, \`PROTOCOL_ENCRYPTION_IV\`, and \`TEST_PROTOCOL_TOKEN\` via \`env:\`. Disabling lifecycle scripts during install removes the path where a compromised transitive dep's \`postinstall\` could read those secrets. Same threat model as the release-job hardening in #506.

**Change 2 (\`ab45cb58\`) — \`persist-credentials: false\` on the release-job \`actions/checkout\`.** By default \`actions/checkout\` leaves \`GITHUB_TOKEN\` in the local git config. The release job doesn't need it there — \`changesets/action\` reads \`GITHUB_TOKEN\` from its env block. Removing persistence reduces token exposure surface during publish.

## Stacking

This PR's base is \`ci/supply-chain-hardening\` (#506). **Merge #506 first**, then this. After #506 lands, GitHub will rebase this PR's diff to show only these 2 commits against \`main\`.

## Risk

**Change 2 has a small risk of breaking the changesets PR-creation flow** if \`changesets/action\` turns out to need the git-config-persisted token. The two changes are committed separately so Change 2 can be reverted in isolation if the next post-merge release fails. Change 1 is independent and low-risk.

## Test plan

- [ ] CI on this PR runs green (smoke test only — the real test for Change 2 is the next release after merge)
- [ ] Post-merge: watch the first changesets-versioned PR land on main. If \`Create Release Pull Request\` step fails with a git-push auth error, revert \`ab45cb58\` only.