### PR TITLE
feat(architect-web): add preview option to ignore skip logic

### DIFF
--- a/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
+++ b/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
@@ -10,6 +10,7 @@ import {
   type SessionPayload,
   Shell,
 } from '@codaco/interview';
+import Button from '~/lib/legacy-ui/components/Button';
 
 import { currentProtocolToPayload } from './currentProtocolToPayload';
 import { isPreviewMessage, type PreviewPayload } from './messages';
@@ -96,13 +97,9 @@ export function PreviewHost() {
       <div className="flex h-dvh w-full flex-col items-center justify-center gap-4 p-8 text-center">
         <h1 className="text-2xl font-semibold">This preview has ended</h1>
         <p>Return to Architect and click Preview again to start a new one.</p>
-        <button
-          type="button"
-          onClick={() => window.close()}
-          className="bg-accent rounded-md px-4 py-2 text-white"
-        >
+        <Button color="sea-green" onClick={() => window.close()}>
           Close tab
-        </button>
+        </Button>
       </div>
     );
   }
@@ -118,23 +115,18 @@ export function PreviewHost() {
           longer responding.
         </p>
         <div className="flex gap-3">
-          <button
-            type="button"
+          <Button
+            color="sea-green"
             onClick={() => {
               setTimedOut(false);
               setRetryNonce((n) => n + 1);
             }}
-            className="bg-accent rounded-md px-4 py-2 text-white"
           >
             Try again
-          </button>
-          <button
-            type="button"
-            onClick={() => window.close()}
-            className="bg-input-active rounded-md px-4 py-2"
-          >
+          </Button>
+          <Button color="platinum" onClick={() => window.close()}>
             Close tab
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
+++ b/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
+import { Alert, AlertDescription } from '@codaco/fresco-ui/Alert';
+import CloseButton from '@codaco/fresco-ui/CloseButton';
 import {
   createInitialNetwork,
   generateNetwork,
@@ -40,6 +42,13 @@ export function PreviewHost() {
   const [currentStep, setCurrentStep] = useState(0);
   const [timedOut, setTimedOut] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
+  // Index of the stage whose skip logic was bypassed for preview, or null.
+  // The notice only shows while that stage is the one being viewed.
+  const [bypassedStageIndex, setBypassedStageIndex] = useState<number | null>(
+    null,
+  );
+  const [skipLogicNoticeDismissed, setSkipLogicNoticeDismissed] =
+    useState(false);
   const onRequestAsset = useAssetResolver();
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: retryNonce is the deliberate retrigger key
@@ -62,6 +71,10 @@ export function PreviewHost() {
         session: buildSession(previewPayload),
       });
       setCurrentStep(previewPayload.startStage);
+      setBypassedStageIndex(
+        previewPayload.skipLogicBypassed ? previewPayload.startStage : null,
+      );
+      setSkipLogicNoticeDismissed(false);
       setTimedOut(false);
     };
 
@@ -137,6 +150,21 @@ export function PreviewHost() {
 
   return (
     <div className="h-screen">
+      {currentStep === bypassedStageIndex && !skipLogicNoticeDismissed && (
+        <div className="fixed right-8 bottom-6 z-50 max-w-sm">
+          <Alert variant="info" icon={false} className="my-0">
+            <AlertDescription className="pr-10 text-sm">
+              This stage has skip logic, so depending on a participant’s
+              responses it may not be shown during an interview.
+            </AlertDescription>
+            <CloseButton
+              size="sm"
+              onClick={() => setSkipLogicNoticeDismissed(true)}
+              className="absolute top-2 right-2"
+            />
+          </Alert>
+        </div>
+      )}
       <Shell
         payload={interviewPayload}
         onSync={noopSync}

--- a/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
+++ b/apps/architect-web/src/components/PreviewHost/__tests__/launchPreview.test.ts
@@ -56,6 +56,7 @@ describe('launchPreview', () => {
       protocol,
       startStage: 2,
       useSyntheticData: true,
+      skipLogicBypassed: false,
     });
 
     expect(openSpy).toHaveBeenCalledWith('/preview/', '_blank');
@@ -69,6 +70,7 @@ describe('launchPreview', () => {
         protocol,
         startStage: 2,
         useSyntheticData: true,
+        skipLogicBypassed: false,
       },
       window.location.origin,
     );
@@ -80,6 +82,7 @@ describe('launchPreview', () => {
       protocol,
       startStage: 1,
       useSyntheticData: false,
+      skipLogicBypassed: false,
     });
     postReadyFromSource(popup);
     await promise;
@@ -99,6 +102,7 @@ describe('launchPreview', () => {
         protocol: makeProtocol(),
         startStage: 0,
         useSyntheticData: true,
+        skipLogicBypassed: false,
       }),
     ).resolves.toEqual({
       kind: 'popup-blocked',
@@ -110,6 +114,7 @@ describe('launchPreview', () => {
       protocol: makeProtocol(),
       startStage: 0,
       useSyntheticData: true,
+      skipLogicBypassed: false,
     });
 
     // Forged message from a different window
@@ -128,6 +133,7 @@ describe('launchPreview', () => {
       protocol,
       startStage: 0,
       useSyntheticData: true,
+      skipLogicBypassed: false,
     });
 
     postReadyFromSource(popup, 'https://attacker.example');
@@ -142,6 +148,7 @@ describe('launchPreview', () => {
       protocol: makeProtocol(),
       startStage: 0,
       useSyntheticData: true,
+      skipLogicBypassed: false,
     });
     const expectation = expect(promise).rejects.toThrow(/didn't load/i);
     await vi.advanceTimersByTimeAsync(10_000);
@@ -153,6 +160,7 @@ describe('launchPreview', () => {
       protocol: makeProtocol(),
       startStage: 0,
       useSyntheticData: true,
+      skipLogicBypassed: false,
     });
 
     postReadyFromSource(popup);

--- a/apps/architect-web/src/components/PreviewHost/launchPreview.ts
+++ b/apps/architect-web/src/components/PreviewHost/launchPreview.ts
@@ -10,6 +10,7 @@ type LaunchOptions = {
   protocol: CurrentProtocol;
   startStage: number;
   useSyntheticData: boolean;
+  skipLogicBypassed: boolean;
 };
 
 type LaunchPreviewResult = { kind: 'delivered' } | { kind: 'popup-blocked' };
@@ -18,6 +19,7 @@ export function launchPreview({
   protocol,
   startStage,
   useSyntheticData,
+  skipLogicBypassed,
 }: LaunchOptions): Promise<LaunchPreviewResult> {
   // Trailing slash is required: a bare '/preview' hits Vite's SPA html fallback
   // (and equivalent static-host fallbacks) and serves the main app's index.html
@@ -40,6 +42,7 @@ export function launchPreview({
     protocol,
     startStage,
     useSyntheticData,
+    skipLogicBypassed,
   };
 
   return new Promise<LaunchPreviewResult>((resolve, reject) => {

--- a/apps/architect-web/src/components/PreviewHost/messages.ts
+++ b/apps/architect-web/src/components/PreviewHost/messages.ts
@@ -7,6 +7,9 @@ export type PreviewPayload = {
   protocol: CurrentProtocol;
   startStage: number;
   useSyntheticData: boolean;
+  // True when skip logic was stripped from the previewed stage so it always
+  // shows. The preview surfaces a notice on that stage when this is set.
+  skipLogicBypassed: boolean;
 };
 
 type PreviewMessage = PreviewReady | PreviewPayload;

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -161,10 +161,12 @@ const StageEditor = (props: StageEditorProps) => {
       return;
     }
 
-    // When ignoring skip logic, strip it from the previewed stage so the
-    // interview never bounces off the stage the user launched into. The
-    // previewed stage is always the one targeted by `startStage`.
-    const omitKeys = ignoreSkipLogic
+    // With "Always show this stage in preview" on (the default), strip skip
+    // logic from the previewed stage so the interview doesn't bounce off the
+    // stage the user launched into. We only consider it "bypassed" when the
+    // stage actually had skip logic to strip.
+    const skipLogicBypassed = ignoreSkipLogic && Boolean(formValues.skipLogic);
+    const omitKeys = skipLogicBypassed
       ? ['_modified', 'skipLogic']
       : ['_modified'];
     const normalizedStage = omit(formValues, omitKeys) as Stage;
@@ -197,6 +199,7 @@ const StageEditor = (props: StageEditorProps) => {
         protocol: previewProtocol,
         startStage,
         useSyntheticData,
+        skipLogicBypassed,
       });
       if (result.kind === 'popup-blocked') {
         dispatch(

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -23,7 +23,9 @@ import { launchPreview } from '~/components/PreviewHost/launchPreview';
 import StageEditorNav from '~/components/ProjectNav/StageEditorNav';
 import { useAppDispatch } from '~/ducks/hooks';
 import {
+  getPreviewIgnoreSkipLogic,
   getPreviewUseSyntheticData,
+  setPreviewIgnoreSkipLogic,
   setPreviewUseSyntheticData,
 } from '~/ducks/modules/app';
 import { actionCreators as dialogActions } from '~/ducks/modules/dialogs';
@@ -101,6 +103,7 @@ const StageEditor = (props: StageEditorProps) => {
   // Preview state
   const [isOpeningPreview, setIsOpeningPreview] = useState(false);
   const useSyntheticData = useSelector(getPreviewUseSyntheticData);
+  const ignoreSkipLogic = useSelector(getPreviewIgnoreSkipLogic);
 
   // Handle form submission
   const onSubmit = useCallback(
@@ -158,7 +161,13 @@ const StageEditor = (props: StageEditorProps) => {
       return;
     }
 
-    const normalizedStage = omit(formValues, ['_modified']) as Stage;
+    // When ignoring skip logic, strip it from the previewed stage so the
+    // interview never bounces off the stage the user launched into. The
+    // previewed stage is always the one targeted by `startStage`.
+    const omitKeys = ignoreSkipLogic
+      ? ['_modified', 'skipLogic']
+      : ['_modified'];
+    const normalizedStage = omit(formValues, omitKeys) as Stage;
     const previewProtocol = buildProtocolWithStage(
       protocol,
       normalizedStage,
@@ -219,6 +228,7 @@ const StageEditor = (props: StageEditorProps) => {
     id,
     insertAtIndex,
     useSyntheticData,
+    ignoreSkipLogic,
   ]);
   const sections = useMemo(
     () => getInterface(interfaceType).sections,
@@ -265,15 +275,28 @@ const StageEditor = (props: StageEditorProps) => {
         sideOffset={8}
         className="bg-surface-accent text-surface-accent-foreground p-3"
       >
-        <label className="flex items-center gap-3">
-          <Switch
-            checked={useSyntheticData}
-            onCheckedChange={(checked) =>
-              dispatch(setPreviewUseSyntheticData(checked))
-            }
-          />
-          <span className="text-sm">Start preview with example data</span>
-        </label>
+        <div className="flex flex-col gap-3">
+          <label className="flex items-center gap-3">
+            <Switch
+              checked={useSyntheticData}
+              onCheckedChange={(checked) =>
+                dispatch(setPreviewUseSyntheticData(checked))
+              }
+            />
+            <span className="text-sm">Start preview with example data</span>
+          </label>
+          <label className="flex items-center gap-3">
+            <Switch
+              checked={ignoreSkipLogic}
+              onCheckedChange={(checked) =>
+                dispatch(setPreviewIgnoreSkipLogic(checked))
+              }
+            />
+            <span className="text-sm">
+              Always show this stage in preview (ignore skip logic)
+            </span>
+          </label>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -296,7 +296,7 @@ const StageEditor = (props: StageEditorProps) => {
               }
             />
             <span className="text-sm">
-              Always show stages in preview when skip logic would hide them
+              Always show this stage in preview when skip logic would hide it
             </span>
           </label>
         </div>

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -296,7 +296,7 @@ const StageEditor = (props: StageEditorProps) => {
               }
             />
             <span className="text-sm">
-              Always show this stage in preview (ignore skip logic)
+              Always show stages in preview when skip logic would hide them
             </span>
           </label>
         </div>

--- a/apps/architect-web/src/ducks/modules/app.ts
+++ b/apps/architect-web/src/ducks/modules/app.ts
@@ -38,4 +38,17 @@ export function getPreviewUseSyntheticData(
   return raw === undefined ? true : Boolean(raw);
 }
 
+const PREVIEW_IGNORE_SKIP_LOGIC_KEY = 'previewIgnoreSkipLogic';
+
+export function setPreviewIgnoreSkipLogic(value: boolean) {
+  return setProperty({ key: PREVIEW_IGNORE_SKIP_LOGIC_KEY, value });
+}
+
+export function getPreviewIgnoreSkipLogic(
+  state: Pick<RootState, 'app'>,
+): boolean {
+  const raw = get(state, ['app', PREVIEW_IGNORE_SKIP_LOGIC_KEY]);
+  return raw === undefined ? true : Boolean(raw);
+}
+
 export default appSlice.reducer;


### PR DESCRIPTION
When previewing stages with skip logic, the interview package enforces skip logic. This creates cases where stages are impossible to preview if the sample data does not meet skip logic criteria.

Fix includes adding a toggleable setting to "Always show this stage in preview (ignore skip logic)". When enabled, skipLogic is stripped from the previewed stage in the preview protocol payload, so the interview does not skip it.

Also shows a dismissible alert on the stage to indicate that the stage has skip logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted preview option to ignore skip logic during preview.
  * Added an informational, dismissible notice when skip logic is bypassed in preview mode.

* **UI Improvements**
  * Updated preview screens to use consistent button components.
  * Added a switch in the preview options to toggle ignoring skip logic.

* **Tests**
  * Updated preview tests to cover the new skip-logic behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/network-canvas-monorepo/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->