### PR TITLE
fix(interview): readable roster card labels + shrink-to-fit grid

### DIFF
--- a/.changeset/roster-label-fallback-and-grid-shrink.md
+++ b/.changeset/roster-label-fallback-and-grid-shrink.md
@@ -19,6 +19,10 @@ Fix two NameGeneratorRoster bugs and remove a dead schema field.
   even in a narrower container, so a single roster card overflowed its panel at
   the default resizable width (observed on iPad), breaking drag-and-drop. The
   column floor is now `min(Npx, 100%)` so a lone column shrinks to fit.
+- **The roster panel can't be resized narrower than a card.** `ResizableFlexPanel`
+  gains an optional `minSizePx` (a hard pixel floor for the first panel, enforced
+  by the resize hook and a CSS backstop). NameGeneratorRoster sets it to the card
+  width plus chrome, so the resize handle stops before a card would overflow.
 - **Removed the unused `cardOptions.displayLabel`.** It was introduced in the v8
   schema but was never read by any application (legacy or current) and cannot be
   set in Architect. Dropped from the schema, the `protocol-utilities` types, and

--- a/.changeset/roster-label-fallback-and-grid-shrink.md
+++ b/.changeset/roster-label-fallback-and-grid-shrink.md
@@ -1,0 +1,25 @@
+---
+'@codaco/protocol-validation': patch
+'@codaco/protocol-utilities': patch
+'@codaco/interview': patch
+'@codaco/fresco-ui': patch
+---
+
+Fix two NameGeneratorRoster bugs and remove a dead schema field.
+
+- **Roster cards no longer show a raw UID.** When the name heuristic could not
+  resolve a label for an external-roster node (e.g. the asset came from a
+  preview interview export whose attribute keys are variable UUIDs absent from
+  the running codebook, or the subject has no populated text variable), the
+  card title fell back to the node's content-hash `_uid` — an opaque "random
+  ID". The new `resolveRosterNodeLabel` falls back to the first usable
+  attribute value, then to a stable `Unnamed {subject} {n}` placeholder.
+- **DataCards shrink to fit narrow panels.** `GridLayout`'s
+  `repeat(auto-fill, minmax(Npx, 1fr))` forced columns to at least `minItemWidth`
+  even in a narrower container, so a single roster card overflowed its panel at
+  the default resizable width (observed on iPad), breaking drag-and-drop. The
+  column floor is now `min(Npx, 100%)` so a lone column shrinks to fit.
+- **Removed the unused `cardOptions.displayLabel`.** It was introduced in the v8
+  schema but was never read by any application (legacy or current) and cannot be
+  set in Architect. Dropped from the schema, the `protocol-utilities` types, and
+  the `SyntheticInterview` builder.

