### PR TITLE
release(interviewer-v8): 8.0.0-alpha.2

### DIFF
--- a/apps/interviewer-v8/android/app/build.gradle
+++ b/apps/interviewer-v8/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "8.0.0-alpha.1"
+        versionName "8.0.0-alpha.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v8",
-  "version": "8.0.0-alpha.1",
+  "version": "8.0.0-alpha.2",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",


### PR DESCRIPTION
Bumps `@codaco/interviewer-v8` to `8.0.0-alpha.2` (+ synced Android `versionName`; iOS `MARKETING_VERSION` stays numeric `8.0.0`).

## Why

This is the **first interviewer-v8 release that will actually publish**. The `8.0.0-alpha.1` bump (#652) merged fine, but the shared `release` job was blocked at the changesets step by an unrelated legacy-interviewer dependency issue (since fixed on `main`), so the v8 build/publish jobs were skipped and no release was created.

Because the detect step diffs `package.json` version against `HEAD^`, alpha.1 can't be republished retroactively — so we move forward: this bump is what establishes the feed.

## What merging this does

- `release` job detects the `alpha.1 → alpha.2` bump → triggers the v8 build/publish jobs.
- **build**: mac / win / linux Electron builds (native modules rebuilt for Electron's ABI), emitting `alpha*.yml` update metadata.
- **publish**: creates the `interviewer-v8@v8.0.0-alpha.2` GitHub release (flagged pre-release) **and** creates the `interviewer-v8-latest` feed the auto-updater reads.

## Note on verifying auto-update

Auto-update needs two published releases to observe end-to-end. This establishes the feed + an installable build; a subsequent `alpha.3` is what an installed alpha.2 will then detect, download, and install. macOS auto-update only applies if the `APPLE_API_KEY`/`CSC_LINK` signing secrets are configured.
