### PR TITLE
fix(release): detect interviewer-v8 bump via push SHA (+ bump to 8.0.0-alpha.3)

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -904,19 +904,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
       - name: Detect interviewer-v8 version bump
-        # changesets/action either opens a "Version Packages" PR or, when no
-        # changesets remain, runs the publish step which has already mutated
-        # apps/interviewer-v8/package.json in-place during the merged version
-        # PR. Diff the file's version against HEAD^ to decide whether to
-        # trigger an Electron build downstream. fetch-depth: 2 above makes
-        # HEAD^ available.
+        # interviewer-v8 is bump-driven: its version is edited directly in a PR
+        # rather than via a changesets "Version Packages" PR. Decide whether to
+        # release by diffing the merged commit's version against its first
+        # parent (the previous main tip).
+        #
+        # Use the immutable push SHA, NOT HEAD/HEAD^: when there are pending
+        # changesets the changesets/action step above creates a local "Version
+        # Packages" commit and checks it out, so by the time this step runs the
+        # working HEAD has advanced and HEAD^ is the merge commit (same version)
+        # instead of the previous main tip. `${{ github.sha }}` is the pushed
+        # commit and `<sha>^` resolves its first parent regardless of where the
+        # working HEAD currently points; fetch-depth: 2 makes both available.
         id: detect_interviewer_v8
         env:
           PKG_JSON: apps/interviewer-v8/package.json
+          SHA: ${{ github.sha }}
         run: |
-          current=$(node -p "require('./$PKG_JSON').version")
-          if git cat-file -e "HEAD^:$PKG_JSON" 2>/dev/null; then
-            previous=$(git show "HEAD^:$PKG_JSON" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          read_version() { git show "$1:$PKG_JSON" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version"; }
+          current=$(read_version "$SHA")
+          if git cat-file -e "$SHA^:$PKG_JSON" 2>/dev/null; then
+            previous=$(read_version "$SHA^")
           else
             previous=""
           fi

--- a/apps/interviewer-v8/android/app/build.gradle
+++ b/apps/interviewer-v8/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "8.0.0-alpha.2"
+        versionName "8.0.0-alpha.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v8",
-  "version": "8.0.0-alpha.2",
+  "version": "8.0.0-alpha.3",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",


### PR DESCRIPTION
Fixes the interviewer-v8 release detection so a version bump actually triggers the Electron build/publish, and bumps to `8.0.0-alpha.3` to exercise it.

## The bug

`8.0.0-alpha.2` (#659) merged and the `release` job **succeeded**, but `interviewer-v8-build`/`interviewer-v8-publish` were **skipped** — so no release was created (again).

Root cause is in the `Detect interviewer-v8 version bump` step. It compared `HEAD` vs `HEAD^`, but when there are pending changesets, the `changesets/action` step that runs *before* it creates a local `Version Packages` commit and checks it out — advancing the working `HEAD`. So `HEAD^` resolves to the **merge commit** (same version) instead of the **previous main tip**, and a real `alpha.1 → alpha.2` bump reads as "unchanged".

From the failed run's log:
```
[changeset-release/main 13fd4d7c] Version Packages      # changesets advances HEAD
interviewer-v8 version unchanged (8.0.0-alpha.2)        # my step then sees HEAD^ == merge commit
```

## The fix

Compare the **immutable push SHA** (`github.sha`) against its first parent (`<sha>^`) instead of the working `HEAD`/`HEAD^`. The push SHA is fixed regardless of what the changesets action does to the working tree.

Verified against the real #659 merge commit `c2b90dc`:
- `c2b90dc` = `alpha.2`, `c2b90dc^` = `alpha.1` → **changed** ✅ (would have fired)
- the team's changesets-fix commit `12b198d2d` = `alpha.1`, parent = `alpha.1` → unchanged ✅ (no false positive)

## Why the bump to alpha.3

alpha.2 is already on `main`, so merging the fix alone wouldn't publish anything (the fix commit's parent is already alpha.2 → no diff). Bumping to `alpha.3` gives this merge a real `alpha.2 → alpha.3` diff for the now-correct detect to act on — making this the **first interviewer-v8 release to actually publish** and establish the `interviewer-v8-latest` feed.

A subsequent `alpha.4` is then the true end-to-end auto-update test (an installed alpha.3 detecting alpha.4).
