### PR TITLE
feat(interviewer-v7): add PostHog analytics with opt-out preference

### DIFF
--- a/apps/interviewer-v7/android/app/build.gradle
+++ b/apps/interviewer-v7/android/app/build.gradle
@@ -38,8 +38,9 @@ dependencies {
     implementation project(':capacitor-android')
     // PostHog Android SDK — native crash/error tracking. Honours the
     // analytics-enabled preference mirrored into Capacitor Preferences; see
-    // AnalyticsApplication. https://posthog.com/docs/error-tracking/installation/android
-    implementation "com.posthog:posthog-android:3.+"
+    // AnalyticsApplication. Version pinned in variables.gradle for reproducible
+    // builds. https://posthog.com/docs/error-tracking/installation/android
+    implementation "com.posthog:posthog-android:$posthogAndroidVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/apps/interviewer-v7/android/app/build.gradle
+++ b/apps/interviewer-v7/android/app/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
+    // PostHog Android SDK — native crash/error tracking. Honours the
+    // analytics-enabled preference mirrored into Capacitor Preferences; see
+    // AnalyticsApplication. https://posthog.com/docs/error-tracking/installation/android
+    implementation "com.posthog:posthog-android:3.+"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/apps/interviewer-v7/android/app/src/main/AndroidManifest.xml
+++ b/apps/interviewer-v7/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        android:name=".AnalyticsApplication"
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/apps/interviewer-v7/android/app/src/main/java/org/complexdatacollective/networkcanvas/interviewer/AnalyticsApplication.java
+++ b/apps/interviewer-v7/android/app/src/main/java/org/complexdatacollective/networkcanvas/interviewer/AnalyticsApplication.java
@@ -1,0 +1,48 @@
+package org.complexdatacollective.networkcanvas.interviewer;
+
+import android.app.Application;
+import android.content.SharedPreferences;
+
+import com.posthog.android.PostHogAndroid;
+import com.posthog.android.PostHogAndroidConfig;
+
+/**
+ * Initialises the PostHog Android SDK for native crash/error tracking.
+ *
+ * <p>The renderer (WebView) cannot call the native SDK directly, so it mirrors
+ * the user's analytics preference into Capacitor Preferences. On Android,
+ * Capacitor Preferences persists values in the {@code CapacitorStorage}
+ * SharedPreferences file, which we read here — before any web code runs — so
+ * the native SDK honours the same opt-out choice as the JS layer.
+ *
+ * <p>Because we read the flag at launch, toggling analytics in Settings takes
+ * effect for native error capture on the next app start. No participant data is
+ * ever captured: screen views, autocapture, and session replay are all
+ * disabled, leaving only crash/error reports keyed to the anonymous
+ * installation id.
+ *
+ * @see <a href="https://posthog.com/docs/error-tracking/installation/android">PostHog Android error tracking</a>
+ */
+public class AnalyticsApplication extends Application {
+    private static final String POSTHOG_API_KEY =
+            "phc_OThPUolJumHmf142W78TKWtjoYYAxGlF0ZZmhcV7J3c";
+    private static final String POSTHOG_HOST = "https://ph-relay.networkcanvas.com";
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        SharedPreferences prefs = getSharedPreferences("CapacitorStorage", MODE_PRIVATE);
+        // Default to enabled (matches StoredSettings.analyticsEnabled) until the
+        // renderer has written a value.
+        boolean analyticsEnabled = !"false".equals(prefs.getString("analytics_enabled", "true"));
+
+        PostHogAndroidConfig config = new PostHogAndroidConfig(POSTHOG_API_KEY, POSTHOG_HOST);
+        config.setCaptureScreenViews(false);
+        config.setCaptureDeepLinks(false);
+        config.setSessionReplay(false);
+        config.setOptOut(!analyticsEnabled);
+
+        PostHogAndroid.Companion.setup(this, config);
+    }
+}

--- a/apps/interviewer-v7/android/variables.gradle
+++ b/apps/interviewer-v7/android/variables.gradle
@@ -13,4 +13,7 @@ ext {
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'
     cordovaAndroidVersion = '10.1.1'
+    // Pinned for reproducible native builds. Confirm against the latest 3.x
+    // release (and its error-tracking API) when bumping.
+    posthogAndroidVersion = '3.11.1'
 }

