### PR TITLE
Update code formatting and linting tools from Biome to oxfmt/oxlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pnpm --filter posthog-proxy-worker deploy
 
 - **Build System**: Vite for fast builds and development
 - **Package Manager**: pnpm with workspace support
-- **Code Formatting**: Biome for consistent code style
+- **Code Formatting**: oxfmt for formatting and oxlint for linting
 - **Type Checking**: TypeScript with shared configurations
 - **Edge Computing**: Cloudflare Workers for serverless functions
 - **CI/CD**: GitHub Actions with optimized workflows
@@ -111,7 +111,7 @@ pnpm --filter posthog-proxy-worker deploy
 
 ## Code Style
 
-This project uses Biome for formatting and linting:
+This project uses [oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [oxfmt](https://github.com/oxc-project/oxfmt) for formatting. Style settings: 2-space indentation, 80-character line width, and single quotes.
 
 ```bash
 # Check formatting and linting
@@ -119,9 +119,15 @@ pnpm lint
 
 # Auto-fix formatting and linting issues
 pnpm lint:fix
+
+# Format only
+pnpm format
+
+# Check formatting only
+pnpm format:check
 ```
 
-Pre-commit hooks automatically format code on commit.
+Pre-commit hooks automatically lint and format staged files.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This monorepo is organized into four main categories:
 | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`@codaco/tailwind-config`](./tooling/tailwind) | Shared Tailwind v4 theme, color palette, and plugins for Fresco and other Codaco apps |
 | [`@codaco/tsconfig`](./tooling/typescript)      | Shared TypeScript configurations                                                      |
+| [`oxlint`](./tooling/oxlint)                    | Shared oxlint configurations (React and Tailwind rule sets) extended by workspaces    |
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Updates the project documentation to reflect the migration from Biome to oxfmt and oxlint for code formatting and linting, aligning the README with the actual tooling setup and conventions documented in CLAUDE.md.

## Changes

- **Updated tool references**: Changed from "Biome for consistent code style" to "oxfmt for formatting and oxlint for linting"
- **Enhanced Code Style section**: Added links to oxlint and oxfmt documentation with explicit style settings (2-space indentation, 80-character line width, single quotes)
- **Updated npm scripts documentation**: Added `pnpm format` and `pnpm format:check` commands to the code style section
- **Clarified pre-commit behavior**: Updated description from "automatically format code" to "automatically lint and format staged files" for accuracy

## Notes

These changes are documentation-only and ensure the README accurately reflects the project's actual code quality tooling and conventions as defined in CLAUDE.md.

https://claude.ai/code/session_01Mh6u7VDmL4QN2tfR8RAB32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development tooling and code style docs to recommend oxfmt/oxlint instead of the previous tooling.
  * Added updated lint/format commands (pnpm lint, pnpm lint:fix, pnpm format, pnpm format:check).
  * Clarified pre-commit behavior to auto-lint/auto-format staged files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/network-canvas-monorepo/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->