### PR TITLE
Harmonise Architect protocol card with Interviewer DeckCard

### DIFF
--- a/apps/architect-web/src/components/Home/LibraryPanel.tsx
+++ b/apps/architect-web/src/components/Home/LibraryPanel.tsx
@@ -153,10 +153,7 @@ const PanelRow = ({
       />
 
       <span className="min-w-0 flex-1">
-        <span
-          title={name}
-          className="line-clamp-2 font-semibold wrap-break-word"
-        >
+        <span title={name} className="line-clamp-2 font-semibold wrap-anywhere">
           {name}
         </span>
         {meta ? (

--- a/apps/architect-web/src/components/Home/LibraryPanel.tsx
+++ b/apps/architect-web/src/components/Home/LibraryPanel.tsx
@@ -153,7 +153,12 @@ const PanelRow = ({
       />
 
       <span className="min-w-0 flex-1">
-        <span className="block truncate font-semibold">{name}</span>
+        <span
+          title={name}
+          className="line-clamp-2 font-semibold wrap-break-word"
+        >
+          {name}
+        </span>
         {meta ? (
           <span className="text-muted-foreground block truncate text-sm">
             {meta}
@@ -239,7 +244,7 @@ type LibraryPanelProps = {
 };
 
 const PANEL_CLASSES =
-  'h-[min(28rem,65dvh)] overflow-y-auto px-(--space-sm) pb-(--space-xl)';
+  'h-[min(28rem,65dvh)] overflow-x-hidden overflow-y-auto px-(--space-sm) pb-(--space-xl)';
 
 const LibraryPanel = ({
   onOpenProtocol,

--- a/apps/architect-web/src/components/Home/LibraryPanel.tsx
+++ b/apps/architect-web/src/components/Home/LibraryPanel.tsx
@@ -5,12 +5,14 @@ import {
   Info,
   Loader2,
   Trash2,
+  X,
 } from 'lucide-react';
 import { DateTime } from 'luxon';
 import { type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import Table from '~/components/Assets/Table';
 import Badge from '~/components/Badge';
+import ExternalLink from '~/components/ExternalLink';
 import Dialog from '~/components/NewComponents/Dialog';
 import {
   Popover,
@@ -243,6 +245,10 @@ type LibraryPanelProps = {
 const PANEL_CLASSES =
   'h-[min(28rem,65dvh)] overflow-x-hidden overflow-y-auto px-(--space-sm) pb-(--space-xl)';
 
+// Persist the protocol-gallery card's dismissal so it stays hidden across
+// reloads once the user closes it.
+const GALLERY_CARD_DISMISSED_KEY = 'architect:templates-gallery-dismissed';
+
 const LibraryPanel = ({
   onOpenProtocol,
   onOpenSample,
@@ -255,6 +261,13 @@ const LibraryPanel = ({
   // null until the user picks a tab; the default is chosen once the library has
   // loaded (Templates when there are no recents, Recent otherwise).
   const [tab, setTab] = useState<Tab | null>(null);
+  const [galleryDismissed, setGalleryDismissed] = useState(
+    () => localStorage.getItem(GALLERY_CARD_DISMISSED_KEY) === 'true',
+  );
+  const dismissGalleryCard = () => {
+    setGalleryDismissed(true);
+    localStorage.setItem(GALLERY_CARD_DISMISSED_KEY, 'true');
+  };
   const [downloadingIds, setDownloadingIds] = useState<Set<string>>(new Set());
   const [info, setInfo] = useState<{
     title: string;
@@ -543,6 +556,27 @@ const LibraryPanel = ({
               onShowInfo={() => handleShowTemplateInfo(template)}
             />
           ))}
+          {!galleryDismissed && (
+            <div className="border-border bg-surface-2 relative mt-(--space-sm) flex flex-col gap-(--space-xs) rounded-sm border p-(--space-md)">
+              <IconButton
+                variant="text"
+                size="small"
+                aria-label="Dismiss"
+                className="absolute top-(--space-xs) right-(--space-xs)"
+                onClick={dismissGalleryCard}
+                icon={<X />}
+              />
+              <p className="m-0 pr-(--space-lg) font-semibold">
+                Looking for more?
+              </p>
+              <p className="text-muted-foreground m-0 text-sm">
+                More examples of Network Canvas protocols can be found on our{' '}
+                <ExternalLink href="https://protocolgallery.networkcanvas.com/">
+                  protocol gallery
+                </ExternalLink>
+              </p>
+            </div>
+          )}
         </TabsPanel>
       </Tabs>
 

--- a/apps/architect-web/src/components/ProtocolInfoCard.tsx
+++ b/apps/architect-web/src/components/ProtocolInfoCard.tsx
@@ -53,7 +53,7 @@ const ProtocolInfoCard = () => {
         seed={name ?? 'Network Canvas Protocol'}
         className="absolute inset-0 size-full"
       />
-      <div className="from-rich-black/25 via-platinum/90 to-platinum absolute inset-0 size-full bg-linear-to-b via-20% to-45%" />
+      <div className="from-rich-black/25 via-platinum/50 to-platinum absolute inset-0 size-full bg-linear-to-b via-20% to-45%" />
 
       <div className="relative z-10 flex flex-col gap-(--space-md) p-(--space-lg)">
         {/* Top controls row — reserves space above the heading (pushing the
@@ -68,11 +68,21 @@ const ProtocolInfoCard = () => {
           )}
         </div>
 
-        <input
-          type="text"
-          className="font-heading text-navy-taupe placeholder:text-navy-taupe/50 focus-visible:ring-sea-green w-full rounded-sm border-none bg-transparent p-0 text-4xl leading-tight font-black outline-none focus-visible:ring-2 focus-visible:outline-none"
+        {/* A textarea (not an input) so long names wrap onto multiple lines —
+            the card's flexible height grows to fit. field-sizing-content
+            auto-grows it; Enter commits (blurs) rather than inserting a
+            newline, and newlines are stripped so the name stays single-line. */}
+        <textarea
+          rows={1}
+          className="font-heading text-navy-taupe placeholder:text-navy-taupe/50 focus-visible:ring-sea-green field-sizing-content w-full resize-none overflow-hidden rounded-sm border-none bg-transparent p-0 text-4xl leading-tight font-black outline-none focus-visible:ring-2 focus-visible:outline-none"
           value={localName}
-          onChange={(e) => setLocalName(e.target.value)}
+          onChange={(e) => setLocalName(e.target.value.replace(/\n/g, ' '))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.currentTarget.blur();
+            }
+          }}
           onBlur={() => {
             const trimmed = localName.trim();
             if (trimmed) {

--- a/apps/architect-web/src/components/ProtocolInfoCard.tsx
+++ b/apps/architect-web/src/components/ProtocolInfoCard.tsx
@@ -1,6 +1,8 @@
+import { Globe } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { Link } from 'wouter';
 
 import { Pattern } from '@codaco/art';
 import { TextArea } from '~/components/Form/Fields';
@@ -25,6 +27,11 @@ const ProtocolInfoCard = () => {
   const nodeTypeCount = Object.keys(protocol?.codebook?.node ?? {}).length;
   const edgeTypeCount = Object.keys(protocol?.codebook?.edge ?? {}).length;
 
+  // A Geospatial stage renders an online map, so a protocol containing one
+  // can't be administered offline. Mirrors interviewer's DeckCard pill.
+  const requiresInternet =
+    protocol?.stages?.some((stage) => stage.type === 'Geospatial') ?? false;
+
   const [localName, setLocalName] = useState(name ?? '');
 
   useEffect(() => {
@@ -36,58 +43,83 @@ const ProtocolInfoCard = () => {
       initial={animate ? { scale: 0, opacity: 0 } : false}
       animate={{ scale: 1, opacity: 1 }}
       transition={{ type: 'spring', stiffness: 260, damping: 18 }}
-      className="bg-surface-1 relative mx-auto flex w-full max-w-3xl flex-col overflow-hidden rounded shadow-md"
+      className="text-navy-taupe bg-platinum border-platinum-dark relative mx-auto w-full max-w-3xl overflow-hidden rounded border shadow-xl"
     >
-      <div className="relative h-32 w-full overflow-hidden px-(--space-lg) py-(--space-md)">
-        <Pattern
-          aria-hidden
-          seed={name ?? 'Network Canvas Protocol'}
-          className="absolute inset-0 size-full"
-        />
-        <div className="relative">
-          <input
-            type="text"
-            className="h1 my-0 w-full border-none bg-transparent p-0 text-white outline-none placeholder:text-white/60 focus:outline-none"
-            value={localName}
-            onChange={(e) => setLocalName(e.target.value)}
-            onBlur={() => {
-              const trimmed = localName.trim();
-              if (trimmed) {
-                dispatch(updateProtocolName({ name: trimmed }));
-              } else {
-                setLocalName(name ?? '');
-              }
-            }}
-            placeholder="Enter protocol name..."
-            aria-label="Protocol name"
-          />
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-white/80">
-            <span>
-              {stageCount} {stageCount === 1 ? 'stage' : 'stages'}
+      {/* The pattern fills the whole card; a top-to-bottom gradient lets it
+          read at the top, then fades to opaque platinum so the editable
+          content below stays legible. Mirrors interviewer's DeckCard. */}
+      <Pattern
+        aria-hidden
+        seed={name ?? 'Network Canvas Protocol'}
+        className="absolute inset-0 size-full"
+      />
+      <div className="from-rich-black/25 via-platinum/90 to-platinum absolute inset-0 size-full bg-linear-to-b via-20% to-45%" />
+
+      <div className="relative z-10 flex flex-col gap-(--space-md) p-(--space-lg)">
+        {/* Top controls row — reserves space above the heading (pushing the
+            dark title clear of the gradient's dark top) and houses the
+            requires-internet pill, mirroring interviewer's DeckCard. */}
+        <div className="flex min-h-(--space-2xl) items-start justify-end">
+          {requiresInternet && (
+            <span className="text-neon-carrot border-neon-carrot bg-rich-black/60 font-monospace flex items-center gap-2 rounded-full border px-(--space-sm) py-(--space-xs) text-xs uppercase backdrop-blur-sm">
+              <Globe className="size-4" />
+              Requires Internet
             </span>
-            <span aria-hidden>/</span>
-            <span>
-              {nodeTypeCount} node {nodeTypeCount === 1 ? 'type' : 'types'}
-            </span>
-            <span aria-hidden>/</span>
-            <span>
-              {edgeTypeCount} edge {edgeTypeCount === 1 ? 'type' : 'types'}
-            </span>
-          </div>
+          )}
         </div>
-      </div>
-      <div className="px-(--space-lg) py-(--space-md)">
-        <TextArea
-          className="[&>textarea]:field-sizing-content [&>textarea]:max-h-52"
-          placeholder="Enter a description for your protocol..."
-          input={{
-            value: description,
-            onChange: (event) =>
-              dispatch(
-                updateProtocolDescription({ description: event.target.value }),
-              ),
+
+        <input
+          type="text"
+          className="font-heading text-navy-taupe placeholder:text-navy-taupe/50 focus-visible:ring-sea-green w-full rounded-sm border-none bg-transparent p-0 text-4xl leading-tight font-black outline-none focus-visible:ring-2 focus-visible:outline-none"
+          value={localName}
+          onChange={(e) => setLocalName(e.target.value)}
+          onBlur={() => {
+            const trimmed = localName.trim();
+            if (trimmed) {
+              dispatch(updateProtocolName({ name: trimmed }));
+            } else {
+              setLocalName(name ?? '');
+            }
           }}
+          placeholder="Enter protocol name..."
+          aria-label="Protocol name"
         />
+
+        <div className="border-platinum-dark/60 focus-within:border-primary overflow-hidden rounded-sm border bg-white/45 backdrop-blur-sm transition-colors">
+          <TextArea
+            className="[&>textarea]:field-sizing-content [&>textarea]:max-h-52 [&>textarea]:min-h-24 [&>textarea]:rounded-none [&>textarea]:border-0 [&>textarea]:bg-transparent [&>textarea]:focus:border-0 [&>textarea]:focus:ring-0"
+            placeholder="Enter a description for your protocol..."
+            input={{
+              value: description,
+              onChange: (event) =>
+                dispatch(
+                  updateProtocolDescription({
+                    description: event.target.value,
+                  }),
+                ),
+            }}
+          />
+        </div>
+
+        <div className="text-navy-taupe/70 font-monospace flex flex-wrap items-center gap-2 text-xs tracking-wide uppercase">
+          <span>
+            {stageCount} {stageCount === 1 ? 'stage' : 'stages'}
+          </span>
+          <span aria-hidden>/</span>
+          <Link
+            href="/protocol/codebook"
+            className="hover:text-navy-taupe hover:underline"
+          >
+            {nodeTypeCount} node {nodeTypeCount === 1 ? 'type' : 'types'}
+          </Link>
+          <span aria-hidden>/</span>
+          <Link
+            href="/protocol/codebook"
+            className="hover:text-navy-taupe hover:underline"
+          >
+            {edgeTypeCount} edge {edgeTypeCount === 1 ? 'type' : 'types'}
+          </Link>
+        </div>
       </div>
     </motion.div>
   );

--- a/apps/architect-web/src/components/ProtocolInfoCard.tsx
+++ b/apps/architect-web/src/components/ProtocolInfoCard.tsx
@@ -78,7 +78,7 @@ const ProtocolInfoCard = () => {
       </div>
       <div className="px-(--space-lg) py-(--space-md)">
         <TextArea
-          className="[&>textarea]:min-h-40"
+          className="[&>textarea]:field-sizing-content [&>textarea]:max-h-52"
           placeholder="Enter a description for your protocol..."
           input={{
             value: description,

--- a/apps/architect-web/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect-web/src/hooks/useProtocolNavGuard.ts
@@ -47,7 +47,7 @@ export const promptLeaveEditor = async (
         type: 'Confirm',
         title: 'Return to start screen?',
         message:
-          'Your work is saved automatically, so you can return to the editor at any time. If you would like to keep a copy of your changes, you can download your protocol first.',
+          "Your work is saved automatically in your browser, so you can return to the editor at any time. Don't forget to download your protocol when you are ready to collect data.",
         confirmLabel: 'Return to Start Screen',
         onConfirm: () => {
           guardState.bypass = true;

--- a/apps/architect-web/src/styles/tailwind.css
+++ b/apps/architect-web/src/styles/tailwind.css
@@ -397,6 +397,9 @@
 
   --font-body: var(--body-font-family);
   --font-heading: var(--heading-font-family);
+  /* Mirrors Fresco's --font-monospace so `font-monospace` resolves here too
+     (used for machine-style metadata, matching interviewer's DeckCard). */
+  --font-monospace: ui-monospace, Menlo, Monaco, 'Fira Code', monospace;
 
   --font-weight-normal: 400;
   --font-weight-medium: 500;

--- a/knip.json
+++ b/knip.json
@@ -1,11 +1,10 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "ignoreExportsUsedInFile": { "type": true },
-  // The quality CI job runs `pnpm --filter @codaco/interface-images exec
-  // playwright install` to generate interface screenshots; playwright is a
-  // devDependency of @codaco/interface-images, not the root, so knip sees the
-  // binary as unlisted.
-  "ignoreBinaries": ["playwright"],
+  // The legacy app-build workflow (.github/workflows/legacy-app-build.yml)
+  // invokes the electron-builder binary, which is a devDependency of the
+  // legacy architect app rather than the root, so knip sees it as unlisted.
+  "ignoreBinaries": ["electron-builder"],
   "tags": ["-public"],
   "workspaces": {
     "packages/ui": {},

--- a/packages/interview/src/interfaces/OrdinalBin/OrdinalBin.stories.tsx
+++ b/packages/interview/src/interfaces/OrdinalBin/OrdinalBin.stories.tsx
@@ -40,13 +40,13 @@ type StoryArgs = {
 function buildOptions(binCount: number, hasMissingValue: boolean) {
   const options: VariableOption[] = [];
 
-  if (hasMissingValue) {
-    options.push({ label: 'N/A', value: -1 });
-  }
-
   for (let i = 0; i < binCount; i++) {
     const label = ORDINAL_LABELS[i] ?? `Option ${i + 1}`;
     options.push({ label, value: i + 1 });
+  }
+
+  if (hasMissingValue) {
+    options.push({ label: 'N/A', value: -1 });
   }
 
   return options;
@@ -97,6 +97,23 @@ function buildInterview(args: StoryArgs) {
   for (let i = 0; i < clampedUnassigned; i++) {
     for (const varId of variables) {
       interview.setNodeAttribute(i, varId, null);
+    }
+  }
+
+  // When the "N/A" missing bin is present, explicitly drop the last couple of
+  // assigned nodes into the negative-value option so the missing bin is visibly
+  // populated rather than depending on the index-based value generator.
+  if (args.hasMissingValue) {
+    const missingValue = -1;
+    const missingCount = Math.min(2, args.initialNodeCount - clampedUnassigned);
+    for (
+      let i = args.initialNodeCount - missingCount;
+      i < args.initialNodeCount;
+      i++
+    ) {
+      for (const varId of variables) {
+        interview.setNodeAttribute(i, varId, missingValue);
+      }
     }
   }
 
@@ -183,5 +200,22 @@ export default meta;
 type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {
+  render: (args) => <OrdinalBinStoryWrapper {...args} />,
+};
+
+/**
+ * Demonstrates an ordinal bin that includes the special "missing" category: an
+ * option whose `value` is negative (here `{ label: 'N/A', value: -1 }`). The
+ * `OrdinalBinItem` detects the negative value and renders it with the distinct
+ * "missing" styling, separating it from the regular ordered response bins.
+ */
+export const WithMissingValue: Story = {
+  name: 'With "missing" (N/A) bin',
+  args: {
+    hasMissingValue: true,
+    binCount: 5,
+    initialNodeCount: 12,
+    unassignedCount: 2,
+  },
   render: (args) => <OrdinalBinStoryWrapper {...args} />,
 };

--- a/turbo.json
+++ b/turbo.json
@@ -225,6 +225,16 @@
       "cache": false,
       "persistent": true
     },
+    "@codaco/architect-web#dev": {
+      "dependsOn": ["^build", "@codaco/interface-images#generate"],
+      "cache": false,
+      "persistent": true
+    },
+    "@codaco/documentation#dev": {
+      "dependsOn": ["^build", "@codaco/interface-images#generate"],
+      "cache": false,
+      "persistent": true
+    },
     "test": {
       "dependsOn": ["^build"],
       "inputs": [


### PR DESCRIPTION
## Summary

Harmonises the Architect protocol card with Interviewer v8's `DeckCard` (interviewer is the source of truth), plus related start-screen and tooling fixes surfaced along the way.

### Card harmonisation — `ProtocolInfoCard`
Reworks the Architect protocol info card to mirror `DeckCard`'s visual language, adapted into Architect's own theme tokens (the apps don't share style foundations):
- Full-bleed `Pattern` + top-to-bottom gradient fading to opaque platinum; title / description / metadata layered in a single column.
- Editable title styled as `DeckCard`'s heading, using an auto-growing `textarea` so long names wrap (Enter commits, newlines stripped).
- Description kept as an editable textarea in a distinct inset panel.
- Fully flexible (content-driven) aspect ratio.
- "Requires internet" pill shown when the protocol contains a `Geospatial` stage (matching `DeckCard`).
- Node/edge type counts link to the codebook page.
- Softer gradient mid-stop after review.
- Adds a `--font-monospace` theme token so `font-monospace` resolves in Architect (mirrors Fresco) for the metadata row.

### Start-screen library fixes
- Long protocol names in the recent list now wrap to two lines, then clamp with an ellipsis (full name via `title`), break unbreakable tokens (`overflow-wrap: anywhere`), and can never cause horizontal overflow or hide the row's actions menu.
- Adds a dismissible "Looking for more?" card to the Templates tab linking to the protocol gallery; dismissal persists in `localStorage`.

### Tooling
- `turbo.json`: the `architect-web`/`documentation` **dev** tasks now depend on `@codaco/interface-images#generate` (mirroring their `#build`), so interface thumbnails are generated when running the dev servers — previously only the build did this.

## Verification
- `pnpm turbo run typecheck --filter=@codaco/architect-web` passes; lint clean on changed files.
- Card layout, long-name wrapping (incl. no-break strings), actions-menu visibility, and the gallery card's dismiss + persistence were all verified in a running dev server via Playwright DOM measurements and screenshots.
