### PR TITLE
fix(interviewer-v8): all-platform Electron builds + 8.0.0-alpha.4

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -998,7 +998,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # macOS 26 (Tahoe): electron-builder 26 composes the Icon Composer
+          # `.icon` asset via actool, which requires Xcode 26 / actool 26.
+          # macos-latest still ships actool 16.4, so pin the newer image.
+          - os: macos-26
             platform: mac
             artifact_name: interviewer-v8-macos
           - os: windows-latest
@@ -1399,7 +1402,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # macOS 26 (Tahoe) for the Icon Composer `.icon` / actool 26
+          # requirement — see the interviewer-v8-build job.
+          - os: macos-26
             platform: mac
             artifact_name: interviewer-v8-macos-pr-${{ github.event.pull_request.number }}
           - os: windows-latest

--- a/apps/interviewer-v8/android/app/build.gradle
+++ b/apps/interviewer-v8/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "8.0.0-alpha.3"
+        versionName "8.0.0-alpha.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v8/electron-builder.config.cjs
+++ b/apps/interviewer-v8/electron-builder.config.cjs
@@ -102,6 +102,10 @@ module.exports = {
   },
   linux: {
     category: 'Education',
+    // electron-builder derives the Linux executableName from the package `name`
+    // when unset; `@codaco/interviewer-v8` sanitizes to `@codacointerviewer-v8`,
+    // whose `@` is rejected for AppImage file paths. Set an explicit, safe name.
+    executableName: 'network-canvas-interviewer',
     // AppImage supports electron-updater auto-update; .deb does not — deb users
     // update via their package manager / a manual download.
     target: ['AppImage', 'deb'],

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v8",
-  "version": "8.0.0-alpha.3",
+  "version": "8.0.0-alpha.4",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",

--- a/packages/interview/vite.config.ts
+++ b/packages/interview/vite.config.ts
@@ -27,6 +27,29 @@ const cssCopyPlugin = (): Plugin => ({
   },
 });
 
+// With `preserveModules`, rolldown rewrites each inter-module import specifier
+// to point at the emitted `.js` file. On Windows that rewrite leaks the source
+// extension (e.g. `./Shell.tsx`, `./useTrack.ts`) into the output, so any
+// consumer bundling `dist/` fails with UNRESOLVED_IMPORT (the emitted files are
+// `.js`). Normalise relative TS/JSX specifiers back to `.js` in the rendered
+// output. A no-op on platforms where rolldown already emits `.js`.
+const normalizeOutputExtensions = (): Plugin => ({
+  name: 'interview-normalize-import-extensions',
+  renderChunk(code) {
+    const re =
+      /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(["'])(\.{1,2}\/[^"']*?)\.(tsx|ts|jsx|mts|cts)\2/g;
+    if (!re.test(code)) return null;
+    re.lastIndex = 0;
+    return {
+      code: code.replace(
+        re,
+        (_m, lead, quote, path) => `${lead}${quote}${path}.js${quote}`,
+      ),
+      map: null,
+    };
+  },
+});
+
 // Skip dts emission for non-library consumers of this config (Storybook builds
 // the preview app; Vitest just runs tests). Storybook's CLI sets STORYBOOK=true;
 // Vitest sets VITEST=true.
@@ -50,6 +73,7 @@ export default defineConfig({
         compilerOptions: { rootDir: resolve(__dirname, 'src') },
         bundleTypes: true,
       }),
+    normalizeOutputExtensions(),
     cssCopyPlugin(),
   ],
   define: {


### PR DESCRIPTION
Makes all three `interviewer-v8-build` platforms succeed, and bumps to `8.0.0-alpha.4` to drive the release that exercises them.

## Background

alpha.3 was the first release where the detect step correctly fired and the `interviewer-v8-build` matrix actually ran. All three platforms then failed — for three independent, pre-existing reasons that had never been exercised in CI before.

## Fixes

**🐧 Linux** — electron-builder derived the AppImage `executableName` from the package `name` (`@codaco/interviewer-v8` → `@codacointerviewer-v8`), whose `@` is invalid in file paths. Set an explicit `linux.executableName: network-canvas-interviewer`.

**🍎 macOS** — electron-builder 26 composes the Icon Composer `.icon` asset via `actool`, which requires **Xcode 26 / actool 26**; `macos-latest` ships actool 16.4. Pinned the v8 build (and PR-snapshot) mac legs to `macos-26` (Tahoe), keeping the Icon Composer icon.

**🪟 Windows** — `@codaco/interview`'s vite library build (`preserveModules`) leaked **source** extensions into its output on Windows — `dist/index.js` imported `./Shell.tsx`, `./analytics/useTrack.ts`, etc. (the emitted files are `.js`), via a rolldown specifier-rewrite path bug. Any consumer bundling `dist/` on Windows then failed with `UNRESOLVED_IMPORT`. Added a `renderChunk` normalizer to interview's vite config that rewrites relative `.ts`/`.tsx`/`.jsx` specifiers to `.js`.
  - Verified locally it's a **no-op** where rolldown already emits `.js` (mac/linux): fresh build still produces `./Shell.js`, typecheck passes.
  - Root cause confirmed: interviewer-v8's own web build succeeds on mac, so the Windows failure was solely the broken interview dist being bundled.

## Verification note

The Windows and macOS fixes can only be fully verified by the CI build itself (a rolldown Windows-only path bug, and a runner Xcode/actool version) — they're verified by the build matrix on merge. Linux + the interview no-op are verified locally.

Once green, this is the first interviewer-v8 release to publish installers + the `interviewer-v8-latest` feed for all platforms. A later `alpha.5` is the end-to-end auto-update test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 8.0.0-alpha.4
  * Updated macOS CI/CD runner to pinned version for stability

* **Bug Fixes**
  * Resolved Linux build executable path generation issue
  * Improved module import handling in the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->