### PR TITLE
feat(interviewer-v8): in-app update/upgrade system

### DIFF
--- a/.changeset/interviewer-v8-update-system.md
+++ b/.changeset/interviewer-v8-update-system.md
@@ -1,5 +1,0 @@
----
-'@codaco/interviewer-v8': minor
----
-
-Add an in-app update system. On launch the app checks GitHub Releases for a newer version and shows a toast (with "skip this release" and "dismiss"); opening it shows a dialog with the rendered release notes and a platform-specific action. On Electron it downloads and installs the update in the background via electron-updater (generic feed maintained by CI); on Capacitor it opens the App Store / Play Store listing.

--- a/.changeset/interviewer-v8-update-system.md
+++ b/.changeset/interviewer-v8-update-system.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer-v8': minor
+---
+
+Add an in-app update system. On launch the app checks GitHub Releases for a newer version and shows a toast (with "skip this release" and "dismiss"); opening it shows a dialog with the rendered release notes and a platform-specific action. On Electron it downloads and installs the update in the background via electron-updater (generic feed maintained by CI); on Capacitor it opens the App Store / Play Store listing.

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1050,9 +1050,16 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
-        run: pnpm electron:dist:${{ matrix.platform }}
+        # `--publish never`: the `publish` config makes electron-builder emit the
+        # latest*.yml auto-update metadata + app-update.yml, but uploading to the
+        # moving feed is done by interviewer-v8-publish via gh, not here.
+        run: |
+          pnpm electron:build
+          pnpm exec electron-builder --${{ matrix.platform }} --config electron-builder.config.cjs --publish never
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          # release-builds/* now also contains latest*.yml (+ .blockmap) so the
+          # publish job can push them to the update feed.
           name: ${{ matrix.artifact_name }}
           path: apps/interviewer-v8/release-builds/*
           if-no-files-found: error
@@ -1085,6 +1092,24 @@ jobs:
           fail_on_unmatched_files: true
           make_latest: 'false'
           generate_release_notes: true
+      # Maintain the stable `interviewer-v8-latest` release that electron-updater's
+      # generic feed reads (see electron-builder.config.cjs `publish`). The release
+      # is recreated each time so stale, differently-named installers from the
+      # previous version don't linger beside the current latest*.yml metadata.
+      - name: Update electron-updater feed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.release.outputs.interviewer_v8_version }}
+        run: |
+          tag=interviewer-v8-latest
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release delete "$tag" --yes --cleanup-tag
+          fi
+          gh release create "$tag" artifacts/* \
+            --title "Interviewer v8 update feed" \
+            --notes "Auto-maintained download feed for the in-app updater (currently v${VERSION}). For release notes see the interviewer-v8@v* releases." \
+            --latest=false
 
   interviewer-release-build:
     needs: legacy-release-detect

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1091,6 +1091,9 @@ jobs:
           files: artifacts/*
           fail_on_unmatched_files: true
           make_latest: 'false'
+          # A version with a prerelease tag (e.g. 8.0.0-alpha.1) is flagged as a
+          # GitHub pre-release.
+          prerelease: ${{ contains(needs.release.outputs.interviewer_v8_version, '-') }}
           generate_release_notes: true
       # Maintain the stable `interviewer-v8-latest` release that electron-updater's
       # generic feed reads (see electron-builder.config.cjs `publish`). The release

--- a/apps/interviewer-v8/RELEASING.md
+++ b/apps/interviewer-v8/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing Interviewer v8
+
+> **Prerelease phase.** While the app ships `8.0.0-alpha.x` builds it is on the
+> changesets `ignore` list, so releases are **not** changeset-driven. Releases
+> are triggered by bumping the version in `package.json`. Once `8.0.0` stable
+> ships, interviewer-v8 rejoins the normal changeset workflow and this file
+> should be revisited.
+
+## Cut a release
+
+1. Bump `version` in `apps/interviewer-v8/package.json` (e.g.
+   `8.0.0-alpha.0` → `8.0.0-alpha.1`).
+2. Sync the native project versions: `pnpm --filter @codaco/interviewer-v8 version:sync`
+   (updates iOS `MARKETING_VERSION` and Android `versionName`).
+3. Open a PR, merge to `main`.
+
+On merge, the `release` job in [`.github/workflows/ci-and-release.yml`](../../.github/workflows/ci-and-release.yml)
+diffs `apps/interviewer-v8/package.json`'s `version` against the previous commit.
+A change triggers:
+
+- **`interviewer-v8-build`** — builds the Electron app for macOS / Windows /
+  Linux. `npmRebuild` rebuilds the native modules (SQLCipher, biometric-keystore)
+  against Electron's ABI; `--publish never` emits the update metadata locally
+  without uploading.
+- **`interviewer-v8-publish`** — creates the GitHub release
+  `interviewer-v8@v<version>` (installers + notes; flagged as a pre-release for
+  `-alpha.x` versions) **and** recreates the stable `interviewer-v8-latest`
+  release that the auto-updater feed points at.
+
+## How auto-update finds it
+
+`electron-builder.config.cjs` configures a **generic** `publish` provider at the
+`interviewer-v8-latest` release URL. The channel is derived from the version:
+
+- `8.0.0-alpha.1` → emits `alpha.yml` and bakes `channel: alpha` into
+  `app-update.yml`, so the updater requests `alpha.yml` (which the build wrote).
+- a stable `8.0.0` → emits/serves `latest.yml`.
+
+`autoUpdater.allowPrerelease = true` ([`electron/update/updater.ts`](electron/update/updater.ts))
+lets an alpha build accept a newer alpha.
+
+**Two releases are needed to observe auto-update:** the first establishes the
+feed + an installable build; a subsequent higher version is what an installed
+build then detects, downloads, and installs. Capacitor (iPad/Android) and web
+read GitHub Releases directly and don't depend on the feed.
+
+## Platform notes
+
+- **macOS** is signed + notarized when `APPLE_API_KEY`/`CSC_LINK` secrets are
+  present — required for auto-update to apply.
+- **Windows** ships unsigned (SmartScreen warns); auto-update still works.
+- **Linux** AppImage auto-updates; `.deb` does not (update via the package
+  manager).

--- a/apps/interviewer-v8/android/app/build.gradle
+++ b/apps/interviewer-v8/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "8.0.0-alpha.0"
+        versionName "8.0.0-alpha.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v8/electron-builder.config.cjs
+++ b/apps/interviewer-v8/electron-builder.config.cjs
@@ -22,6 +22,20 @@ module.exports = {
   appId: 'Network-Canvas-Interviewer-8',
   productName: 'Network Canvas Interviewer',
   copyright: `Copyright © ${new Date().getFullYear()} Complex Data Collective`,
+  // Auto-update feed. The monorepo publishes many products to one repo's
+  // Releases with prefixed tags, so the standard GitHub provider can't identify
+  // interviewer-v8 releases. CI instead maintains a stable `interviewer-v8-latest`
+  // release whose installers + latest*.yml are overwritten each release (see
+  // .github/workflows/ci-and-release.yml); electron-updater reads that fixed URL.
+  // Configuring `publish` also makes electron-builder emit the latest*.yml
+  // metadata and bake app-update.yml into the packaged resources.
+  publish: [
+    {
+      provider: 'generic',
+      url: 'https://github.com/complexdatacollective/network-canvas-monorepo/releases/download/interviewer-v8-latest/',
+      channel: 'latest',
+    },
+  ],
   directories: {
     buildResources: 'build-resources',
     output: 'release-builds',
@@ -83,6 +97,8 @@ module.exports = {
   },
   linux: {
     category: 'Education',
+    // AppImage supports electron-updater auto-update; .deb does not — deb users
+    // update via their package manager / a manual download.
     target: ['AppImage', 'deb'],
   },
 };

--- a/apps/interviewer-v8/electron-builder.config.cjs
+++ b/apps/interviewer-v8/electron-builder.config.cjs
@@ -25,15 +25,20 @@ module.exports = {
   // Auto-update feed. The monorepo publishes many products to one repo's
   // Releases with prefixed tags, so the standard GitHub provider can't identify
   // interviewer-v8 releases. CI instead maintains a stable `interviewer-v8-latest`
-  // release whose installers + latest*.yml are overwritten each release (see
+  // release whose installers + update metadata are overwritten each release (see
   // .github/workflows/ci-and-release.yml); electron-updater reads that fixed URL.
-  // Configuring `publish` also makes electron-builder emit the latest*.yml
-  // metadata and bake app-update.yml into the packaged resources.
+  // Configuring `publish` also makes electron-builder emit the channel metadata
+  // (`<channel>.yml`) and bake app-update.yml into the packaged resources.
+  //
+  // `channel` is intentionally NOT set: electron-builder derives it from the
+  // version's prerelease tag, so an `-alpha.x` build emits `alpha.yml` and bakes
+  // `channel: alpha` into app-update.yml — the file the updater requests and the
+  // file the build writes always agree. (A stable build emits `latest.yml`.) The
+  // CI publish step uploads whichever `*.yml` is produced.
   publish: [
     {
       provider: 'generic',
       url: 'https://github.com/complexdatacollective/network-canvas-monorepo/releases/download/interviewer-v8-latest/',
-      channel: 'latest',
     },
   ],
   directories: {

--- a/apps/interviewer-v8/electron.vite.config.ts
+++ b/apps/interviewer-v8/electron.vite.config.ts
@@ -11,7 +11,12 @@ import { createRendererConfig } from './vite.renderer.config';
 export default defineConfig(
   (): UserConfig => ({
     main: {
-      plugins: [externalizeDepsPlugin()],
+      // electron-updater is bundled (not externalized) into the main process.
+      // The electron-builder `files` config excludes node_modules except the
+      // native binaries, and under pnpm electron-updater's transitive closure
+      // isn't top-level-symlinked, so it can't be re-included by glob — bundling
+      // pulls its pure-JS dependency tree into index.cjs instead.
+      plugins: [externalizeDepsPlugin({ exclude: ['electron-updater'] })],
       build: {
         outDir: 'dist-electron/main',
         rollupOptions: {

--- a/apps/interviewer-v8/electron/handlers/updateHandlers.ts
+++ b/apps/interviewer-v8/electron/handlers/updateHandlers.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron';
+
+import {
+  checkForUpdate,
+  downloadUpdate,
+  quitAndInstall,
+} from '../update/updater';
+
+export function registerUpdateHandlers(): void {
+  ipcMain.handle('update:check', async () => checkForUpdate());
+  ipcMain.handle('update:download', async () => downloadUpdate());
+  ipcMain.handle('update:install', async () => quitAndInstall());
+}

--- a/apps/interviewer-v8/electron/main.ts
+++ b/apps/interviewer-v8/electron/main.ts
@@ -19,7 +19,9 @@ import { bootstrapNoLock } from './auth/vault';
 import { getDbPath, migrateLegacyDbFilename } from './db/service';
 import { registerAuthHandlers } from './handlers/authHandlers';
 import { registerDbHandlers } from './handlers/dbHandlers';
+import { registerUpdateHandlers } from './handlers/updateHandlers';
 import { buildMenu } from './menu';
+import { initAutoUpdater } from './update/updater';
 
 const isDev = !app.isPackaged;
 const RENDERER_DEV_URL =
@@ -194,6 +196,8 @@ app.whenReady().then(() => {
   });
   registerDbHandlers();
   registerAuthHandlers();
+  registerUpdateHandlers();
+  initAutoUpdater(() => mainWindow);
   try {
     bootstrapNoLock();
   } catch (cause) {

--- a/apps/interviewer-v8/electron/preload.ts
+++ b/apps/interviewer-v8/electron/preload.ts
@@ -70,6 +70,35 @@ const systemBridge = {
   storageInfo: () => ipcRenderer.invoke('system:storageInfo'),
 };
 
+type UpdateProgress = {
+  percent: number;
+  transferred: number;
+  total: number;
+  bytesPerSecond: number;
+};
+
+const updateBridge = {
+  check: () => ipcRenderer.invoke('update:check'),
+  download: () => ipcRenderer.invoke('update:download'),
+  install: () => ipcRenderer.invoke('update:install'),
+  onProgress: (callback: (progress: UpdateProgress) => void) => {
+    const handler = (_event: unknown, progress: UpdateProgress) =>
+      callback(progress);
+    ipcRenderer.on('update:progress', handler);
+    return () => ipcRenderer.off('update:progress', handler);
+  },
+  onDownloaded: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('update:downloaded', handler);
+    return () => ipcRenderer.off('update:downloaded', handler);
+  },
+  onError: (callback: (message: string) => void) => {
+    const handler = (_event: unknown, message: string) => callback(message);
+    ipcRenderer.on('update:error', handler);
+    return () => ipcRenderer.off('update:error', handler);
+  },
+};
+
 // Electron only runs on these three platforms; narrow without an `as` cast.
 function rendererPlatform(): 'darwin' | 'win32' | 'linux' {
   const platform = process.platform;
@@ -90,6 +119,7 @@ const electronAPI = {
   db: dbBridge,
   auth: authBridge,
   system: systemBridge,
+  update: updateBridge,
 };
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI);

--- a/apps/interviewer-v8/electron/update/devSimulation.ts
+++ b/apps/interviewer-v8/electron/update/devSimulation.ts
@@ -1,0 +1,80 @@
+import { app, dialog } from 'electron';
+
+import type { UpdateInfo, UpdateProgress } from './types';
+
+// Electron auto-update can only run from a packaged build (it needs the
+// app-update.yml baked in at package time + a real feed). To exercise the
+// desktop flow — toast, dialog, background download with progress, restart &
+// install — in `electron:dev`, the updater simulates an available update when
+// the app is not packaged. A packaged build always uses real electron-updater.
+export function isUpdateSimulated(): boolean {
+  return !app.isPackaged;
+}
+
+export function simulatedUpdate(): UpdateInfo {
+  return {
+    version: '8.1.0',
+    currentVersion: app.getVersion(),
+    releaseName: 'Network Canvas Interviewer 8.1.0 (simulated)',
+    releaseNotesMarkdown: SIMULATED_NOTES,
+    releaseUrl:
+      'https://github.com/complexdatacollective/network-canvas-monorepo/releases',
+    publishedAt: '2026-06-18T00:00:00.000Z',
+  };
+}
+
+// Emits download-progress events that ramp to 100%, then a downloaded event —
+// the same channels the real autoUpdater forwards — so the dialog's progress
+// bar and "Restart & install" transition can be tested. Returns a disposer.
+export function simulateDownload(
+  emitProgress: (progress: UpdateProgress) => void,
+  emitDownloaded: () => void,
+): () => void {
+  const total = 64 * 1024 * 1024;
+  const bytesPerSecond = 6 * 1024 * 1024;
+  let percent = 0;
+
+  const timer = setInterval(() => {
+    percent = Math.min(100, percent + 8);
+    emitProgress({
+      percent,
+      transferred: Math.round((total * percent) / 100),
+      total,
+      bytesPerSecond,
+    });
+    if (percent >= 100) {
+      clearInterval(timer);
+      setTimeout(emitDownloaded, 300);
+    }
+  }, 350);
+
+  return () => clearInterval(timer);
+}
+
+export async function simulateInstall(): Promise<void> {
+  await dialog.showMessageBox({
+    type: 'info',
+    title: 'Simulated update',
+    message: 'Simulated install',
+    detail:
+      'In a packaged build the app would now quit, install the update, and relaunch. Nothing is installed in development.',
+    buttons: ['OK'],
+  });
+}
+
+const SIMULATED_NOTES = [
+  '## What’s new in 8.1.0',
+  '',
+  'This release note is **simulated** for local development.',
+  '',
+  '- **Resumable interviews** that survive an app restart',
+  '- Faster import for large `.netcanvas` protocols',
+  '- A clearer first-run setup flow',
+  '',
+  '### Fixes',
+  '',
+  '- Fixed an edge case in the name generator',
+  '- Improved error messages on export',
+  '',
+  '[View the full changelog](https://github.com/complexdatacollective/network-canvas-monorepo/releases)',
+].join('\n');

--- a/apps/interviewer-v8/electron/update/types.ts
+++ b/apps/interviewer-v8/electron/update/types.ts
@@ -1,0 +1,19 @@
+// Mirrors the renderer's UpdateInfo (src/lib/update/types.ts). Kept as a
+// separate declaration because the main process is a distinct TS build that
+// does not include renderer sources; shared here between updater.ts and
+// devSimulation.ts.
+export type UpdateInfo = {
+  version: string;
+  currentVersion: string;
+  releaseName: string;
+  releaseNotesMarkdown: string;
+  releaseUrl: string;
+  publishedAt: string | null;
+};
+
+export type UpdateProgress = {
+  percent: number;
+  transferred: number;
+  total: number;
+  bytesPerSecond: number;
+};

--- a/apps/interviewer-v8/electron/update/updater.ts
+++ b/apps/interviewer-v8/electron/update/updater.ts
@@ -1,0 +1,166 @@
+import { app, type BrowserWindow, net } from 'electron';
+import electronUpdater from 'electron-updater';
+
+const { autoUpdater } = electronUpdater;
+
+// Mirrors the renderer's UpdateInfo (src/lib/update/types.ts). Kept structural
+// rather than imported because the main process is a separate TS build that
+// does not include renderer sources.
+type UpdateInfo = {
+  version: string;
+  currentVersion: string;
+  releaseName: string;
+  releaseNotesMarkdown: string;
+  releaseUrl: string;
+  publishedAt: string | null;
+};
+
+const REPO = 'complexdatacollective/network-canvas-monorepo';
+const RELEASE_TAG_PREFIX = 'interviewer-v8@v';
+
+let getWindow: () => BrowserWindow | null = () => null;
+
+// Attaches the long-lived download/error listeners once and disables automatic
+// behaviour — download and install are user-initiated from the update dialog.
+export function initAutoUpdater(window: () => BrowserWindow | null): void {
+  getWindow = window;
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on('download-progress', (progress) => {
+    send('update:progress', {
+      percent: progress.percent,
+      transferred: progress.transferred,
+      total: progress.total,
+      bytesPerSecond: progress.bytesPerSecond,
+    });
+  });
+
+  autoUpdater.on('update-downloaded', () => {
+    send('update:downloaded', null);
+  });
+
+  autoUpdater.on('error', (error) => {
+    send(
+      'update:error',
+      error instanceof Error ? error.message : String(error),
+    );
+  });
+}
+
+function send(channel: string, payload: unknown): void {
+  getWindow()?.webContents.send(channel, payload);
+}
+
+// Resolves the latest release's availability via electron-updater (it performs
+// the semver comparison against app.getVersion() internally and emits exactly
+// one of update-available / update-not-available / error), then fetches the
+// human-readable release notes from the GitHub API by tag. Returns null when up
+// to date, in dev (no app-update.yml), or on any failure — the launch check is
+// best-effort and must never block startup.
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  if (!app.isPackaged) return null;
+
+  const availability = new Promise<string | null>((resolve) => {
+    const onAvailable = (info: { version: string }) => {
+      cleanup();
+      resolve(info.version);
+    };
+    const onNotAvailable = () => {
+      cleanup();
+      resolve(null);
+    };
+    const onError = () => {
+      cleanup();
+      resolve(null);
+    };
+    const cleanup = () => {
+      autoUpdater.off('update-available', onAvailable);
+      autoUpdater.off('update-not-available', onNotAvailable);
+      autoUpdater.off('error', onError);
+    };
+    autoUpdater.once('update-available', onAvailable);
+    autoUpdater.once('update-not-available', onNotAvailable);
+    autoUpdater.once('error', onError);
+  });
+
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch {
+    return null;
+  }
+
+  const version = await availability;
+  if (!version) return null;
+
+  const notes = await fetchReleaseNotes(version);
+  return {
+    version,
+    currentVersion: app.getVersion(),
+    releaseName: notes?.name ?? `Version ${version}`,
+    releaseNotesMarkdown: notes?.body ?? '',
+    releaseUrl: notes?.htmlUrl ?? releasePageUrl(version),
+    publishedAt: notes?.publishedAt ?? null,
+  };
+}
+
+export async function downloadUpdate(): Promise<void> {
+  try {
+    await autoUpdater.downloadUpdate();
+  } catch (error) {
+    send(
+      'update:error',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+export function quitAndInstall(): void {
+  autoUpdater.quitAndInstall();
+}
+
+function releasePageUrl(version: string): string {
+  return `https://github.com/${REPO}/releases/tag/${RELEASE_TAG_PREFIX}${version}`;
+}
+
+type ReleaseNotes = {
+  name: string;
+  body: string;
+  htmlUrl: string;
+  publishedAt: string | null;
+};
+
+// Main-process fetch (renderer CSP is connect-src 'self'). Uses Electron's net
+// module so it shares the app's network stack/proxy config.
+async function fetchReleaseNotes(
+  version: string,
+): Promise<ReleaseNotes | null> {
+  const url = `https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG_PREFIX}${version}`;
+  try {
+    const response = await net.fetch(url, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!response.ok) return null;
+    const data: unknown = await response.json();
+    if (typeof data !== 'object' || data === null) return null;
+
+    const name =
+      'name' in data && typeof data.name === 'string' && data.name
+        ? data.name
+        : `Version ${version}`;
+    const body =
+      'body' in data && typeof data.body === 'string' ? data.body : '';
+    const htmlUrl =
+      'html_url' in data && typeof data.html_url === 'string'
+        ? data.html_url
+        : releasePageUrl(version);
+    const publishedAt =
+      'published_at' in data && typeof data.published_at === 'string'
+        ? data.published_at
+        : null;
+
+    return { name, body, htmlUrl, publishedAt };
+  } catch {
+    return null;
+  }
+}

--- a/apps/interviewer-v8/electron/update/updater.ts
+++ b/apps/interviewer-v8/electron/update/updater.ts
@@ -22,6 +22,11 @@ export function initAutoUpdater(window: () => BrowserWindow | null): void {
   getWindow = window;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
+  // The app currently ships -alpha.x prereleases. electron-updater would
+  // otherwise refuse to advertise a prerelease as an update; allow it so an
+  // alpha build can update to a newer alpha. (electron-builder's version-derived
+  // `alpha` channel already keeps prereleases out of the stable `latest` feed.)
+  autoUpdater.allowPrerelease = true;
 
   autoUpdater.on('download-progress', (progress) => {
     send('update:progress', {

--- a/apps/interviewer-v8/electron/update/updater.ts
+++ b/apps/interviewer-v8/electron/update/updater.ts
@@ -1,19 +1,15 @@
 import { app, type BrowserWindow, net } from 'electron';
 import electronUpdater from 'electron-updater';
 
-const { autoUpdater } = electronUpdater;
+import {
+  isUpdateSimulated,
+  simulateDownload,
+  simulateInstall,
+  simulatedUpdate,
+} from './devSimulation';
+import type { UpdateInfo } from './types';
 
-// Mirrors the renderer's UpdateInfo (src/lib/update/types.ts). Kept structural
-// rather than imported because the main process is a separate TS build that
-// does not include renderer sources.
-type UpdateInfo = {
-  version: string;
-  currentVersion: string;
-  releaseName: string;
-  releaseNotesMarkdown: string;
-  releaseUrl: string;
-  publishedAt: string | null;
-};
+const { autoUpdater } = electronUpdater;
 
 const REPO = 'complexdatacollective/network-canvas-monorepo';
 const RELEASE_TAG_PREFIX = 'interviewer-v8@v';
@@ -59,7 +55,9 @@ function send(channel: string, payload: unknown): void {
 // to date, in dev (no app-update.yml), or on any failure — the launch check is
 // best-effort and must never block startup.
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
-  if (!app.isPackaged) return null;
+  // Dev (electron:dev): return a simulated update so the desktop flow can be
+  // tested without a packaged build / real feed. See devSimulation.ts.
+  if (isUpdateSimulated()) return simulatedUpdate();
 
   const offHandlers: Array<() => void> = [];
   const cleanup = () => {
@@ -114,6 +112,13 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
 }
 
 export async function downloadUpdate(): Promise<void> {
+  if (isUpdateSimulated()) {
+    simulateDownload(
+      (progress) => send('update:progress', progress),
+      () => send('update:downloaded', null),
+    );
+    return;
+  }
   try {
     await autoUpdater.downloadUpdate();
   } catch (error) {
@@ -125,6 +130,10 @@ export async function downloadUpdate(): Promise<void> {
 }
 
 export function quitAndInstall(): void {
+  if (isUpdateSimulated()) {
+    void simulateInstall();
+    return;
+  }
   autoUpdater.quitAndInstall();
 }
 

--- a/apps/interviewer-v8/electron/update/updater.ts
+++ b/apps/interviewer-v8/electron/update/updater.ts
@@ -61,6 +61,12 @@ function send(channel: string, payload: unknown): void {
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
   if (!app.isPackaged) return null;
 
+  const offHandlers: Array<() => void> = [];
+  const cleanup = () => {
+    for (const off of offHandlers) off();
+    offHandlers.length = 0;
+  };
+
   const availability = new Promise<string | null>((resolve) => {
     const onAvailable = (info: { version: string }) => {
       cleanup();
@@ -74,19 +80,22 @@ export async function checkForUpdate(): Promise<UpdateInfo | null> {
       cleanup();
       resolve(null);
     };
-    const cleanup = () => {
-      autoUpdater.off('update-available', onAvailable);
-      autoUpdater.off('update-not-available', onNotAvailable);
-      autoUpdater.off('error', onError);
-    };
     autoUpdater.once('update-available', onAvailable);
     autoUpdater.once('update-not-available', onNotAvailable);
     autoUpdater.once('error', onError);
+    offHandlers.push(
+      () => autoUpdater.off('update-available', onAvailable),
+      () => autoUpdater.off('update-not-available', onNotAvailable),
+      () => autoUpdater.off('error', onError),
+    );
   });
 
   try {
     await autoUpdater.checkForUpdates();
   } catch {
+    // checkForUpdates() may reject without emitting an event — remove the
+    // one-shot listeners so they don't accumulate across repeated calls.
+    cleanup();
     return null;
   }
 

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -72,6 +72,7 @@
     "better-sqlite3-multiple-ciphers": "^12.9.0",
     "dexie": "^4.4.3",
     "effect": "catalog:",
+    "electron-updater": "^6.6.2",
     "jszip": "catalog:",
     "lucide-react": "catalog:",
     "motion": "catalog:",

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v8",
-  "version": "8.0.0-alpha.0",
+  "version": "8.0.0-alpha.1",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",

--- a/apps/interviewer-v8/src/components/SetupWizardDialog.tsx
+++ b/apps/interviewer-v8/src/components/SetupWizardDialog.tsx
@@ -1,6 +1,7 @@
 import { Alert, AlertDescription, AlertTitle } from '@codaco/fresco-ui/Alert';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import Surface from '@codaco/fresco-ui/layout/Surface';
+import { useToast } from '@codaco/fresco-ui/Toast';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
@@ -55,6 +56,7 @@ export function useSetupWizard() {
   const { openDialog } = useDialog();
   const { refresh } = useAuth();
   const analytics = useAnalytics();
+  const toast = useToast();
 
   const openSetupWizard = async (): Promise<void> => {
     const result = await openDialog({
@@ -192,29 +194,43 @@ export function useSetupWizard() {
       ],
     });
 
-    if (!result) {
-      // Dismissed.
-      await enrolWithoutSecurity();
-    } else {
-      const data = result as SetupWizardData;
-      if (data.selectedMethod === 'none') {
-        // Step3Configure is skipped for 'none', so no step enrolled a vault.
+    // Enrolment + settings persistence can fail (e.g. the platform store can't
+    // be opened). Surface it instead of leaving the user stranded on the
+    // welcome screen with no feedback — they stay on /welcome and can retry.
+    try {
+      if (!result) {
+        // Dismissed.
         await enrolWithoutSecurity();
+      } else {
+        const data = result as SetupWizardData;
+        if (data.selectedMethod === 'none') {
+          // Step3Configure is skipped for 'none', so no step enrolled a vault.
+          await enrolWithoutSecurity();
+        }
+        const behavior = data.behavior ?? DEFAULT_BEHAVIOR;
+        await updateSettings({
+          idleTimeoutMinutes: behavior.idleTimeoutMinutes,
+          requireUnlockOnEnter: behavior.requireUnlockOnEnter,
+          requireUnlockOnExit: behavior.requireUnlockOnExit,
+          requireUnlockOnExport: behavior.requireUnlockOnExport,
+        });
+        // Persist + apply the analytics choice (defaults to enabled). Routes
+        // through the provider so opt-in/out and the native preference mirror
+        // take effect immediately.
+        await analytics.setEnabled(data.analyticsEnabled ?? true);
       }
-      const behavior = data.behavior ?? DEFAULT_BEHAVIOR;
-      await updateSettings({
-        idleTimeoutMinutes: behavior.idleTimeoutMinutes,
-        requireUnlockOnEnter: behavior.requireUnlockOnEnter,
-        requireUnlockOnExit: behavior.requireUnlockOnExit,
-        requireUnlockOnExport: behavior.requireUnlockOnExport,
-      });
-      // Persist + apply the analytics choice (defaults to enabled). Routes
-      // through the provider so opt-in/out and the native preference mirror
-      // take effect immediately.
-      await analytics.setEnabled(data.analyticsEnabled ?? true);
-    }
 
-    await refresh();
+      await refresh();
+    } catch (cause) {
+      toast.add({
+        title: 'Setup could not be completed',
+        description:
+          cause instanceof Error
+            ? cause.message
+            : 'Something went wrong while setting up this device. Please try again.',
+        variant: 'destructive',
+      });
+    }
   };
 
   return { openSetupWizard };

--- a/apps/interviewer-v8/src/components/StatusRow.tsx
+++ b/apps/interviewer-v8/src/components/StatusRow.tsx
@@ -1,11 +1,15 @@
+import { CircleArrowUp } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Link } from 'wouter';
 
 import { APP_VERSION } from '~/lib/platform/appVersion';
+import type { UpdateInfo } from '~/lib/update/types';
 
 type StatusRowProps = {
   protocolCount: number;
   interviewCount: number;
+  availableUpdate?: UpdateInfo | null;
+  onOpenUpdate?: () => void;
 };
 
 const variants = {
@@ -25,7 +29,12 @@ const variants = {
   },
 } as const;
 
-export function StatusRow({ protocolCount, interviewCount }: StatusRowProps) {
+export function StatusRow({
+  protocolCount,
+  interviewCount,
+  availableUpdate,
+  onOpenUpdate,
+}: StatusRowProps) {
   return (
     <motion.div
       variants={variants}
@@ -45,7 +54,20 @@ export function StatusRow({ protocolCount, interviewCount }: StatusRowProps) {
           interviews
         </span>
       </Link>
-      <span>Interviewer {APP_VERSION}</span>
+      {availableUpdate ? (
+        <button
+          type="button"
+          onClick={onOpenUpdate}
+          // Styling cues from the DeckCard "Requires Internet" pill: pill
+          // shape, bordered, uppercase, icon + label, tinted by intent.
+          className="focusable text-info border-info bg-info/10 hover:bg-info/20 flex cursor-pointer items-center gap-2 rounded-full border px-3 py-1 text-current uppercase transition-colors"
+        >
+          <CircleArrowUp className="size-3.5" />
+          Update available
+        </button>
+      ) : (
+        <span>Interviewer {APP_VERSION}</span>
+      )}
     </motion.div>
   );
 }

--- a/apps/interviewer-v8/src/components/UpdateDialog.tsx
+++ b/apps/interviewer-v8/src/components/UpdateDialog.tsx
@@ -107,12 +107,19 @@ function ElectronUpdateActions({ onClose }: { onClose: () => void }) {
     };
   }, [api]);
 
+  const fail = useCallback((cause: unknown) => {
+    setError(cause instanceof Error ? cause.message : String(cause));
+    setPhase('error');
+  }, []);
+
   const startDownload = useCallback(() => {
     if (!api) return;
     setError(null);
     setPhase('downloading');
-    void api.download();
-  }, [api]);
+    // Download failures normally arrive via onError; this also catches a
+    // rejection of the IPC call itself so the dialog never sticks on "downloading".
+    api.download().catch(fail);
+  }, [api, fail]);
 
   if (!api) return null;
 
@@ -129,7 +136,7 @@ function ElectronUpdateActions({ onClose }: { onClose: () => void }) {
 
   if (phase === 'downloaded') {
     return (
-      <Button color="primary" onClick={() => void api.install()}>
+      <Button color="primary" onClick={() => api.install().catch(fail)}>
         Restart & install
       </Button>
     );

--- a/apps/interviewer-v8/src/components/UpdateDialog.tsx
+++ b/apps/interviewer-v8/src/components/UpdateDialog.tsx
@@ -6,7 +6,6 @@ import {
   ALLOWED_MARKDOWN_SECTION_TAGS,
   RenderMarkdown,
 } from '@codaco/fresco-ui/RenderMarkdown';
-import { ScrollArea } from '@codaco/fresco-ui/ScrollArea';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { isCapacitor, isElectron } from '~/lib/platform/platform';
 import { getStoreTarget } from '~/lib/update/storeUrls';
@@ -19,44 +18,20 @@ const MARKDOWN_TAGS = [
   'blockquote',
 ];
 
-export function UpdateToastActions({
-  info,
-  onView,
-  onSkip,
-  onDismiss,
-}: {
-  info: UpdateInfo;
-  onView: () => void;
-  onSkip: () => void;
-  onDismiss: () => void;
-}) {
-  return (
-    <div className="flex flex-col gap-2">
-      <span>Version {info.version} is available.</span>
-      <div className="flex flex-wrap gap-2">
-        <Button size="sm" color="primary" onClick={onView}>
-          View details
-        </Button>
-        <Button size="sm" onClick={onSkip}>
-          Skip this release
-        </Button>
-        <Button size="sm" variant="text" onClick={onDismiss}>
-          Dismiss
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 export function UpdateNotes({ info }: { info: UpdateInfo }) {
   return (
-    <ScrollArea className="max-h-[50vh]">
-      <div className="pr-4">
+    <div className="flex flex-col gap-4">
+      <Paragraph>
+        Please read the release notes below thoroughly before installing this
+        update.
+      </Paragraph>
+      {/* Inset, recessed panel (own scroll container so the wheel scrolls the
+          notes rather than the dialog). A raised surface level gives contrast
+          against the dialog and feeds the inset-surface plugin's adaptive
+          shadow via its background color. */}
+      <div className="bg-surface-1 text-surface-1-contrast inset-surface max-h-[45vh] overflow-y-auto overscroll-contain rounded px-5 py-4">
         {info.releaseNotesMarkdown ? (
-          <RenderMarkdown
-            allowedElements={MARKDOWN_TAGS}
-            unwrapDisallowed={true}
-          >
+          <RenderMarkdown allowedElements={MARKDOWN_TAGS} unwrapDisallowed>
             {info.releaseNotesMarkdown}
           </RenderMarkdown>
         ) : (
@@ -65,7 +40,7 @@ export function UpdateNotes({ info }: { info: UpdateInfo }) {
           </Paragraph>
         )}
       </div>
-    </ScrollArea>
+    </div>
   );
 }
 

