### PR TITLE
fix(architect-web): use trailing slash for preview popup URL

### DIFF
--- a/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
+++ b/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
@@ -58,7 +58,7 @@ describe('launchPreview', () => {
       useSyntheticData: true,
     });
 
-    expect(openSpy).toHaveBeenCalledWith('/preview', '_blank');
+    expect(openSpy).toHaveBeenCalledWith('/preview/', '_blank');
 
     postReadyFromSource(popup);
     await promise;

--- a/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
+++ b/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
@@ -50,7 +50,7 @@ describe('launchPreview', () => {
     openSpy.mockRestore();
   });
 
-  it('opens /preview, then delivers the payload on receiving preview:ready', async () => {
+  it('opens /preview/, then delivers the payload on receiving preview:ready', async () => {
     const protocol = makeProtocol();
     const promise = launchPreview({
       protocol,

--- a/apps/architect-web/src/components/PreviewHost/launchPreview.ts
+++ b/apps/architect-web/src/components/PreviewHost/launchPreview.ts
@@ -19,7 +19,10 @@ export function launchPreview({
   startStage,
   useSyntheticData,
 }: LaunchOptions): Promise<LaunchPreviewResult> {
-  const popup = window.open('/preview', '_blank');
+  // Trailing slash is required: a bare '/preview' hits Vite's SPA html fallback
+  // (and equivalent static-host fallbacks) and serves the main app's index.html
+  // instead of the preview entry, leaving a blank tab.
+  const popup = window.open('/preview/', '_blank');
   if (!popup) {
     return Promise.resolve({ kind: 'popup-blocked' });
   }


### PR DESCRIPTION
Changes the preview popup to open /preview/ instead of /preview.

Architect is a multi-page Vite build — the preview is a separate entry
  (preview/index.html, see vite.config.ts), distinct from the main app's index.html.

  The bare path /preview only resolved correctly because of host-specific behavior:

  - Netlify auto-resolves /preview → /preview/index.html (pretty-URL handling), so it
  worked in production.
  - Vite's dev server doesn't do that. An unmatched /preview falls through to the SPA
  history fallback and serves the main app's index.html, so the preview tab opened
  blank/wrong locally.

  The trailing slash names the directory explicitly, so both the dev server and the
  static host resolve it directly to preview/index.html — no reliance on either host's
  fallback/redirect behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where opening a preview could open a blank tab by ensuring the preview URL resolves correctly.
* **Tests**
  * Updated automated tests to verify the preview opens using the corrected URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/network-canvas-monorepo/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->