### PR TITLE
feat(protocol-utilities): leave previewed bin/sociogram stages partially complete in synthetic data

### DIFF
--- a/.changeset/spotty-pugs-shave.md
+++ b/.changeset/spotty-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+'@codaco/protocol-utilities': minor
+---
+
+Add an `inProgressStageIndex` option to `generateNetwork` that treats one stage as in progress rather than complete. For interaction-driven stages (OrdinalBin, CategoricalBin, Sociogram) a subset of subject nodes is left without a value for the stage's prompt variables, so previews of those stages still have unplaced nodes to interact with. Architect's preview passes the previewed stage index, leaving all other stages fully populated.

--- a/.changeset/witty-llamas-argue.md
+++ b/.changeset/witty-llamas-argue.md
@@ -1,0 +1,15 @@
+---
+'@codaco/protocol-utilities': major
+---
+
+**Breaking:** `generateNetwork` no longer takes `seed` as a positional argument. It is now part of the options object, so callers no longer need to pass `undefined` to reach the other options:
+
+```ts
+// Before
+generateNetwork(codebook, stages, 42, { simulateDropOut: true });
+generateNetwork(codebook, stages, undefined, { simulateDropOut: true });
+
+// After
+generateNetwork(codebook, stages, { seed: 42, simulateDropOut: true });
+generateNetwork(codebook, stages, { simulateDropOut: true });
+```

