### PR TITLE
fix(interviewer-v7): refresh data table after synthetic data changes

### DIFF
--- a/apps/interviewer-v7/CHANGELOG.md
+++ b/apps/interviewer-v7/CHANGELOG.md
@@ -27,6 +27,8 @@ versioning via `ignore` in `.changeset/config.json`).
 
 ### Fixed
 
+- Generating or deleting synthetic data in Settings now refreshes the data
+  table immediately, instead of leaving it showing stale sessions.
 - App error boundary now shows a non-dismissible modal with a reload action.
 - Dexie remains usable after a web storage revoke.
 - Privacy/analytics copy clarified; toggle thumb styling corrected.

--- a/apps/interviewer-v7/android/app/build.gradle
+++ b/apps/interviewer-v7/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "7.0.0-alpha.0"
+        versionName "8.0.0-alpha.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v7/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/interviewer-v7/ios/App/App.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 8.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = org.complexdatacollective.networkcanvas.interviewer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -386,7 +386,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 7.0.0;
+				MARKETING_VERSION = 8.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.complexdatacollective.networkcanvas.interviewer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/apps/interviewer-v7/package.json
+++ b/apps/interviewer-v7/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v7",
-  "version": "7.0.0-alpha.0",
+  "version": "8.0.0-alpha.0",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",

--- a/apps/interviewer-v7/src/components/DataView.tsx
+++ b/apps/interviewer-v7/src/components/DataView.tsx
@@ -63,6 +63,9 @@ import { downloadBlob } from '~/lib/files/download';
 type DataViewProps = {
   protocols: ProtocolWithCounts[];
   onReload: () => Promise<void>;
+  // Bumped by the parent when sessions change outside this view (e.g.
+  // synthetic-data generation/deletion in Settings) so the table re-queries.
+  refreshKey?: number;
 };
 
 type ChipFilter = 'all' | 'in-progress' | 'complete';
@@ -298,7 +301,7 @@ function SortHeader<TData>({
   );
 }
 
-export function DataView({ protocols, onReload }: DataViewProps) {
+export function DataView({ protocols, onReload, refreshKey }: DataViewProps) {
   const protocolStageCounts = useMemo(() => {
     const map = new Map<string, number>();
     for (const protocol of protocols) {
@@ -400,7 +403,7 @@ export function DataView({ protocols, onReload }: DataViewProps) {
 
   useEffect(() => {
     void reloadData();
-  }, [reloadData]);
+  }, [reloadData, refreshKey]);
 
   const rows: StoredSessionLite[] = data?.rows ?? [];
   const totalCount = data?.totalCount ?? 0;

--- a/apps/interviewer-v7/src/components/SettingsDialog.tsx
+++ b/apps/interviewer-v7/src/components/SettingsDialog.tsx
@@ -52,6 +52,9 @@ import { generateSyntheticSessions } from '~/lib/synthetic/generate';
 type SettingsDialogProps = {
   open: boolean;
   onClose: () => void;
+  // Invoked after synthetic sessions are generated or deleted so the host can
+  // refresh views that read sessions (StatusRow, the data table).
+  onDataChange?: () => void;
 };
 
 type Section = 'about' | 'data' | 'privacy' | 'security' | 'synthetic';
@@ -79,7 +82,11 @@ const NAV_ITEMS: { id: Section; label: string; icon: typeof Info }[] = [
   { id: 'synthetic', label: 'Synthetic data', icon: FlaskConical },
 ];
 
-export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+export function SettingsDialog({
+  open,
+  onClose,
+  onDataChange,
+}: SettingsDialogProps) {
   const auth = useAuth();
   const analytics = useAnalytics();
   const toast = useToast();
@@ -184,6 +191,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         variant: 'success',
       });
       await reloadSynthetic();
+      onDataChange?.();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       toast.add({
@@ -201,6 +209,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     respectSkipLogicAndFiltering,
     toast,
     reloadSynthetic,
+    onDataChange,
   ]);
 
   const handleDeleteSynthetic = useCallback(async () => {
@@ -219,12 +228,13 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             variant: 'success',
           });
           await reloadSynthetic();
+          onDataChange?.();
         } finally {
           setIsDeleting(false);
         }
       },
     });
