### PR TITLE
fix(interviewer-v8): complete all-platform Electron builds + 8.0.0-alpha.5

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1043,7 +1043,9 @@ jobs:
         # but NOT interviewer-v8 itself — electron-vite handles that.
         run: pnpm exec turbo run build --filter=@codaco/interviewer-v8^...
       - name: Decode App Store Connect API key
-        if: matrix.os == 'macos-latest'
+        # Keyed on the platform, not the runner image, so it survives the mac
+        # leg moving to macos-26.
+        if: matrix.platform == 'mac'
         env:
           APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
         run: |
@@ -1059,8 +1061,8 @@ jobs:
           # unsigned per the spec.
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.CSC_KEY_PASSWORD || '' }}
         # `--publish never`: the `publish` config makes electron-builder emit the
         # latest*.yml auto-update metadata + app-update.yml, but uploading to the
         # moving feed is done by interviewer-v8-publish via gh, not here.
@@ -1453,7 +1455,8 @@ jobs:
       - name: Build workspace dependencies
         run: pnpm exec turbo run build --filter=@codaco/interviewer-v8^...
       - name: Decode App Store Connect API key
-        if: matrix.os == 'macos-latest'
+        # Platform-keyed so it survives the mac leg moving to macos-26.
+        if: matrix.platform == 'mac'
         env:
           APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
         run: |
