### PR TITLE
Feat(architect-web): Undo/Redo in stage editor

### DIFF
--- a/apps/architect-web/src/components/ProjectNav/ProjectActions.tsx
+++ b/apps/architect-web/src/components/ProjectNav/ProjectActions.tsx
@@ -1,16 +1,14 @@
 import { ArrowLeftToLine, Check, Download, Redo, Undo } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { useLocation } from 'wouter';
 
 import Tooltip from '~/components/NewComponents/Tooltip';
 import { useAppDispatch } from '~/ducks/hooks';
-import { redo, undo } from '~/ducks/modules/activeProtocol';
 import { actionCreators as dialogActions } from '~/ducks/modules/dialogs';
 import { exportNetcanvas } from '~/ducks/modules/userActions/userActions';
+import { useScopedUndoRedo } from '~/hooks/useScopedUndoRedo';
 import Button, { IconButton } from '~/lib/legacy-ui/components/Button';
-import { getCanRedo, getCanUndo } from '~/selectors/protocol';
 
 import ActionToolbar from './ActionToolbar';
 
@@ -24,8 +22,12 @@ const ProjectActions = ({
   readOnly = false,
 }: ProjectActionsProps) => {
   const dispatch = useAppDispatch();
-  const canUndo = useSelector(getCanUndo);
-  const canRedo = useSelector(getCanRedo);
+  const {
+    canUndo,
+    canRedo,
+    undo: scopedUndo,
+    redo: scopedRedo,
+  } = useScopedUndoRedo();
   const [, setLocation] = useLocation();
   const handleReturnToStart = useCallback(
     () => setLocation('/'),
@@ -35,8 +37,8 @@ const ProjectActions = ({
   const [isExporting, setIsExporting] = useState(false);
   const [downloadSuccess, setDownloadSuccess] = useState(false);
 
-  const handleUndo = useCallback(() => dispatch(undo()), [dispatch]);
-  const handleRedo = useCallback(() => dispatch(redo()), [dispatch]);
+  const handleUndo = useCallback(() => scopedUndo(), [scopedUndo]);
+  const handleRedo = useCallback(() => scopedRedo(), [scopedRedo]);
 
   const handleDownload = useCallback(async () => {
     try {

--- a/apps/architect-web/src/components/ProjectNav/StageEditorNav.tsx
+++ b/apps/architect-web/src/components/ProjectNav/StageEditorNav.tsx
@@ -1,11 +1,13 @@
-import { Check, Eye, Loader2, X } from 'lucide-react';
+import { Check, Eye, Loader2, Redo, Undo, X } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { type ReactNode, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import Issues, { type IssuesHandle } from '~/components/Issues';
 import Tooltip from '~/components/NewComponents/Tooltip';
+import { useScopedUndoRedo } from '~/hooks/useScopedUndoRedo';
 import { Button } from '~/lib/legacy-ui/components';
+import { IconButton } from '~/lib/legacy-ui/components/Button';
 import { getProtocolName } from '~/selectors/protocol';
 
 import ActionToolbar from './ActionToolbar';
@@ -34,6 +36,7 @@ const StageEditorNav = ({
   hasUnsavedChanges,
 }: StageEditorNavProps) => {
   const protocolName = useSelector(getProtocolName);
+  const { canUndo, canRedo, undo, redo } = useScopedUndoRedo();
   const issuesRef = useRef<IssuesHandle>(null);
   const shouldReduceMotion = useReducedMotion();
   const layout = !shouldReduceMotion;
@@ -58,6 +61,20 @@ const StageEditorNav = ({
           className="flex items-center gap-(--space-sm)"
         >
           <Issues ref={issuesRef} />
+          <IconButton
+            variant="text"
+            icon={<Undo />}
+            onClick={undo}
+            disabled={!canUndo}
+            aria-label="Undo"
+          />
+          <IconButton
+            variant="text"
+            icon={<Redo />}
+            onClick={redo}
+            disabled={!canRedo}
+            aria-label="Redo"
+          />
           <Button onClick={onCancel} color="platinum" icon={<X />}>
             Cancel
           </Button>

--- a/apps/architect-web/src/components/ProjectNav/StageEditorNav.tsx
+++ b/apps/architect-web/src/components/ProjectNav/StageEditorNav.tsx
@@ -61,6 +61,9 @@ const StageEditorNav = ({
           className="flex items-center gap-(--space-sm)"
         >
           <Issues ref={issuesRef} />
+          <Button onClick={onCancel} color="platinum" icon={<X />}>
+            Cancel
+          </Button>
           <IconButton
             variant="text"
             icon={<Undo />}
@@ -75,9 +78,6 @@ const StageEditorNav = ({
             disabled={!canRedo}
             aria-label="Redo"
           />
-          <Button onClick={onCancel} color="platinum" icon={<X />}>
-            Cancel
-          </Button>
           <AnimatePresence initial={false}>
             {hasUnsavedChanges && (
               <motion.div

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -2,7 +2,7 @@ import { omit } from 'es-toolkit/compat';
 import { Settings } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { getFormValues, isDirty as isFormDirty, isInvalid } from 'redux-form';
+import { getFormValues, isInvalid } from 'redux-form';
 import { v1 as uuid } from 'uuid';
 import { useLocation } from 'wouter';
 
@@ -30,9 +30,12 @@ import {
 } from '~/ducks/modules/app';
 import { actionCreators as dialogActions } from '~/ducks/modules/dialogs';
 import { actionCreators as stageActions } from '~/ducks/modules/protocol/stages';
+import { resetDraft } from '~/ducks/modules/stageEditorDraft';
 import type { RootState } from '~/ducks/store';
+import { useStageEditorKeyboard } from '~/hooks/useStageEditorKeyboard';
 import { IconButton } from '~/lib/legacy-ui/components/Button';
 import { getProtocol, getStage, getStageIndex } from '~/selectors/protocol';
+import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
 import { ensureError } from '~/utils/ensureError';
 
 import { formName } from './configuration';
@@ -76,6 +79,7 @@ const StageEditor = (props: StageEditorProps) => {
   const { id = null, type, insertAtIndex } = props;
 
   const dispatch = useAppDispatch();
+  useStageEditorKeyboard();
   const [, setLocation] = useLocation();
 
   // Get stage metadata from Redux state
@@ -90,15 +94,17 @@ const StageEditor = (props: StageEditorProps) => {
   const initialValues = stage || { ...template, type: interfaceType };
 
   // Get form state
-  const hasUnsavedChanges = useSelector((state: RootState) =>
-    isFormDirty(formName)(state),
-  );
+  const hasUnsavedChanges = useSelector(getStageDraftDirty);
   const formValues = useSelector((state: RootState) =>
     getFormValues(formName)(state),
   ) as Stage | undefined;
   const isStageInvalid = useSelector((state: RootState) =>
     isInvalid(formName)(state),
   );
+
+  // The draft baseline is seeded by the stageEditorDraft listener on
+  // redux-form INITIALIZE (which fires on mount and on `id` change via
+  // enableReinitialize), so no mount effect is needed here.
 
   // Preview state
   const [isOpeningPreview, setIsOpeningPreview] = useState(false);
@@ -121,6 +127,7 @@ const StageEditor = (props: StageEditorProps) => {
         );
       }
 
+      dispatch(resetDraft(null));
       setLocation('/protocol');
     },
     [id, insertAtIndex, setLocation, dispatch],
@@ -129,6 +136,7 @@ const StageEditor = (props: StageEditorProps) => {
   // Cancel handler with unsaved changes confirmation
   const handleCancel = useCallback((): boolean => {
     if (!hasUnsavedChanges) {
+      dispatch(resetDraft(null));
       setLocation('/protocol');
       return true;
     }
@@ -142,6 +150,7 @@ const StageEditor = (props: StageEditorProps) => {
           'You have unsaved changes. Are you sure you want to leave without saving?',
         confirmLabel: 'Leave Without Saving',
         onConfirm: () => {
+          dispatch(resetDraft(null));
           setLocation('/protocol');
         },
       }),

--- a/apps/architect-web/src/components/__tests__/ProjectActions.test.tsx
+++ b/apps/architect-web/src/components/__tests__/ProjectActions.test.tsx
@@ -35,6 +35,9 @@ const clearActiveProtocolMock = vi.fn(() => ({
 }));
 
 vi.mock('~/ducks/modules/activeProtocol', () => ({
+  // useScopedUndoRedo dispatches the navigation-aware variants on the main timeline.
+  undoWithNavigation: () => undoMock(),
+  redoWithNavigation: () => redoMock(),
   undo: () => undoMock(),
   redo: () => redoMock(),
   clearActiveProtocol: () => clearActiveProtocolMock(),

--- a/apps/architect-web/src/components/__tests__/ProjectActions.test.tsx
+++ b/apps/architect-web/src/components/__tests__/ProjectActions.test.tsx
@@ -68,6 +68,15 @@ const createTestStore = ({ canUndo = true, canRedo = true } = {}) =>
           future: canRedo ? [{}] : [],
         },
       ) => state,
+      // ProjectActions now reads draft undo/redo state via useScopedUndoRedo.
+      // On the '/protocol' route the draft scope is inactive, but the hook
+      // still reads these selectors unconditionally, so the slice must exist.
+      stageEditorDraft: (
+        state = {
+          history: { past: [], present: null, timeline: [], future: [] },
+          ui: { restoring: false, initialValues: null },
+        },
+      ) => state,
     },
   });
 

--- a/apps/architect-web/src/ducks/middleware/__tests__/stageEditorDraftListener.test.ts
+++ b/apps/architect-web/src/ducks/middleware/__tests__/stageEditorDraftListener.test.ts
@@ -1,0 +1,221 @@
+import {
+  combineReducers,
+  configureStore,
+  type Middleware,
+} from '@reduxjs/toolkit';
+import {
+  arrayPush,
+  blur,
+  change,
+  initialize,
+  reducer as formReducer,
+} from 'redux-form';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Stage } from '@codaco/protocol-validation';
+
+import stageEditorDraft, {
+  draftSnapshot,
+  draftTimelineActions,
+  setRestoring,
+} from '../../modules/stageEditorDraft';
+import { stageEditorDraftListenerMiddleware } from '../stageEditorDraftListener';
+
+const FORM_NAME = 'edit-stage';
+
+// The only reliable signal that the listener took a snapshot is a dispatched
+// `draftSnapshot` action. (The underlying timeline reducer pushes a `past`
+// entry for every form action that flows through it, so `past.length` is not a
+// clean snapshot counter.) This middleware records the payload of each
+// `draftSnapshot` so tests can assert on snapshot count and captured values.
+const makeStore = () => {
+  const snapshots: Stage[] = [];
+
+  const recordSnapshots: Middleware = () => (next) => (action) => {
+    if (draftSnapshot.match(action)) {
+      snapshots.push(action.payload);
+    }
+    return next(action);
+  };
+
+  const reducer = combineReducers({
+    form: formReducer,
+    stageEditorDraft,
+  });
+
+  const store = configureStore({
+    reducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false })
+        .concat(recordSnapshots)
+        .prepend(stageEditorDraftListenerMiddleware.middleware),
+  });
+
+  return { store, snapshots };
+};
+
+const getPresent = (store: ReturnType<typeof makeStore>['store']) =>
+  store.getState().stageEditorDraft.history.present;
+
+describe('stageEditorDraftListenerMiddleware', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('seeds initial values on INITIALIZE without taking a snapshot', () => {
+    const { store, snapshots } = makeStore();
+
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial' }));
+
+    // No snapshot dispatched; the draft baseline is seeded via resetDraft.
+    expect(snapshots).toHaveLength(0);
+    expect(getPresent(store)).toEqual({ label: 'Initial' });
+  });
+
+  it('snapshots immediately for a bracketed CHANGE path', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial', prompts: [] }));
+
+    store.dispatch(
+      change(FORM_NAME, 'prompts[0]', { id: 'p1', text: 'Prompt' }),
+    );
+
+    // Immediate: snapshot taken synchronously, before any debounce window.
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({
+      prompts: [{ id: 'p1', text: 'Prompt' }],
+    });
+  });
+
+  it('debounces a leaf CHANGE path', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial' }));
+
+    store.dispatch(change(FORM_NAME, 'label', 'Updated'));
+
+    // No snapshot before the debounce window elapses.
+    expect(snapshots).toHaveLength(0);
+
+    vi.advanceTimersByTime(400);
+
+    // Snapshot taken only after the 400ms debounce delay.
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({ label: 'Updated' });
+    expect(getPresent(store)).toMatchObject({ label: 'Updated' });
+  });
+
+  it('snapshots immediately on ARRAY_PUSH', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial', prompts: [] }));
+
+    store.dispatch(arrayPush(FORM_NAME, 'prompts', { id: 'p1' }));
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({ prompts: [{ id: 'p1' }] });
+  });
+
+  it('flushes a pending debounce on BLUR and does not double-snapshot', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial' }));
+
+    store.dispatch(change(FORM_NAME, 'label', 'Updated'));
+    expect(snapshots).toHaveLength(0);
+
+    // BLUR flushes the pending debounced snapshot immediately.
+    store.dispatch(blur(FORM_NAME, 'label', 'Updated'));
+    expect(snapshots).toHaveLength(1);
+
+    // Advancing past the window must not produce a second snapshot.
+    vi.advanceTimersByTime(400);
+    expect(snapshots).toHaveLength(1);
+  });
+
+  it('does nothing on BLUR when no debounce is pending', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial' }));
+
+    store.dispatch(blur(FORM_NAME, 'label', 'Initial'));
+
+    expect(snapshots).toHaveLength(0);
+  });
+
+  it('cancels a pending leaf debounce when the draft is reset', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial' }));
+
+    // Arm a leaf CHANGE debounce.
+    store.dispatch(change(FORM_NAME, 'label', 'Updated'));
+    expect(snapshots).toHaveLength(0);
+
+    // resetDraft dispatches draftTimelineActions.reset, which must cancel the
+    // armed timer (commit/cancel/stage-switch path). Dispatch the action
+    // directly here — it's exactly what the resetDraft thunk dispatches and
+    // what the listener keys on.
+    store.dispatch(draftTimelineActions.reset(null));
+
+    const pastBefore = store.getState().stageEditorDraft.history.past?.length;
+
+    vi.advanceTimersByTime(400);
+
+    // No phantom snapshot fired after reset.
+    expect(snapshots).toHaveLength(0);
+    expect(store.getState().stageEditorDraft.history.past?.length).toBe(
+      pastBefore,
+    );
+    expect(getPresent(store)).toBeNull();
+  });
+
+  it('dedups identical consecutive snapshots', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial', prompts: [] }));
+
+    // Two immediate bracketed CHANGEs producing identical resulting values.
+    store.dispatch(
+      change(FORM_NAME, 'prompts[0]', { id: 'p1', text: 'Prompt' }),
+    );
+    store.dispatch(
+      change(FORM_NAME, 'prompts[0]', { id: 'p1', text: 'Prompt' }),
+    );
+
+    // Only the first snapshot is recorded; the duplicate is skipped.
+    expect(snapshots).toHaveLength(1);
+  });
+
+  it('debounces a nested-leaf bracketed CHANGE path', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(
+      initialize(FORM_NAME, { label: 'Initial', panels: [{ title: '' }] }),
+    );
+
+    // A nested leaf (text after the last `]`) is per-keystroke and must
+    // debounce, not snapshot immediately.
+    store.dispatch(change(FORM_NAME, 'panels[0].title', 'Hello'));
+    expect(snapshots).toHaveLength(0);
+
+    vi.advanceTimersByTime(400);
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({ panels: [{ title: 'Hello' }] });
+  });
+
+  it('does not snapshot while restoring is true', () => {
+    const { store, snapshots } = makeStore();
+    store.dispatch(initialize(FORM_NAME, { label: 'Initial', prompts: [] }));
+    store.dispatch(setRestoring(true));
+
+    store.dispatch(change(FORM_NAME, 'label', 'Updated'));
+    store.dispatch(
+      change(FORM_NAME, 'prompts[0]', { id: 'p1', text: 'Prompt' }),
+    );
+    store.dispatch(arrayPush(FORM_NAME, 'prompts', { id: 'p2' }));
+    vi.advanceTimersByTime(400);
+
+    // The restoring guard suppresses every snapshot path.
+    expect(snapshots).toHaveLength(0);
+  });
+});

--- a/apps/architect-web/src/ducks/middleware/__tests__/timeline.test.ts
+++ b/apps/architect-web/src/ducks/middleware/__tests__/timeline.test.ts
@@ -4,7 +4,10 @@ import type { Reducer, UnknownAction } from '@reduxjs/toolkit';
 import { v4 as uuid } from 'uuid';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import createTimeline, { timelineActions } from '../timeline';
+import createTimeline, {
+  createTimelineActions,
+  timelineActions,
+} from '../timeline';
 
 vi.mock('uuid');
 
@@ -32,8 +35,10 @@ const defaultReducer: Reducer<DummyState> = vi.fn(
 const getRewindableReducer = (
   reducer: Reducer<DummyState> = defaultReducer,
   options: {
+    name?: string;
     limit?: number;
     exclude?: (action: UnknownAction) => boolean;
+    getPath?: () => string;
   } = {},
 ) => createTimeline(reducer, options);
 
@@ -92,13 +97,87 @@ describe('timeline middleware', () => {
       expect(nextState.past.length).toBe(0);
       expect(nextState.timeline.length).toBe(1);
     });
+
+    it('timeline entries are locus objects with id and path', () => {
+      const reducer = getRewindableReducer(defaultReducer, {
+        getPath: () => '/my-path',
+      });
+
+      const nextState = applyTimes(3, reducer);
+
+      for (const entry of nextState.timeline) {
+        expect(entry).toEqual(
+          expect.objectContaining({
+            id: expect.any(String),
+            path: '/my-path',
+          }),
+        );
+      }
+    });
+
+    it('migrates legacy string timeline entries to locus objects', () => {
+      // Simulate pre-upgrade persisted state where timeline/futureTimeline
+      // entries are bare uuid strings rather than Locus objects.
+      const legacyId1 = 'legacy-id-1';
+      const legacyId2 = 'legacy-id-2';
+      const legacyFutureId = 'legacy-future-id';
+
+      // Dispatch an excluded action so the reducer does not treat it as a new
+      // timeline point (which would otherwise clear futureTimeline before we
+      // can assert that its entries were migrated).
+      const excludedType = 'EXCLUDED';
+      const reducer = getRewindableReducer(defaultReducer, {
+        exclude: (action) => action.type === excludedType,
+      });
+
+      const persistedState = {
+        past: [
+          { dummyState: true, randomProperty: 'a' },
+          { dummyState: true, randomProperty: 'b' },
+        ],
+        present: { dummyState: true, randomProperty: 'c' },
+        timeline: [legacyId1, legacyId2],
+        future: [],
+        futureTimeline: [legacyFutureId],
+      } as unknown as ReturnType<typeof reducer>;
+
+      const nextState = reducer(persistedState, { type: excludedType });
+
+      // Each timeline entry is now a Locus object with the original string as
+      // its id and an empty path.
+      expect(nextState.timeline).toEqual(
+        expect.arrayContaining([
+          { id: legacyId1, path: '' },
+          { id: legacyId2, path: '' },
+        ]),
+      );
+      expect(nextState.futureTimeline).toEqual(
+        expect.arrayContaining([{ id: legacyFutureId, path: '' }]),
+      );
+      for (const entry of [
+        ...nextState.timeline,
+        ...nextState.futureTimeline,
+      ]) {
+        expect(typeof entry).toBe('object');
+        expect(entry.path).toBe('');
+      }
+
+      // jump() by the original string id now finds the entry and reverts.
+      const jumpState = reducer(nextState, timelineActions.jump(legacyId1));
+
+      const jumpIndex = nextState.timeline.findIndex((e) => e.id === legacyId1);
+      expect(jumpState.timeline).toEqual(
+        nextState.timeline.slice(0, jumpIndex + 1),
+      );
+      expect(jumpState.present).toEqual(nextState.past[jumpIndex]);
+    });
   });
 
   describe('jump() action', () => {
     it('can revert to a specific point on the timeline', () => {
       const nextState = applyTimes(10, rewindableReducer);
 
-      const timelineEntry = nextState.timeline[4] ?? '';
+      const timelineEntry = nextState.timeline[4]?.id ?? '';
       const rollbackState = rewindableReducer(
         nextState,
         timelineActions.jump(timelineEntry),
@@ -140,6 +219,72 @@ describe('timeline middleware', () => {
       expect(nextState.timeline.length).toBe(10);
       expect(resetState.timeline.length).toBe(1);
       expect(resetState.past.length).toBe(0);
+    });
+
+    it('reset() with no payload recomputes present via the reducer', () => {
+      const nextState = applyTimes(10, rewindableReducer);
+
+      const resetState = rewindableReducer(nextState, timelineActions.reset());
+
+      // defaultReducer always returns dummyState: true with a new random prop
+      expect(resetState.present).toEqual(
+        expect.objectContaining({ dummyState: true }),
+      );
+      expect(resetState.present).not.toBe(nextState.present);
+      expect(resetState.past.length).toBe(0);
+      expect(resetState.future.length).toBe(0);
+      expect(resetState.futureTimeline.length).toBe(0);
+      expect(resetState.timeline.length).toBe(1);
+    });
+
+    it('reset(payload) seeds present with payload and clears history', () => {
+      const nextState = applyTimes(10, rewindableReducer);
+
+      const payload: DummyState = {
+        dummyState: false,
+        randomProperty: 'seeded',
+      };
+
+      const resetState = rewindableReducer(
+        nextState,
+        timelineActions.reset(payload),
+      );
+
+      expect(resetState.present).toEqual(payload);
+      expect(resetState.past.length).toBe(0);
+      expect(resetState.future.length).toBe(0);
+      expect(resetState.futureTimeline.length).toBe(0);
+      expect(resetState.timeline.length).toBe(1);
+    });
+  });
+
+  describe('createTimelineActions()', () => {
+    it('namespaces action types by name', () => {
+      const actions = createTimelineActions('stageEditorDraft');
+
+      expect(actions.undo().type).toBe('stageEditorDraft/undo');
+      expect(actions.redo().type).toBe('stageEditorDraft/redo');
+      expect(actions.jump('x').type).toBe('stageEditorDraft/jump');
+      expect(actions.reset().type).toBe('stageEditorDraft/reset');
+    });
+
+    it('an instance only responds to its own scoped actions', () => {
+      const reducer = getRewindableReducer(defaultReducer, {
+        name: 'stageEditorDraft',
+      });
+
+      const nextState = applyTimes(5, reducer);
+
+      // A foreign-scoped undo is NOT treated as an undo by this instance: it
+      // does not shrink history (past does not decrease by one).
+      const ignored = reducer(nextState, timelineActions.undo());
+      expect(ignored.past.length).not.toBe(nextState.past.length - 1);
+
+      // Its own scoped undo performs the undo.
+      const scoped = createTimelineActions('stageEditorDraft');
+      const undone = reducer(nextState, scoped.undo());
+      expect(undone.past.length).toBe(nextState.past.length - 1);
+      expect(undone.timeline.length).toBe(nextState.timeline.length - 1);
     });
   });
 

--- a/apps/architect-web/src/ducks/middleware/stageEditorDraftListener.ts
+++ b/apps/architect-web/src/ducks/middleware/stageEditorDraftListener.ts
@@ -1,0 +1,173 @@
+import {
+  createListenerMiddleware,
+  type TypedStartListening,
+} from '@reduxjs/toolkit';
+import { isEqual } from 'es-toolkit/compat';
+import { getFormValues } from 'redux-form';
+
+import type { Stage } from '@codaco/protocol-validation';
+import { getDraftRestoring } from '~/selectors/stageEditorDraft';
+
+import type { RootState } from '../modules/root';
+import {
+  draftSnapshot,
+  draftTimelineActions,
+  resetDraft,
+} from '../modules/stageEditorDraft';
+import type { AppDispatch } from '../store';
+
+// The redux-form name used by the stage editor.
+const FORM_NAME = 'edit-stage';
+
+// Debounce window (ms) for leaf-field CHANGE actions.
+const DEBOUNCE_MS = 400;
+
+// redux-form action type strings we react to.
+const CHANGE = '@@redux-form/CHANGE';
+const BLUR = '@@redux-form/BLUR';
+const INITIALIZE = '@@redux-form/INITIALIZE';
+const DESTROY = '@@redux-form/DESTROY';
+const ARRAY_ACTIONS = new Set([
+  '@@redux-form/ARRAY_PUSH',
+  '@@redux-form/ARRAY_REMOVE',
+  '@@redux-form/ARRAY_INSERT',
+  '@@redux-form/ARRAY_SWAP',
+  '@@redux-form/ARRAY_MOVE',
+]);
+
+// Shape of the redux-form actions we care about.
+type ReduxFormAction = {
+  type: string;
+  meta?: { form?: string; field?: string };
+  payload?: unknown;
+};
+
+const isReduxFormStageAction = (action: unknown): action is ReduxFormAction => {
+  const candidate = action as ReduxFormAction;
+  return (
+    typeof candidate?.type === 'string' &&
+    candidate.type.startsWith('@@redux-form/') &&
+    candidate.meta?.form === FORM_NAME
+  );
+};
+
+export const stageEditorDraftListenerMiddleware = createListenerMiddleware();
+
+type AppStartListening = TypedStartListening<RootState, AppDispatch>;
+const startAppListening =
+  stageEditorDraftListenerMiddleware.startListening as AppStartListening;
+
+// Manual debounce timer, scoped to this middleware instance. A pending timer
+// means a leaf CHANGE is waiting to snapshot; immediate paths and BLUR flush it.
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearPending = () => {
+  if (pendingTimer !== null) {
+    clearTimeout(pendingTimer);
+    pendingTimer = null;
+  }
+};
+
+startAppListening({
+  predicate: (action) =>
+    isReduxFormStageAction(action) || draftTimelineActions.reset.match(action),
+  effect: (action, listenerApi) => {
+    const { dispatch, getState } = listenerApi;
+
+    // Read current form values and dispatch a snapshot if they exist.
+    const snapshot = () => {
+      const state = getState();
+      // Defensive guard: a timer armed before a restore (undo/redo) may fire
+      // mid-restore. Re-read state here and bail so we never snapshot the
+      // intermediate values produced by applyDiff's change() calls.
+      if (getDraftRestoring(state)) {
+        return;
+      }
+      const values = getFormValues(FORM_NAME)(state);
+      if (!values) {
+        return;
+      }
+      // Dedup identical consecutive snapshots: comparing against the current
+      // `present` (matching the slice's isEqual) keeps one undo step == one
+      // logical change and prevents history bloat / no-op undos.
+      if (isEqual(values, state.stageEditorDraft.history.present)) {
+        return;
+      }
+      dispatch(draftSnapshot(values as Stage));
+    };
+
+    // Flush a pending debounce: take the snapshot now and clear the timer.
+    const flush = () => {
+      if (pendingTimer !== null) {
+        clearPending();
+        snapshot();
+      }
+    };
+
+    // A draft reset (commit/cancel/stage-switch, or the INITIALIZE-driven
+    // reset) is not a redux-form action, so cancel any armed leaf-CHANGE timer
+    // here. Without this, a pending debounce could fire ~400ms later against a
+    // now-reset or different stage and push a phantom/cross-stage snapshot.
+    if (draftTimelineActions.reset.match(action)) {
+      clearPending();
+      return;
+    }
+
+    const formAction = action as ReduxFormAction;
+
+    // Guard: ignore form changes produced while restoring (undo/redo).
+    if (getDraftRestoring(getState())) {
+      return;
+    }
+
+    const { type } = formAction;
+
+    // INITIALIZE seeds the draft baseline; never produces a snapshot.
+    if (type === INITIALIZE) {
+      clearPending();
+      dispatch(resetDraft(formAction.payload as Stage));
+      return;
+    }
+
+    // DESTROY tears down the form; cancel any pending debounce and do not
+    // snapshot.
+    if (type === DESTROY) {
+      clearPending();
+      return;
+    }
+
+    // BLUR flushes any pending debounced snapshot; otherwise does nothing.
+    if (type === BLUR) {
+      flush();
+      return;
+    }
+
+    // Array mutations and whole-element CHANGE paths snapshot immediately,
+    // after flushing any pending debounce.
+    //
+    // Invariant: per-keystroke edits of bracket-indexed *nested leaves* (e.g.
+    // `panels[0].title`) must DEBOUNCE — they have text after the last `]`.
+    // Only a whole array-element replacement (e.g. `prompts[2]`) ends with a
+    // closing bracket and is immediate. Note: an inline bracket-indexed
+    // `Field` written directly into `edit-stage` would otherwise snapshot per
+    // keystroke, hence the "ends with `]`" rule rather than "contains `[`".
+    const field = formAction.meta?.field;
+    const isWholeElementChange =
+      type === CHANGE && typeof field === 'string' && field.endsWith(']');
+
+    if (ARRAY_ACTIONS.has(type) || isWholeElementChange) {
+      clearPending();
+      snapshot();
+      return;
+    }
+
+    // Leaf CHANGE paths are debounced: reset the timer and snapshot later.
+    if (type === CHANGE) {
+      clearPending();
+      pendingTimer = setTimeout(() => {
+        pendingTimer = null;
+        snapshot();
+      }, DEBOUNCE_MS);
+    }
+  },
+});

--- a/apps/architect-web/src/ducks/middleware/timeline.ts
+++ b/apps/architect-web/src/ducks/middleware/timeline.ts
@@ -10,33 +10,48 @@ import {
 import { v4 as uuid } from 'uuid';
 
 // Types
+export type Locus = {
+  id: string;
+  path: string;
+};
+
 type TimelineState<T = unknown> = {
   past: T[];
   present: T | null;
-  timeline: string[];
+  timeline: Locus[];
   future: T[];
-  futureTimeline: string[];
+  futureTimeline: Locus[];
 };
 
 type TimelineOptions = {
   name?: string;
   limit?: number;
   exclude?: (action: UnknownAction) => boolean;
+  getPath?: () => string;
 };
 
 const defaultOptions: Required<TimelineOptions> = {
   name: 'timeline',
   limit: 1000,
   exclude: () => false,
+  getPath: () =>
+    typeof window !== 'undefined' && window.location
+      ? window.location.pathname
+      : '',
 };
 
-// Create standalone actions using createAction
-export const timelineActions = {
-  jump: createAction<string, 'timeline/jump'>('timeline/jump'),
-  reset: createAction<void, 'timeline/reset'>('timeline/reset'),
-  undo: createAction<void, 'timeline/undo'>('timeline/undo'),
-  redo: createAction<void, 'timeline/redo'>('timeline/redo'),
-};
+// Create instance-scoped actions using createAction. Action types are
+// namespaced by `name` so multiple wrapped slices don't respond to the
+// same timeline action.
+export const createTimelineActions = (name = 'timeline') => ({
+  jump: createAction<string>(`${name}/jump`),
+  reset: createAction(`${name}/reset`, (payload?: unknown) => ({ payload })),
+  undo: createAction(`${name}/undo`),
+  redo: createAction(`${name}/redo`),
+});
+
+// Default-named instance, preserved for existing imports.
+export const timelineActions = createTimelineActions('timeline');
 
 const createTimelineReducer = <T>(
   reducer: Reducer<T>,
@@ -46,6 +61,10 @@ const createTimelineReducer = <T>(
     ...defaultOptions,
     ...customOptions,
   };
+
+  // Instance-scoped actions, so this slice only responds to its own
+  // `${name}/undo` etc.
+  const actions = createTimelineActions(options.name);
 
   const initialState: TimelineState<T> = {
     past: [],
@@ -62,7 +81,7 @@ const createTimelineReducer = <T>(
     reducers: {},
     extraReducers: (builder) => {
       builder
-        .addCase(timelineActions.undo, (state) => {
+        .addCase(actions.undo, (state) => {
           const {
             past,
             present,
@@ -96,43 +115,42 @@ const createTimelineReducer = <T>(
             futureTimeline: newFutureTimeline,
           });
         })
-        .addCase(
-          timelineActions.jump,
-          (state, action: PayloadAction<string>) => {
-            const { past, timeline } = state;
-            const locus = action.payload;
+        .addCase(actions.jump, (state, action: PayloadAction<string>) => {
+          const { past, timeline } = state;
+          const locusId = action.payload;
 
-            if (!locus) {
-              return state;
-            }
+          if (!locusId) {
+            return state;
+          }
 
-            const locusIndex = timeline.indexOf(locus);
+          const locusIndex = timeline.findIndex(
+            (entry) => entry.id === locusId,
+          );
 
-            // If point in timeline cannot be found do nothing
-            if (locusIndex === -1) {
-              return;
-            }
+          // If point in timeline cannot be found do nothing
+          if (locusIndex === -1) {
+            return;
+          }
 
-            // no events in timeline yet
-            if (timeline.length === 1) {
-              return;
-            }
+          // no events in timeline yet
+          if (timeline.length === 1) {
+            return;
+          }
 
-            // the last point in the timeline is the present
-            if (locusIndex === timeline.length - 1) {
-              return;
-            }
+          // the last point in the timeline is the present
+          if (locusIndex === timeline.length - 1) {
+            return;
+          }
 
-            const newPresent = past[locusIndex];
+          const newPresent = past[locusIndex];
 
-            Object.assign(state, {
-              past: past.slice(0, locusIndex),
-              present: newPresent,
-              timeline: timeline.slice(0, locusIndex + 1),
-            });
-          },
-        )
-        .addCase(timelineActions.redo, (state) => {
+          Object.assign(state, {
+            past: past.slice(0, locusIndex),
+            present: newPresent,
+            timeline: timeline.slice(0, locusIndex + 1),
+          });
+        })
+        .addCase(actions.redo, (state) => {
           const {
             future = [],
             futureTimeline = [],
@@ -164,21 +182,27 @@ const createTimelineReducer = <T>(
             futureTimeline: futureTimeline.slice(1),
           });
         })
-        .addCase(timelineActions.reset, (state) => {
-          const locus = uuid();
-          const newPresent = reducer(
-            (state.present
-              ? current<T>(state.present as Draft<T>)
-              : state.present) as T,
-            {
-              type: '@@RESET',
-            },
-          );
+        .addCase(actions.reset, (state, action) => {
+          const newLocus: Locus = { id: uuid(), path: options.getPath() };
+
+          // If a payload is provided, seed `present` with it directly;
+          // otherwise recompute via the wrapped reducer (existing behavior).
+          const newPresent =
+            action.payload !== undefined
+              ? (action.payload as T)
+              : reducer(
+                  (state.present
+                    ? current<T>(state.present as Draft<T>)
+                    : state.present) as T,
+                  {
+                    type: '@@RESET',
+                  },
+                );
 
           Object.assign(state, {
             past: [],
             present: newPresent ?? null,
-            timeline: [locus],
+            timeline: [newLocus],
             future: [],
             futureTimeline: [],
           });
@@ -187,10 +211,10 @@ const createTimelineReducer = <T>(
           // Don't process timeline actions here - they're handled by the cases above
           if (
             action &&
-            (timelineActions.jump.match(action) ||
-              timelineActions.reset.match(action) ||
-              timelineActions.undo.match(action) ||
-              timelineActions.redo.match(action))
+            (actions.jump.match(action) ||
+              actions.reset.match(action) ||
+              actions.undo.match(action) ||
+              actions.redo.match(action))
           ) {
             return state;
           }
@@ -210,6 +234,20 @@ const createTimelineReducer = <T>(
             );
           }
 
+          // Migrate legacy string timeline entries to Locus objects (for
+          // backwards compatibility with persisted state created before the
+          // timeline entries changed from bare uuid strings to Locus objects).
+          if (state.timeline?.some((e) => typeof e === 'string')) {
+            state.timeline = (state.timeline as (Locus | string)[]).map((e) =>
+              typeof e === 'string' ? { id: e, path: '' } : e,
+            );
+          }
+          if (state.futureTimeline?.some((e) => typeof e === 'string')) {
+            state.futureTimeline = (
+              state.futureTimeline as (Locus | string)[]
+            ).map((e) => (typeof e === 'string' ? { id: e, path: '' } : e));
+          }
+
           const { past, present, timeline } = state;
 
           // Clone present BEFORE calling reducer, because reducer mutates in place
@@ -223,7 +261,7 @@ const createTimelineReducer = <T>(
 
           // This is the first run
           if (timeline.length === 0) {
-            const locus = uuid();
+            const locus: Locus = { id: uuid(), path: options.getPath() };
             Object.assign(state, {
               past: [],
               present: newPresent ?? null,
@@ -241,7 +279,7 @@ const createTimelineReducer = <T>(
 
           // If this is setActiveProtocol, reset the timeline (loading a new protocol)
           if (action.type === 'activeProtocol/setActiveProtocol') {
-            const locus = uuid();
+            const locus: Locus = { id: uuid(), path: options.getPath() };
             Object.assign(state, {
               past: [],
               present: newPresent ?? null,
@@ -266,7 +304,7 @@ const createTimelineReducer = <T>(
           state.future = [];
           state.futureTimeline = [];
 
-          const locus = uuid();
+          const locus: Locus = { id: uuid(), path: options.getPath() };
           const newTimeline = [...timeline, locus].slice(-options.limit - 1);
 
           const validPast = presentSnapshot

--- a/apps/architect-web/src/ducks/modules/__tests__/activeProtocolUndoNavigation.test.ts
+++ b/apps/architect-web/src/ducks/modules/__tests__/activeProtocolUndoNavigation.test.ts
@@ -1,0 +1,239 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { navigate } from 'wouter/use-browser-location';
+
+import type { CurrentProtocol } from '@codaco/protocol-validation';
+import type { AppDispatch, RootState } from '~/ducks/store';
+
+import createTimelineReducer from '../../middleware/timeline';
+import activeProtocolReducer, {
+  actionCreators,
+  redoWithNavigation,
+  undoWithNavigation,
+} from '../activeProtocol';
+
+vi.mock('wouter/use-browser-location', () => ({ navigate: vi.fn() }));
+
+type Entry = { id: string; path: string };
+
+const buildState = (opts: {
+  past?: unknown[];
+  future?: unknown[];
+  timeline?: Entry[];
+  futureTimeline?: Entry[];
+}) =>
+  ({
+    activeProtocol: {
+      past: opts.past ?? [{}],
+      present: { name: 'P', stages: [] },
+      future: opts.future ?? [],
+      timeline: opts.timeline ?? [],
+      futureTimeline: opts.futureTimeline ?? [],
+    },
+  }) as unknown as RootState;
+
+// Fake dispatch that runs nested thunks and records plain actions so we can
+// assert whether the raw undo/redo was applied.
+const makeHarness = (state: RootState) => {
+  const plainActions: { type: string }[] = [];
+  const getState = () => state;
+  const dispatch = ((action: unknown) => {
+    if (typeof action === 'function') {
+      return (action as (d: unknown, g: () => RootState) => unknown)(
+        dispatch,
+        getState,
+      );
+    }
+    plainActions.push(action as { type: string });
+    return action;
+  }) as unknown as AppDispatch;
+  return { dispatch, getState, plainActions };
+};
+
+const setPath = (path: string) => window.history.replaceState({}, '', path);
+const undoApplied = (actions: { type: string }[]) =>
+  actions.some((a) => a.type === 'timeline/undo');
+const redoApplied = (actions: { type: string }[]) =>
+  actions.some((a) => a.type === 'timeline/redo');
+
+describe('undoWithNavigation / redoWithNavigation', () => {
+  beforeEach(() => {
+    vi.mocked(navigate).mockClear();
+    setPath('/protocol');
+  });
+
+  it('reverts in place when the change lives on the current page', () => {
+    setPath('/protocol/codebook');
+    const state = buildState({
+      timeline: [{ id: 'a', path: '/protocol/codebook' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(undoApplied(plainActions)).toBe(true);
+  });
+
+  it('navigates first (without reverting) when the change lives on another page', () => {
+    const state = buildState({
+      timeline: [{ id: 'a', path: '/protocol/codebook' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).toHaveBeenCalledWith('/protocol/codebook');
+    expect(undoApplied(plainActions)).toBe(false);
+  });
+
+  it('reverts on the second press once on the target page', () => {
+    setPath('/protocol/codebook');
+    const state = buildState({
+      timeline: [{ id: 'a', path: '/protocol/codebook' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    // Simulates the press that follows the navigation step.
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(undoApplied(plainActions)).toBe(true);
+  });
+
+  it('routes a committed stage edit to the stage list, not the editor', () => {
+    setPath('/protocol/codebook');
+    const state = buildState({
+      timeline: [{ id: 'a', path: '/protocol/stage/stage-1' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).toHaveBeenCalledWith('/protocol');
+    expect(undoApplied(plainActions)).toBe(false);
+  });
+
+  it('reverts path-less (legacy) entries in place', () => {
+    const state = buildState({ timeline: [{ id: 'a', path: '' }] });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(undoApplied(plainActions)).toBe(true);
+  });
+
+  it('does nothing when there is nothing to undo', () => {
+    const state = buildState({
+      past: [],
+      timeline: [{ id: 'a', path: '/protocol/codebook' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    undoWithNavigation()(dispatch, getState);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(undoApplied(plainActions)).toBe(false);
+  });
+
+  it('redo mirrors undo using the future timeline head', () => {
+    const state = buildState({
+      future: [{}],
+      futureTimeline: [{ id: 'b', path: '/protocol/assets' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    // First press: orient to the page the redone change lives on.
+    redoWithNavigation()(dispatch, getState);
+    expect(navigate).toHaveBeenCalledWith('/protocol/assets');
+    expect(redoApplied(plainActions)).toBe(false);
+
+    // Second press, now on that page: reapply.
+    setPath('/protocol/assets');
+    redoWithNavigation()(dispatch, getState);
+    expect(redoApplied(plainActions)).toBe(true);
+  });
+
+  it('does nothing when there is nothing to redo', () => {
+    const state = buildState({
+      future: [],
+      futureTimeline: [{ id: 'b', path: '/protocol/assets' }],
+    });
+    const { dispatch, getState, plainActions } = makeHarness(state);
+
+    redoWithNavigation()(dispatch, getState);
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(redoApplied(plainActions)).toBe(false);
+  });
+});
+
+// Exercises the thunks against a real timeline-wrapped store so the
+// getUndoTargetPath ↔ middleware-locus assumption is verified end to end (the
+// fake-state unit tests above can't reach the middleware's locus bookkeeping).
+describe('undoWithNavigation (real store integration)', () => {
+  const baseProtocol: CurrentProtocol = {
+    name: 'Orig',
+    description: 'd',
+    schemaVersion: 8,
+    stages: [],
+    codebook: { node: {}, edge: {}, ego: {} },
+    assetManifest: {},
+  };
+
+  const makeStore = () =>
+    configureStore({
+      reducer: { activeProtocol: createTimelineReducer(activeProtocolReducer) },
+      middleware: (getDefault) => getDefault({ serializableCheck: false }),
+    });
+
+  beforeEach(() => {
+    vi.mocked(navigate).mockClear();
+    setPath('/protocol');
+  });
+
+  it('navigates to the editing page first, then reverts on the next press', () => {
+    setPath('/protocol/codebook');
+    const store = makeStore();
+    store.dispatch(actionCreators.setActiveProtocol(baseProtocol));
+    store.dispatch(actionCreators.updateProtocolName({ name: 'Renamed' }));
+    expect(store.getState().activeProtocol.present?.name).toBe('Renamed');
+
+    // The user has since navigated away from where the change was made.
+    setPath('/protocol');
+    store.dispatch(undoWithNavigation());
+    expect(navigate).toHaveBeenCalledWith('/protocol/codebook');
+    // Not reverted off-screen.
+    expect(store.getState().activeProtocol.present?.name).toBe('Renamed');
+
+    // Second press, now on the change's page: revert in view.
+    setPath('/protocol/codebook');
+    store.dispatch(undoWithNavigation());
+    expect(store.getState().activeProtocol.present?.name).toBe('Orig');
+  });
+
+  it('navigates once for consecutive changes on the same page, then reverts in place', () => {
+    setPath('/protocol/codebook');
+    const store = makeStore();
+    store.dispatch(actionCreators.setActiveProtocol(baseProtocol));
+    store.dispatch(actionCreators.updateProtocolName({ name: 'A' }));
+    store.dispatch(
+      actionCreators.updateProtocolDescription({ description: 'B' }),
+    );
+
+    // First press from another page only navigates.
+    setPath('/protocol');
+    store.dispatch(undoWithNavigation());
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/protocol/codebook');
+
+    // Subsequent presses on that page revert both changes without re-navigating.
+    setPath('/protocol/codebook');
+    store.dispatch(undoWithNavigation());
+    store.dispatch(undoWithNavigation());
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(store.getState().activeProtocol.present?.name).toBe('Orig');
+    expect(store.getState().activeProtocol.present?.description).toBe('d');
+  });
+});

--- a/apps/architect-web/src/ducks/modules/__tests__/stageEditorDraft.test.ts
+++ b/apps/architect-web/src/ducks/modules/__tests__/stageEditorDraft.test.ts
@@ -1,13 +1,24 @@
 import crypto from 'node:crypto';
 
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  change,
+  reducer as formReducer,
+  getFormValues,
+  initialize,
+} from 'redux-form';
 import { v4 as uuid } from 'uuid';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Stage } from '@codaco/protocol-validation';
+import type { AppDispatch } from '~/ducks/store';
 
 import reducer, {
+  draftRedo,
   draftSnapshot,
   draftTimelineActions,
+  draftUndo,
+  resetDraft,
   setRestoring,
 } from '../stageEditorDraft';
 
@@ -137,5 +148,57 @@ describe('stageEditorDraft reducer', () => {
       expect(next.history.past).toEqual([]);
       expect(next.history.present).toBe(null);
     });
+  });
+});
+
+describe('draftUndo / draftRedo flush pending edits', () => {
+  const makeStore = () => {
+    const store = configureStore({
+      reducer: { form: formReducer, stageEditorDraft: reducer },
+      middleware: (getDefault) => getDefault({ serializableCheck: false }),
+    });
+    // The thunks are typed against the full RootState; cast once for the test.
+    const dispatch = store.dispatch as unknown as AppDispatch;
+    return { store, dispatch };
+  };
+
+  type Store = ReturnType<typeof makeStore>['store'];
+  const labelOf = (store: Store) =>
+    (getFormValues('edit-stage')(store.getState()) as { label?: string })
+      ?.label;
+
+  // Drives the store to: snapshot 'A', snapshot 'AB', then a still-debounced
+  // (un-snapshotted) edit to 'ABC' — the form is ahead of `present`.
+  const seedPendingEdit = () => {
+    const { store, dispatch } = makeStore();
+    dispatch(initialize('edit-stage', { label: 'A' }));
+    dispatch(resetDraft({ label: 'A' } as unknown as Stage));
+    dispatch(draftSnapshot({ label: 'AB' } as unknown as Stage));
+    dispatch(change('edit-stage', 'label', 'AB'));
+    dispatch(change('edit-stage', 'label', 'ABC')); // pending keystroke
+    return { store, dispatch };
+  };
+
+  it('undo commits the in-progress edit first, reverting to it (not past it)', () => {
+    const { store, dispatch } = seedPendingEdit();
+
+    dispatch(draftUndo());
+
+    // Without the flush, undo would skip 'AB' and jump to 'A'.
+    expect(labelOf(store)).toBe('AB');
+    // The flushed 'ABC' edit is now redoable.
+    expect(
+      store.getState().stageEditorDraft.history.future.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('redo commits the in-progress edit, branching history (redo unavailable)', () => {
+    const { store, dispatch } = seedPendingEdit();
+
+    dispatch(draftRedo());
+
+    // The pending edit is committed and wins; there is nothing to redo past it.
+    expect(labelOf(store)).toBe('ABC');
+    expect(store.getState().stageEditorDraft.history.future.length).toBe(0);
   });
 });

--- a/apps/architect-web/src/ducks/modules/__tests__/stageEditorDraft.test.ts
+++ b/apps/architect-web/src/ducks/modules/__tests__/stageEditorDraft.test.ts
@@ -1,0 +1,141 @@
+import crypto from 'node:crypto';
+
+import { v4 as uuid } from 'uuid';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Stage } from '@codaco/protocol-validation';
+
+import reducer, {
+  draftSnapshot,
+  draftTimelineActions,
+  setRestoring,
+} from '../stageEditorDraft';
+
+vi.mock('uuid');
+
+(vi.mocked(uuid) as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+  () =>
+    Array.from(crypto.randomBytes(20), (b) =>
+      b.toString(16).padStart(2, '0'),
+    ).join(''),
+);
+
+const makeStage = (label: string): Stage =>
+  ({ id: label, type: 'Information', label }) as unknown as Stage;
+
+type DraftState = ReturnType<typeof reducer>;
+
+describe('stageEditorDraft reducer', () => {
+  let state: DraftState;
+
+  beforeEach(() => {
+    state = reducer(undefined, { type: '@@INIT' });
+  });
+
+  describe('initial state', () => {
+    it('has a timeline-shaped history and default ui', () => {
+      expect(state.history).toEqual(
+        expect.objectContaining({
+          past: expect.any(Array),
+          present: null,
+          timeline: expect.any(Array),
+          future: expect.any(Array),
+          futureTimeline: expect.any(Array),
+        }),
+      );
+      expect(state.ui.restoring).toBe(false);
+      expect(state.ui.initialValues).toBe(null);
+    });
+  });
+
+  describe('draftSnapshot', () => {
+    it('sets a new present and grows past/timeline', () => {
+      const first = makeStage('one');
+      const second = makeStage('two');
+
+      const afterFirst = reducer(state, draftSnapshot(first));
+      expect(afterFirst.history.present).toEqual(first);
+
+      const next = reducer(afterFirst, draftSnapshot(second));
+      expect(next.history.present).toEqual(second);
+      expect(next.history.past.length).toBe(afterFirst.history.past.length + 1);
+      expect(next.history.past[next.history.past.length - 1]).toEqual(first);
+      expect(next.history.timeline.length).toBe(
+        afterFirst.history.timeline.length + 1,
+      );
+    });
+
+    it('does not create timeline entries for unrelated actions', () => {
+      const next = reducer(state, { type: 'SOMETHING_ELSE' });
+      expect(next.history.past.length).toBe(0);
+      expect(next.history.present).toBe(null);
+    });
+  });
+
+  describe('draftTimelineActions.reset', () => {
+    it('seeds present, clears history, and records initialValues', () => {
+      const seeded = makeStage('seed');
+
+      let next = reducer(state, draftSnapshot(makeStage('a')));
+      next = reducer(next, draftSnapshot(makeStage('b')));
+      expect(next.history.past.length).toBe(1);
+
+      next = reducer(next, draftTimelineActions.reset(seeded));
+
+      expect(next.history.present).toEqual(seeded);
+      expect(next.history.past.length).toBe(0);
+      expect(next.history.future.length).toBe(0);
+      expect(next.history.timeline.length).toBe(1);
+      expect(next.ui.initialValues).toEqual(seeded);
+      expect(next.ui.restoring).toBe(false);
+    });
+
+    it('sets initialValues to null when reset without payload', () => {
+      const next = reducer(state, draftTimelineActions.reset());
+      expect(next.ui.initialValues).toBe(null);
+      expect(next.ui.restoring).toBe(false);
+    });
+
+    it('clears restoring on reset', () => {
+      let next = reducer(state, setRestoring(true));
+      expect(next.ui.restoring).toBe(true);
+
+      next = reducer(next, draftTimelineActions.reset(makeStage('seed')));
+      expect(next.ui.restoring).toBe(false);
+    });
+  });
+
+  describe('setRestoring', () => {
+    it('toggles ui.restoring', () => {
+      let next = reducer(state, setRestoring(true));
+      expect(next.ui.restoring).toBe(true);
+
+      next = reducer(next, setRestoring(false));
+      expect(next.ui.restoring).toBe(false);
+    });
+  });
+
+  describe('draftTimelineActions.undo', () => {
+    it('shifts present into future after snapshots', () => {
+      let next = reducer(state, draftSnapshot(makeStage('one')));
+      next = reducer(next, draftSnapshot(makeStage('two')));
+      next = reducer(next, draftSnapshot(makeStage('three')));
+
+      const beforeUndo = next;
+      next = reducer(next, draftTimelineActions.undo());
+
+      expect(next.history.past.length).toBe(beforeUndo.history.past.length - 1);
+      expect(next.history.present).toEqual(
+        beforeUndo.history.past[beforeUndo.history.past.length - 1],
+      );
+      expect(next.history.future.length).toBe(1);
+      expect(next.history.future[0]).toEqual(beforeUndo.history.present);
+    });
+
+    it('does nothing with no past history', () => {
+      const next = reducer(state, draftTimelineActions.undo());
+      expect(next.history.past).toEqual([]);
+      expect(next.history.present).toBe(null);
+    });
+  });
+});

--- a/apps/architect-web/src/ducks/modules/activeProtocol.ts
+++ b/apps/architect-web/src/ducks/modules/activeProtocol.ts
@@ -4,10 +4,18 @@ import {
   type PayloadAction,
   type UnknownAction,
 } from '@reduxjs/toolkit';
+import { navigate } from 'wouter/use-browser-location';
 
 import type { CurrentProtocol } from '@codaco/protocol-validation';
-import type { AppDispatch } from '~/ducks/store';
+import type { AppDispatch, RootState } from '~/ducks/store';
+import {
+  getCanRedo,
+  getCanUndo,
+  getRedoTargetPath,
+  getUndoTargetPath,
+} from '~/selectors/protocol';
 import { assetDb } from '~/utils/assetDB';
+import { resolveTimelineNavTarget } from '~/utils/timelineNavigation';
 
 import { timelineActions } from '../middleware/timeline';
 import assetManifest from './protocol/assetManifest';
@@ -124,10 +132,52 @@ export const actionCreators = {
 // Export the reducer as default
 export default activeProtocolSlice.reducer;
 
+// Raw timeline operations. These apply silently and are used by the protocol
+// validation listener's auto-revert; do not navigate from here. `undo` is
+// exported for the listener; `redo` is only used internally below.
 export const undo = () => (dispatch: AppDispatch) => {
   dispatch(timelineActions.undo());
 };
 
-export const redo = () => (dispatch: AppDispatch) => {
+const redo = () => (dispatch: AppDispatch) => {
   dispatch(timelineActions.redo());
 };
+
+const currentPath = () =>
+  typeof window !== 'undefined' && window.location
+    ? window.location.pathname
+    : '';
+
+// User-facing undo/redo. Navigation is a discrete, visible step: when the
+// change to be undone/redone was committed on another page, the first press
+// just navigates there (so the change is reverted in view, never off-screen)
+// and the next press applies it. Committed stage edits resolve to the stage
+// list rather than re-opening the editor (see resolveTimelineNavTarget). Same-
+// page and legacy (path-less) entries apply in place.
+export const undoWithNavigation =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    const state = getState();
+    if (!getCanUndo(state)) return;
+
+    const targetPage = resolveTimelineNavTarget(getUndoTargetPath(state));
+    if (targetPage && targetPage !== currentPath()) {
+      navigate(targetPage);
+      return;
+    }
+
+    dispatch(undo());
+  };
+
+export const redoWithNavigation =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    const state = getState();
+    if (!getCanRedo(state)) return;
+
+    const targetPage = resolveTimelineNavTarget(getRedoTargetPath(state));
+    if (targetPage && targetPage !== currentPath()) {
+      navigate(targetPage);
+      return;
+    }
+
+    dispatch(redo());
+  };

--- a/apps/architect-web/src/ducks/modules/root.ts
+++ b/apps/architect-web/src/ducks/modules/root.ts
@@ -9,6 +9,7 @@ import app from './app';
 import dialogs from './dialogs';
 import protocols from './protocols';
 import protocolValidation from './protocolValidation';
+import stageEditorDraft from './stageEditorDraft';
 
 const protocolPattern = /^(activeProtocol|stages|codebook|assetManifest)\//;
 // Thunk-lifecycle actions dispatched by createAsyncThunk don't carry state mutations themselves;
@@ -37,6 +38,7 @@ export const rootReducer = combineReducers({
   activeProtocol: createTimeline(activeProtocol, timelineOptions),
   protocols,
   protocolValidation,
+  stageEditorDraft,
 });
 
 // Export the root state type

--- a/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
+++ b/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
@@ -93,10 +93,6 @@ export const resetDraft = (values: Stage | null) => (dispatch: AppDispatch) => {
   dispatch(draftTimelineActions.reset(values));
 };
 
-export const draftSnapshotNow = (values: Stage) => (dispatch: AppDispatch) => {
-  dispatch(draftSnapshot(values));
-};
-
 export const draftUndo =
   () => (dispatch: AppDispatch, getState: () => RootState) => {
     const state = getState();

--- a/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
+++ b/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
@@ -1,0 +1,153 @@
+import {
+  combineReducers,
+  createAction,
+  createSlice,
+  type PayloadAction,
+  type UnknownAction,
+} from '@reduxjs/toolkit';
+import { isEqual } from 'es-toolkit/compat';
+import { change, getFormValues } from 'redux-form';
+
+import type { Stage } from '@codaco/protocol-validation';
+import type { AppDispatch, RootState } from '~/ducks/store';
+
+import createTimelineReducer, {
+  createTimelineActions,
+} from '../middleware/timeline';
+
+// Instance-scoped timeline actions for the stage editor draft history.
+export const draftTimelineActions = createTimelineActions('stageEditorDraft');
+
+// Only a snapshot action produces a new `present` in the draft timeline,
+// guaranteeing that unrelated actions never create new timeline entries.
+export const draftSnapshot = createAction<Stage>('stageEditorDraft/snapshot');
+
+const draftPresentReducer = (
+  state: Stage | null = null,
+  action: UnknownAction,
+): Stage | null => {
+  if (draftSnapshot.match(action)) {
+    return action.payload;
+  }
+
+  // Return the same reference for every other action so the timeline reducer
+  // treats them as no-ops (no new point on the timeline).
+  return state;
+};
+
+// `exclude` is essential: the timeline reducer's `present === newPresent`
+// short-circuit never fires (an Immer draft proxy is never reference-equal to
+// the `current()` snapshot the wrapped reducer returns), so without a filter
+// EVERY action dispatched anywhere in the app would push a draft snapshot.
+// Recording only `draftSnapshot` actions makes one undo step == one logical
+// change. The scoped undo/redo/reset/jump actions are handled separately.
+const historyReducer = createTimelineReducer<Stage | null>(
+  draftPresentReducer,
+  {
+    name: 'stageEditorDraft',
+    exclude: (action) => !draftSnapshot.match(action),
+  },
+);
+
+// Sibling UI reducer holds state that has no room in the timeline shape.
+type UiState = {
+  restoring: boolean;
+  initialValues: Stage | null;
+};
+
+const uiInitialState: UiState = {
+  restoring: false,
+  initialValues: null,
+};
+
+const uiSlice = createSlice({
+  name: 'stageEditorDraftUi',
+  initialState: uiInitialState,
+  reducers: {
+    setRestoring: (state, action: PayloadAction<boolean>) => {
+      state.restoring = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(draftTimelineActions.reset, (state, action) => {
+      state.initialValues = (action.payload as Stage) ?? null;
+      state.restoring = false;
+    });
+  },
+});
+
+export const setRestoring = uiSlice.actions.setRestoring;
+
+const uiReducer = uiSlice.reducer;
+
+const reducer = combineReducers({
+  history: historyReducer,
+  ui: uiReducer,
+});
+
+export default reducer;
+
+// Thunks
+
+export const resetDraft = (values: Stage | null) => (dispatch: AppDispatch) => {
+  dispatch(draftTimelineActions.reset(values));
+};
+
+export const draftSnapshotNow = (values: Stage) => (dispatch: AppDispatch) => {
+  dispatch(draftSnapshot(values));
+};
+
+export const draftUndo =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    const state = getState();
+    const past = state.stageEditorDraft.history.past;
+    if (!past || past.length === 0) {
+      return;
+    }
+
+    const target = (past[past.length - 1] ?? {}) as Record<string, unknown>;
+    const current = (getFormValues('edit-stage')(state) ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    dispatch(draftTimelineActions.undo());
+    applyDiff(dispatch, current, target);
+  };
+
+export const draftRedo =
+  () => (dispatch: AppDispatch, getState: () => RootState) => {
+    const state = getState();
+    const future = state.stageEditorDraft.history.future;
+    if (!future || future.length === 0) {
+      return;
+    }
+
+    const target = (future[0] ?? {}) as Record<string, unknown>;
+    const current = (getFormValues('edit-stage')(state) ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    dispatch(draftTimelineActions.redo());
+    applyDiff(dispatch, current, target);
+  };
+
+// Apply only the changed fields from `target` onto the form, wrapped in a
+// restoring flag so listeners can ignore the resulting form changes.
+const applyDiff = (
+  dispatch: AppDispatch,
+  current: Record<string, unknown>,
+  target: Record<string, unknown>,
+) => {
+  dispatch(setRestoring(true));
+
+  const keys = new Set([...Object.keys(current), ...Object.keys(target)]);
+  for (const key of keys) {
+    if (!isEqual(current[key], target[key])) {
+      dispatch(change('edit-stage', key, target[key]));
+    }
+  }
+
+  dispatch(setRestoring(false));
+};

--- a/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
+++ b/apps/architect-web/src/ducks/modules/stageEditorDraft.ts
@@ -10,6 +10,7 @@ import { change, getFormValues } from 'redux-form';
 
 import type { Stage } from '@codaco/protocol-validation';
 import type { AppDispatch, RootState } from '~/ducks/store';
+import { getDraftRestoring } from '~/selectors/stageEditorDraft';
 
 import createTimelineReducer, {
   createTimelineActions,
@@ -93,8 +94,25 @@ export const resetDraft = (values: Stage | null) => (dispatch: AppDispatch) => {
   dispatch(draftTimelineActions.reset(values));
 };
 
+// Leaf-field edits are debounced before they snapshot (see the draft
+// listener), so the latest keystrokes may not be in history yet when the user
+// undoes/redoes — via the keyboard shortcut OR the toolbar button. Commit any
+// such in-progress edit first, so a step never skips or drops it. (The
+// listener's stale debounce timer, if any, is harmless: after the step the form
+// matches `present`, so it dedupes to a no-op; a fresh edit clears it.)
+const flushPendingEdit = (dispatch: AppDispatch, getState: () => RootState) => {
+  const state = getState();
+  if (getDraftRestoring(state)) return;
+  const values = getFormValues('edit-stage')(state);
+  if (!values) return;
+  if (isEqual(values, state.stageEditorDraft.history.present)) return;
+  dispatch(draftSnapshot(values as Stage));
+};
+
 export const draftUndo =
   () => (dispatch: AppDispatch, getState: () => RootState) => {
+    flushPendingEdit(dispatch, getState);
+
     const state = getState();
     const past = state.stageEditorDraft.history.past;
     if (!past || past.length === 0) {
@@ -113,6 +131,10 @@ export const draftUndo =
 
 export const draftRedo =
   () => (dispatch: AppDispatch, getState: () => RootState) => {
+    // A pending edit branches history: committing it correctly clears the redo
+    // stack, so an in-progress edit always wins over a stale redo.
+    flushPendingEdit(dispatch, getState);
+
     const state = getState();
     const future = state.stageEditorDraft.history.future;
     if (!future || future.length === 0) {

--- a/apps/architect-web/src/ducks/store.ts
+++ b/apps/architect-web/src/ducks/store.ts
@@ -5,6 +5,7 @@ import { analyticsListenerMiddleware } from './middleware/analyticsListener';
 import logger from './middleware/logger';
 import { protocolValidationListenerMiddleware } from './middleware/protocolValidationListener';
 import { scrollPositionsListenerMiddleware } from './middleware/scrollPositionsListener';
+import { stageEditorDraftListenerMiddleware } from './middleware/stageEditorDraftListener';
 import type { RootState } from './modules/root';
 import { rootReducer } from './modules/root';
 
@@ -26,7 +27,8 @@ const store = configureStore({
       .concat(logger)
       .prepend(protocolValidationListenerMiddleware.middleware)
       .prepend(analyticsListenerMiddleware.middleware)
-      .prepend(scrollPositionsListenerMiddleware.middleware),
+      .prepend(scrollPositionsListenerMiddleware.middleware)
+      .prepend(stageEditorDraftListenerMiddleware.middleware),
   enhancers: (getDefaultEnhancers) =>
     getDefaultEnhancers().concat(
       rememberEnhancer(

--- a/apps/architect-web/src/hooks/__tests__/useScopedUndoRedo.test.tsx
+++ b/apps/architect-web/src/hooks/__tests__/useScopedUndoRedo.test.tsx
@@ -1,0 +1,102 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScopedUndoRedo } from '../useScopedUndoRedo';
+
+const mockLocation = vi.fn(() => '/protocol');
+vi.mock('wouter', () => ({
+  useLocation: () => [mockLocation(), vi.fn()],
+}));
+
+const undoWithNavigation = vi.fn(() => ({ type: 'main/undo' }));
+const redoWithNavigation = vi.fn(() => ({ type: 'main/redo' }));
+vi.mock('~/ducks/modules/activeProtocol', () => ({
+  undoWithNavigation: () => undoWithNavigation(),
+  redoWithNavigation: () => redoWithNavigation(),
+}));
+
+const draftUndo = vi.fn(() => ({ type: 'draft/undo' }));
+const draftRedo = vi.fn(() => ({ type: 'draft/redo' }));
+vi.mock('~/ducks/modules/stageEditorDraft', () => ({
+  draftUndo: () => draftUndo(),
+  draftRedo: () => draftRedo(),
+}));
+
+// Main timeline has nothing to undo/redo; the draft history does. This lets us
+// assert that the hook reads the can-undo/redo flags from the scope matching
+// the current route, not just that it dispatches the right action.
+const createStore = () =>
+  configureStore({
+    reducer: {
+      activeProtocol: (
+        state = { past: [], present: { name: 'P' }, future: [] },
+      ) => state,
+      stageEditorDraft: (
+        state = {
+          history: { past: [{}], present: null, timeline: [], future: [{}] },
+          ui: { restoring: false, initialValues: null },
+        },
+      ) => state,
+    },
+  });
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <Provider store={createStore()}>{children}</Provider>
+);
+
+describe('useScopedUndoRedo', () => {
+  beforeEach(() => {
+    mockLocation.mockReturnValue('/protocol');
+    undoWithNavigation.mockClear();
+    redoWithNavigation.mockClear();
+    draftUndo.mockClear();
+    draftRedo.mockClear();
+  });
+
+  describe('outside the stage editor', () => {
+    beforeEach(() => mockLocation.mockReturnValue('/protocol'));
+
+    it('reports the main-timeline can-undo/redo flags', () => {
+      const { result } = renderHook(() => useScopedUndoRedo(), { wrapper });
+      expect(result.current.canUndo).toBe(false);
+      expect(result.current.canRedo).toBe(false);
+    });
+
+    it('dispatches the navigation-aware main-timeline ops', () => {
+      const { result } = renderHook(() => useScopedUndoRedo(), { wrapper });
+
+      result.current.undo();
+      result.current.redo();
+
+      expect(undoWithNavigation).toHaveBeenCalledTimes(1);
+      expect(redoWithNavigation).toHaveBeenCalledTimes(1);
+      expect(draftUndo).not.toHaveBeenCalled();
+      expect(draftRedo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('inside the stage editor', () => {
+    beforeEach(() => mockLocation.mockReturnValue('/protocol/stage/stage-1'));
+
+    it('reports the draft-history can-undo/redo flags', () => {
+      const { result } = renderHook(() => useScopedUndoRedo(), { wrapper });
+      expect(result.current.canUndo).toBe(true);
+      expect(result.current.canRedo).toBe(true);
+    });
+
+    it('dispatches the draft ops, not the main-timeline ops', () => {
+      const { result } = renderHook(() => useScopedUndoRedo(), { wrapper });
+
+      result.current.undo();
+      result.current.redo();
+
+      expect(draftUndo).toHaveBeenCalledTimes(1);
+      expect(draftRedo).toHaveBeenCalledTimes(1);
+      expect(undoWithNavigation).not.toHaveBeenCalled();
+      expect(redoWithNavigation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/architect-web/src/hooks/useScopedUndoRedo.ts
+++ b/apps/architect-web/src/hooks/useScopedUndoRedo.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo } from 'react';
+import { useLocation } from 'wouter';
+
+import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
+import { redo, undo } from '~/ducks/modules/activeProtocol';
+import { draftRedo, draftUndo } from '~/ducks/modules/stageEditorDraft';
+import { getCanRedo, getCanUndo } from '~/selectors/protocol';
+import { getCanRedoDraft, getCanUndoDraft } from '~/selectors/stageEditorDraft';
+
+type ScopedUndoRedo = {
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+};
+
+/**
+ * Returns undo/redo state and actions scoped to the current route. When the
+ * stage editor is on screen, operations target the stage editor draft history;
+ * otherwise they target the main protocol timeline.
+ */
+export const useScopedUndoRedo = (): ScopedUndoRedo => {
+  const [location] = useLocation();
+  const isStageEditor = location.startsWith('/protocol/stage/');
+
+  const dispatch = useAppDispatch();
+
+  // Hooks must be called unconditionally, so always read both scopes.
+  const canUndoDraft = useAppSelector(getCanUndoDraft);
+  const canRedoDraft = useAppSelector(getCanRedoDraft);
+  const canUndoMain = useAppSelector(getCanUndo);
+  const canRedoMain = useAppSelector(getCanRedo);
+
+  const handleUndo = useCallback(() => {
+    if (isStageEditor) {
+      dispatch(draftUndo());
+    } else {
+      dispatch(undo());
+    }
+  }, [dispatch, isStageEditor]);
+
+  const handleRedo = useCallback(() => {
+    if (isStageEditor) {
+      dispatch(draftRedo());
+    } else {
+      dispatch(redo());
+    }
+  }, [dispatch, isStageEditor]);
+
+  return useMemo(
+    () => ({
+      canUndo: isStageEditor ? canUndoDraft : canUndoMain,
+      canRedo: isStageEditor ? canRedoDraft : canRedoMain,
+      undo: handleUndo,
+      redo: handleRedo,
+    }),
+    [
+      isStageEditor,
+      canUndoDraft,
+      canRedoDraft,
+      canUndoMain,
+      canRedoMain,
+      handleUndo,
+      handleRedo,
+    ],
+  );
+};

--- a/apps/architect-web/src/hooks/useScopedUndoRedo.ts
+++ b/apps/architect-web/src/hooks/useScopedUndoRedo.ts
@@ -2,7 +2,10 @@ import { useCallback, useMemo } from 'react';
 import { useLocation } from 'wouter';
 
 import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
-import { redo, undo } from '~/ducks/modules/activeProtocol';
+import {
+  redoWithNavigation,
+  undoWithNavigation,
+} from '~/ducks/modules/activeProtocol';
 import { draftRedo, draftUndo } from '~/ducks/modules/stageEditorDraft';
 import { getCanRedo, getCanUndo } from '~/selectors/protocol';
 import { getCanRedoDraft, getCanUndoDraft } from '~/selectors/stageEditorDraft';
@@ -35,7 +38,7 @@ export const useScopedUndoRedo = (): ScopedUndoRedo => {
     if (isStageEditor) {
       dispatch(draftUndo());
     } else {
-      dispatch(undo());
+      dispatch(undoWithNavigation());
     }
   }, [dispatch, isStageEditor]);
 
@@ -43,7 +46,7 @@ export const useScopedUndoRedo = (): ScopedUndoRedo => {
     if (isStageEditor) {
       dispatch(draftRedo());
     } else {
-      dispatch(redo());
+      dispatch(redoWithNavigation());
     }
   }, [dispatch, isStageEditor]);
 

--- a/apps/architect-web/src/hooks/useStageEditorKeyboard.ts
+++ b/apps/architect-web/src/hooks/useStageEditorKeyboard.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+import { useAppDispatch } from '~/ducks/hooks';
+import { draftRedo, draftUndo } from '~/ducks/modules/stageEditorDraft';
+
+/**
+ * Registers a document-level keydown listener that maps the standard
+ * undo/redo shortcuts to the stage editor draft history while mounted.
+ *
+ * - Cmd/Ctrl+Z         -> undo
+ * - Cmd/Ctrl+Shift+Z   -> redo
+ * - Cmd/Ctrl+Y         -> redo
+ *
+ * Intended to be mounted inside the StageEditor component, so it is only
+ * active while the stage editor is on screen.
+ */
+export const useStageEditorKeyboard = (): void => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Slate RichText editors handle their own undo/redo and call
+      // preventDefault(); bailing on defaultPrevented/contenteditable keeps a
+      // single Cmd+Z from both editing rich text AND rewinding the draft.
+      if (e.defaultPrevented) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      if (e.isComposing) return; // don't swallow IME composition commits
+
+      const modifier = e.metaKey || e.ctrlKey;
+      if (!modifier) return;
+
+      if (e.code === 'KeyZ' && !e.shiftKey) {
+        e.preventDefault();
+        dispatch(draftUndo());
+        return;
+      }
+
+      if (e.code === 'KeyZ' && e.shiftKey) {
+        e.preventDefault();
+        dispatch(draftRedo());
+        return;
+      }
+
+      if (e.code === 'KeyY') {
+        e.preventDefault();
+        dispatch(draftRedo());
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [dispatch]);
+};

--- a/apps/architect-web/src/selectors/protocol.ts
+++ b/apps/architect-web/src/selectors/protocol.ts
@@ -82,18 +82,12 @@ export const getExperiments = (state: RootState) => {
 };
 
 // Timeline selector
-export const getTimelineLocus = (state: RootState) => {
-  // Check new activeProtocol store first
-  const activeProtocolTimeline = state.activeProtocol?.timeline;
-  if (activeProtocolTimeline?.length > 0) {
-    return activeProtocolTimeline[activeProtocolTimeline.length - 1];
-  }
-
-  // Fall back to old protocol store
-  const protocolTimeline = state.activeProtocol.timeline;
-
-  if (protocolTimeline && protocolTimeline.length > 0) {
-    return protocolTimeline[protocolTimeline.length - 1];
+export const getTimelineLocus = (state: RootState): string | null => {
+  // Timeline entries are now Locus objects ({ id, path }); return the id.
+  const timeline = state.activeProtocol?.timeline;
+  if (timeline && timeline.length > 0) {
+    const entry = timeline[timeline.length - 1];
+    return entry?.id ?? null;
   }
 
   return null;

--- a/apps/architect-web/src/selectors/protocol.ts
+++ b/apps/architect-web/src/selectors/protocol.ts
@@ -93,6 +93,20 @@ export const getTimelineLocus = (state: RootState): string | null => {
   return null;
 };
 
+// Path recorded on the entry that the next undo would revert (the locus of the
+// current present) and the next redo would reapply (the head of futureTimeline).
+export const getUndoTargetPath = (state: RootState): string => {
+  const timeline = state.activeProtocol?.timeline;
+  if (!timeline || timeline.length === 0) return '';
+  return timeline[timeline.length - 1]?.path ?? '';
+};
+
+export const getRedoTargetPath = (state: RootState): string => {
+  const futureTimeline = state.activeProtocol?.futureTimeline;
+  if (!futureTimeline || futureTimeline.length === 0) return '';
+  return futureTimeline[0]?.path ?? '';
+};
+
 // Undo/redo selectors
 export const getCanUndo = (state: RootState): boolean => {
   const past = state.activeProtocol?.past || [];

--- a/apps/architect-web/src/selectors/stageEditorDraft.ts
+++ b/apps/architect-web/src/selectors/stageEditorDraft.ts
@@ -1,0 +1,30 @@
+import { isEqual, omit } from 'es-toolkit/compat';
+import { getFormValues } from 'redux-form';
+
+import type { RootState } from '~/ducks/modules/root';
+
+export const getCanUndoDraft = (state: RootState): boolean =>
+  (state.stageEditorDraft.history.past?.length ?? 0) > 0;
+
+export const getCanRedoDraft = (state: RootState): boolean =>
+  (state.stageEditorDraft.history.future?.length ?? 0) > 0;
+
+export const getDraftRestoring = (state: RootState): boolean =>
+  state.stageEditorDraft.ui.restoring;
+
+export const getStageDraftDirty = (state: RootState): boolean => {
+  // Until the baseline is seeded, comparing populated values against {} would
+  // report dirty spuriously and flash the "Finished Editing" button on entry.
+  if (state.stageEditorDraft.ui.initialValues == null) return false;
+
+  const current = omit(
+    (getFormValues('edit-stage')(state) ?? {}) as Record<string, unknown>,
+    ['_modified'],
+  );
+  const initial = omit(
+    (state.stageEditorDraft.ui.initialValues ?? {}) as Record<string, unknown>,
+    ['_modified'],
+  );
+
+  return !isEqual(current, initial);
+};

--- a/apps/architect-web/src/utils/__tests__/timelineNavigation.test.ts
+++ b/apps/architect-web/src/utils/__tests__/timelineNavigation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTimelineNavTarget } from '../timelineNavigation';
+
+describe('resolveTimelineNavTarget', () => {
+  it('collapses stage editor paths to the stage list', () => {
+    expect(resolveTimelineNavTarget('/protocol/stage/stage-1')).toBe(
+      '/protocol',
+    );
+    expect(resolveTimelineNavTarget('/protocol/stage/new')).toBe('/protocol');
+  });
+
+  it('returns non-stage paths unchanged', () => {
+    expect(resolveTimelineNavTarget('/protocol/codebook')).toBe(
+      '/protocol/codebook',
+    );
+    expect(resolveTimelineNavTarget('/protocol/assets')).toBe(
+      '/protocol/assets',
+    );
+    expect(resolveTimelineNavTarget('/protocol')).toBe('/protocol');
+    expect(resolveTimelineNavTarget('')).toBe('');
+  });
+});

--- a/apps/architect-web/src/utils/timelineNavigation.ts
+++ b/apps/architect-web/src/utils/timelineNavigation.ts
@@ -1,0 +1,9 @@
+// Resolve a main-timeline entry's recorded `path` into the page the user should
+// be on to see that change undone/redone. Committed stage edits collapse to the
+// stage list (`/protocol`) rather than re-opening the editor, so the main
+// timeline and the stage editor's draft history never share a screen. Every
+// other path resolves to itself.
+const STAGE_PREFIX = '/protocol/stage/';
+
+export const resolveTimelineNavTarget = (path: string): string =>
+  path.startsWith(STAGE_PREFIX) ? '/protocol' : path;


### PR DESCRIPTION
Adds undo/redo inside the stage editor while you're mid-edit, and makes the main protocol timeline's undo/redo navigate you to changes made on other screens instead of reverting them silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped Undo/Redo with visible Undo/Redo controls and keyboard shortcuts (Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z or Cmd/Ctrl+Y).
  * Smarter undo/redo navigation that routes stage-related undos/redos to the stage list when appropriate.
  * More reliable unsaved-change tracking that resets on submit/cancel/confirm-leave.

* **Bug Fixes**
  * More reliable enable/disable state and behavior for undo/redo across editor and protocol views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/complexdatacollective/network-canvas-monorepo/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->