--- a/apps/interviewer-v8/src/components/UpdateDialog.tsx
+++ b/apps/interviewer-v8/src/components/UpdateDialog.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import Button from '@codaco/fresco-ui/Button';
+import ProgressBar from '@codaco/fresco-ui/ProgressBar';
+import {
+  ALLOWED_MARKDOWN_SECTION_TAGS,
+  RenderMarkdown,
+} from '@codaco/fresco-ui/RenderMarkdown';
+import { ScrollArea } from '@codaco/fresco-ui/ScrollArea';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import { isCapacitor, isElectron } from '~/lib/platform/platform';
+import { getStoreTarget } from '~/lib/update/storeUrls';
+import type { UpdateInfo } from '~/lib/update/types';
+
+const MARKDOWN_TAGS = [
+  ...ALLOWED_MARKDOWN_SECTION_TAGS,
+  'code',
+  'pre',
+  'blockquote',
+];
+
+export function UpdateToastActions({
+  info,
+  onView,
+  onSkip,
+  onDismiss,
+}: {
+  info: UpdateInfo;
+  onView: () => void;
+  onSkip: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span>Version {info.version} is available.</span>
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" color="primary" onClick={onView}>
+          View details
+        </Button>
+        <Button size="sm" onClick={onSkip}>
+          Skip this release
+        </Button>
+        <Button size="sm" variant="text" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function UpdateNotes({ info }: { info: UpdateInfo }) {
+  return (
+    <ScrollArea className="max-h-[50vh]">
+      <div className="pr-4">
+        {info.releaseNotesMarkdown ? (
+          <RenderMarkdown
+            allowedElements={MARKDOWN_TAGS}
+            unwrapDisallowed={true}
+          >
+            {info.releaseNotesMarkdown}
+          </RenderMarkdown>
+        ) : (
+          <Paragraph className="text-text/60">
+            No release notes were provided for this version.
+          </Paragraph>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+export function UpdateActions({
+  info,
+  onClose,
+}: {
+  info: UpdateInfo;
+  onClose: () => void;
+}) {
+  if (isElectron) return <ElectronUpdateActions onClose={onClose} />;
+  if (isCapacitor) return <CapacitorUpdateActions onClose={onClose} />;
+  return <WebUpdateActions info={info} onClose={onClose} />;
+}
+
+type DownloadPhase = 'idle' | 'downloading' | 'downloaded' | 'error';
+
+function ElectronUpdateActions({ onClose }: { onClose: () => void }) {
+  const api = window.electronAPI?.update;
+  const [phase, setPhase] = useState<DownloadPhase>('idle');
+  const [percent, setPercent] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) return undefined;
+    const offProgress = api.onProgress((progress) => {
+      setPhase('downloading');
+      setPercent(progress.percent);
+    });
+    const offDownloaded = api.onDownloaded(() => setPhase('downloaded'));
+    const offError = api.onError((message) => {
+      setError(message);
+      setPhase('error');
+    });
+    return () => {
+      offProgress();
+      offDownloaded();
+      offError();
+    };
+  }, [api]);
+
+  const startDownload = useCallback(() => {
+    if (!api) return;
+    setError(null);
+    setPhase('downloading');
+    void api.download();
+  }, [api]);
+
+  if (!api) return null;
+
+  if (phase === 'downloading') {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <ProgressBar orientation="horizontal" percentProgress={percent} />
+        <Paragraph className="text-text/60 text-sm">
+          Downloading update… {Math.round(percent)}%
+        </Paragraph>
+      </div>
+    );
+  }
+
+  if (phase === 'downloaded') {
+    return (
+      <Button color="primary" onClick={() => void api.install()}>
+        Restart & install
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      {error && (
+        <Paragraph className="text-destructive w-full text-sm">
+          {error}
+        </Paragraph>
+      )}
+      <Button onClick={onClose}>Not now</Button>
+      <Button color="primary" onClick={startDownload}>
+        {phase === 'error' ? 'Try again' : 'Download & install'}
+      </Button>
+    </>
+  );
+}
+
+function CapacitorUpdateActions({ onClose }: { onClose: () => void }) {
+  const target = getStoreTarget();
+  if (!target) return null;
+
+  if (!target.available) {
+    return (
+      <>
+        <Button onClick={onClose}>Close</Button>
+        <Button color="primary" disabled>
+          {target.label} (coming soon)
+        </Button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Button onClick={onClose}>Close</Button>
+      <Button
+        color="primary"
+        onClick={() => {
+          window.open(target.url, '_blank');
+          onClose();
+        }}
+      >
+        {target.label}
+      </Button>
+    </>
+  );
+}
+
+function WebUpdateActions({
+  info,
+  onClose,
+}: {
+  info: UpdateInfo;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <Button onClick={onClose}>Close</Button>
+      <Button
+        color="primary"
+        onClick={() => {
+          window.open(info.releaseUrl, '_blank', 'noopener,noreferrer');
+          onClose();
+        }}
+      >
+        View download page
+      </Button>
+    </>
+  );
+}

--- a/apps/interviewer-v8/src/global.d.ts
+++ b/apps/interviewer-v8/src/global.d.ts
@@ -12,6 +12,7 @@ import type {
   StoredSessionLite,
   StoredSettings,
 } from './lib/db/types';
+import type { UpdateInfo } from './lib/update/types';
 
 declare module '*.css';
 
@@ -145,6 +146,22 @@ declare global {
     }>;
   };
 
+  type UpdateProgress = {
+    percent: number;
+    transferred: number;
+    total: number;
+    bytesPerSecond: number;
+  };
+
+  type UpdateBridge = {
+    check: () => Promise<UpdateInfo | null>;
+    download: () => Promise<void>;
+    install: () => Promise<void>;
+    onProgress: (callback: (progress: UpdateProgress) => void) => () => void;
+    onDownloaded: (callback: () => void) => () => void;
+    onError: (callback: (message: string) => void) => () => void;
+  };
+
   type ElectronAPI = {
     openFile: () => Promise<{
       canceled: boolean;
@@ -165,6 +182,7 @@ declare global {
     db: DbBridge;
     auth: AuthBridge;
     system: SystemBridge;
+    update: UpdateBridge;
   };
 
   // `interface` is required (not `type`) so this declaration MERGES with

--- a/apps/interviewer-v8/src/lib/update/__tests__/checkForUpdate.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/checkForUpdate.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { checkForUpdate } from '../checkForUpdate';
 import type { RemoteRelease } from '../githubReleases';
+import type { UpdateInfo } from '../types';
 
 const platform = vi.hoisted(() => ({ isElectron: false, isCapacitor: false }));
 const fetchLatestRelease = vi.hoisted(() => vi.fn());
 const getInfo = vi.hoisted(() => vi.fn());
+const simulatedWebUpdate = vi.hoisted(() => vi.fn());
 
 vi.mock('../../platform/platform', () => ({
   get isElectron() {
@@ -20,6 +22,10 @@ vi.mock('../githubReleases', () => ({
   fetchLatestRelease: () => fetchLatestRelease(),
 }));
 
+vi.mock('../devSimulation', () => ({
+  simulatedWebUpdate: () => simulatedWebUpdate(),
+}));
+
 vi.mock('@capacitor/app', () => ({
   App: { getInfo: () => getInfo() },
 }));
@@ -32,11 +38,21 @@ const remote: RemoteRelease = {
   publishedAt: '2026-06-01T00:00:00Z',
 };
 
+const simulated: UpdateInfo = {
+  version: '8.1.0',
+  currentVersion: '8.0.0-alpha.0',
+  releaseName: 'Simulated',
+  releaseNotesMarkdown: '## notes',
+  releaseUrl: 'https://example.test/r',
+  publishedAt: null,
+};
+
 beforeEach(() => {
   platform.isElectron = false;
   platform.isCapacitor = false;
   fetchLatestRelease.mockReset();
   getInfo.mockReset();
+  simulatedWebUpdate.mockReset().mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -44,7 +60,13 @@ afterEach(() => {
 });
 
 describe('checkForUpdate (web)', () => {
-  it('returns null on web', async () => {
+  it('returns the simulated update when one is provided (dev)', async () => {
+    simulatedWebUpdate.mockReturnValue(simulated);
+    expect(await checkForUpdate()).toEqual(simulated);
+  });
+
+  it('returns null when simulation is off (production web)', async () => {
+    simulatedWebUpdate.mockReturnValue(null);
     expect(await checkForUpdate()).toBeNull();
   });
 });

--- a/apps/interviewer-v8/src/lib/update/__tests__/checkForUpdate.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/checkForUpdate.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { checkForUpdate } from '../checkForUpdate';
+import type { RemoteRelease } from '../githubReleases';
+
+const platform = vi.hoisted(() => ({ isElectron: false, isCapacitor: false }));
+const fetchLatestRelease = vi.hoisted(() => vi.fn());
+const getInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('../../platform/platform', () => ({
+  get isElectron() {
+    return platform.isElectron;
+  },
+  get isCapacitor() {
+    return platform.isCapacitor;
+  },
+}));
+
+vi.mock('../githubReleases', () => ({
+  fetchLatestRelease: () => fetchLatestRelease(),
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: { getInfo: () => getInfo() },
+}));
+
+const remote: RemoteRelease = {
+  version: '8.1.0',
+  releaseName: 'Shiny',
+  body: '## notes',
+  htmlUrl: 'https://example.test/r',
+  publishedAt: '2026-06-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  platform.isElectron = false;
+  platform.isCapacitor = false;
+  fetchLatestRelease.mockReset();
+  getInfo.mockReset();
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window, 'electronAPI');
+});
+
+describe('checkForUpdate (web)', () => {
+  it('returns null on web', async () => {
+    expect(await checkForUpdate()).toBeNull();
+  });
+});
+
+describe('checkForUpdate (capacitor)', () => {
+  beforeEach(() => {
+    platform.isCapacitor = true;
+  });
+
+  it('returns update info when the remote release is newer', async () => {
+    getInfo.mockResolvedValue({ version: '8.0.0' });
+    fetchLatestRelease.mockResolvedValue(remote);
+
+    const info = await checkForUpdate();
+    expect(info).toEqual({
+      version: '8.1.0',
+      currentVersion: '8.0.0',
+      releaseName: 'Shiny',
+      releaseNotesMarkdown: '## notes',
+      releaseUrl: 'https://example.test/r',
+      publishedAt: '2026-06-01T00:00:00Z',
+    });
+  });
+
+  it('returns null when already up to date', async () => {
+    getInfo.mockResolvedValue({ version: '8.1.0' });
+    fetchLatestRelease.mockResolvedValue(remote);
+    expect(await checkForUpdate()).toBeNull();
+  });
+
+  it('returns null when there is no release', async () => {
+    getInfo.mockResolvedValue({ version: '8.0.0' });
+    fetchLatestRelease.mockResolvedValue(null);
+    expect(await checkForUpdate()).toBeNull();
+  });
+});
+
+describe('checkForUpdate (electron)', () => {
+  beforeEach(() => {
+    platform.isElectron = true;
+  });
+
+  it('delegates to the electron update bridge', async () => {
+    const check = vi.fn().mockResolvedValue({
+      version: '8.1.0',
+      currentVersion: '8.0.0',
+      releaseName: 'Shiny',
+      releaseNotesMarkdown: '## notes',
+      releaseUrl: 'https://example.test/r',
+      publishedAt: null,
+    });
+    Object.assign(window, { electronAPI: { update: { check } } });
+
+    const info = await checkForUpdate();
+    expect(check).toHaveBeenCalledOnce();
+    expect(info?.version).toBe('8.1.0');
+  });
+
+  it('returns null when the bridge is unavailable', async () => {
+    expect(await checkForUpdate()).toBeNull();
+  });
+});

--- a/apps/interviewer-v8/src/lib/update/__tests__/devSimulation.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/devSimulation.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { simulatedWebUpdate } from '../devSimulation';
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe('simulatedWebUpdate', () => {
+  it('returns a simulated update in dev (the vitest default)', () => {
+    const info = simulatedWebUpdate();
+    expect(info?.version).toBe('8.1.0');
+    expect(info?.releaseNotesMarkdown).toContain('simulated');
+    expect(info?.releaseName).toContain('simulated');
+  });
+
+  it('returns null in a production build', () => {
+    vi.stubEnv('DEV', false);
+    expect(simulatedWebUpdate()).toBeNull();
+  });
+});

--- a/apps/interviewer-v8/src/lib/update/__tests__/githubReleases.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/githubReleases.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchLatestRelease, parseVersionFromTag } from '../githubReleases';
+
+// A plain implementation holder rather than a vi.fn: vitest tracks a mocked
+// function's settled results, and a tracked fn returning a rejected promise
+// surfaces a spurious unhandled rejection. Routing through a plain function
+// avoids that while still letting each test choose the response.
+type RequestImpl = () => Promise<{ status: number; data: unknown }>;
+const state = vi.hoisted(() => ({
+  impl: (() => Promise.resolve({ status: 200, data: [] })) as RequestImpl,
+}));
+
+vi.mock('@capacitor/core', () => ({
+  CapacitorHttp: { request: () => state.impl() },
+}));
+
+function resolveWith(status: number, data: unknown) {
+  state.impl = () => Promise.resolve({ status, data });
+}
+
+function release(overrides: Record<string, unknown>) {
+  return {
+    tag_name: 'interviewer-v8@v8.0.0',
+    name: 'Release',
+    body: 'notes',
+    html_url: 'https://example.test/r',
+    published_at: '2026-06-01T00:00:00Z',
+    draft: false,
+    ...overrides,
+  };
+}
+
+describe('parseVersionFromTag', () => {
+  it('extracts the version from a prefixed tag', () => {
+    expect(parseVersionFromTag('interviewer-v8@v8.0.1')).toBe('8.0.1');
+  });
+
+  it('rejects tags for other products', () => {
+    expect(parseVersionFromTag('v8.0.1')).toBeNull();
+    expect(parseVersionFromTag('architect@v1.0.0')).toBeNull();
+    expect(parseVersionFromTag('interviewer-v8@v')).toBeNull();
+  });
+});
+
+describe('fetchLatestRelease', () => {
+  beforeEach(() => resolveWith(200, []));
+
+  it('returns the highest-version interviewer-v8 release', async () => {
+    resolveWith(200, [
+      release({ tag_name: 'interviewer-v8@v8.0.0' }),
+      release({ tag_name: 'interviewer-v8@v8.2.0', name: 'Newest' }),
+      release({ tag_name: 'interviewer-v8@v8.1.0' }),
+    ]);
+
+    const result = await fetchLatestRelease();
+    expect(result?.version).toBe('8.2.0');
+    expect(result?.releaseName).toBe('Newest');
+  });
+
+  it('ignores other products and draft releases', async () => {
+    resolveWith(200, [
+      release({ tag_name: 'architect@v9.9.9' }),
+      release({ tag_name: 'interviewer-v8@v9.0.0', draft: true }),
+      release({ tag_name: 'interviewer-v8@v8.0.5' }),
+    ]);
+
+    const result = await fetchLatestRelease();
+    expect(result?.version).toBe('8.0.5');
+  });
+
+  it('returns null on a non-2xx response', async () => {
+    resolveWith(403, {});
+    expect(await fetchLatestRelease()).toBeNull();
+  });
+
+  it('returns null when the request rejects', async () => {
+    state.impl = () => Promise.reject(new Error('offline'));
+    expect(await fetchLatestRelease()).toBeNull();
+  });
+
+  it('returns null when no interviewer-v8 release exists', async () => {
+    resolveWith(200, [release({ tag_name: 'architect@v1.0.0' })]);
+    expect(await fetchLatestRelease()).toBeNull();
+  });
+});

--- a/apps/interviewer-v8/src/lib/update/__tests__/githubReleases.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/githubReleases.test.ts
@@ -7,8 +7,8 @@ import { fetchLatestRelease, parseVersionFromTag } from '../githubReleases';
 // surfaces a spurious unhandled rejection. Routing through a plain function
 // avoids that while still letting each test choose the response.
 type RequestImpl = () => Promise<{ status: number; data: unknown }>;
-const state = vi.hoisted(() => ({
-  impl: (() => Promise.resolve({ status: 200, data: [] })) as RequestImpl,
+const state = vi.hoisted((): { impl: RequestImpl } => ({
+  impl: () => Promise.resolve({ status: 200, data: [] }),
 }));
 
 vi.mock('@capacitor/core', () => ({

--- a/apps/interviewer-v8/src/lib/update/__tests__/useUpdateCheck.test.tsx
+++ b/apps/interviewer-v8/src/lib/update/__tests__/useUpdateCheck.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { UpdateInfo } from '../types';
+
+const checkForUpdate = vi.hoisted(() => vi.fn());
+const getSettings = vi.hoisted(() => vi.fn());
+const updateSettings = vi.hoisted(() => vi.fn());
+const add = vi.hoisted(() => vi.fn((_data: unknown) => 'toast-id'));
+const close = vi.hoisted(() => vi.fn());
+const openDialog = vi.hoisted(() => vi.fn());
+const closeDialog = vi.hoisted(() => vi.fn());
+
+vi.mock('../checkForUpdate', () => ({
+  checkForUpdate: () => checkForUpdate(),
+}));
+vi.mock('~/lib/db/api', () => ({
+  getSettings: () => getSettings(),
+  updateSettings: (patch: unknown) => updateSettings(patch),
+}));
+vi.mock('@codaco/fresco-ui/Toast', () => ({
+  useToast: () => ({ add, close }),
+}));
+vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
+  default: () => ({ openDialog, closeDialog }),
+}));
+vi.mock('~/components/UpdateDialog', () => ({
+  UpdateNotes: () => null,
+  UpdateActions: () => null,
+  UpdateToastActions: () => null,
+}));
+
+const info: UpdateInfo = {
+  version: '8.1.0',
+  currentVersion: '8.0.0',
+  releaseName: 'Shiny',
+  releaseNotesMarkdown: 'notes',
+  releaseUrl: 'https://example.test/r',
+  publishedAt: null,
+};
+
+async function importHook() {
+  const mod = await import('../useUpdateCheck');
+  return mod.useUpdateCheck;
+}
+
+beforeEach(() => {
+  vi.resetModules(); // resets the module-level run-once guard
+  checkForUpdate.mockReset();
+  getSettings.mockReset();
+  updateSettings.mockReset();
+  add.mockReset().mockReturnValue('toast-id');
+  close.mockReset();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('useUpdateCheck', () => {
+  it('shows a toast for a fresh, non-skipped release', async () => {
+    checkForUpdate.mockResolvedValue(info);
+    getSettings.mockResolvedValue({ dismissedUpdates: [] });
+
+    const useUpdateCheck = await importHook();
+    renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(add).toHaveBeenCalledOnce());
+    expect(add.mock.calls[0]?.[0]).toMatchObject({
+      title: 'Update available',
+      variant: 'info',
+      timeout: 0,
+    });
+  });
+
+  it('does not show a toast when the version was skipped', async () => {
+    checkForUpdate.mockResolvedValue(info);
+    getSettings.mockResolvedValue({ dismissedUpdates: ['8.1.0'] });
+
+    const useUpdateCheck = await importHook();
+    renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(getSettings).toHaveBeenCalled());
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no update is available', async () => {
+    checkForUpdate.mockResolvedValue(null);
+
+    const useUpdateCheck = await importHook();
+    renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(checkForUpdate).toHaveBeenCalled());
+    expect(getSettings).not.toHaveBeenCalled();
+    expect(add).not.toHaveBeenCalled();
+  });
+});

--- a/apps/interviewer-v8/src/lib/update/__tests__/version.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/version.test.ts
@@ -33,6 +33,10 @@ describe('compareVersions', () => {
   it('treats unparseable versions as equal so no false update is claimed', () => {
     expect(compareVersions('not-a-version', '8.0.0')).toBe(0);
     expect(compareVersions('8.0', '8.0.0')).toBe(0);
+    // parseInt is lenient ("0abc" -> 0); the regex guard must reject these.
+    expect(compareVersions('8.0.0abc', '8.0.0')).toBe(0);
+    expect(compareVersions('8..0', '8.0.0')).toBe(0);
+    expect(compareVersions('8.0.0.1', '8.0.0')).toBe(0);
   });
 });
 

--- a/apps/interviewer-v8/src/lib/update/__tests__/version.test.ts
+++ b/apps/interviewer-v8/src/lib/update/__tests__/version.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions, isNewer } from '../version';
+
+describe('compareVersions', () => {
+  it('orders by major, minor, patch', () => {
+    expect(compareVersions('8.0.1', '8.0.0')).toBe(1);
+    expect(compareVersions('8.1.0', '8.0.9')).toBe(1);
+    expect(compareVersions('9.0.0', '8.9.9')).toBe(1);
+    expect(compareVersions('8.0.0', '8.0.1')).toBe(-1);
+    expect(compareVersions('8.0.0', '8.0.0')).toBe(0);
+  });
+
+  it('ranks a release above its prereleases', () => {
+    expect(compareVersions('8.0.0', '8.0.0-alpha.0')).toBe(1);
+    expect(compareVersions('8.0.0-alpha.0', '8.0.0')).toBe(-1);
+  });
+
+  it('orders prerelease identifiers per semver precedence', () => {
+    expect(compareVersions('8.0.0-alpha.1', '8.0.0-alpha.0')).toBe(1);
+    expect(compareVersions('8.0.0-beta.0', '8.0.0-alpha.9')).toBe(1);
+    // A larger set of fields outranks a smaller prefix.
+    expect(compareVersions('8.0.0-alpha.1', '8.0.0-alpha')).toBe(1);
+    // Numeric identifiers rank below alphanumeric ones.
+    expect(compareVersions('8.0.0-1', '8.0.0-alpha')).toBe(-1);
+  });
+
+  it('ignores a leading v and build metadata', () => {
+    expect(compareVersions('v8.0.1', '8.0.1')).toBe(0);
+    expect(compareVersions('8.0.1+build.5', '8.0.1+build.9')).toBe(0);
+  });
+
+  it('treats unparseable versions as equal so no false update is claimed', () => {
+    expect(compareVersions('not-a-version', '8.0.0')).toBe(0);
+    expect(compareVersions('8.0', '8.0.0')).toBe(0);
+  });
+});
+
+describe('isNewer', () => {
+  it('is true only when the remote strictly exceeds the current version', () => {
+    expect(isNewer('8.0.1', '8.0.0')).toBe(true);
+    expect(isNewer('8.0.0', '8.0.0-alpha.0')).toBe(true);
+    expect(isNewer('8.0.0', '8.0.0')).toBe(false);
+    expect(isNewer('8.0.0-alpha.0', '8.0.0')).toBe(false);
+  });
+});

--- a/apps/interviewer-v8/src/lib/update/checkForUpdate.ts
+++ b/apps/interviewer-v8/src/lib/update/checkForUpdate.ts
@@ -1,18 +1,21 @@
 import { App } from '@capacitor/app';
 
 import { isCapacitor, isElectron } from '../platform/platform';
+import { simulatedWebUpdate } from './devSimulation';
 import { fetchLatestRelease } from './githubReleases';
 import type { UpdateInfo } from './types';
 import { isNewer } from './version';
 
 // Returns details of an available newer release, or null when up to date / on a
-// platform where checks don't apply (web). Best-effort: never throws — a failed
-// check simply yields null so app launch is unaffected.
+// platform where checks don't apply. Best-effort: never throws — a failed check
+// simply yields null so app launch is unaffected. On web it has no real release
+// feed; in `vite dev` it returns a simulated update so the flow can be tested
+// (production web builds return null — see devSimulation.ts).
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
   try {
     if (isElectron) return await checkElectron();
     if (isCapacitor) return await checkCapacitor();
-    return null;
+    return simulatedWebUpdate();
   } catch {
     return null;
   }

--- a/apps/interviewer-v8/src/lib/update/checkForUpdate.ts
+++ b/apps/interviewer-v8/src/lib/update/checkForUpdate.ts
@@ -1,0 +1,46 @@
+import { App } from '@capacitor/app';
+
+import { isCapacitor, isElectron } from '../platform/platform';
+import { fetchLatestRelease } from './githubReleases';
+import type { UpdateInfo } from './types';
+import { isNewer } from './version';
+
+// Returns details of an available newer release, or null when up to date / on a
+// platform where checks don't apply (web). Best-effort: never throws — a failed
+// check simply yields null so app launch is unaffected.
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  try {
+    if (isElectron) return await checkElectron();
+    if (isCapacitor) return await checkCapacitor();
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Electron resolves availability + download via electron-updater in the main
+// process (the renderer CSP blocks api.github.com); the main process also
+// fetches the release notes markdown. See electron/update/updater.ts.
+async function checkElectron(): Promise<UpdateInfo | null> {
+  const api = window.electronAPI?.update;
+  if (!api) return null;
+  return api.check();
+}
+
+async function checkCapacitor(): Promise<UpdateInfo | null> {
+  const [{ version: currentVersion }, release] = await Promise.all([
+    App.getInfo(),
+    fetchLatestRelease(),
+  ]);
+
+  if (!release || !isNewer(release.version, currentVersion)) return null;
+
+  return {
+    version: release.version,
+    currentVersion,
+    releaseName: release.releaseName,
+    releaseNotesMarkdown: release.body,
+    releaseUrl: release.htmlUrl,
+    publishedAt: release.publishedAt,
+  };
+}

--- a/apps/interviewer-v8/src/lib/update/devSimulation.ts
+++ b/apps/interviewer-v8/src/lib/update/devSimulation.ts
@@ -1,0 +1,38 @@
+import { APP_VERSION } from '../platform/appVersion';
+import type { UpdateInfo } from './types';
+
+// The web target exists for development only (see CLAUDE.md). To exercise the
+// full update UX — toast, release-notes dialog, skip/dismiss — without a real
+// GitHub release, `vite dev` returns a canned "update available" here. Guarded
+// by `import.meta.env.DEV`, so a production web build (DEV === false) returns
+// null and never simulates. Electron/Capacitor never reach this path.
+export function simulatedWebUpdate(): UpdateInfo | null {
+  if (!import.meta.env.DEV) return null;
+
+  return {
+    version: '8.1.0',
+    currentVersion: APP_VERSION,
+    releaseName: 'Network Canvas Interviewer 8.1.0 (simulated)',
+    releaseNotesMarkdown: SIMULATED_NOTES,
+    releaseUrl:
+      'https://github.com/complexdatacollective/network-canvas-monorepo/releases',
+    publishedAt: '2026-06-18T00:00:00.000Z',
+  };
+}
+
+const SIMULATED_NOTES = [
+  '## What’s new in 8.1.0',
+  '',
+  'This release note is **simulated** for local development.',
+  '',
+  '- **Resumable interviews** that survive an app restart',
+  '- Faster import for large `.netcanvas` protocols',
+  '- A clearer first-run setup flow',
+  '',
+  '### Fixes',
+  '',
+  '- Fixed an edge case in the name generator',
+  '- Improved error messages on export',
+  '',
+  '[View the full changelog](https://github.com/complexdatacollective/network-canvas-monorepo/releases)',
+].join('\n');

--- a/apps/interviewer-v8/src/lib/update/githubReleases.ts
+++ b/apps/interviewer-v8/src/lib/update/githubReleases.ts
@@ -1,0 +1,77 @@
+import { CapacitorHttp } from '@capacitor/core';
+
+import { compareVersions } from './version';
+
+const REPO = 'complexdatacollective/network-canvas-monorepo';
+const RELEASES_URL = `https://api.github.com/repos/${REPO}/releases`;
+
+// Interviewer v8 releases are tagged `interviewer-v8@v<version>` in the shared
+// monorepo (see .github/workflows/ci-and-release.yml). Other products publish
+// to the same repo, so the prefix is how we isolate ours.
+const RELEASE_TAG_PREFIX = 'interviewer-v8@v';
+
+export type RemoteRelease = {
+  version: string;
+  releaseName: string;
+  body: string;
+  htmlUrl: string;
+  publishedAt: string | null;
+};
+
+export function parseVersionFromTag(tag: string): string | null {
+  if (!tag.startsWith(RELEASE_TAG_PREFIX)) return null;
+  const version = tag.slice(RELEASE_TAG_PREFIX.length);
+  return version.length > 0 ? version : null;
+}
+
+function toRelease(raw: unknown): RemoteRelease | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  if ('draft' in raw && raw.draft === true) return null;
+  if (!('tag_name' in raw) || typeof raw.tag_name !== 'string') return null;
+  const version = parseVersionFromTag(raw.tag_name);
+  if (!version) return null;
+
+  const name =
+    'name' in raw && typeof raw.name === 'string' && raw.name
+      ? raw.name
+      : version;
+  const body = 'body' in raw && typeof raw.body === 'string' ? raw.body : '';
+  const htmlUrl =
+    'html_url' in raw && typeof raw.html_url === 'string' ? raw.html_url : '';
+  const publishedAt =
+    'published_at' in raw && typeof raw.published_at === 'string'
+      ? raw.published_at
+      : null;
+
+  return { version, releaseName: name, body, htmlUrl, publishedAt };
+}
+
+// Capacitor-only: runs through the native HTTP stack so the WebView's
+// `connect-src 'self'` CSP and CORS don't apply (mirrors
+// `src/lib/files/fetchFromUrl.ts`). Returns the highest-version interviewer-v8
+// release, or null if none / on error (the launch check is best-effort).
+export async function fetchLatestRelease(): Promise<RemoteRelease | null> {
+  let response: { status: number; data: unknown };
+  try {
+    response = await CapacitorHttp.request({
+      url: RELEASES_URL,
+      method: 'GET',
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+  } catch {
+    return null;
+  }
+
+  if (response.status < 200 || response.status >= 300) return null;
+  if (!Array.isArray(response.data)) return null;
+
+  const releases = response.data
+    .map((raw) => toRelease(raw))
+    .filter((r): r is RemoteRelease => r !== null);
+
+  if (releases.length === 0) return null;
+
+  return releases.reduce((best, candidate) =>
+    compareVersions(candidate.version, best.version) > 0 ? candidate : best,
+  );
+}

--- a/apps/interviewer-v8/src/lib/update/storeUrls.ts
+++ b/apps/interviewer-v8/src/lib/update/storeUrls.ts
@@ -1,0 +1,41 @@
+import { Capacitor } from '@capacitor/core';
+
+// Android package id (matches `capacitor.config.ts` appId). The Play Store
+// listing URL is derivable from it.
+const ANDROID_APP_ID = 'org.complexdatacollective.networkcanvas.interviewer';
+
+// TODO: fill in once the App Store listing is live. The App Store URL needs the
+// numeric app id assigned by App Store Connect, which does not exist yet. Until
+// then the iOS store button is shown disabled (see `available: false`).
+const APP_STORE_ID = '';
+
+type StoreTarget = {
+  url: string;
+  label: string;
+  // `false` when the listing isn't published yet — the action button is shown
+  // disabled with a "coming soon" hint rather than opening a broken link.
+  available: boolean;
+};
+
+export function getStoreTarget(): StoreTarget | null {
+  const platform = Capacitor.getPlatform();
+
+  if (platform === 'android') {
+    return {
+      url: `https://play.google.com/store/apps/details?id=${ANDROID_APP_ID}`,
+      label: 'Open Google Play',
+      available: true,
+    };
+  }
+
+  if (platform === 'ios') {
+    const hasAppStoreId = APP_STORE_ID.length > 0;
+    return {
+      url: hasAppStoreId ? `https://apps.apple.com/app/id${APP_STORE_ID}` : '',
+      label: 'Open App Store',
+      available: hasAppStoreId,
+    };
+  }
+
+  return null;
+}

--- a/apps/interviewer-v8/src/lib/update/storeUrls.ts
+++ b/apps/interviewer-v8/src/lib/update/storeUrls.ts
@@ -4,10 +4,8 @@ import { Capacitor } from '@capacitor/core';
 // listing URL is derivable from it.
 const ANDROID_APP_ID = 'org.complexdatacollective.networkcanvas.interviewer';
 
-// TODO: fill in once the App Store listing is live. The App Store URL needs the
-// numeric app id assigned by App Store Connect, which does not exist yet. Until
-// then the iOS store button is shown disabled (see `available: false`).
-const APP_STORE_ID = '';
+// Numeric App Store app id (App Store Connect). Used to build the listing URL.
+const APP_STORE_ID = '6781689516';
 
 type StoreTarget = {
   url: string;

--- a/apps/interviewer-v8/src/lib/update/types.ts
+++ b/apps/interviewer-v8/src/lib/update/types.ts
@@ -1,0 +1,10 @@
+// Normalized "an update is available" payload shared by the renderer UI, the
+// platform-dispatching `checkForUpdate`, and the Electron `update:check` IPC.
+export type UpdateInfo = {
+  version: string;
+  currentVersion: string;
+  releaseName: string;
+  releaseNotesMarkdown: string;
+  releaseUrl: string;
+  publishedAt: string | null;
+};

--- a/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
+++ b/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
@@ -68,7 +68,7 @@ export function useUpdateCheck(): UseUpdateCheck {
       toast.add({
         id: toastId,
         title: 'Update available',
-        description: `Version ${info.version} is available.`,
+        description: `Version ${info.version} is available. Click for more info.`,
         variant: 'info',
         timeout: 0,
         // Clicking the toast opens the release-notes dialog; the close (X)

--- a/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
+++ b/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
@@ -1,35 +1,36 @@
-import { createElement, useCallback, useEffect } from 'react';
+import { createElement, useCallback, useEffect, useState } from 'react';
 
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useToast } from '@codaco/fresco-ui/Toast';
-import {
-  UpdateActions,
-  UpdateNotes,
-  UpdateToastActions,
-} from '~/components/UpdateDialog';
+import { UpdateActions, UpdateNotes } from '~/components/UpdateDialog';
 import { getSettings, updateSettings } from '~/lib/db/api';
 
 import { checkForUpdate } from './checkForUpdate';
 import type { UpdateInfo } from './types';
 
 // Module-level so the check runs once per app session, not once per Home mount
-// (HomeRoute remounts when navigating back from an interview).
+// (HomeRoute remounts when navigating back from an interview). `cachedUpdate`
+// re-hydrates the badge state on remount without re-running the check.
 let hasRun = false;
+let cachedUpdate: UpdateInfo | null = null;
 
-function formatPublishedAt(publishedAt: string | null): string | undefined {
-  if (!publishedAt) return undefined;
-  const date = new Date(publishedAt);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return new Intl.DateTimeFormat(undefined, { dateStyle: 'long' }).format(date);
-}
+export type UseUpdateCheck = {
+  availableUpdate: UpdateInfo | null;
+  openUpdateDialog: (info: UpdateInfo) => void;
+};
 
 // Runs the launch-time update check exactly once. On a fresh, non-skipped
-// release it raises a toast; the toast's "View details" opens a dialog with the
-// rendered release notes and a platform-specific action. Best-effort — any
-// failure in checkForUpdate resolves to null and is silently ignored.
-export function useUpdateCheck(): void {
+// release it raises a toast; clicking the toast (or the home-screen badge)
+// opens a dialog with the rendered release notes and a platform-specific
+// action. Returns the available update (independent of skip/dismiss, which only
+// govern the toast) so the home screen can show a persistent badge.
+// Best-effort — any failure in checkForUpdate resolves to null and is ignored.
+export function useUpdateCheck(): UseUpdateCheck {
   const toast = useToast();
   const dialog = useDialog();
+  const [availableUpdate, setAvailableUpdate] = useState<UpdateInfo | null>(
+    cachedUpdate,
+  );
 
   const skipRelease = useCallback(async (version: string) => {
     try {
@@ -51,7 +52,6 @@ export function useUpdateCheck(): void {
         type: 'custom',
         id: dialogId,
         title: info.releaseName,
-        description: formatPublishedAt(info.publishedAt),
         children: createElement(UpdateNotes, { info }),
         footer: createElement(UpdateActions, {
           info,
@@ -68,20 +68,20 @@ export function useUpdateCheck(): void {
       toast.add({
         id: toastId,
         title: 'Update available',
+        description: `Version ${info.version} is available.`,
         variant: 'info',
         timeout: 0,
-        description: createElement(UpdateToastActions, {
-          info,
-          onView: () => {
-            openNotesDialog(info);
-            toast.close(toastId);
-          },
-          onSkip: () => {
-            void skipRelease(info.version);
-            toast.close(toastId);
-          },
-          onDismiss: () => toast.close(toastId),
-        }),
+        // Clicking the toast opens the release-notes dialog; the close (X)
+        // dismisses; the single action button skips this release.
+        onClick: () => {
+          openNotesDialog(info);
+          toast.close(toastId);
+        },
+        cancelLabel: 'Skip this release',
+        onCancel: () => {
+          void skipRelease(info.version);
+          toast.close(toastId);
+        },
       });
     },
     [toast, openNotesDialog, skipRelease],
@@ -94,6 +94,8 @@ export function useUpdateCheck(): void {
     void (async () => {
       try {
         const info = await checkForUpdate();
+        cachedUpdate = info;
+        setAvailableUpdate(info);
         if (!info) return;
         const settings = await getSettings();
         if (settings.dismissedUpdates.includes(info.version)) return;
@@ -103,4 +105,6 @@ export function useUpdateCheck(): void {
       }
     })();
   }, [showToast]);
+
+  return { availableUpdate, openUpdateDialog: openNotesDialog };
 }

--- a/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
+++ b/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
@@ -1,0 +1,97 @@
+import { createElement, useCallback, useEffect } from 'react';
+
+import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
+import { useToast } from '@codaco/fresco-ui/Toast';
+import {
+  UpdateActions,
+  UpdateNotes,
+  UpdateToastActions,
+} from '~/components/UpdateDialog';
+import { getSettings, updateSettings } from '~/lib/db/api';
+
+import { checkForUpdate } from './checkForUpdate';
+import type { UpdateInfo } from './types';
+
+// Module-level so the check runs once per app session, not once per Home mount
+// (HomeRoute remounts when navigating back from an interview).
+let hasRun = false;
+
+function formatPublishedAt(publishedAt: string | null): string | undefined {
+  if (!publishedAt) return undefined;
+  const date = new Date(publishedAt);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'long' }).format(date);
+}
+
+// Runs the launch-time update check exactly once. On a fresh, non-skipped
+// release it raises a toast; the toast's "View details" opens a dialog with the
+// rendered release notes and a platform-specific action. Best-effort — any
+// failure in checkForUpdate resolves to null and is silently ignored.
+export function useUpdateCheck(): void {
+  const toast = useToast();
+  const dialog = useDialog();
+
+  const skipRelease = useCallback(async (version: string) => {
+    const settings = await getSettings();
+    if (settings.dismissedUpdates.includes(version)) return;
+    await updateSettings({
+      dismissedUpdates: [...settings.dismissedUpdates, version],
+    });
+  }, []);
+
+  const openNotesDialog = useCallback(
+    (info: UpdateInfo) => {
+      const dialogId = crypto.randomUUID();
+      void dialog.openDialog({
+        type: 'custom',
+        id: dialogId,
+        title: info.releaseName,
+        description: formatPublishedAt(info.publishedAt),
+        children: createElement(UpdateNotes, { info }),
+        footer: createElement(UpdateActions, {
+          info,
+          onClose: () => void dialog.closeDialog(dialogId, null),
+        }),
+      });
+    },
+    [dialog],
+  );
+
+  const showToast = useCallback(
+    (info: UpdateInfo) => {
+      const toastId = crypto.randomUUID();
+      toast.add({
+        id: toastId,
+        title: 'Update available',
+        variant: 'info',
+        timeout: 0,
+        description: createElement(UpdateToastActions, {
+          info,
+          onView: () => {
+            openNotesDialog(info);
+            toast.close(toastId);
+          },
+          onSkip: () => {
+            void skipRelease(info.version);
+            toast.close(toastId);
+          },
+          onDismiss: () => toast.close(toastId),
+        }),
+      });
+    },
+    [toast, openNotesDialog, skipRelease],
+  );
+
+  useEffect(() => {
+    if (hasRun) return;
+    hasRun = true;
+
+    void (async () => {
+      const info = await checkForUpdate();
+      if (!info) return;
+      const settings = await getSettings();
+      if (settings.dismissedUpdates.includes(info.version)) return;
+      showToast(info);
+    })();
+  }, [showToast]);
+}

--- a/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
+++ b/apps/interviewer-v8/src/lib/update/useUpdateCheck.ts
@@ -32,11 +32,16 @@ export function useUpdateCheck(): void {
   const dialog = useDialog();
 
   const skipRelease = useCallback(async (version: string) => {
-    const settings = await getSettings();
-    if (settings.dismissedUpdates.includes(version)) return;
-    await updateSettings({
-      dismissedUpdates: [...settings.dismissedUpdates, version],
-    });
+    try {
+      const settings = await getSettings();
+      if (settings.dismissedUpdates.includes(version)) return;
+      await updateSettings({
+        dismissedUpdates: [...settings.dismissedUpdates, version],
+      });
+    } catch {
+      // Best-effort: failing to persist a skip just means the toast may
+      // reappear next launch.
+    }
   }, []);
 
   const openNotesDialog = useCallback(
@@ -87,11 +92,15 @@ export function useUpdateCheck(): void {
     hasRun = true;
 
     void (async () => {
-      const info = await checkForUpdate();
-      if (!info) return;
-      const settings = await getSettings();
-      if (settings.dismissedUpdates.includes(info.version)) return;
-      showToast(info);
+      try {
+        const info = await checkForUpdate();
+        if (!info) return;
+        const settings = await getSettings();
+        if (settings.dismissedUpdates.includes(info.version)) return;
+        showToast(info);
+      } catch {
+        // Best-effort: a failed launch check must never disrupt the app.
+      }
     })();
   }, [showToast]);
 }

--- a/apps/interviewer-v8/src/lib/update/version.ts
+++ b/apps/interviewer-v8/src/lib/update/version.ts
@@ -15,10 +15,13 @@ function parse(version: string): ParsedVersion | null {
   const withoutBuild = version.trim().replace(/^v/, '').split('+')[0] ?? '';
   const [core, ...prereleaseParts] = withoutBuild.split('-');
   const segments = (core ?? '').split('.');
-  if (segments.length !== 3) return null;
+  // Require exactly three all-numeric segments — `Number.parseInt` is lenient
+  // ("0abc" → 0, "" → NaN), so validate the shape explicitly first.
+  if (segments.length !== 3 || !segments.every((s) => /^\d+$/.test(s))) {
+    return null;
+  }
 
   const main = segments.map((s) => Number.parseInt(s, 10));
-  if (main.some((n) => Number.isNaN(n))) return null;
 
   const prerelease =
     prereleaseParts.length > 0 ? prereleaseParts.join('-').split('.') : [];

--- a/apps/interviewer-v8/src/lib/update/version.ts
+++ b/apps/interviewer-v8/src/lib/update/version.ts
@@ -1,0 +1,80 @@
+// Minimal semver precedence comparison — `semver` is not a workspace dependency
+// and we only need ordering for the launch update check. Follows the semver.org
+// precedence rules: numeric major/minor/patch, then prerelease handling where a
+// version WITHOUT a prerelease tag outranks one with it, and prerelease
+// identifiers compare field-by-field (numeric < alphanumeric). Build metadata
+// (after `+`) is ignored. The current app version is itself a prerelease
+// (`8.0.0-alpha.0`), so prerelease ordering must be correct.
+
+type ParsedVersion = {
+  main: [number, number, number];
+  prerelease: string[];
+};
+
+function parse(version: string): ParsedVersion | null {
+  const withoutBuild = version.trim().replace(/^v/, '').split('+')[0] ?? '';
+  const [core, ...prereleaseParts] = withoutBuild.split('-');
+  const segments = (core ?? '').split('.');
+  if (segments.length !== 3) return null;
+
+  const main = segments.map((s) => Number.parseInt(s, 10));
+  if (main.some((n) => Number.isNaN(n))) return null;
+
+  const prerelease =
+    prereleaseParts.length > 0 ? prereleaseParts.join('-').split('.') : [];
+
+  return {
+    main: [main[0]!, main[1]!, main[2]!],
+    prerelease,
+  };
+}
+
+function comparePrerelease(a: string[], b: string[]): number {
+  // A version with no prerelease has higher precedence than one with a
+  // prerelease (1.0.0 > 1.0.0-alpha).
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const ai = a[i];
+    const bi = b[i];
+    // A larger set of fields outranks a smaller one when all preceding
+    // fields are equal (1.0.0-alpha.1 > 1.0.0-alpha).
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    if (ai === bi) continue;
+
+    const aNum = /^\d+$/.test(ai);
+    const bNum = /^\d+$/.test(bi);
+    if (aNum && bNum) {
+      const diff = Number.parseInt(ai, 10) - Number.parseInt(bi, 10);
+      if (diff !== 0) return diff < 0 ? -1 : 1;
+      continue;
+    }
+    // Numeric identifiers always have lower precedence than alphanumeric ones.
+    if (aNum) return -1;
+    if (bNum) return 1;
+    return ai < bi ? -1 : 1;
+  }
+  return 0;
+}
+
+export function compareVersions(a: string, b: string): number {
+  const pa = parse(a);
+  const pb = parse(b);
+  // Unparseable versions sort as equal-to-everything so we never claim an
+  // update for a malformed tag.
+  if (!pa || !pb) return 0;
+
+  for (let i = 0; i < 3; i++) {
+    const diff = pa.main[i]! - pb.main[i]!;
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return comparePrerelease(pa.prerelease, pb.prerelease);
+}
+
+export function isNewer(remote: string, current: string): boolean {
+  return compareVersions(remote, current) > 0;
+}

--- a/apps/interviewer-v8/src/routes/Home.tsx
+++ b/apps/interviewer-v8/src/routes/Home.tsx
@@ -51,7 +51,7 @@ export function HomeRoute() {
   const dialog = useDialog();
   const toast = useToast();
 
-  useUpdateCheck();
+  const { availableUpdate, openUpdateDialog } = useUpdateCheck();
 
   // If the pending hash has since been deleted (e.g. cascade-delete from
   // the Protocols route while a card was still pending), drop the pending
@@ -220,6 +220,12 @@ export function HomeRoute() {
               <StatusRow
                 protocolCount={protocols.length}
                 interviewCount={sessions.length}
+                availableUpdate={availableUpdate}
+                onOpenUpdate={
+                  availableUpdate
+                    ? () => openUpdateDialog(availableUpdate)
+                    : undefined
+                }
               />
             </div>
           </motion.div>

--- a/apps/interviewer-v8/src/routes/Home.tsx
+++ b/apps/interviewer-v8/src/routes/Home.tsx
@@ -18,6 +18,7 @@ import {
   type ImportRequest,
   useProtocolImport,
 } from '~/lib/protocol/useProtocolImport';
+import { useUpdateCheck } from '~/lib/update/useUpdateCheck';
 
 import { buildDeleteProtocolMessage } from './deleteProtocolMessage';
 import {
@@ -49,6 +50,8 @@ export function HomeRoute() {
   const view = viewFromLocation(location);
   const dialog = useDialog();
   const toast = useToast();
+
+  useUpdateCheck();
 
   // If the pending hash has since been deleted (e.g. cascade-delete from
   // the Protocols route while a card was still pending), drop the pending

--- a/knip.json
+++ b/knip.json
@@ -4,8 +4,10 @@
   // The quality CI job runs `pnpm --filter @codaco/interface-images exec
   // playwright install` to generate interface screenshots; playwright is a
   // devDependency of @codaco/interface-images, not the root, so knip sees the
-  // binary as unlisted.
-  "ignoreBinaries": ["playwright"],
+  // binary as unlisted. electron-builder is likewise invoked directly in the
+  // release/legacy-app-build workflows but is a devDependency of the Electron
+  // apps, not the root.
+  "ignoreBinaries": ["playwright", "electron-builder"],
   "tags": ["-public"],
   "workspaces": {
     "packages/ui": {},

--- a/packages/fresco-ui/src/Toast.tsx
+++ b/packages/fresco-ui/src/Toast.tsx
@@ -49,12 +49,21 @@ type ToastData = {
   icon?: React.ReactNode;
   timeout?: number;
   onCancel?: () => void;
+  // Label for the action button rendered when `onCancel` is set. Defaults to
+  // "Cancel".
+  cancelLabel?: string;
+  // When set, the toast's title + description become a clickable region (the
+  // close button and action button remain separate). Use for "click the toast
+  // to see more" affordances.
+  onClick?: () => void;
   onClose?: () => void;
 };
 
 type ToastCustomData = {
   variant?: ToastVariant;
   onCancel?: () => void;
+  cancelLabel?: string;
+  onClick?: () => void;
   icon?: React.ReactNode;
 };
 
@@ -108,18 +117,33 @@ function ToastItem({ toast }: ToastItemProps) {
           )
         )}
         <div className="flex-1">
-          <Toast.Title render={<Heading level="h4" />} />
-          <Toast.Description
-            render={<div className="font-body text-pretty not-last:mb-4" />}
-          />
+          {toast.data?.onClick ? (
+            <button
+              type="button"
+              onClick={toast.data.onClick}
+              className="block w-full cursor-pointer text-left"
+            >
+              <Toast.Title render={<Heading level="h4" />} />
+              <Toast.Description
+                render={<div className="font-body text-pretty" />}
+              />
+            </button>
+          ) : (
+            <>
+              <Toast.Title render={<Heading level="h4" />} />
+              <Toast.Description
+                render={<div className="font-body text-pretty not-last:mb-4" />}
+              />
+            </>
+          )}
           {toast.data?.onCancel && (
             <Button
               type="button"
               size="sm"
               onClick={toast.data.onCancel}
-              className="mb-1"
+              className="mt-3 mb-1"
             >
-              Cancel
+              {toast.data.cancelLabel ?? 'Cancel'}
             </Button>
           )}
         </div>
@@ -147,23 +171,28 @@ export function useToast(): TypedUseToastManager {
   const toastManager = Toast.useToastManager();
 
   const add = (toastData: ToastData) => {
-    const { onCancel, onClose, icon, variant, ...rest } = toastData;
+    const { onCancel, cancelLabel, onClick, onClose, icon, variant, ...rest } =
+      toastData;
     return toastManager.add({
       ...rest,
       type: variant,
       onClose,
-      data: { onCancel, icon },
+      data: { onCancel, cancelLabel, onClick, icon },
     });
   };
 
   const update = (id: string, toastData: Partial<ToastData>) => {
-    const { onCancel, onClose, icon, variant, ...rest } = toastData;
+    const { onCancel, cancelLabel, onClick, onClose, icon, variant, ...rest } =
+      toastData;
     toastManager.update(id, {
       ...rest,
       ...(variant !== undefined && { type: variant }),
       ...(onClose !== undefined && { onClose }),
-      ...((onCancel !== undefined || icon !== undefined) && {
-        data: { onCancel, icon },
+      ...((onCancel !== undefined ||
+        cancelLabel !== undefined ||
+        onClick !== undefined ||
+        icon !== undefined) && {
+        data: { onCancel, cancelLabel, onClick, icon },
       }),
     });
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,6 +1214,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 3.21.2
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.8.9
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -8466,6 +8469,9 @@ packages:
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-vite@6.0.0-beta.1:
     resolution: {integrity: sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -10303,6 +10309,9 @@ packages:
 
   lodash.escape@4.0.1:
     resolution: {integrity: sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
   lodash.flattendeep@4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
@@ -13153,6 +13162,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
@@ -20478,6 +20490,19 @@ snapshots:
 
   electron-to-chromium@1.5.344: {}
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@6.0.0-beta.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7
@@ -22755,6 +22780,8 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.escape@4.0.1: {}
+
+  lodash.escaperegexp@4.1.2: {}
 
   lodash.flattendeep@4.4.0: {}
 
@@ -26573,6 +26600,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tiny-warning@1.0.3: {}
 


### PR DESCRIPTION
## What

Adds an in-app update/upgrade system to Interviewer v8 (Electron desktop + Capacitor tablet + dev web). There was no update mechanism before this.

On launch the app checks **GitHub Releases** (the source of truth) for a newer version and, if one exists and hasn't been skipped, shows a toast with **Skip this release** and **Dismiss**. Opening it shows a dialog with the rendered markdown release notes and a platform-specific action:

- **Electron** — background download with a progress bar, then in-app install, via `electron-updater`.
- **Capacitor** — opens the App Store / Play Store listing.
- **Web** — links to the release download page.

## How

- **Renderer `src/lib/update/`** — `checkForUpdate()` dispatches by platform and returns a normalized `UpdateInfo | null` (non-null only when the remote is strictly newer; best-effort, never throws). `version.ts` does semver comparison incl. prereleases (current version is `8.0.0-alpha.0`). `githubReleases.ts` filters the shared repo's releases to the `interviewer-v8@v*` tag prefix.
- **UI** — toast + dialog reuse fresco-ui (`useToast`, `useDialog`, `RenderMarkdown`, `ProgressBar`). "Skip this release" persists to the already-existing `StoredSettings.dismissedUpdates`. Launch check mounted in `HomeRoute` (past the auth gate), runs once per session.
- **Electron main** — `electron/update/updater.ts` + IPC handlers + preload `update` bridge (typed in `global.d.ts`). `electron-updater` with `autoDownload` off; availability via its events, release notes fetched in-process with Electron `net` (renderer CSP is `connect-src 'self'`).

## Why the chosen approach

- **Renderer CSP is `connect-src 'self'`**, so the GitHub call can't run in the renderer — it runs in the Electron main process (like the existing `protocol:fetchFromUrl`) or via `CapacitorHttp`; web no-ops.
- The monorepo publishes **many products to one repo's Releases** with prefixed tags + `make_latest:false`, so electron-updater's standard GitHub provider can't identify v8 releases. Instead it uses a **generic provider** pointed at a stable `interviewer-v8-latest` release whose installers + `latest*.yml` CI overwrites each release.
- `electron-updater` is **bundled** into the main process (excluded from `externalizeDepsPlugin`) because the packaged app ships no transitive `node_modules`.

## CI / release changes

- `electron-builder.config.cjs` gains a `generic` `publish` block (also makes electron-builder emit `latest*.yml` + `app-update.yml`).
- Build step uses `--publish never` (generate metadata, don't upload); a new publish step maintains the recreated-each-release `interviewer-v8-latest` feed.

## Tests

22 new unit tests (118 total pass): semver ordering, release filtering/selection, platform dispatch, and the launch hook (skip / no-update suppression). `pnpm electron:build` confirmed `electron-updater` bundles into the main bundle.

## Not covered here (manual / follow-up)

- Packaged-build auto-update smoke test (mac signed / Windows unsigned / Linux AppImage; `.deb` doesn't auto-update).
- On-device Capacitor store-button check.
- **App Store numeric ID** is a TODO placeholder in `src/lib/update/storeUrls.ts` — the iOS button stays disabled until provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic update checking and installation capability for Interviewer app
  * Introduced update notification system with release notes and progress tracking

* **Improvements**
  * Enhanced editor messaging to clarify automatic protocol saving behavior
  * Refined text area component sizing for better content adaptation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->