-  }, [confirm, reloadSynthetic, syntheticCount, toast]);
+  }, [confirm, onDataChange, reloadSynthetic, syntheticCount, toast]);
 
   const storagePercent = storage.percent !== null ? storage.percent / 100 : 0;
   const storageHasValues = storage.usage !== null && storage.quota !== null;

--- a/apps/interviewer-v7/src/routes/Home.tsx
+++ b/apps/interviewer-v7/src/routes/Home.tsx
@@ -98,9 +98,9 @@ export function HomeRoute() {
 
   // Synthetic data was generated or deleted in Settings: refresh the home
   // data (protocol counts, StatusRow) and signal the DataView to re-query.
-  const handleSyntheticDataChange = useCallback(async () => {
+  const handleSyntheticDataChange = useCallback(() => {
     setDataRefreshKey((key) => key + 1);
-    await reload();
+    void reload();
   }, [reload]);
 
   const handleDeleteProtocol = useCallback(

--- a/apps/interviewer-v7/src/routes/Home.tsx
+++ b/apps/interviewer-v7/src/routes/Home.tsx
@@ -42,6 +42,9 @@ export function HomeRoute() {
   const [pendingProtocolHash, setPendingProtocolHash] = useState<string | null>(
     null,
   );
+  // Bumped when sessions are mutated outside the DataView (synthetic-data
+  // generation/deletion in Settings) so the data table re-queries.
+  const [dataRefreshKey, setDataRefreshKey] = useState(0);
   const [location, navigate] = useLocation();
   const view = viewFromLocation(location);
   const dialog = useDialog();
@@ -92,6 +95,13 @@ export function HomeRoute() {
     [navigate],
   );
   const closeNewSession = useCallback(() => setPendingProtocolHash(null), []);
+
+  // Synthetic data was generated or deleted in Settings: refresh the home
+  // data (protocol counts, StatusRow) and signal the DataView to re-query.
+  const handleSyntheticDataChange = useCallback(async () => {
+    setDataRefreshKey((key) => key + 1);
+    await reload();
+  }, [reload]);
 
   const handleDeleteProtocol = useCallback(
     async (hash: string) => {
@@ -204,7 +214,12 @@ export function HomeRoute() {
             </div>
           </motion.div>
         ) : (
-          <DataView key="data" protocols={protocols} onReload={reload} />
+          <DataView
+            key="data"
+            protocols={protocols}
+            onReload={reload}
+            refreshKey={dataRefreshKey}
+          />
         )}
       </AnimatePresence>
 
@@ -219,6 +234,7 @@ export function HomeRoute() {
           setOpenDialog(null);
           void reload();
         }}
+        onDataChange={handleSyntheticDataChange}
       />
     </motion.div>
   );


### PR DESCRIPTION
## Summary

Fixes a bug in Interviewer v7 where generating (or deleting) synthetic data from the **Settings → Synthetic data** menu did not update the data table.

### Root cause

`DataView` queries its own sessions internally via `querySessions`, and the effect that runs that query only re-fires when its derived `queryParams` change. Synthetic-data generation/deletion happens inside `SettingsDialog`, which only refreshed its own local state (`reloadSynthetic`). Closing the dialog called the Home `reload`, but that only updates `useHomeData` (protocols/sessions/settings) — it never signalled the `DataView` to re-query, so the table kept showing stale rows.

### Fix

- `SettingsDialog` now accepts an `onDataChange` callback, fired after a successful generation and after a deletion.
- `Home` wires that callback to bump a `dataRefreshKey` (and reload home data for `StatusRow`/protocol counts).
- `DataView` accepts a `refreshKey` prop and includes it in its reload effect's dependencies, so it re-queries whenever the key changes.

This mirrors the existing reload pattern already used by `DataView`'s own export/delete flows (`Promise.all([onReload(), reloadData()])`).

## Version bump

Also bumps the app version `7.0.0-alpha.0` → `8.0.0-alpha.0` and runs the platform version sync (iOS `MARKETING_VERSION` → `8.0.0`, Android `versionName` → `8.0.0-alpha.0`).

## Testing

- `turbo run typecheck --filter=@codaco/interviewer-v7` ✅
- `turbo run test --filter=@codaco/interviewer-v7` ✅ (18 files, 78 tests)
- `pnpm lint:fix` ✅

https://claude.ai/code/session_01KgFjgRr5XPwvurrK2m3hqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgFjgRr5XPwvurrK2m3hqD)_