### PR TITLE
fix(interview): keep navigation on-screen when resizing a Geospatial stage

### DIFF
--- a/.changeset/interview-geospatial-resize-nav.md
+++ b/.changeset/interview-geospatial-resize-nav.md
@@ -1,0 +1,10 @@
+---
+'@codaco/interview': patch
+---
+
+Fix the navigation bar disappearing off-screen when the browser is resized
+smaller while a Geospatial stage is open. The Mapbox canvas participates in
+layout flow (the package doesn't ship Mapbox's stylesheet), so a stale,
+oversized canvas was forcing the stage wider than the viewport. The map now
+resizes with its container via a `ResizeObserver`, the map container clips its
+overflow, and the stage flex item can shrink horizontally (`min-w-0`).

--- a/packages/interview/src/Shell.tsx
+++ b/packages/interview/src/Shell.tsx
@@ -104,7 +104,7 @@ function Interview({ onExit }: { onExit?: () => void }) {
                   <motion.div
                     key={displayedStep}
                     data-stage-step={displayedStep}
-                    className="flex min-h-0 flex-1"
+                    className="flex min-h-0 min-w-0 flex-1"
                     initial="initial"
                     animate="animate"
                     exit="exit"

--- a/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
+++ b/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
@@ -366,7 +366,7 @@ export default function GeospatialInterface({
   return (
     <div className="relative flex size-full flex-col" ref={dragSafeRef}>
       <motion.div
-        className="size-full"
+        className="size-full min-h-0 min-w-0 overflow-hidden"
         ref={useStub ? undefined : mapContainerRef}
         variants={fadeVariants}
         data-testid="map-container"

--- a/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
+++ b/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
@@ -1,6 +1,5 @@
 import type { Action } from '@reduxjs/toolkit';
 import { LocateFixed, ZoomIn, ZoomOut } from 'lucide-react';
-// import 'mapbox-gl/dist/mapbox-gl.css';
 import { AnimatePresence, motion, type Variants } from 'motion/react';
 import {
   lazy,

--- a/packages/interview/src/interfaces/Geospatial/__tests__/useMapbox.test.tsx
+++ b/packages/interview/src/interfaces/Geospatial/__tests__/useMapbox.test.tsx
@@ -1,0 +1,190 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Module mocks (must appear before imports that use them) ---
+
+// Minimal Mapbox Map stub. `load` never fires in jsdom, so the layer/source
+// setup attached to it is never invoked — only the resize/remove surface and
+// the event registration matter here. Hoisted so the (hoisted) vi.mock factory
+// can reference it.
+const { mapInstance, MapConstructor } = vi.hoisted(() => {
+  const instance = {
+    on: vi.fn(),
+    resize: vi.fn(),
+    remove: vi.fn(),
+  };
+  // A regular (non-arrow) function so it can be invoked with `new`.
+  return {
+    mapInstance: instance,
+    MapConstructor: vi.fn(function MapMock() {
+      return instance;
+    }),
+  };
+});
+
+vi.mock('mapbox-gl', () => ({
+  default: { Map: MapConstructor, accessToken: '' },
+}));
+
+vi.mock('~/contract/context', () => ({
+  useContractFlags: () => ({ isE2E: false }),
+}));
+
+vi.mock('~/selectors/protocol', () => ({
+  // `useSelector(makeGetApiKeyAssetValue)` resolves to the
+  // `(tokenAssetId) => value` reader the hook then calls.
+  makeGetApiKeyAssetValue: () => () => 'test-access-token',
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+// The hook under test (imported after mocks are declared)
+import { type ExtendedMapOptions, useMapbox } from '../useMapbox';
+
+// --- ResizeObserver stub (mirrors hooks/__tests__/useNodeMeasurement.test.tsx) ---
+
+let observerInstances: MockResizeObserver[];
+
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+  observeSpy = vi.fn();
+  disconnectSpy = vi.fn();
+
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+    observerInstances.push(this);
+  }
+
+  observe(target: Element) {
+    this.observeSpy(target);
+  }
+
+  disconnect() {
+    this.disconnectSpy();
+  }
+
+  unobserve() {
+    // no-op: required by ResizeObserver interface
+  }
+}
+
+const triggerResize = () => {
+  for (const obs of observerInstances) {
+    obs.callback(
+      [] as unknown as ResizeObserverEntry[],
+      obs as unknown as ResizeObserver,
+    );
+  }
+};
+
+// requestAnimationFrame stub that defers callbacks so coalescing and
+// cleanup-cancellation can be asserted deterministically.
+let rafCallbacks: FrameRequestCallback[];
+const cancelRaf = vi.fn();
+
+const flushRaf = () => {
+  const callbacks = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of callbacks) cb(0);
+};
+
+const baseMapOptions = {
+  center: [0, 0],
+  initialZoom: 0,
+  tokenAssetId: 'token-asset',
+  color: 'primary-color-seq-1',
+  targetFeatureProperty: 'id',
+  style: 'mapbox://styles/mapbox/streets-v12',
+  showTransit: false,
+} as unknown as ExtendedMapOptions;
+
+function TestHarness({ mapOptions }: { mapOptions: ExtendedMapOptions }) {
+  const { mapContainerRef } = useMapbox({
+    mapOptions,
+    dataSourceAssetId: null,
+    dataSourceUrl: null,
+    onSelectionChange: () => {
+      // no-op: not exercised by these tests
+    },
+  });
+  return <div data-testid="map" ref={mapContainerRef} />;
+}
+
+beforeEach(() => {
+  observerInstances = [];
+  rafCallbacks = [];
+  mapInstance.on.mockClear();
+  mapInstance.resize.mockClear();
+  mapInstance.remove.mockClear();
+  MapConstructor.mockClear();
+  cancelRaf.mockClear();
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal('cancelAnimationFrame', cancelRaf);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useMapbox resize handling', () => {
+  it('observes the map container once the map is initialised', () => {
+    render(<TestHarness mapOptions={baseMapOptions} />);
+
+    expect(MapConstructor).toHaveBeenCalledTimes(1);
+    expect(observerInstances).toHaveLength(1);
+    expect(observerInstances[0]!.observeSpy).toHaveBeenCalled();
+  });
+
+  it('resizes the map (on the next frame) when the container resizes', () => {
+    render(<TestHarness mapOptions={baseMapOptions} />);
+
+    act(() => {
+      triggerResize();
+    });
+    // The resize is coalesced into a requestAnimationFrame callback, so nothing
+    // happens until the frame runs.
+    expect(mapInstance.resize).not.toHaveBeenCalled();
+
+    act(() => {
+      flushRaf();
+    });
+    expect(mapInstance.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces multiple resize callbacks into a single resize per frame', () => {
+    render(<TestHarness mapOptions={baseMapOptions} />);
+
+    act(() => {
+      triggerResize();
+      triggerResize();
+      triggerResize();
+    });
+    act(() => {
+      flushRaf();
+    });
+
+    expect(mapInstance.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects the observer and cancels a pending frame on cleanup', () => {
+    const { unmount } = render(<TestHarness mapOptions={baseMapOptions} />);
+
+    // Schedule a frame without flushing it, so cleanup has something to cancel.
+    act(() => {
+      triggerResize();
+    });
+    act(() => {
+      unmount();
+    });
+
+    expect(observerInstances[0]!.disconnectSpy).toHaveBeenCalled();
+    expect(cancelRaf).toHaveBeenCalled();
+    expect(mapInstance.remove).toHaveBeenCalled();
+  });
+});

--- a/packages/interview/src/interfaces/Geospatial/useMapbox.ts
+++ b/packages/interview/src/interfaces/Geospatial/useMapbox.ts
@@ -395,7 +395,25 @@ export const useMapbox = ({
       setIsMapIdleEvent(false);
     });
 
+    // Keep the Mapbox canvas in sync with its container. The interview shell
+    // resizes the stage area whenever the browser window is resized or the
+    // navigation flips between portrait and landscape orientation. We don't
+    // ship Mapbox's stylesheet (which would absolutely-position the canvas), so
+    // the canvas participates in normal layout flow: a stale, oversized canvas
+    // forces the stage wider than the viewport and pushes the navigation bar
+    // off-screen. Resizing the map on every container size change keeps the
+    // canvas matched to the available space.
+    const container = mapContainerRef.current;
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        mapRef.current?.resize();
+      });
+      resizeObserver.observe(container);
+    }
+
     return () => {
+      resizeObserver?.disconnect();
       mapRef.current?.remove();
     };
   }, [

--- a/packages/interview/src/interfaces/Geospatial/useMapbox.ts
+++ b/packages/interview/src/interfaces/Geospatial/useMapbox.ts
@@ -403,16 +403,26 @@ export const useMapbox = ({
     // forces the stage wider than the viewport and pushes the navigation bar
     // off-screen. Resizing the map on every container size change keeps the
     // canvas matched to the available space.
+    //
+    // ResizeObserver can fire several times during a single layout pass, so we
+    // coalesce the work into one resize per animation frame to avoid redundant
+    // map re-layout and ResizeObserver loop-limit warnings.
     const container = mapContainerRef.current;
     let resizeObserver: ResizeObserver | undefined;
+    let resizeFrame: number | null = null;
     if (typeof ResizeObserver !== 'undefined') {
       resizeObserver = new ResizeObserver(() => {
-        mapRef.current?.resize();
+        if (resizeFrame !== null) return;
+        resizeFrame = requestAnimationFrame(() => {
+          resizeFrame = null;
+          mapRef.current?.resize();
+        });
       });
       resizeObserver.observe(container);
     }
 
     return () => {
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
       resizeObserver?.disconnect();
       mapRef.current?.remove();
     };


### PR DESCRIPTION
## Problem

When viewing a stage that uses the **Geospatial** interface during an interview, resizing the browser **smaller** after the interface loads caused the navigation bar to disappear off the edge of the screen.

## Root cause

The interview package deliberately does **not** import `mapbox-gl/dist/mapbox-gl.css` (it's commented out in `Geospatial.tsx`), unlike `architect-web`. That stylesheet is what gives `.mapboxgl-map { overflow: hidden }` and `.mapboxgl-canvas { position: absolute }`. Without it, the Mapbox canvas — whose pixel `width`/`height` are set inline at init time — **participates in normal layout flow**.

On initial load the canvas exactly matches its container, so everything looks fine. When the window shrinks, Mapbox is never told to resize, so the stale, oversized canvas gives the stage a large min-content width. The stage flex item (`flex min-h-0 flex-1` in `Shell.tsx`) lacked `min-w-0`, so it refused to shrink below that width. The stage then overflowed `<main>` (which is `flex-row-reverse overflow-hidden` in landscape), pushing the navigation bar off the edge.

## Fix

- **`useMapbox.ts`** — observe the map container with a `ResizeObserver` and call `map.resize()` on every size change, keeping the canvas matched to its container (covers browser resize *and* portrait/landscape navigation flips).
- **`Geospatial.tsx`** — add `overflow-hidden` (plus `min-w-0`/`min-h-0`) to the map container so an oversized canvas is clipped and can't drive the layout's intrinsic size. This mirrors the `overflow: hidden` that Mapbox's own stylesheet would apply.
- **`Shell.tsx`** — add `min-w-0` to the stage flex item so it can shrink horizontally (it already had `min-h-0` for the portrait axis).

## Testing

- `turbo run typecheck --filter=@codaco/interview` ✅
- Geospatial unit tests pass ✅
- oxlint/oxfmt clean (no new warnings) ✅

A changeset (`@codaco/interview`: patch) is included.

https://claude.ai/code/session_01JtvECgJUGbq32pdCCG4eKa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtvECgJUGbq32pdCCG4eKa)_