### PR TITLE
fix(architect-web): render timeline icons via SVG image for Safari

### DIFF
--- a/apps/architect-web/src/components/Home/TransitMap.tsx
+++ b/apps/architect-web/src/components/Home/TransitMap.tsx
@@ -89,6 +89,16 @@ export default function TransitMap({ stops, count }: TransitMapProps) {
               fill="url(#nc-timeline-fade)"
             />
           </mask>
+          {/* Forces the (default-black) icon shapes to solid white while
+              preserving their alpha — the SVG-native equivalent of the
+              `brightness-0 invert` CSS filter, which is reliable in Safari
+              where `<img>` inside `<foreignObject>` is not. */}
+          <filter id="nc-icon-white">
+            <feColorMatrix
+              type="matrix"
+              values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"
+            />
+          </filter>
         </defs>
 
         <g mask="url(#nc-timeline-mask)">
@@ -254,21 +264,15 @@ function Station({
         )}
         <circle cx={x} cy={y} r={STATION_R} fill="#fff" />
         <circle cx={x} cy={y} r={STATION_INNER_R} fill={meta.color} />
-        <foreignObject
+        <image
+          href={meta.icon}
           x={x - ICON_SIZE / 2}
           y={y - ICON_SIZE / 2}
           width={ICON_SIZE}
           height={ICON_SIZE}
-          overflow="visible"
-        >
-          <div className="flex h-full w-full items-center justify-center brightness-0 invert">
-            <img
-              src={meta.icon}
-              alt=""
-              style={{ width: ICON_SIZE, height: ICON_SIZE }}
-            />
-          </div>
-        </foreignObject>
+          preserveAspectRatio="xMidYMid meet"
+          filter="url(#nc-icon-white)"
+        />
       </motion.g>
 
       {/* Label pill: slide in from its outer side */}


### PR DESCRIPTION
- fixes issue where icons were mispositioned on timeline animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated station icon rendering on the transit map using an improved rendering technique.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/network-canvas-monorepo/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->