### PR TITLE
fix: connect codebook node shape everywhere nodes are rendered

### DIFF
--- a/.changeset/node-shape-audit.md
+++ b/.changeset/node-shape-audit.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Respect the codebook node shape everywhere nodes are rendered: per-alter and per-alter-edge form headers no longer force a circle, the categorical bin "specify other" dialog, the roster drag preview, and the roster drop overlay now resolve the node shape, and the quick-add toggle previews the shape of the node being created.

--- a/apps/architect-web/src/components/Query/Rules/PreviewText.tsx
+++ b/apps/architect-web/src/components/Query/Rules/PreviewText.tsx
@@ -1,7 +1,7 @@
 import { get, isArray, isNil, join } from 'es-toolkit/compat';
 import type { CSSProperties } from 'react';
 
-import Node from '@codaco/fresco-ui/Node';
+import Node, { type NodeShape } from '@codaco/fresco-ui/Node';
 
 import { SimpleVariablePill } from '../../Form/Fields/VariablePicker/VariablePill';
 import PreviewEdge from '../../sections/fields/EntitySelectField/PreviewEdge';
@@ -122,14 +122,15 @@ const Copy = ({ children = '' }: CopyProps) => <div>{children}</div>;
 type RuleEntityProps = {
   type: string;
   color: string;
+  shape?: NodeShape;
   label: string;
 };
 
