### PR TITLE
interviewer-v8: export via native share sheet on tablet

### DIFF
--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -56,6 +56,7 @@
     "@capacitor/ios": "^8.3.4",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/preferences": "^8.0.1",
+    "@capacitor/share": "^8.0.1",
     "@codaco/art": "workspace:*",
     "@codaco/biometric-keystore": "workspace:*",
     "@codaco/fresco-ui": "workspace:*",

--- a/apps/interviewer-v8/src/lib/files/__tests__/download.test.ts
+++ b/apps/interviewer-v8/src/lib/files/__tests__/download.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('~/lib/platform/platform', () => ({
+  isElectron: false,
+  isCapacitor: true,
+  hostAppName: 'interviewer-v8',
+}));
+
+vi.mock('@capacitor/filesystem', () => ({
+  Filesystem: {
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+  },
+  Directory: { Cache: 'CACHE', Documents: 'DOCUMENTS' },
+}));
+
+vi.mock('@capacitor/share', () => ({
+  Share: {
+    canShare: vi.fn(),
+    share: vi.fn(),
+  },
+}));
+
+import { Filesystem } from '@capacitor/filesystem';
+import { Share } from '@capacitor/share';
+
+import { downloadBlob } from '../download';
+
+const CACHE_URI = 'file:///cache/network-canvas-export.zip';
+
+function makeBlob() {
+  return new Blob(['export-bytes'], { type: 'application/zip' });
+}
+
+describe('downloadBlob (Capacitor)', () => {
+  beforeEach(() => {
+    vi.mocked(Filesystem.writeFile).mockResolvedValue({ uri: CACHE_URI });
+    vi.mocked(Filesystem.deleteFile).mockResolvedValue(undefined);
+    vi.mocked(Share.canShare).mockResolvedValue({ value: true });
+    vi.mocked(Share.share).mockResolvedValue({
+      activityType: 'com.apple.UIKit.activity.SaveToFiles',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes to Cache, presents the share sheet, and cleans up', async () => {
+    const result = await downloadBlob(makeBlob(), 'network-canvas-export.zip');
+
+    expect(Filesystem.writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'network-canvas-export.zip',
+        directory: 'CACHE',
+      }),
+    );
+    expect(Share.share).toHaveBeenCalledWith(
+      expect.objectContaining({ files: [CACHE_URI] }),
+    );
+    expect(Filesystem.deleteFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'network-canvas-export.zip',
+        directory: 'CACHE',
+      }),
+    );
+    expect(result).toEqual({ saved: true });
+  });
+
+  it('returns saved:false when the user cancels the share sheet', async () => {
+    vi.mocked(Share.share).mockRejectedValue(new Error('Share canceled'));
+
+    const result = await downloadBlob(makeBlob(), 'export.zip');
+
+    expect(result).toEqual({ saved: false });
+    expect(Filesystem.deleteFile).toHaveBeenCalled();
+  });
+
+  it('rethrows a non-cancellation share error and still cleans up', async () => {
+    vi.mocked(Share.share).mockRejectedValue(new Error('Some native failure'));
+
+    await expect(downloadBlob(makeBlob(), 'export.zip')).rejects.toThrow(
+      'Some native failure',
+    );
+    expect(Filesystem.deleteFile).toHaveBeenCalled();
+  });
+
+  it('throws when sharing is unavailable, without presenting the sheet', async () => {
+    vi.mocked(Share.canShare).mockResolvedValue({ value: false });
+
+    await expect(downloadBlob(makeBlob(), 'export.zip')).rejects.toThrow(
+      /not available/i,
+    );
+    expect(Share.share).not.toHaveBeenCalled();
+    expect(Filesystem.deleteFile).toHaveBeenCalled();
+  });
+});

--- a/apps/interviewer-v8/src/lib/files/__tests__/download.test.ts
+++ b/apps/interviewer-v8/src/lib/files/__tests__/download.test.ts
@@ -76,6 +76,15 @@ describe('downloadBlob (Capacitor)', () => {
     expect(Filesystem.deleteFile).toHaveBeenCalled();
   });
 