--- a/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
+++ b/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
@@ -24,8 +24,15 @@ const noopFinish = async () => {};
 function buildSession(payload: PreviewPayload): SessionPayload {
   const now = new Date().toISOString();
   const network = payload.useSyntheticData
-    ? generateNetwork(payload.protocol.codebook, payload.protocol.stages)
-        .network
+    ? generateNetwork(
+        payload.protocol.codebook,
+        payload.protocol.stages,
+        undefined,
+        // Leave the previewed stage partially complete so interaction-driven
+        // interfaces (ordinal/categorical bins, sociogram) still have
+        // unplaced nodes to work with.
+        { inProgressStageIndex: payload.startStage },
+      ).network
     : createInitialNetwork();
   return {
     id: uuid(),

--- a/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
+++ b/apps/architect-web/src/components/PreviewHost/PreviewHost.tsx
@@ -24,15 +24,12 @@ const noopFinish = async () => {};
 function buildSession(payload: PreviewPayload): SessionPayload {
   const now = new Date().toISOString();
   const network = payload.useSyntheticData
-    ? generateNetwork(
-        payload.protocol.codebook,
-        payload.protocol.stages,
-        undefined,
+    ? generateNetwork(payload.protocol.codebook, payload.protocol.stages, {
         // Leave the previewed stage partially complete so interaction-driven
         // interfaces (ordinal/categorical bins, sociogram) still have
         // unplaced nodes to work with.
-        { inProgressStageIndex: payload.startStage },
-      ).network
+        inProgressStageIndex: payload.startStage,
+      }).network
     : createInitialNetwork();
   return {
     id: uuid(),

--- a/apps/architect-web/src/components/PreviewHost/__tests__/PreviewHost.test.tsx
+++ b/apps/architect-web/src/components/PreviewHost/__tests__/PreviewHost.test.tsx
@@ -134,6 +134,67 @@ describe('PreviewHost', () => {
     expect(call.currentStep).toBe(0);
   });
 
+  it('leaves the previewed stage partially complete in synthetic data', () => {
+    render(<PreviewHost />);
+    const protocol = {
+      name: 'T',
+      description: '',
+      schemaVersion: 8,
+      stages: [
+        {
+          id: 's1',
+          type: 'NameGenerator',
+          label: 'NG',
+          subject: { entity: 'node', type: 'node-1' },
+          prompts: [{ id: 'p1', text: 'Add people' }],
+          behaviours: { minNodes: 4, maxNodes: 8 },
+        },
+        {
+          id: 's2',
+          type: 'OrdinalBin',
+          label: 'OB',
+          subject: { entity: 'node', type: 'node-1' },
+          prompts: [{ id: 'p2', text: 'How close?', variable: 'var-ord' }],
+        },
+      ],
+      codebook: {
+        node: {
+          'node-1': {
+            variables: {
+              'var-ord': {
+                name: 'Closeness',
+                type: 'ordinal',
+                options: [
+                  { label: 'Low', value: 1 },
+                  { label: 'High', value: 2 },
+                ],
+              },
+            },
+          },
+        },
+        edge: {},
+        ego: {},
+      },
+      assetManifest: {},
+    };
+    postPayload(openerStub, {
+      type: 'preview:payload',
+      protocol,
+      startStage: 1,
+      useSyntheticData: true,
+    });
+
+    const call = shellMock.mock.calls.at(-1)?.[0] as {
+      payload: InterviewPayload;
+    };
+    const nodes = call.payload.session.network.nodes;
+    expect(nodes.length).toBeGreaterThan(0);
+    const unplaced = nodes.filter((n) => n.attributes['var-ord'] === null);
+    const placed = nodes.filter((n) => n.attributes['var-ord'] !== null);
+    expect(unplaced.length).toBeGreaterThan(0);
+    expect(placed.length).toBeGreaterThan(0);
+  });
+
   it('ignores payload messages from a non-opener source', () => {
     render(<PreviewHost />);
     const protocol = makeProtocol();

--- a/apps/interviewer-v7/src/lib/synthetic/generate.ts
+++ b/apps/interviewer-v7/src/lib/synthetic/generate.ts
@@ -40,7 +40,6 @@ export async function generateSyntheticSessions(
     const { network, stageMetadata, currentStep, droppedOut } = generateNetwork(
       protocol.codebook,
       protocol.protocol.stages,
-      undefined,
       genOptions,
     );
 
@@ -75,7 +74,6 @@ export async function generateSyntheticSessions(
         const { network, stageMetadata, currentStep } = generateNetwork(
           protocol.codebook,
           protocol.protocol.stages,
-          undefined,
           { ...genOptions, simulateDropOut: false },
         );
         await updateSession(row.sessionId, {

--- a/packages/interview/README.md
+++ b/packages/interview/README.md
@@ -343,7 +343,7 @@ sub-path exports — host code never reaches into the package's internals.
 
 ### Synthetic data
 
-- `generateNetwork(codebook, stages, seed?, options?)` — deterministic
+- `generateNetwork(codebook, stages, options?)` — deterministic
   network generator that walks a protocol's stages and produces nodes,
   edges, ego attributes, and stage metadata. Use it for storybook
   fixtures, load tests, and the synthetic preview mode.

--- a/packages/protocol-utilities/README.md
+++ b/packages/protocol-utilities/README.md
@@ -4,7 +4,7 @@ Synthetic network generation and interview-payload builder for Network Canvas pr
 
 ## Exports
 
-- `generateNetwork(codebook, stages, seed?, options?)` — pure function that produces an `NcNetwork` (plus stage metadata and step state) for a given protocol. Used by `architect-web`'s PreviewHost to populate previews and by tests that need a deterministic network shape.
+- `generateNetwork(codebook, stages, options?)` — pure function that produces an `NcNetwork` (plus stage metadata and step state) for a given protocol. Used by `architect-web`'s PreviewHost to populate previews and by tests that need a deterministic network shape.
 - `SyntheticInterview` — fluent builder that constructs codebooks, stages, prompts, forms, and full interview payloads. Used by `@codaco/interview`'s Storybook stories.
 
 Both share a `ValueGenerator` (`@faker-js/faker` wrapper) for deterministic value synthesis.

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -286,6 +286,190 @@ describe('generateNetwork', () => {
     });
   });
 
+  describe('inProgressStageIndex option', () => {
+    function makeBinCodebook(): Codebook {
+      return makeCodebook({
+        node: {
+          'node-type-1': {
+            color: 'node-color-seq-1',
+            variables: {
+              'var-name': { name: 'Name', type: 'text' },
+              'var-ordinal': {
+                name: 'Closeness',
+                type: 'ordinal',
+                options: [
+                  { label: 'Low', value: 1 },
+                  { label: 'Mid', value: 2 },
+                  { label: 'High', value: 3 },
+                ],
+              },
+              'var-cat': {
+                name: 'Group',
+                type: 'categorical',
+                options: [
+                  { label: 'A', value: 'a' },
+                  { label: 'B', value: 'b' },
+                ],
+              },
+              'var-other': { name: 'Other group', type: 'text' },
+            },
+          },
+        },
+      });
+    }
+
+    function makeOrdinalBinStage(): Stage {
+      return {
+        id: 'stage-ob',
+        label: 'Ordinal Bin',
+        type: 'OrdinalBin',
+        subject: { entity: 'node', type: 'node-type-1' },
+        prompts: [
+          { id: 'prompt-ob', text: 'How close?', variable: 'var-ordinal' },
+        ],
+      } as Stage;
+    }
+
+    function makeCategoricalBinStage(): Stage {
+      return {
+        id: 'stage-cb',
+        label: 'Categorical Bin',
+        type: 'CategoricalBin',
+        subject: { entity: 'node', type: 'node-type-1' },
+        prompts: [
+          {
+            id: 'prompt-cb',
+            text: 'Which group?',
+            variable: 'var-cat',
+            otherVariable: 'var-other',
+          },
+        ],
+      } as Stage;
+    }
+
+    it('leaves every node placed when the option is not set', () => {
+      const codebook = makeBinCodebook();
+      const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
+
+      const { network } = generateNetwork(codebook, stages, 42);
+
+      expect(network.nodes.length).toBeGreaterThan(0);
+      for (const node of network.nodes) {
+        expect(node[entityAttributesProperty]['var-ordinal']).not.toBeNull();
+      }
+    });
+
+    it('clears the prompt variable on roughly half the nodes of an in-progress OrdinalBin', () => {
+      const codebook = makeBinCodebook();
+      const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
+
+      const { network } = generateNetwork(codebook, stages, 42, {
+        inProgressStageIndex: 1,
+      });
+
+      const nodeCount = network.nodes.length;
+      const unplaced = network.nodes.filter(
+        (n) => n[entityAttributesProperty]['var-ordinal'] === null,
+      );
+      const placed = network.nodes.filter(
+        (n) => n[entityAttributesProperty]['var-ordinal'] !== null,
+      );
+
+      expect(unplaced.length).toBe(Math.max(1, Math.floor(nodeCount / 2)));
+      expect(placed.length).toBeGreaterThan(0);
+
+      const optionValues = new Set([1, 2, 3]);
+      for (const node of placed) {
+        expect(
+          optionValues.has(
+            node[entityAttributesProperty]['var-ordinal'] as number,
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('clears both the prompt variable and otherVariable of an in-progress CategoricalBin', () => {
+      const codebook = makeBinCodebook();
+      const stages = [makeNameGeneratorStage(), makeCategoricalBinStage()];
+
+      const { network } = generateNetwork(codebook, stages, 42, {
+        inProgressStageIndex: 1,
+      });
+
+      const uncategorised = network.nodes.filter(
+        (n) => n[entityAttributesProperty]['var-cat'] === null,
+      );
+      expect(uncategorised.length).toBeGreaterThan(0);
+
+      for (const node of uncategorised) {
+        expect(node[entityAttributesProperty]['var-other']).toBeNull();
+      }
+    });
+
+    it('clears the layout variable of an in-progress Sociogram', () => {
+      const codebook = makeCodebook({
+        node: {
+          'node-type-1': {
+            color: 'node-color-seq-1',
+            variables: {
+              'var-name': { name: 'Name', type: 'text' },
+              'var-layout': { name: 'Layout', type: 'layout' },
+            },
+          },
+        },
+      });
+      const stages = [
+        makeNameGeneratorStage(),
+        {
+          id: 'stage-soc',
+          label: 'Sociogram',
+          type: 'Sociogram',
+          subject: { entity: 'node', type: 'node-type-1' },
+          prompts: [
+            {
+              id: 'prompt-soc',
+              text: 'Place people',
+              layout: { layoutVariable: 'var-layout' },
+            },
+          ],
+        } as Stage,
+      ];
+
+      const { network } = generateNetwork(codebook, stages, 42, {
+        inProgressStageIndex: 1,
+      });
+
+      const unplaced = network.nodes.filter(
+        (n) => n[entityAttributesProperty]['var-layout'] === null,
+      );
+      expect(unplaced.length).toBe(
+        Math.max(1, Math.floor(network.nodes.length / 2)),
+      );
+    });
+
+    it('has no effect when the in-progress stage is not interaction-driven', () => {
+      const codebook = makeBinCodebook();
+      const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
+
+      const { network } = generateNetwork(codebook, stages, 42, {
+        inProgressStageIndex: 0,
+      });
+
+      for (const node of network.nodes) {
+        expect(node[entityAttributesProperty]['var-ordinal']).not.toBeNull();
+      }
+    });
+
+    it('ignores an out-of-range stage index', () => {
+      const codebook = makeBinCodebook();
+      const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
+
+      expect(() =>
+        generateNetwork(codebook, stages, 42, { inProgressStageIndex: 99 }),
+      ).not.toThrow();
+    });
+  });
+
   describe('stage type coverage', () => {
     it('should handle every stage type defined in the protocol validation schema', () => {
       const allStageTypes = getAllStageTypes();

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -119,7 +119,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThan(0);
 
@@ -132,7 +132,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       expect(network.edges.length).toBeGreaterThan(0);
 
@@ -145,7 +145,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       const codebookNodeTypes = new Set(Object.keys(codebook.node ?? {}));
 
@@ -158,7 +158,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       for (const node of network.nodes) {
         const attrs = node[entityAttributesProperty];
@@ -175,7 +175,7 @@ describe('generateNetwork', () => {
         }),
       ];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       expect(network.nodes.length).toBe(0);
       expect(network.edges.length).toBe(0);
@@ -197,7 +197,7 @@ describe('generateNetwork', () => {
         makeFamilyPedigreeStage(),
       ];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       for (const node of network.nodes) {
         expect(node.type).not.toBe('person');
@@ -212,7 +212,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { stageMetadata } = generateNetwork(codebook, stages, 42);
+      const { stageMetadata } = generateNetwork(codebook, stages, { seed: 42 });
 
       expect(stageMetadata).toEqual({ 0: { isNetworkCommitted: true } });
       expect(StageMetadataSchema.safeParse(stageMetadata).success).toBe(true);
@@ -222,7 +222,9 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeNameGeneratorStage(), makeDyadCensusStage()];
 
-      const { stageMetadata, network } = generateNetwork(codebook, stages, 42);
+      const { stageMetadata, network } = generateNetwork(codebook, stages, {
+        seed: 42,
+      });
 
       expect(stageMetadata).not.toBeNull();
       const meta = stageMetadata?.[1];
@@ -250,7 +252,9 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeNameGeneratorStage(), makeTieStrengthCensusStage()];
 
-      const { stageMetadata, network } = generateNetwork(codebook, stages, 42);
+      const { stageMetadata, network } = generateNetwork(codebook, stages, {
+        seed: 42,
+      });
 
       const meta = stageMetadata?.[1];
       expect(Array.isArray(meta)).toBe(true);
@@ -278,7 +282,7 @@ describe('generateNetwork', () => {
         makeFamilyPedigreeStage({ id: 'stage-fp-2' }),
       ];
 
-      const { stageMetadata } = generateNetwork(codebook, stages, 42);
+      const { stageMetadata } = generateNetwork(codebook, stages, { seed: 42 });
 
       const result = StageMetadataSchema.safeParse(stageMetadata);
       expect(result.success).toBe(true);
@@ -351,7 +355,7 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42);
+      const { network } = generateNetwork(codebook, stages, { seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThan(0);
       for (const node of network.nodes) {
@@ -363,7 +367,8 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42, {
+      const { network } = generateNetwork(codebook, stages, {
+        seed: 42,
         inProgressStageIndex: 1,
       });
 
@@ -392,7 +397,8 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeCategoricalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42, {
+      const { network } = generateNetwork(codebook, stages, {
+        seed: 42,
         inProgressStageIndex: 1,
       });
 
@@ -435,7 +441,8 @@ describe('generateNetwork', () => {
         } as Stage,
       ];
 
-      const { network } = generateNetwork(codebook, stages, 42, {
+      const { network } = generateNetwork(codebook, stages, {
+        seed: 42,
         inProgressStageIndex: 1,
       });
 
@@ -451,7 +458,8 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, 42, {
+      const { network } = generateNetwork(codebook, stages, {
+        seed: 42,
         inProgressStageIndex: 0,
       });
 
@@ -465,7 +473,10 @@ describe('generateNetwork', () => {
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
       expect(() =>
-        generateNetwork(codebook, stages, 42, { inProgressStageIndex: 99 }),
+        generateNetwork(codebook, stages, {
+          seed: 42,
+          inProgressStageIndex: 99,
+        }),
       ).not.toThrow();
     });
   });
@@ -504,7 +515,7 @@ describe('generateNetwork', () => {
         } as Stage;
 
         expect(
-          () => generateNetwork(codebook, [stage], 42),
+          () => generateNetwork(codebook, [stage], { seed: 42 }),
           `Stage type "${stageType}" is not handled by generateNetwork`,
         ).not.toThrow();
       }
@@ -518,7 +529,7 @@ describe('generateNetwork', () => {
         type: 'SomeNewStageType',
       } as unknown as Stage;
 
-      expect(() => generateNetwork(codebook, [stage], 42)).toThrow(
+      expect(() => generateNetwork(codebook, [stage], { seed: 42 })).toThrow(
         /Unsupported stage type "SomeNewStageType"/,
       );
     });

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -61,6 +61,14 @@ type Codebook = {
 export type GenerateNetworkOptions = {
   simulateDropOut?: boolean;
   respectSkipLogicAndFiltering?: boolean;
+  /**
+   * Index of a stage to treat as in progress rather than complete. For
+   * interaction-driven stages (OrdinalBin, CategoricalBin, Sociogram), a
+   * subset of subject nodes is left without a value for the stage's prompt
+   * variables, so the stage's interaction can still be exercised. Has no
+   * effect on stage types where complete data is preferable (e.g. forms).
+   */
+  inProgressStageIndex?: number;
 };
 
 export type GenerateNetworkResult = {
@@ -317,6 +325,82 @@ function getStageFilteredEdges(
   return getEdgesOfType(filtered.edges, edgeType);
 }
 
+/**
+ * Variables an in-progress stage would not yet have written for unvisited
+ * nodes. Clearing these returns a node to the stage's "unplaced" bucket.
+ */
+function getInProgressClearableVariables(stage: Stage): string[] {
+  const prompts = getStagePrompts(stage);
+
+  switch (getStageType(stage)) {
+    case 'OrdinalBin':
+      return prompts.flatMap((p) =>
+        typeof p.variable === 'string' ? [p.variable] : [],
+      );
+    case 'CategoricalBin':
+      // A node only counts as uncategorised when both the prompt variable
+      // and any "other" variable are nil.
+      return prompts.flatMap((p) =>
+        [p.variable, p.otherVariable].filter(
+          (v): v is string => typeof v === 'string',
+        ),
+      );
+    case 'Sociogram':
+      return prompts.flatMap((p) => {
+        const layout = p.layout as { layoutVariable?: string } | undefined;
+        return layout?.layoutVariable ? [layout.layoutVariable] : [];
+      });
+    default:
+      return [];
+  }
+}
+
+/**
+ * Clears the stage's prompt variables on roughly half of its subject nodes
+ * (always at least one) so the stage presents as partially complete: some
+ * nodes already placed, others still awaiting interaction.
+ */
+function markStageInProgress(
+  stage: Stage,
+  nodes: NcNode[],
+  edges: NcEdge[],
+  egoUid: string,
+  egoAttributes: Record<string, unknown>,
+  valueGen: ValueGenerator,
+  respectFiltering: boolean,
+): void {
+  const variables = getInProgressClearableVariables(stage);
+  if (variables.length === 0) return;
+
+  const subject = getStageSubject(stage);
+  if (subject?.entity !== 'node') return;
+
+  const subjectNodes = getStageFilteredNodes(
+    nodes,
+    edges,
+    egoUid,
+    egoAttributes,
+    stage,
+    subject.type,
+    respectFiltering,
+  );
+  if (subjectNodes.length === 0) return;
+
+  const indices = subjectNodes.map((_, idx) => idx);
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = valueGen.randomInt(0, i);
+    [indices[i], indices[j]] = [indices[j]!, indices[i]!];
+  }
+
+  const clearCount = Math.max(1, Math.floor(subjectNodes.length / 2));
+  for (const idx of indices.slice(0, clearCount)) {
+    const attrs = subjectNodes[idx]![entityAttributesProperty];
+    for (const varId of variables) {
+      attrs[varId] = null;
+    }
+  }
+}
+
 export function generateNetwork(
   codebook: Codebook,
   stages: Stage[],
@@ -332,8 +416,11 @@ export function generateNetwork(
   const stageMetadata: Record<string, unknown> = {};
   const egoUid = uuid();
 
-  const { simulateDropOut = false, respectSkipLogicAndFiltering = false } =
-    options;
+  const {
+    simulateDropOut = false,
+    respectSkipLogicAndFiltering = false,
+    inProgressStageIndex,
+  } = options;
   const totalStages = stages.length;
   let currentStep = 0;
   let droppedOut = false;
@@ -834,6 +921,25 @@ export function generateNetwork(
             'Synthetic data generation does not yet support this stage type.',
         );
     }
+  }
+
+  // Applied as a post-pass: node creation populates every codebook variable,
+  // and later stages may rewrite the same variable, so values must be cleared
+  // after all stages have run.
+  const inProgressStage =
+    inProgressStageIndex !== undefined
+      ? stages[inProgressStageIndex]
+      : undefined;
+  if (inProgressStage) {
+    markStageInProgress(
+      inProgressStage,
+      nodes,
+      edges,
+      egoUid,
+      egoAttributes,
+      valueGen,
+      respectSkipLogicAndFiltering,
+    );
   }
 
   if (!droppedOut) {

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -59,6 +59,10 @@ type Codebook = {
 };
 
 export type GenerateNetworkOptions = {
+  /**
+   * Seed for deterministic output. A random seed is used when omitted.
+   */
+  seed?: number;
   simulateDropOut?: boolean;
   respectSkipLogicAndFiltering?: boolean;
   /**
@@ -404,9 +408,15 @@ function markStageInProgress(
 export function generateNetwork(
   codebook: Codebook,
   stages: Stage[],
-  seed?: number,
   options: GenerateNetworkOptions = {},
 ): GenerateNetworkResult {
+  const {
+    seed,
+    simulateDropOut = false,
+    respectSkipLogicAndFiltering = false,
+    inProgressStageIndex,
+  } = options;
+
   const valueGen = new ValueGenerator(
     seed ?? Math.floor(Math.random() * 100000),
   );
@@ -415,12 +425,6 @@ export function generateNetwork(
   const egoAttributes: Record<string, unknown> = {};
   const stageMetadata: Record<string, unknown> = {};
   const egoUid = uuid();
-
-  const {
-    simulateDropOut = false,
-    respectSkipLogicAndFiltering = false,
-    inProgressStageIndex,
-  } = options;
   const totalStages = stages.length;
   let currentStep = 0;
   let droppedOut = false;


### PR DESCRIPTION
## Problem

Synthetic data generated for Architect's preview always completes every stage. For form-style interfaces (e.g. the per-alter form) this is desirable, but for interaction-driven interfaces such as the ordinal bin or categorical bin, every node is already placed when the preview opens — leaving the researcher nothing to interact with.

## Approach

Treat the *previewed* stage as **in progress** rather than complete:

- `generateNetwork` gains an `inProgressStageIndex` option. For interaction-driven stages, roughly half of the stage's subject nodes (always at least one) have the stage's prompt variables cleared to `null`, returning them to the interface's unplaced bucket. All other stages remain fully populated, so form-style stages are unaffected.
- The clearing runs as a **post-pass** after all stages have generated, because node creation populates every codebook variable up front and later stages can rewrite the same variable.
- Covered stage types, matching each interface's "nil value = needs interaction" semantics:
  - **OrdinalBin** — prompt `variable`
  - **CategoricalBin** — prompt `variable` *and* `otherVariable` (the interface only counts a node as uncategorised when both are nil)
  - **Sociogram** — `layout.layoutVariable` (nodes return to the drawer)
- Node selection uses the existing seeded generator (deterministic with a seed) and respects stage filters via the same path as the stage handlers.
- Architect's `PreviewHost` passes `inProgressStageIndex: payload.startStage` when synthetic data is enabled.

Geospatial was deliberately excluded (it steps through nodes regardless of values, so there is no unplaced bucket), as were the census stages (partially-answered pairs would require `stageMetadata` manipulation).

## Testing

- New unit tests in `generateNetwork.test.ts`: unplaced/placed counts for OrdinalBin, both categorical variables cleared, Sociogram layout cleared, no-op for non-interactive target stages, out-of-range index tolerated, and unchanged behaviour when the option is unset.
- New `PreviewHost` test asserting end-to-end that the previewed OrdinalBin stage receives both placed and unplaced nodes.
- `turbo run test`, `typecheck`, `lint:fix`, and `knip` all clean; changeset added for `@codaco/protocol-utilities`.

https://claude.ai/code/session_01PKjTeHB9NxF8Zd5gTzJPbd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKjTeHB9NxF8Zd5gTzJPbd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stage previews can be shown as partially complete so architects see a subset of nodes left unplaced for more realistic interactive-stage previews.

* **Tests**
  * Added tests verifying partial-completion preview behavior across multiple interactive stage types and edge cases.

* **Documentation**
  * Updated generator API signature in READMEs to reflect the new options-based call pattern.

* **Chores**
  * Package versioning/changesets updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->