--- a/apps/interviewer-v7/docs/analytics.md
+++ b/apps/interviewer-v7/docs/analytics.md
@@ -1,0 +1,93 @@
+# Analytics
+
+Interviewer v7 sends **anonymous, opt-out** usage and error telemetry to the
+Codaco-managed PostHog project, mirroring the approach used by Fresco and the
+`@codaco/interview` engine. This document describes what is collected, how the
+user controls it, and how the preference reaches the native mobile SDKs.
+
+## Principles
+
+- **No participant data, ever.** Network data, interview responses, case IDs,
+  protocol contents, and asset files never leave the device.
+- **No user-identifiable data.** Events are associated only with a random
+  per-device installation id (`installationId.ts`). The single-user invariant
+  holds: `installationId` identifies the device, not a user.
+- **Opt-out, defaults on.** `StoredSettings.analyticsEnabled` defaults to
+  `true`. Existing installs inherit the default because both the Dexie and
+  SQLCipher settings backends merge `DEFAULT_SETTINGS` over stored rows.
+- **Telemetry never breaks the app.** Client init, tracking, and exception
+  capture all swallow errors.
+
+## Where the preference lives
+
+`StoredSettings.analyticsEnabled` (in `src/lib/db/types.ts`) is the source of
+truth. It is editable in two places:
+
+- **Onboarding wizard** — `SetupWizard/Step5Analytics.tsx` ("Help improve the
+  app"), persisted on finish by `SetupWizardDialog.tsx`.
+- **Settings → Privacy** — `SettingsDialog.tsx`, applied immediately.
+
+Both routes go through `AnalyticsProvider.setEnabled()`, which:
+
+1. persists `analyticsEnabled` via `updateSettings`,
+2. opts the shared posthog-js client in or out, and
+3. mirrors the flag into Capacitor Preferences for the native SDKs.
+
+## Web / JS layer
+
+`src/lib/analytics/`:
+
+- `config.ts` — API key, proxy host, instance name, native pref key.
+- `client.ts` — lazily-initialised singleton posthog-js client. Autocapture,
+  page views, and session replay are off; `capture_exceptions` is on so
+  uncaught JS errors and unhandled rejections are reported.
+- `AnalyticsProvider.tsx` — React context exposing `enabled`, `client`,
+  `setEnabled`, `track`, and `captureException`. Registers anonymous super
+  properties (`app`, `installation_id`, `host_version`) and identifies by
+  installation id.
+
+The same client is passed into the `@codaco/interview` `Shell`
+(`routes/Interview.tsx`) via `posthogClient`, with `disableAnalytics` bound to
+the inverse of the preference, so the engine's built-in events share one client
+and one opt-out switch.
+
+`AppErrorBoundary.tsx` reports React render errors (which PostHog's uncaught
+handler does not see) through `captureException`.
+
+### App-level events
+
+| Event                     | Where                 | Properties (anonymous)                                            |
+| ------------------------- | --------------------- | ----------------------------------------------------------------- |
+| `protocol_installed`      | `routes/Home.tsx`     | `source`, `migrated`, `protocol_hash`                             |
+| `protocol_install_failed` | `routes/Home.tsx`     | `source`, `reason`                                                |
+| `data_exported`           | `components/DataView` | `interview_count`, `failed_count`, `export_graphml`, `export_csv` |
+
+Interview-engine events (stage navigation, node/edge mutations, form
+interactions, etc.) are emitted by `@codaco/interview` itself.
+
+## Native mobile (Capacitor) error tracking
+
+The renderer runs in a WebView and cannot call the native PostHog SDKs, so the
+preference is mirrored into Capacitor Preferences
+(`writeNativeAnalyticsPreference`) under key `analytics_enabled`:
+
+- **iOS** — `UserDefaults`, key `CapacitorStorage.analytics_enabled`. Read in
+  `ios/App/App/AppDelegate.swift`, which initialises `PostHogSDK` with
+  `optOut` set from the flag. Pod added in `ios/App/Podfile`.
+- **Android** — `CapacitorStorage` SharedPreferences, key `analytics_enabled`.
+  Read in `AnalyticsApplication.java`, which calls `PostHogAndroid.setup` with
+  `optOut` set from the flag. Dependency added in `android/app/build.gradle` and
+  the `Application` registered in `AndroidManifest.xml`.
+
+Because the flag is read at launch, toggling analytics in Settings takes effect
+for **native** crash/error capture on the next app start (the JS layer reacts
+immediately). Screen views, autocapture, and session replay are disabled on both
+platforms, so native telemetry is limited to crash/error reports keyed to the
+anonymous installation id.
+
+> **Build note:** the native changes (Podfile, Gradle, `AppDelegate.swift`,
+> `AnalyticsApplication.java`, manifest) require the iOS/Android toolchains to
+> compile and were not built in CI for this change. Run `pnpm capacitor:sync`
+> followed by a native build (`pnpm capacitor:run:ios` /
+> `pnpm capacitor:run:android`) to verify, and confirm the exact PostHog SDK
+> setup signatures against the linked docs for the resolved SDK versions.

--- a/apps/interviewer-v7/ios/App/App/AppDelegate.swift
+++ b/apps/interviewer-v7/ios/App/App/AppDelegate.swift
@@ -1,14 +1,48 @@
 import UIKit
 import Capacitor
+import PostHog
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
+    // PostHog API key + proxy host, matching the JS layer and Android.
+    private let posthogApiKey = "phc_OThPUolJumHmf142W78TKWtjoYYAxGlF0ZZmhcV7J3c"
+    private let posthogHost = "https://ph-relay.networkcanvas.com"
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        setUpAnalytics()
         return true
+    }
+
+    // Initialises the PostHog iOS SDK for native crash/error tracking.
+    //
+    // The renderer (WebView) cannot call the native SDK directly, so it mirrors
+    // the user's analytics preference into Capacitor Preferences. On iOS,
+    // Capacitor Preferences stores values in UserDefaults with the key prefixed
+    // by its group, so the flag lives at "CapacitorStorage.analytics_enabled".
+    // We read it here — before any web code runs — so the native SDK honours the
+    // same opt-out choice as the JS layer. A toggle therefore takes effect for
+    // native error capture on the next launch.
+    //
+    // No participant data is ever captured: screen views, app-lifecycle
+    // autocapture, and session replay are all disabled, leaving only
+    // crash/error reports keyed to the anonymous installation id.
+    // https://posthog.com/docs/error-tracking/installation/ios
+    private func setUpAnalytics() {
+        // Default to enabled (matches StoredSettings.analyticsEnabled) until the
+        // renderer has written a value.
+        let stored = UserDefaults.standard.string(forKey: "CapacitorStorage.analytics_enabled")
+        let analyticsEnabled = stored != "false"
+
+        let config = PostHogConfig(apiKey: posthogApiKey, host: posthogHost)
+        config.captureScreenViews = false
+        config.captureApplicationLifecycleEvents = false
+        config.sessionReplay = false
+        config.optOut = !analyticsEnabled
+
+        PostHogSDK.shared.setup(config)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/apps/interviewer-v7/ios/App/Podfile
+++ b/apps/interviewer-v7/ios/App/Podfile
@@ -19,7 +19,10 @@ end
 
 target 'App' do
   capacitor_pods
-  # Add your Pods here
+  # PostHog iOS SDK — native crash/error tracking. Honours the analytics
+  # preference mirrored into Capacitor Preferences (read in AppDelegate).
+  # https://posthog.com/docs/error-tracking/installation/ios
+  pod 'PostHog', '~> 3.0'
 end
 
 post_install do |installer|

--- a/apps/interviewer-v7/package.json
+++ b/apps/interviewer-v7/package.json
@@ -73,6 +73,7 @@
     "jszip": "^3.10.1",
     "lucide-react": "catalog:",
     "motion": "catalog:",
+    "posthog-js": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "swiper": "^12.2.0",

--- a/apps/interviewer-v7/src/App.tsx
+++ b/apps/interviewer-v7/src/App.tsx
@@ -4,6 +4,7 @@ import { Route, Switch, useLocation } from 'wouter';
 import { BackgroundBlobs } from '@codaco/art';
 import { ThemedRegion } from '@codaco/fresco-ui/ThemedRegion';
 
+import { AppErrorBoundary } from './components/AppErrorBoundary';
 import { AuthGate } from './components/AuthGate';
 import { isElectron } from './lib/platform/platform';
 import { AppProviders } from './providers/AppProviders';
@@ -33,54 +34,58 @@ export default function App() {
 
   return (
     <AppProviders>
-      <ThemedRegion theme="interview" className="isolate">
-        {isElectron && (
-          <div
-            aria-hidden
-            className="app-drag fixed inset-x-0 top-0 z-50 h-8"
-          />
-        )}
-        <motion.div
-          className="fixed inset-0 -z-10 blur-[10rem]"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.8 }}
-          transition={{ duration: 2 }}
-        >
-          <BackgroundBlobs
-            large={0}
-            medium={4}
-            small={0}
-            compositeOperation="color-dodge"
-          />
-        </motion.div>
-        <AuthGate>
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={pageKeyFor(location)}
-              variants={pageWrapperVariants}
-              initial="hidden"
-              animate="visible"
-              exit="exit"
-            >
-              <Switch location={location}>
-                <Route path="/welcome" component={WelcomeRoute} />
-                <Route path="/interview/:sessionId">
-                  {({ sessionId }) => <InterviewRoute sessionId={sessionId} />}
-                </Route>
-                <Route path="/:view?">
-                  {(params) => {
-                    if (params.view !== undefined && params.view !== 'data') {
-                      return <NotFoundRoute />;
-                    }
-                    return <HomeRoute />;
-                  }}
-                </Route>
-                <Route component={NotFoundRoute} />
-              </Switch>
-            </motion.div>
-          </AnimatePresence>
-        </AuthGate>
-      </ThemedRegion>
+      <AppErrorBoundary>
+        <ThemedRegion theme="interview" className="isolate">
+          {isElectron && (
+            <div
+              aria-hidden
+              className="app-drag fixed inset-x-0 top-0 z-50 h-8"
+            />
+          )}
+          <motion.div
+            className="fixed inset-0 -z-10 blur-[10rem]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.8 }}
+            transition={{ duration: 2 }}
+          >
+            <BackgroundBlobs
+              large={0}
+              medium={4}
+              small={0}
+              compositeOperation="color-dodge"
+            />
+          </motion.div>
+          <AuthGate>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={pageKeyFor(location)}
+                variants={pageWrapperVariants}
+                initial="hidden"
+                animate="visible"
+                exit="exit"
+              >
+                <Switch location={location}>
+                  <Route path="/welcome" component={WelcomeRoute} />
+                  <Route path="/interview/:sessionId">
+                    {({ sessionId }) => (
+                      <InterviewRoute sessionId={sessionId} />
+                    )}
+                  </Route>
+                  <Route path="/:view?">
+                    {(params) => {
+                      if (params.view !== undefined && params.view !== 'data') {
+                        return <NotFoundRoute />;
+                      }
+                      return <HomeRoute />;
+                    }}
+                  </Route>
+                  <Route component={NotFoundRoute} />
+                </Switch>
+              </motion.div>
+            </AnimatePresence>
+          </AuthGate>
+        </ThemedRegion>
+      </AppErrorBoundary>
     </AppProviders>
   );
 }