@@ -1465,8 +1468,8 @@ jobs:
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.CSC_KEY_PASSWORD || '' }}
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.CSC_KEY_PASSWORD || '' }}
         run: pnpm electron:dist:${{ matrix.platform }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/apps/interviewer-v8/android/app/build.gradle
+++ b/apps/interviewer-v8/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "8.0.0-alpha.4"
+        versionName "8.0.0-alpha.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/interviewer-v8/electron-builder.config.cjs
+++ b/apps/interviewer-v8/electron-builder.config.cjs
@@ -106,6 +106,10 @@ module.exports = {
     // when unset; `@codaco/interviewer-v8` sanitizes to `@codacointerviewer-v8`,
     // whose `@` is rejected for AppImage file paths. Set an explicit, safe name.
     executableName: 'network-canvas-interviewer',
+    // The default artifact filename uses the (scoped) package name, so the .deb
+    // target becomes `@codaco/interviewer-v8_<ver>_amd64.deb` and fpm treats the
+    // `/` as a directory that doesn't exist. Use an explicit slash-free name.
+    artifactName: 'network-canvas-interviewer-${version}-${arch}.${ext}',
     // AppImage supports electron-updater auto-update; .deb does not — deb users
     // update via their package manager / a manual download.
     target: ['AppImage', 'deb'],

--- a/apps/interviewer-v8/package.json
+++ b/apps/interviewer-v8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-v8",
-  "version": "8.0.0-alpha.4",
+  "version": "8.0.0-alpha.5",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",

--- a/packages/interview/package.json
+++ b/packages/interview/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "sideEffects": [
     "**/*.css",
-    "**/Shell.js"
+    "./dist/index.js"
   ],
   "exports": {
     ".": {

--- a/packages/interview/vite.config.ts
+++ b/packages/interview/vite.config.ts
@@ -27,29 +27,6 @@ const cssCopyPlugin = (): Plugin => ({
   },
 });
 
-// With `preserveModules`, rolldown rewrites each inter-module import specifier
-// to point at the emitted `.js` file. On Windows that rewrite leaks the source
-// extension (e.g. `./Shell.tsx`, `./useTrack.ts`) into the output, so any
-// consumer bundling `dist/` fails with UNRESOLVED_IMPORT (the emitted files are
-// `.js`). Normalise relative TS/JSX specifiers back to `.js` in the rendered
-// output. A no-op on platforms where rolldown already emits `.js`.
-const normalizeOutputExtensions = (): Plugin => ({
-  name: 'interview-normalize-import-extensions',
-  renderChunk(code) {
-    const re =
-      /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(["'])(\.{1,2}\/[^"']*?)\.(tsx|ts|jsx|mts|cts)\2/g;
-    if (!re.test(code)) return null;
-    re.lastIndex = 0;
-    return {
-      code: code.replace(
-        re,
-        (_m, lead, quote, path) => `${lead}${quote}${path}.js${quote}`,
-      ),
-      map: null,
-    };
-  },
-});
-
 // Skip dts emission for non-library consumers of this config (Storybook builds
 // the preview app; Vitest just runs tests). Storybook's CLI sets STORYBOOK=true;
 // Vitest sets VITEST=true.
@@ -73,16 +50,24 @@ export default defineConfig({
         compilerOptions: { rootDir: resolve(__dirname, 'src') },
         bundleTypes: true,
       }),
-    normalizeOutputExtensions(),
     cssCopyPlugin(),
   ],
   define: {
     __PACKAGE_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
+    // Bundle to a single ESM entry rather than `preserveModules`. rolldown's
+    // preserveModules rewrites inter-module specifiers from the emitted file
+    // paths, and on Windows that leaks source extensions / mismatched paths
+    // (e.g. `./Shell.tsx`, unresolved `./Shell.js`), breaking any consumer that
+    // bundles `dist/`. A single bundle has no inter-module specifiers to rewrite
+    // and so builds identically across platforms. CSS is unaffected — no JS here
+    // imports `.css`; `src/styles.css` is copied verbatim by cssCopyPlugin and
+    // consumed via the `./styles.css` export.
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       formats: ['es'],
+      fileName: 'index',
     },
     rollupOptions: {
       external: (id) =>
@@ -90,11 +75,6 @@ export default defineConfig({
         !id.startsWith('/') &&
         !id.startsWith('~/') &&
         !id.includes('\0'),
-      output: {
-        preserveModules: true,
-        preserveModulesRoot: 'src',
-        entryFileNames: '[name].js',
-      },
     },
     sourcemap: true,
     minify: false,


### PR DESCRIPTION
Completes the all-platform Electron build. The alpha.4 run finally exercised the full build matrix, and each platform surfaced one more issue past the previous fix. Bumps to `8.0.0-alpha.5`.

## Fixes

**🐧 Linux** — the executableName fix landed (AppImage built ✓). The `.deb` then failed because its artifact filename defaulted to the scoped package name, so fpm tried to write `@codaco/interviewer-v8_<ver>_amd64.deb` and choked on the `/` (`Parent directory does not exist: …/@codaco`). Set an explicit slash-free `linux.artifactName`.

**🍎 macOS** — self-inflicted regression: moving the mac leg to `macos-26` invalidated the signing-cred gates, which keyed on `matrix.os == 'macos-latest'` — so `CSC_LINK`/`CSC_KEY_PASSWORD`/`APPLE_API_KEY` went empty and signing failed. Re-keyed those gates on `matrix.platform == 'mac'` (both the build and pr-snapshot jobs; left the unrelated legacy jobs on `macos-latest`). Icon composition under actool 26 was already validated locally on Xcode 26.5.

**🪟 Windows** — the renderChunk normalizer fixed the `.ts`/`.tsx` specifiers, but a *second facet* of the same rolldown `preserveModules` bug remained (unresolved `./Shell.js` — emitted file paths didn't match). Rather than chase rolldown's Windows path handling facet-by-facet, **replaced `preserveModules` with a single bundled ESM entry** for `@codaco/interview`. A bundle has no inter-module specifiers to mis-rewrite, so output is identical across platforms — the bug class is gone, not patched.
  - CSS unaffected: no JS in the package imports `.css`; `src/styles.css` is copied verbatim and consumed via the `./styles.css` export.
  - `sideEffects` updated (`**/Shell.js` → `./dist/index.js`) to preserve the original "don't tree-shake Shell's side effects" intent.

## Verification (local)

- `@codaco/interview` unit tests: **427 passed** (49 files).
- **interviewer-v8** web build (the Windows-affected consumer): ✓
- **architect-web** build (the other shared consumer, incl. interview Storybook): ✓
- macОS `.icon` composes under actool 26 + full `--dir` build through signing: ✓ (validated in the alpha.4 cycle on local Xcode 26.5).

Windows itself can only be confirmed by CI (no local Windows env), but the fix removes the failing mechanism entirely rather than working around it.

On merge this should publish installers + the `interviewer-v8-latest` feed for all three platforms — the first complete release. A later `alpha.6` is then the end-to-end auto-update test.