+  it('treats a non-Error cancellation carrying a message as canceled', async () => {
+    vi.mocked(Share.share).mockRejectedValue({ message: 'Share canceled' });
+
+    const result = await downloadBlob(makeBlob(), 'export.zip');
+
+    expect(result).toEqual({ saved: false });
+    expect(Filesystem.deleteFile).toHaveBeenCalled();
+  });
+
   it('rethrows a non-cancellation share error and still cleans up', async () => {
     vi.mocked(Share.share).mockRejectedValue(new Error('Some native failure'));
 

--- a/apps/interviewer-v8/src/lib/files/download.ts
+++ b/apps/interviewer-v8/src/lib/files/download.ts
@@ -84,8 +84,24 @@ function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
-// `@capacitor/share` rejects with a "share canceled" message when the user
-// dismisses the sheet (iOS); treat that as a non-error cancellation.
+// `@capacitor/share` rejects when the user dismisses the sheet; treat a
+// "cancel" message as a non-error cancellation. The rejection may arrive as an
+// Error, a bare string, or a plugin object carrying `message`, so normalise
+// before matching rather than assuming an Error instance.
 function isShareCanceled(cause: unknown): boolean {
-  return cause instanceof Error && /cancel/i.test(cause.message);
+  return /cancel/i.test(errorMessage(cause));
+}
+
+function errorMessage(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string') return cause;
+  if (
+    typeof cause === 'object' &&
+    cause !== null &&
+    'message' in cause &&
+    typeof cause.message === 'string'
+  ) {
+    return cause.message;
+  }
+  return '';
 }

--- a/apps/interviewer-v8/src/lib/files/download.ts
+++ b/apps/interviewer-v8/src/lib/files/download.ts
@@ -21,16 +21,38 @@ export async function downloadBlob(
 
   if (isCapacitor) {
     const { Filesystem, Directory } = await import('@capacitor/filesystem');
+    const { Share } = await import('@capacitor/share');
     const base64 = await blobToBase64(blob);
-    // Omit `encoding` so Capacitor decodes the base64 string to binary bytes;
-    // passing an encoding writes the literal base64 text instead.
-    const result = await Filesystem.writeFile({
+    // Write to Cache (ephemeral, shareable) rather than Documents so we leave no
+    // copy behind; the share sheet lets the user choose the real destination.
+    const { uri } = await Filesystem.writeFile({
       path: suggestedName,
       data: base64,
-      directory: Directory.Documents,
+      directory: Directory.Cache,
       recursive: true,
     });
-    return { saved: true, path: result.uri };
+    try {
+      const { value: canShare } = await Share.canShare();
+      if (!canShare) {
+        throw new Error('Sharing is not available on this device');
+      }
+      await Share.share({ title: suggestedName, files: [uri] });
+      return { saved: true };
+    } catch (cause) {
+      if (isShareCanceled(cause)) {
+        return { saved: false };
+      }
+      throw cause;
+    } finally {
+      try {
+        await Filesystem.deleteFile({
+          path: suggestedName,
+          directory: Directory.Cache,
+        });
+      } catch {
+        // Best-effort cleanup; a leftover cache entry must not mask the result.
+      }
+    }
   }
 
   const url = URL.createObjectURL(blob);
@@ -60,4 +82,10 @@ function blobToBase64(blob: Blob): Promise<string> {
       reject(reader.error ?? new Error('FileReader failed'));
     reader.readAsDataURL(blob);
   });
+}
+
+// `@capacitor/share` rejects with a "share canceled" message when the user
+// dismisses the sheet (iOS); treat that as a non-error cancellation.
+function isShareCanceled(cause: unknown): boolean {
+  return cause instanceof Error && /cancel/i.test(cause.message);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,6 +1163,9 @@ importers:
       '@capacitor/preferences':
         specifier: ^8.0.1
         version: 8.0.1(@capacitor/core@8.4.0)
+      '@capacitor/share':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.4.0)
       '@codaco/art':
         specifier: workspace:*
         version: link:../../packages/art


### PR DESCRIPTION
## What

On the **Capacitor (iPadOS / Android)** build of `apps/interviewer-v8`, exporting interview data now presents the **native OS share sheet** (with "Save to Files", AirDrop, cloud apps, Mail, …) so the user chooses where the archive goes — instead of silently writing the zip into the app's `Documents/` directory with no prompt.

Desktop (Electron) already shows a native save dialog and web triggers a browser download; **both are unchanged**. Only the Capacitor branch of `downloadBlob` changes.

## How

`src/lib/files/download.ts` — Capacitor branch only:
- Writes the zip to `Directory.Cache` (ephemeral, shareable) rather than `Documents`, so no copy is left behind.
- Guards with `Share.canShare()`, then presents `Share.share({ title, files: [uri] })`.
- Resolve → `{ saved: true }`; user cancel (plugin rejects with a "cancel" message) → `{ saved: false }` (existing "Export canceled" toast); any other error rethrows to the existing handler.
- `finally` best-effort deletes the cache file on every path.

The `downloadBlob` signature and the `DownloadResult` contract are unchanged, so the sole caller (`useSessionMutations.handleExport`), its toasts, and `markSessionsExported` need no edits.

## Testing

- New `src/lib/files/__tests__/download.test.ts` (4 cases): writes to Cache → shares the cache URI → cleans up; cancel → `{ saved: false }`; non-cancel error rethrows; unavailable-share throws without presenting the sheet.
- `pnpm --filter @codaco/interviewer-v8 test` → **95/95 passing**; typecheck clean.

## Out of scope (deliberate)

- **Native plugin registration (`cap sync`)** is intentionally excluded: the working tree has unrelated in-flight uncommitted native changes (Podfile) and the Android project is mid-resync. `@capacitor/share@^8.0.1` is added to `package.json`, so the next `cap sync` on a clean tree registers it automatically (iOS Pods + Android gradle).
- On-device share-sheet behavior must be confirmed manually on an iPad/Android build after that sync. Note for the device test: on some Android targets a *successful* share can return `RESULT_CANCELED`; this branch degrades fail-safe (under-marks rather than over-marks exported).

Spec: `docs/superpowers/specs/2026-06-17-tablet-export-share-sheet-design.md`
Plan: `docs/superpowers/plans/2026-06-17-tablet-export-share-sheet.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