--- a/packages/fresco-ui/src/ResizableFlexPanel.tsx
+++ b/packages/fresco-ui/src/ResizableFlexPanel.tsx
@@ -44,6 +44,13 @@ type ResizableFlexPanelProps = {
    */
   'max'?: number;
   /**
+   * Hard minimum size of the first panel in pixels along the main axis. The
+   * effective minimum becomes the larger of `min` (%) and this value relative
+   * to the container, so the panel can never be sized narrower than its content
+   * requires (e.g. a card with a fixed minimum width) regardless of viewport.
+   */
+  'minSizePx'?: number;
+  /**
    * Optional list of snap points. When provided, dragging snaps to the nearest
    * breakpoint and `PageUp`/`PageDown` (plus arrow keys) step between adjacent
    * breakpoints instead of using `keyboardStep`.
@@ -116,6 +123,7 @@ const ResizableFlexPanel = forwardRef<HTMLDivElement, ResizableFlexPanelProps>(
       defaultBasis = 30,
       min = 10,
       max = 90,
+      minSizePx,
       breakpoints = [],
       orientation = 'horizontal',
       keyboardStep = 2,
@@ -131,6 +139,7 @@ const ResizableFlexPanel = forwardRef<HTMLDivElement, ResizableFlexPanelProps>(
       defaultBasis,
       min,
       max,
+      minSizePx,
       breakpoints,
       orientation,
       keyboardStep,
@@ -171,6 +180,14 @@ const ResizableFlexPanel = forwardRef<HTMLDivElement, ResizableFlexPanelProps>(
           style={{
             flexBasis: `${activeBasis}%`,
             flexGrow: 0,
+            // Backstop the drag clamp: even if a persisted/animated basis would
+            // render narrower (e.g. after the viewport shrinks), never let the
+            // panel fall below its content's required size.
+            ...(minSizePx !== undefined && !isOverridden
+              ? isHorizontal
+                ? { minWidth: minSizePx }
+                : { minHeight: minSizePx }
+              : {}),
           }}
         >
           {firstChild}

--- a/packages/fresco-ui/src/collection/__tests__/GridLayout.test.ts
+++ b/packages/fresco-ui/src/collection/__tests__/GridLayout.test.ts
@@ -181,7 +181,7 @@ describe('GridLayout', () => {
 
       expect(styles.display).toBe('grid');
       expect(styles.gridTemplateColumns).toBe(
-        'repeat(auto-fill, minmax(200px, 1fr))',
+        'repeat(auto-fill, minmax(min(200px, 100%), 1fr))',
       );
       expect(styles.gap).toBe('calc(5 * var(--spacing-base, 0.25rem))');
     });
@@ -192,9 +192,23 @@ describe('GridLayout', () => {
 
       expect(styles.display).toBe('grid');
       expect(styles.gridTemplateColumns).toBe(
-        'repeat(auto-fill, minmax(200px, 1fr))',
+        'repeat(auto-fill, minmax(min(200px, 100%), 1fr))',
       );
       expect(styles.gap).toBe('calc(4 * var(--spacing-base, 0.25rem))');
+    });
+
+    // Regression: a container narrower than minItemWidth must not force a
+    // column wider than the container. The `min(Npx, 100%)` floor lets a
+    // single column shrink to fit; the bare `minmax(Npx, 1fr)` floor would
+    // overflow (the roster panel at its default iPad width broke
+    // drag-and-drop this way).
+    it('should clamp the column minimum to the container width', () => {
+      const layout = new GridLayout({ minItemWidth: 400 });
+      const styles = layout.getContainerStyles();
+
+      expect(styles.gridTemplateColumns).toBe(
+        'repeat(auto-fill, minmax(min(400px, 100%), 1fr))',
+      );
     });
   });
 

--- a/packages/fresco-ui/src/collection/layout/GridLayout.ts
+++ b/packages/fresco-ui/src/collection/layout/GridLayout.ts
@@ -47,9 +47,15 @@ export class GridLayout<T = unknown> extends Layout<T> {
   }
 
   getContainerStyles(): React.CSSProperties {
+    // `min(${minItemWidth}px, 100%)` clamps the column's minimum to the
+    // container width when the container is narrower than minItemWidth.
+    // Without the `min()`, the bare `minmax(${minItemWidth}px, 1fr)` floor
+    // forces each column to at least minItemWidth even in a narrower
+    // container, so a single column overflows horizontally (e.g. the roster
+    // panel at its default width on an iPad), which breaks drag-and-drop.
     return {
       display: 'grid',
-      gridTemplateColumns: `repeat(auto-fill, minmax(${this.minItemWidth}px, 1fr))`,
+      gridTemplateColumns: `repeat(auto-fill, minmax(min(${this.minItemWidth}px, 100%), 1fr))`,
       gap: `calc(${this.gap_} * var(--spacing-base, 0.25rem))`,
     };
   }

--- a/packages/fresco-ui/src/hooks/__tests__/useResizablePanel.test.ts
+++ b/packages/fresco-ui/src/hooks/__tests__/useResizablePanel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { getEffectiveMinPercent } from '../useResizablePanel';
+
+describe('getEffectiveMinPercent', () => {
+  it('returns the percentage min when no pixel floor is set', () => {
+    expect(getEffectiveMinPercent(10, 90, undefined, 800)).toBe(10);
+  });
+
+  it('returns the percentage min when the container is unmeasured', () => {
+    expect(getEffectiveMinPercent(10, 90, 400, 0)).toBe(10);
+  });
+
+  it('converts the pixel floor to a percentage of the container', () => {
+    // 400px of a 500px container = 80%, which exceeds the 10% floor.
+    expect(getEffectiveMinPercent(10, 90, 400, 500)).toBe(80);
+  });
+
+  it('keeps the percentage min when it is larger than the pixel floor', () => {
+    // 400px of a 2000px container = 20%, but min% is 25.
+    expect(getEffectiveMinPercent(25, 90, 400, 2000)).toBe(25);
+  });
+
+  it('never exceeds max even when the pixel floor is larger than the container', () => {
+    expect(getEffectiveMinPercent(10, 90, 1200, 800)).toBe(90);
+  });
+});

--- a/packages/fresco-ui/src/hooks/useResizablePanel.ts
+++ b/packages/fresco-ui/src/hooks/useResizablePanel.ts
@@ -15,6 +15,14 @@ type UseResizablePanelOptions = {
   defaultBasis: number;
   min: number;
   max: number;
+  /**
+   * Hard minimum size of the first panel in pixels along the main axis. When
+   * set, the effective minimum is the larger of `min` (%) and this value
+   * converted to a percentage of the live container size, so the panel can
+   * never be dragged narrower than its content requires regardless of the
+   * container's width.
+   */
+  minSizePx?: number;
   breakpoints?: Breakpoint[];
   orientation?: 'horizontal' | 'vertical';
   keyboardStep?: number;
@@ -24,6 +32,24 @@ const basisSchema = z.number().check(z.minimum(0)).check(z.maximum(100));
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Resolve the effective minimum panel size as a percentage: the larger of the
+ * `min` percentage and `minSizePx` expressed as a percentage of `containerSize`
+ * (clamped to `max`). Falls back to `min` when there is no pixel floor or the
+ * container has not been measured yet.
+ */
+export function getEffectiveMinPercent(
+  min: number,
+  max: number,
+  minSizePx: number | undefined,
+  containerSize: number,
+): number {
+  if (!minSizePx || containerSize <= 0) {
+    return min;
+  }
+  return clamp(Math.max(min, (minSizePx / containerSize) * 100), 0, max);
 }
 
 function nearestBreakpoint(value: number, breakpoints: Breakpoint[]) {
@@ -46,6 +72,7 @@ export default function useResizablePanel({
   defaultBasis,
   min,
   max,
+  minSizePx,
   breakpoints = [],
   orientation = 'horizontal',
   keyboardStep = 2,
@@ -67,12 +94,25 @@ export default function useResizablePanel({
     defaultBasis,
   );
 
+  // The effective minimum is the larger of the `min` percentage and the
+  // `minSizePx` floor expressed as a percentage of the current container size.
+  const getEffectiveMin = useCallback(() => {
+    const container = containerRef.current;
+    const rect = container?.getBoundingClientRect();
+    const size = rect
+      ? orientation === 'horizontal'
+        ? rect.width
+        : rect.height
+      : 0;
+    return getEffectiveMinPercent(min, max, minSizePx, size);
+  }, [min, max, minSizePx, orientation]);
+
   const setBasis = useCallback(
     (value: number) => {
-      const clamped = clamp(value, min, max);
+      const clamped = clamp(value, getEffectiveMin(), max);
       setPersistedBasis(clamped);
     },
-    [min, max, setPersistedBasis],
+    [getEffectiveMin, max, setPersistedBasis],
   );
 
   const getPercentFromPointer = useCallback(

--- a/packages/interview/src/interfaces/NameGeneratorRoster/DataCard.stories.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/DataCard.stories.tsx
@@ -15,7 +15,8 @@ const meta = {
   argTypes: {
     label: {
       control: 'text',
-      description: 'The card title — typically the displayLabel attribute',
+      description:
+        'The card title — derived from the node’s name heuristic or fallback',
     },
     details: {
       control: 'object',

--- a/packages/interview/src/interfaces/NameGeneratorRoster/DataCard.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/DataCard.tsx
@@ -8,7 +8,7 @@ type DataCardProps = Omit<
   React.ComponentPropsWithRef<'article'>,
   'aria-label'
 > & {
-  /** The card title — typically the displayLabel attribute */
+  /** The card title — derived from the node's name heuristic or fallback */
   label: string;
   /** Label → value pairs to render below the title */
   details?: DataCardDetails;

--- a/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.capture.stories.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.capture.stories.tsx
@@ -24,7 +24,6 @@ const build = () => {
     subject: { entity: 'node', type: nodeType.id },
     dataSource: 'externalData',
     cardOptions: {
-      displayLabel: nameVar.id,
       additionalProperties: [
         { label: 'Age', variable: ageVar.id },
         { label: 'Location', variable: locationVar.id },

--- a/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.stories.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.stories.tsx
@@ -44,7 +44,6 @@ function buildInterview(args: StoryArgs) {
     dataSource: 'externalData',
     behaviours: Object.keys(behaviours).length > 0 ? behaviours : undefined,
     cardOptions: {
-      displayLabel: nameVar.id,
       additionalProperties: [
         { label: 'Age', variable: ageVar.id },
         { label: 'Location', variable: locationVar.id },
@@ -191,6 +190,90 @@ export const MultiplePrompts: Story = {
     promptCount: 3,
     initialSelectedCount: 2,
   },
+};
+
+/**
+ * Builds a roster whose nodes are keyed by variable UUIDs that are NOT present
+ * in the running codebook, mimicking data exported from a preview interview.
+ * The "name" heuristic therefore finds nothing, exercising the fallback path.
+ */
+function buildUuidMismatchInterview() {
+  const si = new SyntheticInterview();
+
+  // addNodeType seeds a "name" text variable, so the codebook HAS a name
+  // attribute — but the roster nodes below are keyed under unrelated UUIDs, so
+  // the heuristic cannot match against it.
+  const nodeType = si.addNodeType({ name: 'Person' });
+
+  si.addStage('NameGeneratorRoster', {
+    label: 'Select People',
+    subject: { entity: 'node', type: nodeType.id },
+    dataSource: 'externalData',
+  }).addPrompt({
+    text: 'Please select the people you know from this list.',
+  });
+
+  const rosterNodes = [
+    {
+      attributes: {
+        'mismatched-uuid-name': 'Alice Smith',
+        'mismatched-uuid-age': 30,
+      },
+    },
+    {
+      attributes: {
+        'mismatched-uuid-name': 'Bob Jones',
+        'mismatched-uuid-age': 42,
+      },
+    },
+    // A value-less node: no usable attribute values, so it must fall through to
+    // the "Unnamed Person N" placeholder rather than showing its _uid hash.
+    { attributes: {} },
+  ];
+
+  const url = `data:application/json;base64,${btoa(
+    JSON.stringify({ nodes: rosterNodes }),
+  )}`;
+
+  si.addAsset({
+    key: 'asset-external-data',
+    assetId: 'externalData',
+    name: 'External Data',
+    type: 'network',
+    url,
+    size: 0,
+  });
+
+  return si;
+}
+
+const UuidMismatchStoryWrapper = () => {
+  const interview = useMemo(() => buildUuidMismatchInterview(), []);
+  const rawPayload = useMemo(
+    () =>
+      SuperJSON.stringify(interview.getInterviewPayload({ currentStep: 0 })),
+    [interview],
+  );
+
+  return (
+    <div className="flex h-dvh w-full">
+      <StoryInterviewShell rawPayload={rawPayload} />
+    </div>
+  );
+};
+
+/**
+ * Reproduces the preview-export roster bug. The asset is served inline via a
+ * `data:` URL whose nodes are keyed by variable UUIDs absent from the codebook,
+ * so `getNodeLabelAttribute` returns null.
+ *
+ * Before the fix, the cards fell back to the content-hash `_uid` and showed an
+ * opaque random ID. After the fix, each card shows the first available value
+ * ("Alice Smith", "Bob Jones"), and the value-less node shows the
+ * "Unnamed Person 3" placeholder.
+ */
+export const PreviewExportUuidMismatch: Story = {
+  render: () => <UuidMismatchStoryWrapper />,
 };
 
 /**

--- a/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.tsx
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/NameGeneratorRoster.tsx
@@ -70,7 +70,17 @@ const ErrorMessage = (_props: { error: Error }) => (
   </div>
 );
 
-const layout = new GridLayout<UseItemElement>({ gap: 2, minItemWidth: 400 });
+// Desired minimum width of a roster DataCard (the grid column floor).
+const CARD_MIN_WIDTH = 400;
+// Minimum width of the source panel: the card width plus the ScrollArea
+// viewport padding (px-2 = 16px) and a scrollbar allowance, so the resize
+// handle can never drag the panel narrow enough for a card to overflow.
+const SOURCE_PANEL_MIN_WIDTH = CARD_MIN_WIDTH + 32;
+
+const layout = new GridLayout<UseItemElement>({
+  gap: 2,
+  minItemWidth: CARD_MIN_WIDTH,
+});
 
 const keyExtractor = (item: UseItemElement) => item.id;
 
@@ -383,6 +393,7 @@ const NameGeneratorRoster = (props: NameGeneratorRosterProps) => {
       <ResizableFlexPanel
         storageKey="name-generator-roster-panels"
         defaultBasis={50}
+        minSizePx={SOURCE_PANEL_MIN_WIDTH}
         className="min-h-0 w-full flex-1 basis-full"
         aria-label="Resize panel and node list areas"
       >

--- a/packages/interview/src/interfaces/NameGeneratorRoster/useItems.ts
+++ b/packages/interview/src/interfaces/NameGeneratorRoster/useItems.ts
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from 'react';
 
 import {
   type EntityPrimaryKey,
-  entityAttributesProperty,
   entityPrimaryKeyProperty,
   type NcEntity,
   type NcNode,
@@ -13,9 +12,9 @@ import useExternalData from '~/hooks/useExternalData';
 import { useStageSelector } from '~/hooks/useStageSelector';
 import { getStageCardOptions } from '~/selectors/name-generator';
 import { getNetworkNodes, getNodeTypeDefinition } from '~/selectors/session';
-import { getNodeLabelAttribute } from '~/utils/getNodeLabelAttribute';
 import getParentKeyByNameValue from '~/utils/getParentKeyByNameValue';
 import { getEntityAttributes } from '~/utils/networkEntities';
+import { resolveRosterNodeLabel } from '~/utils/resolveRosterNodeLabel';
 
 import type { NameGeneratorRosterProps } from './helpers';
 
@@ -84,22 +83,16 @@ const useItems = (props: NameGeneratorRosterProps) => {
   // data, meaning we do not expect it to be encrypted.
   // TODO: this must be updated if we want rosters to support encrypted data.
   const codebookVariables = nodeTypeDefinition?.variables;
+  const subjectLabel = nodeTypeDefinition?.name ?? 'node';
   const getNodeLabel = useCallback(
-    (node: NcNode) => {
-      const attribute = getNodeLabelAttribute(
+    (node: NcNode, sequentialNumber: number) =>
+      resolveRosterNodeLabel({
         codebookVariables,
-        node[entityAttributesProperty],
-      );
-
-      if (attribute) {
-        return String(
-          node[entityAttributesProperty][attribute] as string | number,
-        );
-      }
-
-      return node[entityPrimaryKeyProperty];
-    },
-    [codebookVariables],
+        node,
+        subjectLabel,
+        sequentialNumber,
+      }),
+    [codebookVariables, subjectLabel],
   );
 
   const items = useMemo(() => {
@@ -107,11 +100,11 @@ const useItems = (props: NameGeneratorRosterProps) => {
       return [] as UseItemElement[];
     }
 
-    return externalData.map((item) => ({
+    return externalData.map((item, index) => ({
       id: item[entityPrimaryKeyProperty],
       data: item,
       props: {
-        label: getNodeLabel(item),
+        label: getNodeLabel(item, index + 1),
         data: detailsWithVariableUUIDs({
           ...props,
           nodeTypeDefinition,

--- a/packages/interview/src/utils/__tests__/resolveRosterNodeLabel.test.ts
+++ b/packages/interview/src/utils/__tests__/resolveRosterNodeLabel.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NodeDefinition } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import { resolveRosterNodeLabel } from '../resolveRosterNodeLabel';
+
+const makeNode = (attributes: NcNode['attributes']): NcNode => ({
+  type: 'person',
+  [entityPrimaryKeyProperty]: 'a1b2c3d4-content-hash-uid',
+  [entityAttributesProperty]: attributes,
+});
+
+describe('resolveRosterNodeLabel', () => {
+  it('returns the value found by the name heuristic when one matches', () => {
+    const codebookVariables: NodeDefinition['variables'] = {
+      'var-name': { name: 'name', type: 'text' },
+      'var-age': { name: 'age', type: 'number' },
+    };
+
+    const node = makeNode({ 'var-name': 'John Doe', 'var-age': 30 });
+
+    const result = resolveRosterNodeLabel({
+      codebookVariables,
+      node,
+      subjectLabel: 'Person',
+      sequentialNumber: 1,
+    });
+
+    expect(result).toBe('John Doe');
+  });
+
+  it('falls back to the first non-empty string/number value when the heuristic returns null (UUID mismatch)', () => {
+    // Codebook defines a "name" variable, but the roster node's attributes are
+    // keyed by UUIDs that are NOT present in the codebook (e.g. a preview-export
+    // roster), so the heuristic finds nothing.
+    const codebookVariables: NodeDefinition['variables'] = {
+      'codebook-name-uuid': { name: 'name', type: 'text' },
+    };
+
+    const node = makeNode({
+      'mismatched-uuid-1': 'Alice Smith',
+      'mismatched-uuid-2': 30,
+    });
+
+    const result = resolveRosterNodeLabel({
+      codebookVariables,
+      node,
+      subjectLabel: 'Person',
+      sequentialNumber: 2,
+    });
+
+    expect(result).toBe('Alice Smith');
+  });
+
+  it('skips empty/null and non-primitive values when choosing the first value', () => {
+    const node = makeNode({
+      'empty': '',
+      'nullish': null,
+      'object-value': { x: 1, y: 2 },
+      'first-real': 42,
+    });
+
+    const result = resolveRosterNodeLabel({
+      codebookVariables: undefined,
+      node,
+      subjectLabel: 'Person',
+      sequentialNumber: 3,
+    });
+
+    expect(result).toBe('42');
+  });
+
+  it('returns a placeholder with the subject label and sequential number for a value-less node', () => {
+    const node = makeNode({});
+
+    const result = resolveRosterNodeLabel({
+      codebookVariables: {
+        'codebook-name-uuid': { name: 'name', type: 'text' },
+      },
+      node,
+      subjectLabel: 'Person',
+      sequentialNumber: 3,
+    });
+
+    expect(result).toBe('Unnamed Person 3');
+  });
+});

--- a/packages/interview/src/utils/resolveRosterNodeLabel.ts
+++ b/packages/interview/src/utils/resolveRosterNodeLabel.ts
@@ -1,0 +1,53 @@
+import type { NodeDefinition } from '@codaco/protocol-validation';
+import { entityAttributesProperty, type NcNode } from '@codaco/shared-consts';
+
+import { getNodeLabelAttribute } from './getNodeLabelAttribute';
+
+type ResolveRosterNodeLabelArgs = {
+  codebookVariables: NodeDefinition['variables'];
+  node: NcNode;
+  subjectLabel: string;
+  sequentialNumber: number;
+};
+
+// Only string/number values produce a meaningful title; everything else
+// (objects, arrays, null) would stringify to noise like "[object Object]".
+const coerceToLabel = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value === '' ? null : value;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return null;
+};
+
+// Derives a human-readable title for an external-roster card. Falls back through
+// the name heuristic, then the first usable attribute value (covers
+// preview-export rosters whose attribute keys are UUIDs absent from the running
+// codebook), then a stable placeholder so we never surface the content-hash _uid.
+export const resolveRosterNodeLabel = ({
+  codebookVariables,
+  node,
+  subjectLabel,
+  sequentialNumber,
+}: ResolveRosterNodeLabelArgs): string => {
+  const attributes = node[entityAttributesProperty];
+
+  const attribute = getNodeLabelAttribute(codebookVariables, attributes);
+  if (attribute) {
+    const label = coerceToLabel(attributes[attribute]);
+    if (label !== null) {
+      return label;
+    }
+  }
+
+  for (const value of Object.values(attributes)) {
+    const label = coerceToLabel(value);
+    if (label !== null) {
+      return label;
+    }
+  }
+
+  return `Unnamed ${subjectLabel} ${sequentialNumber}`;
+};

--- a/packages/protocol-utilities/src/SyntheticInterview.ts
+++ b/packages/protocol-utilities/src/SyntheticInterview.ts
@@ -478,7 +478,6 @@ export class SyntheticInterview {
       entry.dataSource = opts?.dataSource ?? 'externalData';
       if (opts?.cardOptions) {
         entry.cardOptions = {
-          displayLabel: opts.cardOptions.displayLabel ?? 'name',
           additionalProperties: opts.cardOptions.additionalProperties,
         };
       }

--- a/packages/protocol-utilities/src/__tests__/SyntheticInterview.test.ts
+++ b/packages/protocol-utilities/src/__tests__/SyntheticInterview.test.ts
@@ -532,7 +532,9 @@ describe('SyntheticInterview', () => {
       const si = new SyntheticInterview();
       const stage = si.addStage('NameGeneratorRoster', {
         dataSource: 'externalData',
-        cardOptions: { displayLabel: 'name' },
+        cardOptions: {
+          additionalProperties: [{ label: 'Name', variable: 'name' }],
+        },
         sortOptions: {
           sortOrder: [{ property: 'name', direction: 'asc' }],
           sortableProperties: [{ variable: 'name', label: 'Name' }],

--- a/packages/protocol-utilities/src/types.ts
+++ b/packages/protocol-utilities/src/types.ts
@@ -232,7 +232,6 @@ export type StageEntry = {
   // NameGeneratorRoster
   dataSource?: string;
   cardOptions?: {
-    displayLabel: string;
     additionalProperties?: { label: string; variable: string }[];
   };
   sortOptions?: {
@@ -358,7 +357,6 @@ export type AddStageInput = {
   // NameGeneratorRoster
   dataSource?: string;
   cardOptions?: {
-    displayLabel?: string;
     additionalProperties?: { label: string; variable: string }[];
   };
   sortOptions?: {

--- a/packages/protocol-validation/src/schemas/8/stages/name-generator-roster.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/name-generator-roster.ts
@@ -14,7 +14,6 @@ export const nameGeneratorRosterStage = baseStageSchema.extend({
   dataSource: z.string().generateMock(() => getAssetId()),
   cardOptions: z
     .strictObject({
-      displayLabel: z.string().optional(),
       additionalProperties: z
         .array(z.strictObject({ label: z.string(), variable: z.string() }))
         .optional(),


### PR DESCRIPTION
## Summary

Fixes two NameGeneratorRoster bugs and removes a dead schema field.

### 1. Roster cards showed a raw UID instead of a name
When the name heuristic (`getNodeLabelAttribute`) could not resolve a label for an external-roster node, `useItems` fell back to the node's content-hash `_uid` — the confusing "random ID" the cards displayed.

This happens when the heuristic returns `null`, e.g.:
- the roster asset came from a **preview interview export**, whose attribute keys are variable **UUIDs that don't belong to the running protocol's codebook**, so every codebook-keyed lookup misses; or
- the subject node type has no populated **text** variable.

New `resolveRosterNodeLabel` resolves in order: name heuristic → first usable (string/number) attribute value → stable `Unnamed {subject} {n}` placeholder. The raw `_uid` is never surfaced.

### 2. DataCards didn't shrink → overflow broke drag-and-drop
`GridLayout.getContainerStyles()` emitted `repeat(auto-fill, minmax(${minItemWidth}px, 1fr))`. In a container narrower than `minItemWidth` (the roster panel at its default resizable width on an iPad ≈ 380px vs. a 400px floor), the `minmax` floor forced the single column to 400px, overflowing the panel and breaking DnD hit areas. The floor is now `min(${minItemWidth}px, 100%)`, so a lone column shrinks to fit while keeping the desired width when there's room.

### 3. Removed unused `cardOptions.displayLabel`
Introduced in the v8 schema but **never read by any app** (legacy or current) and not settable in Architect. Removed from the schema, `protocol-utilities` types, and the `SyntheticInterview` builder. Safe to drop: nothing writes it, so no real protocol carries it (the `cardOptions` schema is `strictObject`).

## Reproduction
`PreviewExportUuidMismatch` story added to `NameGeneratorRoster.stories.tsx` — serves a roster keyed by foreign UUIDs via a `data:` URL (no protocol install needed). Before the fix the cards showed `_uid`; now they show the first value, with the placeholder for value-less nodes.

## Tests
- `resolveRosterNodeLabel.test.ts` — heuristic hit, UUID-mismatch first-value fallback, empty/non-stringable skipping, placeholder.
- `GridLayout.test.ts` — `getContainerStyles` regression asserting the clamped `min(Npx, 100%)` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Roster item cards now display readable fallback labels instead of raw identifiers when primary label resolution fails, using the first available attribute value or a stable "Unnamed" placeholder
  * Cards and layout columns now properly shrink to fit narrow panels
  * Roster panel width resizing is constrained to prevent sizing narrower than individual cards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->