### PR TITLE
fix(build): with-turbo Windows shell spawn (unblocks legacy Windows builds)

### DIFF
--- a/scripts/with-turbo.mjs
+++ b/scripts/with-turbo.mjs
@@ -43,7 +43,12 @@ function resolveTurbo() {
 
 function runReal(realCommand) {
   const [cmd, ...args] = realCommand;
-  const result = spawnSync(cmd, args, { stdio: 'inherit' });
+  // On Windows the real command is a node_modules/.bin shim (e.g. vite.CMD);
+  // Node won't resolve/execute the extensionless name without a shell.
+  const result = spawnSync(cmd, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
   process.exit(result.status ?? 1);
 }
 


### PR DESCRIPTION
One-line fix: when inside turbo, `with-turbo.mjs` spawns the package's real command (e.g. `vite build`) directly; on Windows that's a `.CMD` shim Node can't execute without a shell, so workspace-dependency builds (`@codaco/shared-consts`) fail with exit 1 and no output. Pass `shell:true` on win32 only; posix unchanged.

Surfaced by the first end-to-end legacy Windows build. Unblocks the Windows `.exe` artifacts for the 6.6.0 release.