### PR TITLE
ci: build-only workflow for legacy apps (Architect/Interviewer)

### DIFF
--- a/.github/workflows/legacy-app-build.yml
+++ b/.github/workflows/legacy-app-build.yml
@@ -1,0 +1,75 @@
+# Build the legacy desktop apps (Architect / Interviewer) for every platform and
+# upload the installers as workflow artifacts — WITHOUT mirroring source to the
+# external repos or creating any GitHub release. This is the build half of the
+# legacy release split out as a standalone, manually-dispatched tool, so a release
+# can be assembled by hand: download the artifacts here, then attach them to a
+# draft release on the external repo. To rebuild a single failed platform, use
+# "Re-run failed jobs" on the run.
+#
+# macOS builds are signed (MAC_CSC_LINK/MAC_CSC_KEY_PASSWORD) and notarized via
+# Apple ID credentials (APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID). The
+# electron-builder configs gate `notarize` on APPLE_ID being present. Windows and
+# Linux ship unsigned (no certificates configured).
+name: Legacy App Build (no release)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [architect, interviewer]
+        target:
+          - os: macos-latest
+            platform: mac
+          - os: windows-latest
+            platform: win
+          - os: ubuntu-latest
+            platform: linux
+    runs-on: ${{ matrix.target.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - if: matrix.target.os == 'ubuntu-latest'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-turbo-
+      # Architect's build graph depends on network-canvas-interviewer (its preview
+      # window renders the Interviewer bundle), so this also produces
+      # apps/interviewer/out, which the architect electron-builder config vendors
+      # via extraResources.
+      - name: Build app + workspace deps
+        run: pnpm exec turbo run build --filter=network-canvas-${{ matrix.app }}
+      # Build only — no publishing. macOS notarization runs automatically when
+      # APPLE_ID is set (the config gates `notarize` on it).
+      - name: Package
+        working-directory: apps/${{ matrix.app }}
+        env:
+          CSC_LINK: ${{ matrix.target.os == 'macos-latest' && secrets.MAC_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.target.os == 'macos-latest' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.target.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.target.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.target.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
+        run: >-
+          pnpm exec electron-builder --${{ matrix.target.platform }}
+          --config ${{ matrix.app == 'architect' && 'electron-builder.config.js' || 'electron-builder.config.cjs' }}
+          --publish never
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: legacy-${{ matrix.app }}-${{ matrix.target.platform }}
+          path: apps/${{ matrix.app }}/release-builds/*
+          if-no-files-found: error
+          retention-days: 30

--- a/apps/architect/electron-builder.config.js
+++ b/apps/architect/electron-builder.config.js
@@ -85,10 +85,11 @@ module.exports = {
         arch: ['x64', 'arm64'],
       },
     ],
-    // Notarize via electron-builder's built-in notarytool when App Store Connect
-    // API credentials are present (APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER).
-    // Evaluates to false on local/unsigned builds, which skips notarization.
-    notarize: Boolean(process.env.APPLE_API_KEY),
+    // Notarize via electron-builder's built-in notarytool when credentials are
+    // present — either App Store Connect API key (APPLE_API_KEY/APPLE_API_KEY_ID/
+    // APPLE_API_ISSUER) or Apple ID (APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/
+    // APPLE_TEAM_ID). Evaluates to false on local/unsigned builds, skipping it.
+    notarize: Boolean(process.env.APPLE_API_KEY || process.env.APPLE_ID),
   },
 
   // DMG configuration

--- a/apps/interviewer/electron-builder.config.cjs
+++ b/apps/interviewer/electron-builder.config.cjs
@@ -64,10 +64,15 @@ module.exports = {
     gatekeeperAssess: false,
     entitlements: './build-resources/entitlements.mac.inherit.plist',
     entitlementsInherit: './build-resources/entitlements.mac.inherit.plist',
-    // Notarize via electron-builder's built-in notarytool when App Store Connect
-    // API credentials are present (APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER).
-    // Evaluates to false on local/unsigned builds, which skips notarization.
-    notarize: Boolean(process.env.APPLE_API_KEY),
+    target: [
+      { target: 'dmg', arch: ['x64', 'arm64'] },
+      { target: 'zip', arch: ['x64', 'arm64'] },
+    ],
+    // Notarize via electron-builder's built-in notarytool when credentials are
+    // present — either App Store Connect API key (APPLE_API_KEY/APPLE_API_KEY_ID/
+    // APPLE_API_ISSUER) or Apple ID (APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/
+    // APPLE_TEAM_ID). Evaluates to false on local/unsigned builds, skipping it.
+    notarize: Boolean(process.env.APPLE_API_KEY || process.env.APPLE_ID),
   },
   linux: {
     maintainer: 'Joshua Melville <joshmelville@gmail.com>',


### PR DESCRIPTION
Adds a manually-dispatched **Legacy App Build (no release)** workflow that builds Architect and Interviewer for macOS / Windows / Linux and uploads the installers as workflow artifacts — **without** mirroring source to the external repos or creating any GitHub release. It's the build half of the legacy release pipeline, split out so a release can be assembled by hand (download artifacts → attach to a draft release on the external repo). Single-platform retries use GitHub's "Re-run failed jobs".

### Why
The existing legacy release jobs in `ci-and-release.yml` reference signing/notarization secrets (`APPLE_API_KEY`, `CSC_LINK`, …, `LEGACY_RELEASE_GH_TOKEN`) that are **not configured** — the org provides differently-named ones (`MAC_CSC_LINK`, `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID`). This build-only workflow uses the secrets that actually exist, so macOS builds are signed + notarized.

### Changes
- New `.github/workflows/legacy-app-build.yml` (build matrix: 2 apps × 3 platforms, `electron-builder --publish never`, artifacts named `legacy-<app>-<platform>`).
- electron-builder configs: gate `notarize` on `APPLE_ID` as well as `APPLE_API_KEY`, so the Apple-ID notarization path is used.
- Interviewer mac config had no `target`/`arch` (host-arch only) — set `dmg`+`zip` for `x64`+`arm64` to match Architect and produce native **Apple Silicon** builds.

### Note (follow-up, not in this PR)
The legacy release jobs in `ci-and-release.yml` still reference the non-existent secret names; they're skipped in normal operation. Worth reconciling separately.