-const RuleEntity = ({ type, color, label }: RuleEntityProps) =>
+const RuleEntity = ({ type, color, shape, label }: RuleEntityProps) =>
   type === 'edge' ? (
     <PreviewEdge color={color} label={label} surface={2} />
   ) : (
-    <PreviewNode color={color} label={label} size="xs" />
+    <PreviewNode color={color} shape={shape} label={label} size="xs" />
   );
 
 const PreviewText = ({ type, options, summary }: PreviewTextProps) => {
@@ -174,6 +175,7 @@ const PreviewText = ({ type, options, summary }: PreviewTextProps) => {
         <RuleEntity
           type={type}
           color={options.typeColor ?? ''}
+          shape={options.typeShape}
           label={options.typeLabel ?? ''}
         />
         <TypeOperator value={options.operator} />
@@ -186,6 +188,7 @@ const PreviewText = ({ type, options, summary }: PreviewTextProps) => {
         <RuleEntity
           type={type}
           color={options.typeColor ?? ''}
+          shape={options.typeShape}
           label={options.typeLabel ?? ''}
         />
         <Operator value={options.operator} />
@@ -198,6 +201,7 @@ const PreviewText = ({ type, options, summary }: PreviewTextProps) => {
       <RuleEntity
         type={type}
         color={options.typeColor ?? ''}
+        shape={options.typeShape}
         label={options.typeLabel ?? ''}
       />
       <Copy>where</Copy>
@@ -232,6 +236,7 @@ type PreviewTextOptions = {
   value?: string | number | boolean | Array<string | number>;
   variableType?: string;
   typeColor?: string;
+  typeShape?: NodeShape;
   typeLabel?: string;
 };
 

--- a/apps/architect-web/src/components/Query/Rules/withDisplayOptions.tsx
+++ b/apps/architect-web/src/components/Query/Rules/withDisplayOptions.tsx
@@ -1,6 +1,8 @@
 import { get } from 'es-toolkit/compat';
 import { withProps } from 'react-recompose';
 
+import type { NodeShape } from '@codaco/fresco-ui/Node';
+
 type OptionItem = {
   value: string | number;
   label: string;
@@ -17,7 +19,12 @@ type InputProps = {
   codebook: {
     node?: Record<
       string,
-      { name: string; color: string; variables?: Record<string, unknown> }
+      {
+        name: string;
+        color: string;
+        shape?: { default: NodeShape };
+        variables?: Record<string, unknown>;
+      }
     >;
     edge?: Record<
       string,
@@ -38,6 +45,14 @@ const withDisplayOptions = withProps<{ options: unknown }, InputProps>(
     const typeColor = options.type
       ? get(codebook, [entityType, options.type, 'color'], '#000')
       : '#000'; // noop for ego
+    const typeShape =
+      type === 'node' && options.type
+        ? (get(
+            codebook,
+            [entityType, options.type, 'shape', 'default'],
+            undefined,
+          ) as NodeShape | undefined)
+        : undefined; // only nodes have shapes
     const variablePath =
       options.attribute && type === 'ego'
         ? (['ego', 'variables', options.attribute, 'name'] as const)
@@ -117,6 +132,7 @@ const withDisplayOptions = withProps<{ options: unknown }, InputProps>(
         ...options,
         ...(typeLabel ? { typeLabel } : {}),
         ...(typeColor ? { typeColor } : {}),
+        ...(typeShape ? { typeShape } : {}),
         attribute: variableLabel,
         variableType,
         value: valueWithFormatting(),

--- a/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -96,25 +96,29 @@ const EntitySelectField = ({
     setShowNewTypeDialog(false);
   }, []);
 
-  const PreviewComponent = useMemo(() => {
-    if (entityType === 'edge') {
-      return PreviewEdge;
-    }
-    return PreviewNode;
-  }, [entityType]);
-
   const renderOptions = useCallback(
     () =>
-      options.map(({ label: optionLabel, color, value: optionValue }) => (
-        <PreviewComponent
-          key={optionValue}
-          label={optionLabel}
-          color={color ?? 'node-color-seq-1'}
-          onClick={() => handleClickItem(optionValue)}
-          selected={value === optionValue}
-        />
-      )),
-    [options, value, handleClickItem, PreviewComponent],
+      options.map(({ label: optionLabel, color, shape, value: optionValue }) =>
+        entityType === 'edge' ? (
+          <PreviewEdge
+            key={optionValue}
+            label={optionLabel}
+            color={color ?? 'edge-color-seq-1'}
+            onClick={() => handleClickItem(optionValue)}
+            selected={value === optionValue}
+          />
+        ) : (
+          <PreviewNode
+            key={optionValue}
+            label={optionLabel}
+            color={color ?? 'node-color-seq-1'}
+            shape={shape}
+            onClick={() => handleClickItem(optionValue)}
+            selected={value === optionValue}
+          />
+        ),
+      ),
+    [options, value, handleClickItem, entityType],
   );
 
   return (

--- a/apps/architect-web/src/selectors/utils.ts
+++ b/apps/architect-web/src/selectors/utils.ts
@@ -1,5 +1,6 @@
 import { map, pickBy } from 'es-toolkit/compat';
 
+import type { NodeShape } from '@codaco/fresco-ui/Node';
 import type { VariableOptions } from '@codaco/protocol-validation';
 
 const extraProperties = new Set(['type', 'color']);
@@ -9,6 +10,7 @@ type Item = {
   name: string;
   type?: string;
   color?: string;
+  shape?: { default: NodeShape };
   options?: VariableOptions;
   [key: string]: unknown;
 };
@@ -18,6 +20,7 @@ type Option = {
   value: string;
   type?: string;
   color?: string;
+  shape?: NodeShape;
   options?: VariableOptions;
 };
 
@@ -31,6 +34,9 @@ const asOption = (item: Item, id: string): Option => {
     (value, key) => value && extraProperties.has(key),
   ) as Pick<Option, 'type' | 'color'>;
 
+  // Node type definitions carry a shape; surface the default for previews
+  const shapeField = item.shape ? { shape: item.shape.default } : {};
+
   // Include options for categorical/ordinal variables
   const optionsField =
     item.type && typesWithOptions.has(item.type) && item.options
@@ -39,6 +45,7 @@ const asOption = (item: Item, id: string): Option => {
 
   return {
     ...extra,
+    ...shapeField,
     ...optionsField,
     ...required,
   };

--- a/packages/interview/src/interfaces/AlterEdgeForm/AlterEdgeForm.tsx
+++ b/packages/interview/src/interfaces/AlterEdgeForm/AlterEdgeForm.tsx
@@ -42,7 +42,6 @@ function EdgeHeader({ item }: { item: NcEdge }) {
         <Node
           nodeId={fromNode[entityPrimaryKeyProperty]}
           type={fromNode.type}
-          className="rounded-full"
         />
       )}
       <div
@@ -52,11 +51,7 @@ function EdgeHeader({ item }: { item: NcEdge }) {
         )}
       />
       {toNode && (
-        <Node
-          nodeId={toNode[entityPrimaryKeyProperty]}
-          type={toNode.type}
-          className="rounded-full"
-        />
+        <Node nodeId={toNode[entityPrimaryKeyProperty]} type={toNode.type} />
       )}
     </div>
   );

--- a/packages/interview/src/interfaces/AlterForm/AlterForm.tsx
+++ b/packages/interview/src/interfaces/AlterForm/AlterForm.tsx
@@ -51,7 +51,7 @@ const AlterForm = (props: StageProps<'AlterForm'>) => {
       <Node
         nodeId={item[entityPrimaryKeyProperty]}
         type={item.type}
-        className="shrink-0 rounded-full"
+        className="shrink-0"
       />
     );
   }, []);

--- a/packages/interview/src/interfaces/CategoricalBin/CategoricalBin.tsx
+++ b/packages/interview/src/interfaces/CategoricalBin/CategoricalBin.tsx
@@ -20,7 +20,11 @@ import { useCurrentStep } from '~/contexts/CurrentStepContext';
 import useReadyForNextStage from '~/hooks/useReadyForNextStage';
 import { useStageSelector } from '~/hooks/useStageSelector';
 import { makeGetCodebookForNodeType } from '~/selectors/protocol';
-import { getNodeColorSelector } from '~/selectors/session';
+import {
+  getNodeColorSelector,
+  getNodeTypeDefinition,
+  resolveNodeShape,
+} from '~/selectors/session';
 import { updateNode } from '~/store/modules/session';
 import { useAppDispatch } from '~/store/store';
 import type { StageProps } from '~/types';
@@ -160,6 +164,7 @@ const CategoricalBin = (_props: CategoricalBinStageProps) => {
   const { currentStep } = useCurrentStep();
   const { openDialog } = useDialog();
   const nodeColor = useStageSelector(getNodeColorSelector);
+  const nodeTypeDefinition = useStageSelector(getNodeTypeDefinition);
   const getCodebookForNodeType = useSelector(makeGetCodebookForNodeType);
 
   const handleDropNode = async (node: NcNode, binIndex: number) => {
@@ -192,6 +197,14 @@ const CategoricalBin = (_props: CategoricalBinStageProps) => {
             <div className="shrink-0">
               <UINode
                 color={nodeColor}
+                shape={
+                  nodeTypeDefinition
+                    ? resolveNodeShape(
+                        nodeTypeDefinition.shape,
+                        node[entityAttributesProperty],
+                      )
+                    : undefined
+                }
                 label={getNodeLabel(node, getCodebookForNodeType)}
               />
             </div>

--- a/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
@@ -30,7 +30,12 @@ import {
 import { useCelebrate } from '~/hooks/useCelebrate';
 import { useStageSelector } from '~/hooks/useStageSelector';
 import { getNodeIconName } from '~/selectors/name-generator';
-import { getNodeColorSelector } from '~/selectors/session';
+import {
+  getNodeColorSelector,
+  getNodeTypeDefinition,
+  getPromptAdditionalAttributes,
+  resolveNodeShape,
+} from '~/selectors/session';
 
 function convertToNodeColor(color: NodeColorSequence): string {
   switch (color) {
@@ -140,7 +145,16 @@ export default function QuickAddField({
   };
 
   const nodeColor = useStageSelector(getNodeColorSelector);
+  const nodeTypeDefinition = useStageSelector(getNodeTypeDefinition);
+  const newNodeAttributes = useStageSelector(getPromptAdditionalAttributes);
   const icon = useStageSelector(getNodeIconName);
+
+  // When open, the toggle previews the node being created, so it takes the
+  // shape the new node will have (resolved against the prompt's additional
+  // attributes, which are the only attributes set at creation time).
+  const nodeShape = nodeTypeDefinition
+    ? resolveNodeShape(nodeTypeDefinition.shape, newNodeAttributes)
+    : 'circle';
 
   // Close form when disabled
   useEffect(() => {
@@ -245,7 +259,9 @@ export default function QuickAddField({
               data-toggle-circle
               className={cx(
                 actionCircleVariants(),
-                'relative aspect-square size-28 transition-[background-color,filter] duration-300',
+                'relative aspect-square size-28 transition-[background-color,filter,border-radius,rotate,scale] duration-300',
+                checked && nodeShape !== 'circle' && 'rounded',
+                checked && nodeShape === 'diamond' && 'scale-[0.85] rotate-45',
                 disabled ? 'cursor-not-allowed saturate-0' : 'cursor-pointer',
               )}
               style={{
@@ -261,7 +277,12 @@ export default function QuickAddField({
                     initial={{ y: '-100%' }}
                     animate={{ y: 0 }}
                     exit={{ y: '-100%' }}
-                    className="flex h-full items-center justify-center"
+                    className={cx(
+                      'flex h-full items-center justify-center',
+                      // Counter-rotate content inside the rotated diamond,
+                      // mirroring the Node component's treatment.
+                      nodeShape === 'diamond' && 'scale-[1.176] -rotate-45',
+                    )}
                   >
                     {fieldProps.value ? (
                       <span className={labelVariants()}>

--- a/packages/interview/src/interfaces/NameGeneratorRoster/DropOverlay.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/DropOverlay.tsx
@@ -1,7 +1,10 @@
 import { motion } from 'motion/react';
 
 import { type DndStore, useDndStore } from '@codaco/fresco-ui/dnd/dnd';
-import UINode, { type NodeColorSequence } from '@codaco/fresco-ui/Node';
+import UINode, {
+  type NodeColorSequence,
+  type NodeShape,
+} from '@codaco/fresco-ui/Node';
 
 const variants = {
   visible: { opacity: 1 },
@@ -29,12 +32,14 @@ const iconVariants = {
 type DropOverlayProps = {
   dropTargetId: string;
   nodeColor: NodeColorSequence;
+  nodeShape?: NodeShape;
   message: string;
 };
 
 const DropOverlay = ({
   dropTargetId,
   nodeColor,
+  nodeShape,
   message,
 }: DropOverlayProps) => {
   const isOver = useDndStore(
@@ -50,7 +55,7 @@ const DropOverlay = ({
       exit="hidden"
     >
       <motion.div variants={iconVariants} animate={isOver ? 'over' : 'initial'}>
-        <UINode label="" color={nodeColor} />
+        <UINode label="" color={nodeColor} shape={nodeShape} />
       </motion.div>
       <h2>{message}</h2>
     </motion.div>

--- a/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.tsx
@@ -36,8 +36,10 @@ import { getCodebookVariablesForSubjectType } from '~/selectors/protocol';
 import {
   getNetworkNodesForPrompt,
   getNodeColorSelector,
+  getNodeTypeDefinition,
   getPromptAdditionalAttributes,
   getStageNodeCount,
+  resolveNodeShape,
 } from '~/selectors/session';
 import { addNode, deleteNode } from '~/store/modules/session';
 import { useAppDispatch } from '~/store/store';
@@ -94,6 +96,7 @@ const NameGeneratorRoster = (props: NameGeneratorRosterProps) => {
   const nodesForPrompt = useStageSelector(getNetworkNodesForPrompt);
 
   const dropNodeColor = useStageSelector(getNodeColorSelector);
+  const nodeTypeDefinition = useStageSelector(getNodeTypeDefinition);
 
   const { status: itemsStatus, items, excludeItems } = useItems(props);
 
@@ -336,6 +339,14 @@ const NameGeneratorRoster = (props: NameGeneratorRosterProps) => {
       return (
         <Node
           color={dropNodeColor ?? 'node-color-seq-1'}
+          shape={
+            nodeTypeDefinition && item.data
+              ? resolveNodeShape(
+                  nodeTypeDefinition.shape,
+                  item.data[entityAttributesProperty],
+                )
+              : undefined
+          }
           label={item.props.label}
           size="md"
         />
@@ -436,6 +447,7 @@ const NameGeneratorRoster = (props: NameGeneratorRosterProps) => {
                   <DropOverlay
                     dropTargetId={sourceDropTargetId}
                     nodeColor={dropNodeColor}
+                    nodeShape={nodeTypeDefinition?.shape.default}
                     message="Drop here to remove"
                   />
                 )}


### PR DESCRIPTION
## Summary

Audit of every `@codaco/fresco-ui/Node` render site across `architect-web` and the `interview` package, fixing all places where the codebook's node `shape` was dropped (nodes silently fell back to a circle).

## Fixes

### `@codaco/interview`

- **AlterForm / AlterEdgeForm (per-alter forms)** — the slide headers passed `rounded-full` in `className` to `ConnectedNode`. Because `cva` runs `twMerge` with the consumer class last, it overrode the shape variant's border-radius, forcing square/diamond nodes to render as circles. Removed the override; `ConnectedNode` already resolves the correct shape.
- **CategoricalBin** — the "Specify other" dialog node now resolves shape via `resolveNodeShape` against the dropped node's attributes.
- **NameGeneratorRoster** — the drag preview for roster items now resolves shape from the stage's node type definition and the item's attributes.
- **NameGeneratorRoster DropOverlay** — the "drop here to remove" placeholder node now takes the node type's default shape (no instance attributes exist for a placeholder).
- **QuickAddField** — when open, the toggle previews the node being created; it now morphs to the shape the new node will have (resolved against the prompt's additional attributes), including the diamond's rotate/counter-rotate treatment from the Node component.

### `architect-web`

- **EntitySelectField (stage subject chooser)** — `asOptions` stripped `shape` from node type definitions, so the chooser always showed circles. The option mapper now surfaces `shape.default`, and the field passes it to `PreviewNode`. (Also corrected the edge color fallback from `node-color-seq-1` to `edge-color-seq-1`.)
- **Query rule previews** — `withDisplayOptions` now derives a `typeShape` from the codebook (node rules only), and `PreviewText`/`RuleEntity` pass it through to `PreviewNode`. Covers both the rules editor and the protocol summary.

## Audited and confirmed correct

`ConnectedNode`, `NodeList`, `Pair` (Dyad/TieStrength census), `CanvasNode` (Sociogram/Narrative), Sociogram `DrawerNode`, `ExternalNodeItem`, `PedigreeNode`, Geospatial, OneToManyDyadCensus, Codebook `EntityIcon`/`EntityType`/`EntityBadge`, and `ShapePicker`. The `PedigreeView` measurement node is shape-agnostic (all shapes are aspect-square).

## Testing

- `pnpm typecheck` — all 22 packages pass
- `pnpm lint:fix` / `pnpm knip` — clean
- Unit tests pass for `@codaco/interview` (423) and `architect-web` (305); browser-mode tests couldn't launch in this environment (no Playwright browsers installed)

Includes a patch changeset for `@codaco/interview`.

https://claude.ai/code/session_01WXKz4hJSTsszD3YYc9bTPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXKz4hJSTsszD3YYc9bTPF)_