--- a/apps/interviewer-v7/src/components/AppErrorBoundary.tsx
+++ b/apps/interviewer-v7/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+import Button from '@codaco/fresco-ui/Button';
+import Surface from '@codaco/fresco-ui/layout/Surface';
+import Heading from '@codaco/fresco-ui/typography/Heading';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
+
+type Props = {
+  children: ReactNode;
+  onError: (error: Error, info: ErrorInfo) => void;
+};
+
+type State = { hasError: boolean };
+
+// posthog-js `capture_exceptions` catches uncaught errors and unhandled
+// rejections, but React swallows render errors at the nearest boundary, so we
+// add one here to both report those to PostHog and show a recoverable fallback.
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError(error, info);
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div className="bg-background flex h-dvh items-center justify-center p-8">
+        <Surface
+          level={1}
+          spacing="lg"
+          shadow="lg"
+          className="flex max-w-lg flex-col items-center gap-4 text-center"
+        >
+          <Heading level="h1">Something went wrong</Heading>
+          <Paragraph>
+            The app hit an unexpected error. Your collected data is saved on
+            this device and is not affected. Try reloading to continue.
+          </Paragraph>
+          <Button onClick={() => window.location.reload()}>Reload</Button>
+        </Surface>
+      </div>
+    );
+  }
+}
+
+export function AppErrorBoundary({ children }: { children: ReactNode }) {
+  const analytics = useAnalytics();
+  return (
+    <ErrorBoundary
+      onError={(error, info) =>
+        analytics.captureException(error, {
+          feature: 'react-error-boundary',
+          component_stack: info.componentStack,
+        })
+      }
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/interviewer-v7/src/components/DataView.tsx
+++ b/apps/interviewer-v7/src/components/DataView.tsx
@@ -36,6 +36,7 @@ import {
 import ProgressBar from '@codaco/fresco-ui/ProgressBar';
 import TimeAgo from '@codaco/fresco-ui/TimeAgo';
 import { useToast } from '@codaco/fresco-ui/Toast';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import { useStepUpAuth } from '~/lib/auth/StepUpAuthProvider';
 import {
   deleteSessions,
@@ -308,6 +309,7 @@ export function DataView({ protocols, onReload }: DataViewProps) {
 
   const toast = useToast();
   const dialog = useDialog();
+  const analytics = useAnalytics();
   const { requireFreshUnlock } = useStepUpAuth();
   const [, navigate] = useLocation();
   const [selection, setSelection] = useState<Selection>({ mode: 'none' });
@@ -726,6 +728,13 @@ export function DataView({ protocols, onReload }: DataViewProps) {
       await markSessionsExported(
         result.successfulExports.map((s) => s.sessionId),
       );
+      // Counts only — never session contents, case IDs, or file names.
+      analytics.track('data_exported', {
+        interview_count: result.successfulExports.length,
+        failed_count: result.failedExports.length,
+        export_graphml: settings.exportGraphML,
+        export_csv: settings.exportCSV,
+      });
       if (result.failedExports.length > 0) {
         toast.add({
           title: 'Export completed with errors',
@@ -742,6 +751,7 @@ export function DataView({ protocols, onReload }: DataViewProps) {
       setSelection({ mode: 'none' });
       await Promise.all([onReload(), reloadData()]);
     } catch (cause) {
+      analytics.captureException(cause, { feature: 'export' });
       toast.add({
         title: 'Export failed',
         description: cause instanceof Error ? cause.message : String(cause),
@@ -751,6 +761,7 @@ export function DataView({ protocols, onReload }: DataViewProps) {
       setExporting(false);
     }
   }, [
+    analytics,
     exporting,
     onReload,
     reloadData,

--- a/apps/interviewer-v7/src/components/SettingsDialog.tsx
+++ b/apps/interviewer-v7/src/components/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import {
   FlaskConical,
   Info,
+  LineChart,
   Shield,
   Trash2,
   Upload as UploadIcon,
@@ -28,6 +29,7 @@ import SecurityBehaviorControls, {
   type Behavior,
 } from '~/components/SecurityBehaviorControls';
 import { SettingsRow } from '~/components/SettingsRow';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import { useAuth } from '~/lib/auth/AuthContext';
 import {
   countSyntheticSessions,
@@ -52,7 +54,7 @@ type SettingsDialogProps = {
   onClose: () => void;
 };
 
-type Section = 'about' | 'data' | 'security' | 'synthetic';
+type Section = 'about' | 'data' | 'privacy' | 'security' | 'synthetic';
 
 const NAV_BUTTON_BASE =
   'flex w-full items-center gap-3 px-4 py-3 border-0 rounded-[var(--radius-pill)] font-heading font-extrabold text-sm text-left cursor-pointer';
@@ -72,12 +74,14 @@ function StorageProgress({ value }: { value: number }) {
 const NAV_ITEMS: { id: Section; label: string; icon: typeof Info }[] = [
   { id: 'about', label: 'About', icon: Info },
   { id: 'data', label: 'Data export', icon: UploadIcon },
+  { id: 'privacy', label: 'Privacy', icon: LineChart },
   { id: 'security', label: 'Security', icon: Shield },
   { id: 'synthetic', label: 'Synthetic data', icon: FlaskConical },
 ];
 
 export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const auth = useAuth();
+  const analytics = useAnalytics();
   const toast = useToast();
   const { confirm } = useDialog();
   const [section, setSection] = useState<Section>('about');
@@ -394,6 +398,48 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
                   }
                 }}
               />
+            </>
+          ) : null}
+
+          {section === 'privacy' ? (
+            <>
+              <UnconnectedField
+                name="analyticsEnabled"
+                label="Enable analytics"
+                hint="Send anonymous usage and error data to help the Network Canvas team improve the app."
+                inline
+                component={ToggleField}
+                value={analytics.enabled}
+                onChange={(next: boolean | undefined) =>
+                  void analytics.setEnabled(next === true)
+                }
+              />
+              <Paragraph intent="smallText" emphasis="muted">
+                When analytics are enabled, the app sends a small amount of
+                anonymous information about how it is used — for example which
+                interview stages and features are exercised, when protocols are
+                imported, when data is exported, and details of any errors or
+                crashes. This helps us find bugs and decide what to improve.
+              </Paragraph>
+              <Alert variant="info">
+                <strong>No participant data is ever collected.</strong> Network
+                data, responses, case IDs, protocol contents, and asset files
+                never leave this device. Analytics also contain no
+                user-identifiable information: events are associated only with a
+                random per-device installation ID
+                {installationId ? (
+                  <>
+                    {' '}
+                    (
+                    <span className="font-monospace text-xs">
+                      {installationId}
+                    </span>
+                    )
+                  </>
+                ) : null}
+                , never your name, email, or any account. You can turn analytics
+                off at any time, and the change applies immediately.
+              </Alert>
             </>
           ) : null}
 

--- a/apps/interviewer-v7/src/components/SetupWizard/Step4Behavior.tsx
+++ b/apps/interviewer-v7/src/components/SetupWizard/Step4Behavior.tsx
@@ -48,11 +48,8 @@ export default function Step4Behavior() {
 
   useEffect(() => {
     wizard.setNextEnabled(true);
-    wizard.setNextLabel('Finish');
+    wizard.setNextLabel('Continue');
     wizard.setBeforeNext(null);
-    return () => {
-      wizard.setNextLabel('Continue');
-    };
   }, [wizard]);
 
   return (

--- a/apps/interviewer-v7/src/components/SetupWizard/Step5Analytics.tsx
+++ b/apps/interviewer-v7/src/components/SetupWizard/Step5Analytics.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+
+import { Alert, AlertDescription, AlertTitle } from '@codaco/fresco-ui/Alert';
+import { useWizard } from '@codaco/fresco-ui/dialogs/useWizard';
+import UnconnectedField from '@codaco/fresco-ui/form/Field/UnconnectedField';
+import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+
+// Analytics defaults to on. The wizard reads `data.analyticsEnabled`; an
+// undefined value (the user never touched the toggle) is treated as enabled.
+function asAnalyticsEnabled(value: unknown): boolean {
+  return typeof value === 'boolean' ? value : true;
+}
+
+export default function Step5Analytics() {
+  const wizard = useWizard();
+  const enabled = asAnalyticsEnabled(wizard.data.analyticsEnabled);
+
+  useEffect(() => {
+    wizard.setNextEnabled(true);
+    wizard.setNextLabel('Finish');
+    wizard.setBeforeNext(null);
+    return () => {
+      wizard.setNextLabel('Continue');
+    };
+  }, [wizard]);
+
+  return (
+    <>
+      <Paragraph>
+        You can help us improve Network Canvas Interviewer by sending anonymous
+        usage and error data. This tells us which features are used, when
+        protocols are imported or data is exported, and details of any errors or
+        crashes — so we can fix bugs and decide what to build next.
+      </Paragraph>
+      <UnconnectedField
+        name="analyticsEnabled"
+        label="Send anonymous analytics"
+        inline
+        component={ToggleField}
+        value={enabled}
+        onChange={(next: boolean | undefined) =>
+          wizard.setStepData({ analyticsEnabled: next === true })
+        }
+      />
+      <Alert variant="info">
+        <AlertTitle>No participant or personal data is collected</AlertTitle>
+        <AlertDescription>
+          Network data, interview responses, case IDs, protocol contents, and
+          asset files never leave this device. Analytics contain no
+          user-identifiable information — events are tied only to a random
+          per-device installation ID, never your name, email, or any account.
+          You can change this any time in Settings → Privacy.
+        </AlertDescription>
+      </Alert>
+    </>
+  );
+}

--- a/apps/interviewer-v7/src/components/SetupWizardDialog.tsx
+++ b/apps/interviewer-v7/src/components/SetupWizardDialog.tsx
@@ -1,4 +1,5 @@
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import * as authApi from '~/lib/auth/api';
 import { useAuth } from '~/lib/auth/AuthContext';
 import type { IdleTimeoutMinutes } from '~/lib/auth/AuthContext';
@@ -9,6 +10,7 @@ import Step1Intro from './SetupWizard/Step1Intro';
 import Step2MethodPicker from './SetupWizard/Step2MethodPicker';
 import Step3Configure from './SetupWizard/Step3Configure';
 import Step4Behavior from './SetupWizard/Step4Behavior';
+import Step5Analytics from './SetupWizard/Step5Analytics';
 
 export type WizardSelectedMethod = 'biometric' | 'pin' | 'passphrase';
 
@@ -21,6 +23,8 @@ export type SetupWizardData = {
     requireUnlockOnExit: boolean;
     requireUnlockOnExport: boolean;
   };
+  // Undefined when the user never touched the toggle — defaults to enabled.
+  analyticsEnabled?: boolean;
 };
 
 const DEFAULT_BEHAVIOR: SetupWizardData['behavior'] = {
@@ -33,6 +37,7 @@ const DEFAULT_BEHAVIOR: SetupWizardData['behavior'] = {
 export function useSetupWizard() {
   const { openDialog } = useDialog();
   const { refresh } = useAuth();
+  const analytics = useAnalytics();
 
   const openSetupWizard = async (): Promise<void> => {
     const result = await openDialog({
@@ -64,6 +69,11 @@ export function useSetupWizard() {
           title: 'Lock behavior',
           description: 'Decide when the app re-locks.',
           content: Step4Behavior,
+        },
+        {
+          title: 'Help improve the app',
+          description: 'Optional anonymous analytics.',
+          content: Step5Analytics,
           nextLabel: 'Finish',
         },
       ],
@@ -86,6 +96,10 @@ export function useSetupWizard() {
         requireUnlockOnExit: behavior.requireUnlockOnExit,
         requireUnlockOnExport: behavior.requireUnlockOnExport,
       });
+      // Persist + apply the analytics choice (defaults to enabled). Routes
+      // through the provider so opt-in/out and the native preference mirror
+      // take effect immediately.
+      await analytics.setEnabled(data.analyticsEnabled ?? true);
     }
 
     await refresh();

--- a/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
+++ b/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
@@ -1,0 +1,157 @@
+import type { PostHog } from 'posthog-js';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { useAuth } from '~/lib/auth/AuthContext';
+import { getSettings, updateSettings } from '~/lib/db/api';
+import { APP_VERSION } from '~/lib/platform/appVersion';
+import { getInstallationId } from '~/lib/platform/installationId';
+import { hostAppName } from '~/lib/platform/platform';
+
+import { getAnalyticsClient } from './client';
+import { writeNativeAnalyticsPreference } from './nativePreference';
+
+export type AnalyticsContextValue = {
+  // Current opt-in state, sourced from StoredSettings.analyticsEnabled.
+  enabled: boolean;
+  // The shared posthog-js client, or null if it failed to load. Passed to the
+  // `@codaco/interview` Shell so interview-engine events use the same instance.
+  client: PostHog | null;
+  // Persist a new preference and apply it immediately (opt in/out + native).
+  setEnabled: (enabled: boolean) => Promise<void>;
+  // App-level event tracking. No-ops when disabled or the client is missing.
+  track: (event: string, properties?: Record<string, unknown>) => void;
+  // App-level error reporting. No-ops when disabled or the client is missing.
+  captureException: (
+    error: unknown,
+    properties?: Record<string, unknown>,
+  ) => void;
+};
+
+const NOOP_CONTEXT: AnalyticsContextValue = {
+  enabled: false,
+  client: null,
+  setEnabled: async () => {},
+  track: () => {},
+  captureException: () => {},
+};
+
+const AnalyticsContext = createContext<AnalyticsContextValue>(NOOP_CONTEXT);
+
+// Super properties attached to every app-level event. Keys are snake_case to
+// match the `@codaco/interview` package so app and interview events share a
+// consistent schema in PostHog. Crucially, this is anonymous and per-device:
+// `installation_id` identifies the installation, never a user or participant.
+function registerSuperProperties(client: PostHog) {
+  client.register({
+    app: hostAppName,
+    installation_id: getInstallationId(),
+    host_version: APP_VERSION,
+  });
+}
+
+// Apply the preference to the live client: register identity + super props and
+// opt in, or opt out so nothing is sent.
+function applyPreference(client: PostHog, enabled: boolean) {
+  if (enabled) {
+    registerSuperProperties(client);
+    client.identify(getInstallationId());
+    client.opt_in_capturing();
+  } else {
+    client.opt_out_capturing();
+  }
+}
+
+export function AnalyticsProvider({ children }: { children: ReactNode }) {
+  const { kind } = useAuth();
+  const [enabled, setEnabledState] = useState(false);
+  const clientRef = useRef<PostHog | null>(null);
+  const [client, setClient] = useState<PostHog | null>(null);
+
+  // Load the stored preference once the app is unlocked, then initialise the
+  // client and apply. Reading settings is DB-backed; on Electron the SQLCipher
+  // database is only open after unlock, so we must wait for that. Analytics
+  // stays opted out (the safe default) until then. Re-runs on a lock/unlock
+  // cycle are idempotent.
+  useEffect(() => {
+    if (kind !== 'unlocked') return;
+    let active = true;
+    const init = async () => {
+      try {
+        const [settings, resolved] = await Promise.all([
+          getSettings(),
+          getAnalyticsClient(),
+        ]);
+        if (!active) return;
+        clientRef.current = resolved;
+        setClient(resolved);
+        setEnabledState(settings.analyticsEnabled);
+        if (resolved) applyPreference(resolved, settings.analyticsEnabled);
+        void writeNativeAnalyticsPreference(settings.analyticsEnabled);
+      } catch {
+        // Never let telemetry setup break the app.
+      }
+    };
+    void init();
+    return () => {
+      active = false;
+    };
+  }, [kind]);
+
+  const setEnabled = useCallback(async (next: boolean) => {
+    await updateSettings({ analyticsEnabled: next });
+    setEnabledState(next);
+    if (clientRef.current) applyPreference(clientRef.current, next);
+    await writeNativeAnalyticsPreference(next);
+  }, []);
+
+  const track = useCallback(
+    (event: string, properties?: Record<string, unknown>) => {
+      const c = clientRef.current;
+      if (!c || !enabled) return;
+      try {
+        c.capture(event, properties);
+      } catch {
+        // Telemetry never throws.
+      }
+    },
+    [enabled],
+  );
+
+  const captureException = useCallback(
+    (error: unknown, properties?: Record<string, unknown>) => {
+      const c = clientRef.current;
+      if (!c || !enabled) return;
+      try {
+        const err = error instanceof Error ? error : new Error(String(error));
+        c.captureException(err, properties);
+      } catch {
+        // Telemetry never throws.
+      }
+    },
+    [enabled],
+  );
+
+  const value = useMemo<AnalyticsContextValue>(
+    () => ({ enabled, client, setEnabled, track, captureException }),
+    [enabled, client, setEnabled, track, captureException],
+  );
+
+  return (
+    <AnalyticsContext.Provider value={value}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export function useAnalytics(): AnalyticsContextValue {
+  return useContext(AnalyticsContext);
+}

--- a/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
+++ b/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
@@ -107,10 +107,18 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   }, [kind]);
 
   const setEnabled = useCallback(async (next: boolean) => {
-    await updateSettings({ analyticsEnabled: next });
+    // Reflect the choice in the UI immediately, then persist + apply. Callers
+    // often `void` this, so the promise must never reject: a DB/IPC failure in
+    // updateSettings or a misbehaving client must not surface as an unhandled
+    // rejection (telemetry must never break the app).
     setEnabledState(next);
-    if (clientRef.current) applyPreference(clientRef.current, next);
-    await writeNativeAnalyticsPreference(next);
+    try {
+      await updateSettings({ analyticsEnabled: next });
+      if (clientRef.current) applyPreference(clientRef.current, next);
+      await writeNativeAnalyticsPreference(next);
+    } catch {
+      // Swallow — the in-memory preference still took effect above.
+    }
   }, []);
 
   const track = useCallback(

--- a/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
+++ b/apps/interviewer-v7/src/lib/analytics/AnalyticsProvider.tsx
@@ -75,6 +75,10 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   const [enabled, setEnabledState] = useState(false);
   const clientRef = useRef<PostHog | null>(null);
   const [client, setClient] = useState<PostHog | null>(null);
+  // Bumped on every explicit user toggle. The async init() captures this at
+  // start and bails if it changed, so a slow settings load can't clobber a
+  // newer user choice that landed while it was in flight.
+  const preferenceRevisionRef = useRef(0);
 
   // Load the stored preference once the app is unlocked, then initialise the
   // client and apply. Reading settings is DB-backed; on Electron the SQLCipher
@@ -84,13 +88,17 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (kind !== 'unlocked') return;
     let active = true;
+    const revisionAtStart = preferenceRevisionRef.current;
     const init = async () => {
       try {
         const [settings, resolved] = await Promise.all([
           getSettings(),
           getAnalyticsClient(),
         ]);
-        if (!active) return;
+        // Bail if torn down, or if the user toggled while we were loading —
+        // their choice (already applied by setEnabled) must win.
+        if (!active || revisionAtStart !== preferenceRevisionRef.current)
+          return;
         clientRef.current = resolved;
         setClient(resolved);
         setEnabledState(settings.analyticsEnabled);
@@ -111,6 +119,7 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
     // often `void` this, so the promise must never reject: a DB/IPC failure in
     // updateSettings or a misbehaving client must not surface as an unhandled
     // rejection (telemetry must never break the app).
+    preferenceRevisionRef.current += 1;
     setEnabledState(next);
     try {
       await updateSettings({ analyticsEnabled: next });

--- a/apps/interviewer-v7/src/lib/analytics/client.ts
+++ b/apps/interviewer-v7/src/lib/analytics/client.ts
@@ -1,0 +1,46 @@
+import type { PostHog } from 'posthog-js';
+
+import { POSTHOG_API_KEY, POSTHOG_HOST, POSTHOG_INSTANCE_NAME } from './config';
+
+// Single lazily-initialised posthog-js client shared by the app and (via the
+// AnalyticsProvider) the `@codaco/interview` Shell. Initialisation is async
+// because posthog-js is dynamically imported to keep it out of the initial
+// bundle and so a failure to load never breaks app startup.
+let clientPromise: Promise<PostHog | null> | null = null;
+
+export function getAnalyticsClient(): Promise<PostHog | null> {
+  clientPromise ??= initClient();
+  return clientPromise;
+}
+
+async function initClient(): Promise<PostHog | null> {
+  try {
+    const { default: posthog } = await import('posthog-js');
+    return posthog.init(
+      POSTHOG_API_KEY,
+      {
+        api_host: POSTHOG_HOST,
+        // This is a research-data-collection app, not a website: never capture
+        // DOM interactions, page views, or session recordings, any of which
+        // could incidentally include participant data on screen.
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        disable_session_recording: true,
+        // Autocapture *uncaught* exceptions and unhandled rejections for error
+        // tracking. These carry stack traces only, never network/participant
+        // data.
+        capture_exceptions: true,
+        // Persist opt-in/opt-out state across launches.
+        persistence: 'localStorage',
+        // Respect the stored preference: start opted out and let the
+        // AnalyticsProvider opt in once it has read the setting.
+        opt_out_capturing_by_default: true,
+      },
+      POSTHOG_INSTANCE_NAME,
+    );
+  } catch {
+    // Telemetry must never break the app. Swallow and run without analytics.
+    return null;
+  }
+}

--- a/apps/interviewer-v7/src/lib/analytics/config.ts
+++ b/apps/interviewer-v7/src/lib/analytics/config.ts
@@ -1,0 +1,21 @@
+// PostHog configuration for Interviewer v7.
+//
+// These mirror the values used by the `@codaco/interview` package and the
+// Fresco app so that app-level events and interview-engine events land in the
+// same Codaco-managed PostHog project, behind the same proxy host. The proxy
+// (https://ph-relay.networkcanvas.com) is a Cloudflare Worker that forwards to
+// PostHog so the app never talks to a third-party domain directly.
+export const POSTHOG_API_KEY =
+  'phc_OThPUolJumHmf142W78TKWtjoYYAxGlF0ZZmhcV7J3c';
+export const POSTHOG_HOST = 'https://ph-relay.networkcanvas.com';
+
+// Distinct instance name so this app's posthog-js client never collides with
+// the one the `@codaco/interview` Shell may lazily create for itself. We pass
+// our client into the Shell explicitly, so in practice only this instance runs.
+export const POSTHOG_INSTANCE_NAME = 'interviewer-v7';
+
+// Key under which the analytics-enabled flag is mirrored into Capacitor
+// Preferences (UserDefaults on iOS, SharedPreferences on Android) so the native
+// crash/error SDKs can read the user's preference at launch. See
+// docs/analytics.md and the native AppDelegate / Application classes.
+export const NATIVE_ANALYTICS_PREF_KEY = 'analytics_enabled';

--- a/apps/interviewer-v7/src/lib/analytics/nativePreference.ts
+++ b/apps/interviewer-v7/src/lib/analytics/nativePreference.ts
@@ -1,0 +1,27 @@
+import { isCapacitor } from '../platform/platform';
+import { NATIVE_ANALYTICS_PREF_KEY } from './config';
+
+// Mirrors the analytics-enabled flag into Capacitor Preferences so the native
+// iOS/Android crash + error SDKs can honour the user's choice at launch. The
+// renderer (WebView) cannot call the native PostHog SDK directly, so we persist
+// the preference where native code can read it:
+//   - iOS:     UserDefaults, key "CapacitorStorage.analytics_enabled"
+//   - Android: SharedPreferences file "CapacitorStorage", key "analytics_enabled"
+// Native init reads this value (see ios/App/App/AppDelegate.swift and
+// android/.../AnalyticsApplication.kt). A toggle therefore takes effect for
+// native error capture on the next app launch.
+export async function writeNativeAnalyticsPreference(
+  enabled: boolean,
+): Promise<void> {
+  if (!isCapacitor) return;
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    await Preferences.set({
+      key: NATIVE_ANALYTICS_PREF_KEY,
+      value: enabled ? 'true' : 'false',
+    });
+  } catch {
+    // Best effort — a failure here only affects native crash capture, never
+    // the JS-side preference, which is the source of truth.
+  }
+}

--- a/apps/interviewer-v7/src/lib/db/types.ts
+++ b/apps/interviewer-v7/src/lib/db/types.ts
@@ -119,6 +119,10 @@ export type StoredSettings = {
   requireUnlockOnExit: boolean;
   requireUnlockOnExport: boolean;
   sampleProtocolDismissed: boolean;
+  // Opt-out analytics. Defaults to true; when false, no anonymous usage or
+  // error telemetry is sent. Never carries participant data or a user
+  // identifier — only the per-device installation id (see installationId.ts).
+  analyticsEnabled: boolean;
 };
 
 export type ProtocolWithCounts = StoredProtocol & {
@@ -138,4 +142,5 @@ export const DEFAULT_SETTINGS: StoredSettings = {
   requireUnlockOnExit: false,
   requireUnlockOnExport: false,
   sampleProtocolDismissed: false,
+  analyticsEnabled: true,
 };

--- a/apps/interviewer-v7/src/providers/AppProviders.tsx
+++ b/apps/interviewer-v7/src/providers/AppProviders.tsx
@@ -7,6 +7,7 @@ import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { DndStoreProvider } from '@codaco/fresco-ui/dnd/dnd';
 import { Toaster } from '@codaco/fresco-ui/Toast';
 import { TooltipProvider } from '@codaco/fresco-ui/Tooltip';
+import { AnalyticsProvider } from '~/lib/analytics/AnalyticsProvider';
 import { AuthProvider } from '~/lib/auth/AuthContext';
 import { StepUpAuthProvider } from '~/lib/auth/StepUpAuthProvider';
 
@@ -18,9 +19,11 @@ export function AppProviders({ children }: { children: ReactNode }) {
           <TooltipProvider>
             <DndStoreProvider>
               <AuthProvider>
-                <DialogProvider>
-                  <StepUpAuthProvider>{children}</StepUpAuthProvider>
-                </DialogProvider>
+                <AnalyticsProvider>
+                  <DialogProvider>
+                    <StepUpAuthProvider>{children}</StepUpAuthProvider>
+                  </DialogProvider>
+                </AnalyticsProvider>
               </AuthProvider>
             </DndStoreProvider>
           </TooltipProvider>

--- a/apps/interviewer-v7/src/routes/Home.tsx
+++ b/apps/interviewer-v7/src/routes/Home.tsx
@@ -14,6 +14,7 @@ import { ResumePill } from '~/components/ResumePill';
 import { SettingsDialog } from '~/components/SettingsDialog';
 import { StatusRow } from '~/components/StatusRow';
 import { TopActionBar } from '~/components/TopActionBar';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import {
   deleteProtocol,
   getSettings,
@@ -105,6 +106,7 @@ export function HomeRoute() {
   const view = viewFromLocation(location);
   const dialog = useDialog();
   const toast = useToast();
+  const analytics = useAnalytics();
 
   const [pendingImports, setPendingImports] = useState<PendingImport[]>([]);
 
@@ -200,6 +202,13 @@ export function HomeRoute() {
           }
           await reload();
           setPendingImports((prev) => prev.filter((entry) => entry.id !== id));
+          // No protocol name or contents — only the anonymous content hash,
+          // import source, and whether a schema migration ran.
+          analytics.track('protocol_installed', {
+            source: request.source,
+            migrated: result.migrated,
+            protocol_hash: result.hash,
+          });
           toast.add({
             title: 'Protocol imported',
             description: result.migrated
@@ -209,6 +218,10 @@ export function HomeRoute() {
           });
         } else {
           setPendingImports((prev) => prev.filter((entry) => entry.id !== id));
+          analytics.track('protocol_install_failed', {
+            source: request.source,
+            reason: result.error,
+          });
           toast.add({
             title: 'Import failed',
             description: result.message,
@@ -219,7 +232,7 @@ export function HomeRoute() {
 
       void run();
     },
-    [reload, toast],
+    [analytics, reload, toast],
   );
 
   // If the pending hash has since been deleted (e.g. cascade-delete from

--- a/apps/interviewer-v7/src/routes/Interview.tsx
+++ b/apps/interviewer-v7/src/routes/Interview.tsx
@@ -12,6 +12,7 @@ import {
   Shell,
 } from '@codaco/interview';
 import { InterviewComplete } from '~/components/InterviewComplete';
+import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import {
   buildResolvedAssets,
   makeAssetResolver,
@@ -26,6 +27,7 @@ import {
   updateSettings,
 } from '~/lib/db/api';
 import type { StoredSession } from '~/lib/db/types';
+import { APP_VERSION } from '~/lib/platform/appVersion';
 import { getInstallationId } from '~/lib/platform/installationId';
 import { hostAppName } from '~/lib/platform/platform';
 
@@ -139,8 +141,14 @@ export function InterviewRoute({ sessionId }: { sessionId: string }) {
     setAuthorizedInterviewId,
   ]);
 
+  const { client: posthogClient, enabled: analyticsEnabled } = useAnalytics();
+
   const analytics = useMemo(
-    () => ({ installationId: getInstallationId(), hostApp: hostAppName }),
+    () => ({
+      installationId: getInstallationId(),
+      hostApp: hostAppName,
+      hostVersion: APP_VERSION,
+    }),
     [],
   );
 
@@ -224,7 +232,8 @@ export function InterviewRoute({ sessionId }: { sessionId: string }) {
         onFinish={handleFinish}
         onRequestAsset={state.resolver}
         analytics={analytics}
-        disableAnalytics
+        posthogClient={posthogClient ?? undefined}
+        disableAnalytics={!analyticsEnabled}
         onExit={() => void handleExit()}
       />
     </div>

--- a/apps/interviewer-v7/vitest.config.ts
+++ b/apps/interviewer-v7/vitest.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
+  // `__APP_VERSION__` is injected by vite.renderer.config.ts for real builds;
+  // stub it here so modules reading APP_VERSION can be imported under test.
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
+  },
   test: {
     exclude: ['**/node_modules/**', '**/dist/**', '**/storybook-static/**'],
     projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,6 +1108,9 @@ importers:
       motion:
         specifier: 'catalog:'
         version: 12.40.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      posthog-js:
+        specifier: 'catalog:'
+        version: 1.376.5
       react:
         specifier: 'catalog:'
         version: 19.2.6


### PR DESCRIPTION
## Summary

Adds PostHog analytics to **Interviewer v7**, mirroring the patterns already used in Fresco and exposed by the `@codaco/interview` engine. The user preference is wired through every layer — JS, the interview shell, and native mobile crash/error tracking.

Analytics are **opt-out (default on)** and strictly anonymous: no participant data or user-identifiable information is ever sent. Events are keyed only to the random per-device installation id (the single-user invariant holds — `installationId` identifies the device, not a user).

## What's included

**"Enable analytics" preference (defaults on)**
- New `StoredSettings.analyticsEnabled` (default `true`). Existing installs inherit the default via the `DEFAULT_SETTINGS` merge in both the Dexie and SQLCipher backends.
- New **Settings → Privacy** section and a dedicated **onboarding-wizard step** ("Help improve the app"), both with user-facing copy on what is collected, why, and the guarantee that no participant/identifiable data leaves the device.

**Connected to the interview shell**
- New `src/lib/analytics/` module: a lazily-initialised, opt-out-by-default `posthog-js` client and an `AnalyticsProvider` context (`enabled`, `client`, `setEnabled`, `track`, `captureException`).
- `Interview.tsx` passes the same client into the `@codaco/interview` `Shell` via `posthogClient`, with `disableAnalytics` bound to the inverse of the preference, so app and engine events share one instance and one opt-out switch. Adds `hostVersion`.
- The provider gates the DB-backed settings load on the `unlocked` auth state (Electron's encrypted DB isn't open before unlock); all telemetry paths swallow errors.

**Additional events + error tracking**
- `protocol_installed` / `protocol_install_failed` (Home), `data_exported` (DataView) — counts/hashes only, never names or contents.
- `capture_exceptions` for uncaught JS errors, plus a top-level `AppErrorBoundary` reporting React render errors.

**Native mobile (iOS/Android)**
- The flag is mirrored into Capacitor Preferences and read at launch by `AppDelegate.swift` (PostHog iOS pod) and `AnalyticsApplication.java` (PostHog Android dep + manifest registration), which init their SDKs with `optOut` set from the preference. Screen views, autocapture, and session replay are all disabled.

See `apps/interviewer-v7/docs/analytics.md` for the full design.

## Verification

- `pnpm typecheck` (via turbo) — passes
- `oxlint` / `oxfmt` — clean
- `pnpm test` — 47/47 unit tests pass (added an `__APP_VERSION__` stub to the vitest config since `Interview.tsx` now imports the app version)

## Notes for reviewers

- ⚠️ **Native changes are unverifiable in CI here** (no Xcode/Android SDK). The exact PostHog SDK setup signatures should be confirmed against the [iOS](https://posthog.com/docs/error-tracking/installation/ios) / [Android](https://posthog.com/docs/error-tracking/installation/android) docs for the resolved SDK versions via `pnpm capacitor:sync` + a native build. This caveat is documented in `docs/analytics.md`.
- Reuses the same PostHog API key/proxy host as `@codaco/interview` and Fresco so events land in the same project — easy to switch to a dedicated key if preferred.

https://claude.ai/code/session_01Fx1VKExnrpwxgvvZJPGEZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx1VKExnrpwxgvvZJPGEZA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional anonymous analytics and error tracking to help improve the app.
  * Analytics can be enabled or disabled in Settings → Privacy.
  * Analytics preference is presented during initial setup.
  * All analytics are anonymous and device-scoped; participant data is never collected.
  * Improved error reporting for better app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->