### PR TITLE
Improve Codebook page usability in Architect-Web

### DIFF
--- a/apps/architect-web/src/components/Codebook/Codebook.tsx
+++ b/apps/architect-web/src/components/Codebook/Codebook.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Section } from '~/components/EditorLayout';
+import Checkbox from '~/components/Form/Fields/Checkbox';
 import { Button } from '~/lib/legacy-ui/components';
 import { getCodebook } from '~/selectors/protocol';
 
@@ -60,24 +61,23 @@ const Codebook = ({ onEditEntity }: CodebookProps) => {
 
   return (
     <div className="my-(--space-xl)">
-      <div className="mb-(--space-lg) flex flex-wrap items-center gap-(--space-md)">
+      <div className="bg-surface-1 mb-(--space-lg) flex flex-wrap items-center gap-(--space-lg) rounded p-6 shadow-md">
         <input
           type="text"
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search node and edge types by name…"
-          aria-label="Search node and edge types by name"
-          className="border-divider bg-surface-2 flex-1 rounded border px-(--space-md) py-(--space-xs)"
+          placeholder="Search types and variables by name…"
+          aria-label="Search the codebook by name"
+          className="border-border bg-surface-2 h-12 flex-1 rounded border px-(--space-md) text-lg"
         />
-        <label className="flex items-center gap-(--space-xs)">
-          <input
-            type="checkbox"
-            checked={unusedOnly}
-            onChange={(event) => setUnusedOnly(event.target.checked)}
-            aria-label="Show unused entities only"
-          />
-          <span>Unused only</span>
-        </label>
+        <Checkbox
+          label="Show unused only"
+          input={{
+            name: 'codebook-unused-only',
+            value: unusedOnly,
+            onChange: (value) => setUnusedOnly(Boolean(value)),
+          }}
+        />
       </div>
 
       {!hasAnyContent && (
@@ -93,7 +93,7 @@ const Codebook = ({ onEditEntity }: CodebookProps) => {
       <div className="mb-(--space-lg)">
         <h2 className="mt-0 mb-(--space-md)">Ego</h2>
         <Section layout="vertical" required={false}>
-          <EgoType />
+          <EgoType search={search} unusedOnly={unusedOnly} />
         </Section>
       </div>
 

--- a/apps/architect-web/src/components/Codebook/Codebook.tsx
+++ b/apps/architect-web/src/components/Codebook/Codebook.tsx
@@ -1,6 +1,9 @@
+import { Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Section } from '~/components/EditorLayout';
+import { Button } from '~/lib/legacy-ui/components';
 import { getCodebook } from '~/selectors/protocol';
 
 import EgoType from './EgoType';
@@ -27,31 +30,89 @@ const Codebook = ({ onEditEntity }: CodebookProps) => {
   const hasAnyContent =
     hasEgoVariables || hasNodes || hasEdges || hasNetworkAssets;
 
+  const [search, setSearch] = useState('');
+  const [unusedOnly, setUnusedOnly] = useState(false);
+
+  const filterEntities = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return <T extends { name: string; inUse: boolean }>(
+      items: readonly T[],
+    ): readonly T[] =>
+      items.filter((item) => {
+        if (unusedOnly && item.inUse) {
+          return false;
+        }
+        if (term && !item.name.toLowerCase().includes(term)) {
+          return false;
+        }
+        return true;
+      });
+  }, [search, unusedOnly]);
+
+  const filteredNodes = useMemo(
+    () => filterEntities(nodes),
+    [filterEntities, nodes],
+  );
+  const filteredEdges = useMemo(
+    () => filterEntities(edges),
+    [filterEntities, edges],
+  );
+
   return (
     <div className="my-(--space-xl)">
+      <div className="mb-(--space-lg) flex flex-wrap items-center gap-(--space-md)">
+        <input
+          type="text"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search node and edge types by name…"
+          aria-label="Search node and edge types by name"
+          className="border-divider bg-surface-2 flex-1 rounded border px-(--space-md) py-(--space-xs)"
+        />
+        <label className="flex items-center gap-(--space-xs)">
+          <input
+            type="checkbox"
+            checked={unusedOnly}
+            onChange={(event) => setUnusedOnly(event.target.checked)}
+            aria-label="Show unused entities only"
+          />
+          <span>Unused only</span>
+        </label>
+      </div>
+
       {!hasAnyContent && (
-        <div className="bg-surface-2 border-divider rounded border p-(--space-lg)">
+        <div className="bg-surface-2 border-divider mb-(--space-lg) rounded border p-(--space-lg)">
           <p className="text-muted-foreground text-center">
             There are currently no types or variables defined in this protocol.
-            When you have created some interview stages, the types and variables
-            will be shown here.
+            Use the buttons below to create your first node or edge type, or add
+            ego variables.
           </p>
         </div>
       )}
 
-      {hasEgoVariables && (
-        <div className="mb-(--space-lg)">
-          <h2 className="mt-0 mb-(--space-md)">Ego</h2>
-          <Section layout="vertical" required={false}>
-            <EgoType />
-          </Section>
-        </div>
-      )}
+      <div className="mb-(--space-lg)">
+        <h2 className="mt-0 mb-(--space-md)">Ego</h2>
+        <Section layout="vertical" required={false}>
+          <EgoType />
+        </Section>
+      </div>
 
-      {hasNodes && (
-        <div className="mb-(--space-lg)">
-          <h2 className="mt-0 mb-(--space-md)">Node Types</h2>
-          {nodes.map((node) => (
+      <div className="mb-(--space-lg)">
+        <div className="mb-(--space-md) flex items-center gap-(--space-md)">
+          <h2 className="my-0">Node Types ({nodes.length})</h2>
+          <Button
+            color="sea-green"
+            size="small"
+            icon={<Plus />}
+            onClick={() => onEditEntity?.('node')}
+          >
+            Create node type
+          </Button>
+        </div>
+        {nodes.length === 0 ? (
+          <p className="text-muted-foreground">No node types yet.</p>
+        ) : (
+          filteredNodes.map((node) => (
             <EntityType
               key={node.type}
               entity={node.entity}
@@ -60,14 +121,26 @@ const Codebook = ({ onEditEntity }: CodebookProps) => {
               usage={[...node.usage]}
               onEditEntity={onEditEntity}
             />
-          ))}
-        </div>
-      )}
+          ))
+        )}
+      </div>
 
-      {hasEdges && (
-        <div className="mb-(--space-lg)">
-          <h2 className="mt-0 mb-(--space-md)">Edge Types</h2>
-          {edges.map((edge) => (
+      <div className="mb-(--space-lg)">
+        <div className="mb-(--space-md) flex items-center gap-(--space-md)">
+          <h2 className="my-0">Edge Types ({edges.length})</h2>
+          <Button
+            color="sea-green"
+            size="small"
+            icon={<Plus />}
+            onClick={() => onEditEntity?.('edge')}
+          >
+            Create edge type
+          </Button>
+        </div>
+        {edges.length === 0 ? (
+          <p className="text-muted-foreground">No edge types yet.</p>
+        ) : (
+          filteredEdges.map((edge) => (
             <EntityType
               key={edge.type}
               entity={edge.entity}
@@ -76,13 +149,15 @@ const Codebook = ({ onEditEntity }: CodebookProps) => {
               usage={[...edge.usage]}
               onEditEntity={onEditEntity}
             />
-          ))}
-        </div>
-      )}
+          ))
+        )}
+      </div>
 
-      {hasNetworkAssets && (
+      {processedNetworkAssets.length > 0 && (
         <div className="mb-(--space-lg)">
-          <h2 className="mt-0 mb-(--space-md)">Network Assets</h2>
+          <h2 className="mt-0 mb-(--space-md)">
+            Network Assets ({processedNetworkAssets.length})
+          </h2>
           {processedNetworkAssets.map((networkAsset) => (
             <ExternalEntity
               key={networkAsset.id}

--- a/apps/architect-web/src/components/Codebook/ControlsColumn.tsx
+++ b/apps/architect-web/src/components/Codebook/ControlsColumn.tsx
@@ -8,17 +8,23 @@ type ControlsColumnProps = {
   onDelete: (id: string) => void;
 };
 
-const ControlsColumn = ({ id, inUse, onDelete }: ControlsColumnProps) => (
-  <>
-    {!inUse && (
-      <Button
-        color="neon-coral"
-        icon={<DeleteIcon />}
-        onClick={() => onDelete(id)}
-        title="Delete variable"
-      />
-    )}
-  </>
-);
+const ControlsColumn = ({ id, inUse, onDelete }: ControlsColumnProps) => {
+  const title = inUse ? 'In use — cannot be deleted' : 'Delete variable';
+
+  return (
+    <Button
+      color="neon-coral"
+      icon={<DeleteIcon />}
+      onClick={() => {
+        if (!inUse) {
+          onDelete(id);
+        }
+      }}
+      disabled={inUse}
+      title={title}
+      aria-label={title}
+    />
+  );
+};
 
 export default ControlsColumn;

--- a/apps/architect-web/src/components/Codebook/ControlsColumn.tsx
+++ b/apps/architect-web/src/components/Codebook/ControlsColumn.tsx
@@ -9,21 +9,21 @@ type ControlsColumnProps = {
 };
 
 const ControlsColumn = ({ id, inUse, onDelete }: ControlsColumnProps) => {
-  const title = inUse ? 'In use — cannot be deleted' : 'Delete variable';
+  const label = inUse ? 'In use — cannot be deleted' : 'Delete variable';
 
+  // The title lives on the wrapping span rather than the Button: a disabled
+  // Button gets `pointer-events-none`, so a `title` on it would never show on
+  // hover. `disabled` already blocks the click, so no extra guard is needed.
   return (
-    <Button
-      color="neon-coral"
-      icon={<DeleteIcon />}
-      onClick={() => {
-        if (!inUse) {
-          onDelete(id);
-        }
-      }}
-      disabled={inUse}
-      title={title}
-      aria-label={title}
-    />
+    <span title={label} className="inline-block">
+      <Button
+        color="neon-coral"
+        icon={<DeleteIcon />}
+        onClick={() => onDelete(id)}
+        disabled={inUse}
+        aria-label={label}
+      />
+    </span>
   );
 };
 

--- a/apps/architect-web/src/components/Codebook/EgoType.tsx
+++ b/apps/architect-web/src/components/Codebook/EgoType.tsx
@@ -1,4 +1,3 @@
-import type { ComponentProps } from 'react';
 import { useState } from 'react';
 import { compose } from 'react-recompose';
 import { connect } from 'react-redux';
@@ -31,19 +30,35 @@ type VariablesComponentProps = {
 
 type EgoTypeProps = {
   variables?: Record<string, Variable>;
+  search?: string;
+  unusedOnly?: boolean;
 };
 
-const EgoType = ({ variables = {} }: EgoTypeProps) => {
+const EgoType = ({
+  variables = {},
+  search = '',
+  unusedOnly = false,
+}: EgoTypeProps) => {
   const [showAddVariable, setShowAddVariable] = useState(false);
 
   const variableArray = Object.values(variables);
+  const term = search.trim().toLowerCase();
+  const filteredVariables = variableArray.filter((variable) => {
+    if (unusedOnly && variable.inUse) {
+      return false;
+    }
+    if (term && !variable.name.toLowerCase().includes(term)) {
+      return false;
+    }
+    return true;
+  });
+
   const VariablesTyped =
     Variables as unknown as React.ComponentType<VariablesComponentProps>;
 
   return (
     <div className="py-(--space-md)">
-      <div className="flex items-center gap-(--space-md)">
-        <h3 className="my-0">Variables:</h3>
+      <div className="flex justify-end">
         <Button
           color="sea-green"
           size="small"
@@ -52,11 +67,13 @@ const EgoType = ({ variables = {} }: EgoTypeProps) => {
           Add variable
         </Button>
       </div>
-      {variableArray.length > 0 ? (
-        <VariablesTyped variables={variableArray} entity="ego" />
+      {filteredVariables.length > 0 ? (
+        <VariablesTyped variables={filteredVariables} entity="ego" />
       ) : (
         <p className="text-muted-foreground mt-(--space-md)">
-          No ego variables yet.
+          {variableArray.length === 0
+            ? 'No ego variables yet.'
+            : 'No ego variables match the current filter.'}
         </p>
       )}
       <NewVariableWindow
@@ -75,6 +92,12 @@ const mapStateToProps = (state: RootState) => {
   return entityProperties;
 };
 
-export default compose<ComponentProps<typeof EgoType>, typeof EgoType>(
-  connect(mapStateToProps),
-)(EgoType);
+// Props passed in by the parent; `variables` is injected by `connect`.
+type EgoOwnProps = {
+  search?: string;
+  unusedOnly?: boolean;
+};
+
+export default compose<EgoTypeProps, EgoOwnProps>(connect(mapStateToProps))(
+  EgoType,
+);

--- a/apps/architect-web/src/components/Codebook/EgoType.tsx
+++ b/apps/architect-web/src/components/Codebook/EgoType.tsx
@@ -1,8 +1,11 @@
 import type { ComponentProps } from 'react';
+import { useState } from 'react';
 import { compose } from 'react-recompose';
 import { connect } from 'react-redux';
 
+import NewVariableWindow from '~/components/NewVariableWindow/NewVariableWindow';
 import type { RootState } from '~/ducks/store';
+import { Button } from '~/lib/legacy-ui/components';
 
 import { getEntityProperties } from './helpers';
 import Variables from './Variables';
@@ -31,18 +34,38 @@ type EgoTypeProps = {
 };
 
 const EgoType = ({ variables = {} }: EgoTypeProps) => {
+  const [showAddVariable, setShowAddVariable] = useState(false);
+
   const variableArray = Object.values(variables);
   const VariablesTyped =
     Variables as unknown as React.ComponentType<VariablesComponentProps>;
 
   return (
     <div className="py-(--space-md)">
-      {variableArray.length > 0 && (
-        <div>
-          <h3>Variables:</h3>
-          <VariablesTyped variables={variableArray} entity="ego" />
-        </div>
+      <div className="flex items-center gap-(--space-md)">
+        <h3 className="my-0">Variables:</h3>
+        <Button
+          color="sea-green"
+          size="small"
+          onClick={() => setShowAddVariable(true)}
+        >
+          Add variable
+        </Button>
+      </div>
+      {variableArray.length > 0 ? (
+        <VariablesTyped variables={variableArray} entity="ego" />
+      ) : (
+        <p className="text-muted-foreground mt-(--space-md)">
+          No ego variables yet.
+        </p>
       )}
+      <NewVariableWindow
+        show={showAddVariable}
+        entity="ego"
+        type=""
+        onComplete={() => setShowAddVariable(false)}
+        onCancel={() => setShowAddVariable(false)}
+      />
     </div>
   );
 };

--- a/apps/architect-web/src/components/Codebook/EntityType.tsx
+++ b/apps/architect-web/src/components/Codebook/EntityType.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { compose, withHandlers } from 'react-recompose';
 import { connect } from 'react-redux';
 import { Link } from 'wouter';
 
 import type { NodeShape } from '@codaco/fresco-ui/Node';
 import { Section } from '~/components/EditorLayout';
+import NewVariableWindow from '~/components/NewVariableWindow/NewVariableWindow';
 import { actionCreators as dialogActionCreators } from '~/ducks/modules/dialogs';
 import { deleteTypeAsync } from '~/ducks/modules/protocol/codebook';
 import type { RootState } from '~/ducks/store';
@@ -62,25 +64,25 @@ const EntityType = ({
   handleEdit = () => {},
   handleDelete = () => {},
 }: EntityTypeProps) => {
+  const [showAddVariable, setShowAddVariable] = useState(false);
+
   const variableArray = Object.values(variables);
   const VariablesTyped =
     Variables as unknown as React.ComponentType<VariablesComponentProps>;
 
-  const stages = usage.map(({ id, label }) =>
-    id ? (
-      <Link
-        href={`/protocol/stage/${id}`}
-        key={id}
-        className="decoration-action px-1 underline underline-offset-4"
-      >
-        {label}
+  const stages = usage.map(({ id, label }) => {
+    // If there is no id, don't create a link. This is the case for
+    // usages that are only present as validation options.
+    if (!id) {
+      return <Tag key={`validation-${label}`}>{label}</Tag>;
+    }
+
+    return (
+      <Link key={id} href={`/protocol/stage/${id}`}>
+        <Tag>{label}</Tag>
       </Link>
-    ) : (
-      <span key={`validation-${label}`} className="px-1">
-        {label}
-      </span>
-    ),
-  );
+    );
+  });
 
   return (
     <Section layout="vertical" required={false}>
@@ -95,30 +97,56 @@ const EntityType = ({
         </div>
         <h2 className="my-0">{name}</h2>
         <div className="flex-1">
-          {!inUse && <Tag>not in use</Tag>}
+          {!inUse && <Tag notUsed>not in use</Tag>}
           {inUse && (
-            <>
-              <em>used in:</em> {stages}
-            </>
+            <div className="flex flex-wrap items-center gap-(--space-xs)">
+              <span>used in:</span>
+              {stages}
+            </div>
           )}
         </div>
         <Button onClick={handleEdit} color="sea-green">
           Edit entity
         </Button>
-        <Button color="neon-coral" onClick={handleDelete}>
+        <Button
+          color="neon-coral"
+          onClick={handleDelete}
+          disabled={inUse}
+          title={
+            inUse
+              ? `In use in ${usage.length} stage(s) — remove usages first`
+              : 'Delete entity'
+          }
+        >
           Delete entity
         </Button>
       </div>
-      {variableArray.length > 0 && (
-        <div className="mt-(--space-md)">
-          <h3>Variables:</h3>
+      <div className="mt-(--space-md)">
+        <div className="flex items-center gap-(--space-md)">
+          <h3 className="my-0">Variables:</h3>
+          <Button
+            color="sea-green"
+            size="small"
+            onClick={() => setShowAddVariable(true)}
+          >
+            Add variable
+          </Button>
+        </div>
+        {variableArray.length > 0 && (
           <VariablesTyped
             variables={variableArray}
             entity={entity}
             type={type}
           />
-        </div>
-      )}
+        )}
+      </div>
+      <NewVariableWindow
+        show={showAddVariable}
+        entity={entity}
+        type={type}
+        onComplete={() => setShowAddVariable(false)}
+        onCancel={() => setShowAddVariable(false)}
+      />
     </Section>
   );
 };

--- a/apps/architect-web/src/components/Codebook/EntityType.tsx
+++ b/apps/architect-web/src/components/Codebook/EntityType.tsx
@@ -123,8 +123,7 @@ const EntityType = ({
         </span>
       </div>
       <div className="mt-(--space-md)">
-        <div className="flex items-center gap-(--space-md)">
-          <h3 className="my-0">Variables:</h3>
+        <div className="flex justify-end">
           <Button
             color="sea-green"
             size="small"

--- a/apps/architect-web/src/components/Codebook/EntityType.tsx
+++ b/apps/architect-web/src/components/Codebook/EntityType.tsx
@@ -70,11 +70,12 @@ const EntityType = ({
   const VariablesTyped =
     Variables as unknown as React.ComponentType<VariablesComponentProps>;
 
-  const stages = usage.map(({ id, label }) => {
+  const stages = usage.map(({ id, label }, index) => {
     // If there is no id, don't create a link. This is the case for
-    // usages that are only present as validation options.
+    // usages that are only present as validation options. Include the index
+    // in the key since validation labels can repeat (e.g. "unknown").
     if (!id) {
-      return <Tag key={`validation-${label}`}>{label}</Tag>;
+      return <Tag key={`validation-${index}-${label}`}>{label}</Tag>;
     }
 
     return (
@@ -108,18 +109,18 @@ const EntityType = ({
         <Button onClick={handleEdit} color="sea-green">
           Edit entity
         </Button>
-        <Button
-          color="neon-coral"
-          onClick={handleDelete}
-          disabled={inUse}
+        <span
           title={
             inUse
               ? `In use in ${usage.length} stage(s) — remove usages first`
               : 'Delete entity'
           }
+          className="inline-block"
         >
-          Delete entity
-        </Button>
+          <Button color="neon-coral" onClick={handleDelete} disabled={inUse}>
+            Delete entity
+          </Button>
+        </span>
       </div>
       <div className="mt-(--space-md)">
         <div className="flex items-center gap-(--space-md)">

--- a/apps/architect-web/src/components/Codebook/Tag.tsx
+++ b/apps/architect-web/src/components/Codebook/Tag.tsx
@@ -8,8 +8,8 @@ type TagProps = {
 const Tag = ({ children = null, notUsed = false }: TagProps) => (
   <div
     className={cx(
-      'inline-block rounded px-(--space-sm) py-(--space-xs) text-[0.9em] wrap-break-word text-white',
-      notUsed ? 'bg-warning' : 'bg-mustard-dark',
+      'inline-block rounded px-(--space-sm) py-(--space-xs) text-[0.9em] wrap-break-word',
+      notUsed ? 'bg-warning text-white' : 'bg-platinum text-charcoal',
     )}
   >
     {children}

--- a/apps/architect-web/src/components/Codebook/UsageColumn.tsx
+++ b/apps/architect-web/src/components/Codebook/UsageColumn.tsx
@@ -21,11 +21,12 @@ const UsageColumn = ({ inUse, usage }: UsageColumnProps) => {
     );
   }
 
-  const stages = usage.map(({ id, label }) => {
+  const stages = usage.map(({ id, label }, index) => {
     // If there is no id, don't create a link. This is the case for
-    // variables that are only in use as validation options.
+    // variables that are only in use as validation options. Include the index
+    // in the key since validation labels can repeat (e.g. "unknown").
     if (!id) {
-      return <Tag key="validation-option">{label}</Tag>;
+      return <Tag key={`validation-option-${index}`}>{label}</Tag>;
     }
 
     const href = `/protocol/stage/${id}`;

--- a/apps/architect-web/src/components/Codebook/Variables.tsx
+++ b/apps/architect-web/src/components/Codebook/Variables.tsx
@@ -57,7 +57,7 @@ const Heading = ({
 
   return (
     <th
-      className="m-0 px-(--space-sm) py-(--space-md) text-left align-middle text-base font-black normal-case"
+      className="bg-surface-2 border-border m-0 border-b-2 px-(--space-md) py-(--space-md) text-left align-middle text-base font-black normal-case"
       aria-sort={ariaSort}
     >
       <button
@@ -118,8 +118,8 @@ const Variables = ({
   };
 
   return (
-    <div>
-      <table className="mt-(--space-lg) w-full">
+    <div className="border-border mt-(--space-lg) overflow-hidden rounded border">
+      <table className="w-full border-collapse">
         <thead>
           <tr>
             <Heading
@@ -130,35 +130,31 @@ const Variables = ({
               Name
             </Heading>
             <Heading
-              name="component"
-              // eslint-disable-next-line react/jsx-props-no-spreading
-              {...headingProps}
-            >
-              Input control
-            </Heading>
-            <Heading
               name="usageString"
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...headingProps}
             >
               Used In
             </Heading>
-            <th aria-label="Actions" />
+            <th
+              aria-label="Actions"
+              className="bg-surface-2 border-border w-px border-b-2"
+            />
           </tr>
         </thead>
         <tbody>
-          {variables.map(({ id, component, inUse, usage }) => (
-            <tr key={id}>
-              <td className="m-0 px-(--space-sm) py-(--space-sm) text-base">
+          {variables.map(({ id, inUse, usage }) => (
+            <tr
+              key={id}
+              className="border-border/40 hover:bg-surface-2/40 border-b last:border-b-0"
+            >
+              <td className="m-0 px-(--space-md) py-(--space-sm) text-base">
                 <EditableVariablePill uuid={id} width="25rem" />
               </td>
-              <td className="m-0 px-(--space-sm) py-(--space-sm) text-base">
-                {component}
-              </td>
-              <td className="m-0 px-(--space-sm) py-(--space-sm) text-base">
+              <td className="border-border/40 m-0 border-l px-(--space-md) py-(--space-sm) text-base">
                 <UsageColumn inUse={inUse} usage={usage} />
               </td>
-              <td className="m-0 px-(--space-sm) py-(--space-sm) text-base">
+              <td className="border-border/40 m-0 border-l px-(--space-md) py-(--space-sm) text-right text-base">
                 <ControlsColumn onDelete={onDelete} inUse={inUse} id={id} />
               </td>
             </tr>

--- a/apps/architect-web/src/components/Codebook/Variables.tsx
+++ b/apps/architect-web/src/components/Codebook/Variables.tsx
@@ -49,12 +49,24 @@ const Heading = ({
     ? SortDirection.ASC
     : reverseSort(sortDirection);
 
+  const ariaSort = !isSorted
+    ? 'none'
+    : sortDirection === SortDirection.ASC
+      ? 'ascending'
+      : 'descending';
+
   return (
     <th
       className="m-0 px-(--space-sm) py-(--space-md) text-left align-middle text-base font-black normal-case"
-      onClick={() => onSort({ sortBy: name, sortDirection: newSortDirection })}
+      aria-sort={ariaSort}
     >
-      <span className="inline-flex items-center gap-(--space-xs)">
+      <button
+        type="button"
+        className="inline-flex cursor-pointer appearance-none items-center gap-(--space-xs) border-0 bg-transparent p-0 text-left font-[inherit]"
+        onClick={() =>
+          onSort({ sortBy: name, sortDirection: newSortDirection })
+        }
+      >
         {children}
         {isSorted &&
           (sortDirection === SortDirection.ASC ? (
@@ -62,7 +74,7 @@ const Heading = ({
           ) : (
             <ChevronUp size={16} className="text-action" />
           ))}
-      </span>
+      </button>
     </th>
   );
 };
@@ -131,7 +143,6 @@ const Variables = ({
             >
               Used In
             </Heading>
-            <th aria-label="Actions" />
             <th aria-label="Actions" />
           </tr>
         </thead>

--- a/apps/architect-web/src/components/Codebook/useCodebookData.ts
+++ b/apps/architect-web/src/components/Codebook/useCodebookData.ts
@@ -16,6 +16,7 @@ type UsageMeta = {
 type EntityWithUsage = {
   readonly entity: 'node' | 'edge';
   readonly type: string;
+  readonly name: string;
   readonly inUse: boolean;
   readonly usage: readonly UsageMeta[];
 };
@@ -63,8 +64,12 @@ const useEntityProcessors = () => {
 const processEntityEntries = (
   entries: [string, unknown][],
   processor: (value: unknown, id: string) => unknown,
+  getName: (value: unknown, id: string) => string,
 ): EntityWithUsage[] => {
-  return entries.map(([id, value]) => processor(value, id) as EntityWithUsage);
+  return entries.map(([id, value]) => ({
+    ...(processor(value, id) as EntityWithUsage),
+    name: getName(value, id),
+  }));
 };
 
 const processNetworkAssets = (
@@ -97,13 +102,21 @@ export const useCodebookData = (codebook: Codebook | null): CodebookData => {
   // Memoize node processing
   const nodes = useMemo(() => {
     if (!codebook?.node) return [];
-    return processEntityEntries(Object.entries(codebook.node), nodeProcessor);
+    return processEntityEntries(
+      Object.entries(codebook.node),
+      nodeProcessor,
+      (_value, id) => codebook.node?.[id]?.name ?? id,
+    );
   }, [codebook?.node, nodeProcessor]);
 
   // Memoize edge processing
   const edges = useMemo(() => {
     if (!codebook?.edge) return [];
-    return processEntityEntries(Object.entries(codebook.edge), edgeProcessor);
+    return processEntityEntries(
+      Object.entries(codebook.edge),
+      edgeProcessor,
+      (_value, id) => codebook.edge?.[id]?.name ?? id,
+    );
   }, [codebook?.edge, edgeProcessor]);
 
   // Memoize network assets processing

--- a/apps/architect-web/src/components/pages/CodebookPage.tsx
+++ b/apps/architect-web/src/components/pages/CodebookPage.tsx
@@ -36,7 +36,7 @@ const CodebookPage = () => {
       <Layout>
         <PageHeading
           title="Codebook"
-          description="Overview of the node and edge types defined in your protocol. Unused entities can be deleted."
+          description="Overview of the ego, node and edge types, their variables, and network assets defined in your protocol. Create, edit, and delete types and variables here. Unused entities can be deleted."
         />
         <div className="mx-(--space-5xl) w-full max-w-7xl">
           <Codebook onEditEntity={handleOpenEntityDialog} />


### PR DESCRIPTION
## Summary

Addresses several usability issues on the Architect-Web Codebook page (`/protocol/codebook`). Previously the page was a read-mostly report: you could only edit/delete entities that stages had already created, deletion of in-use items failed via an after-the-fact dialog, usage was styled inconsistently, the table had an a11y gap and a column mismatch, and there was no way to cope with large protocols.

All changes are scoped to `apps/architect-web/src/components/Codebook/*` and `pages/CodebookPage.tsx`.

## Changes

**Creation & editing affordances**
- Add **Create node type** / **Create edge type** buttons; the Node/Edge sections now always render so the first type can be created here (reuses `EntityTypeDialog`'s existing create mode).
- Add **Add variable** buttons per node/edge type and for Ego (reuses the existing `NewVariableWindow`).
- Give the **Ego** section parity with node/edge sections (heading, add-variable, placeholder).

**Discoverability & consistency**
- Disable the **Delete** buttons (entity and variable) when an item is in use, with an explanatory tooltip — instead of erroring on click (entities) or hiding the control entirely (variables).
- Unify usage display as `Tag` pills across both entity headers and variable rows.

**Scalability**
- Add a **search** box (filter types by name) and an **Unused only** toggle.
- Show entity **counts** in section headings, with muted placeholders for empty sections.

**Accessibility & correctness**
- Make sortable table headers keyboard-accessible (`<button>` + `aria-sort`).
- Fix the variables table **header/body column mismatch** (removed a duplicate `<th>`).
- Add accessible labels to the search input and unused-only checkbox.

**Copy**
- Update the page description to mention ego variables, network assets, and editing.
- Improve the empty state to point at the now-always-visible create affordances.

## Notes / scope

- Editing an *existing* variable's **type/options** is intentionally not added here: there is no existing dialog for it and changing a variable's type post-hoc is unsafe. Inline renaming via the variable pill is unchanged; the new "Add variable" flow uses the standard `NewVariableWindow`.
- `@codaco/architect-web` is a private app, so no changeset is included (consistent with the repo's changeset usage for published packages only).

## Verification

Run for `@codaco/architect-web`:
- `turbo run typecheck` ✅
- `oxlint` + `oxfmt --check` ✅
- `vitest run src/components/Codebook` ✅
- `turbo run build` ✅

https://claude.ai/code/session_015avvfUk3DeVVUjKVSMXVv2

---
_Generated by [Claude Code](https://claude.ai/code/session_015avvfUk3DeVVUjKVSMXVv2)_