### PR TITLE
fix(fresco-ui): make wrapped RichSelectGroup option cards fill container width

### DIFF
--- a/.changeset/rich-select-group-wrap-width.md
+++ b/.changeset/rich-select-group-wrap-width.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Fix `RichSelectGroup` option cards not filling the container width when a `horizontal` group wraps onto multiple lines. Wrapped cards now `grow` to the full width of their line, so every option reaches the container edge regardless of how long its description is. Cards that share a line in a content-sized group are unaffected.

--- a/packages/fresco-ui/src/form/fields/RichSelectGroup.stories.tsx
+++ b/packages/fresco-ui/src/form/fields/RichSelectGroup.stories.tsx
@@ -175,6 +175,47 @@ export const Horizontal: Story = {
   },
 };
 
+export const HorizontalWrapping: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'In `horizontal` orientation, when the available width cannot fit every option on one line the options wrap into a vertical stack. Each wrapped option should still extend to the full width of the container, even when their descriptions differ in length.',
+      },
+    },
+  },
+  render: function Render() {
+    const [value, setValue] = useState<
+      string | number | (string | number)[] | undefined
+    >('passkey');
+
+    return (
+      <div className="w-full max-w-xl">
+        <RichSelectGroupField
+          options={[
+            {
+              value: 'passkey',
+              label: 'Passkey',
+              description:
+                'Use biometrics or your device security to sign in. No password to remember — the most secure option.',
+            },
+            {
+              value: 'password',
+              label: 'Password',
+              description:
+                'Traditional username and password. Requires a strong password.',
+            },
+          ]}
+          value={value}
+          onChange={setValue}
+          orientation="horizontal"
+          aria-label="Select an authentication method"
+        />
+      </div>
+    );
+  },
+};
+
 export const WithColumns: Story = {
   render: function Render() {
     const manyOptions: RichSelectOption[] = Array.from(

--- a/packages/fresco-ui/src/form/fields/RichSelectGroup.tsx
+++ b/packages/fresco-ui/src/form/fields/RichSelectGroup.tsx
@@ -64,6 +64,15 @@ const optionCardVariants = compose(
         readOnly: 'pointer-events-none cursor-default',
         invalid: 'border-destructive',
       },
+      // In horizontal orientation the group wraps onto multiple lines once the
+      // options no longer fit side by side. `grow` lets a wrapped card expand to
+      // fill its line so every option reaches the container edge regardless of
+      // how long its description is. It is a no-op when cards already share a
+      // line in a `w-fit` container (no free space to distribute).
+      orientation: {
+        vertical: '',
+        horizontal: 'grow',
+      },
     },
     compoundVariants: [
       {
@@ -80,6 +89,7 @@ const optionCardVariants = compose(
     defaultVariants: {
       selected: false,
       state: 'normal',
+      orientation: 'vertical',
     },
   }),
 );
@@ -389,6 +399,7 @@ export default function RichSelectGroupField(props: RichSelectGroupProps) {
             selected: optionSelected,
             state: optionState,
             size,
+            orientation,
             className: option.className,
           })}
           onClick={() => {


### PR DESCRIPTION
## Problem

In `horizontal` orientation, `RichSelectGroup` wraps its options onto multiple lines once they no longer fit side by side. When wrapped into a vertical stack, each card sized to its **own content width** rather than the container width — so an option with a short description (e.g. _Password_) stopped short of the container edge, while one with a long description (e.g. _Passkey_) reached it. This produced the mismatched-width rendering seen in the Fresco onboarding wizard's authentication-method picker.

## Root cause

The option group container is full width, but each card was `flex: 0 1 auto`, so its used width equalled its `max-content` size. On a wrapped line (one card per row) the shorter card never filled the row.

Measured in Storybook (container 576px):

| Card | Before | After |
| --- | --- | --- |
| Passkey (long) | 576px | 576px |
| Password (short) | **509px** | **576px** |

## Fix

Add `grow` to the option card in `horizontal` orientation only. A wrapped card then expands to fill its line, so every option reaches the container edge regardless of description length.

This is a no-op for the side-by-side case: when cards share a line in a content-sized (`w-fit`) group there is no free space to distribute, so their widths are unchanged (verified empirically). Vertical orientation is untouched (it already stretches via `items-stretch`).

## Verification

- Added a `HorizontalWrapping` story reproducing the wrapped-stack layout (also serves as a Chromatic regression case).
- Confirmed in Storybook that both cards now reach the container edge, and that side-by-side / vertical layouts are unchanged.
- `pnpm --filter @codaco/fresco-ui typecheck` ✓
- `pnpm --filter @codaco/fresco-ui test` ✓ (619 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed horizontal option groups: wrapped cards now expand to fill the full width of their line, reaching container edges regardless of description length.

* **Documentation**
  * Added visual example demonstrating horizontal group wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->