### PR TITLE
fix(architect-web): make Home hero height-responsive on short viewports

### DIFF
--- a/apps/architect-web/src/components/Home/Home.tsx
+++ b/apps/architect-web/src/components/Home/Home.tsx
@@ -238,7 +238,7 @@ const Home = () => {
 
         {/* Hero section */}
 
-        <main className="mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col gap-8 overflow-y-auto px-8 pb-8 xl:gap-12 xl:px-12">
+        <main className="short:gap-4 mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col gap-8 overflow-y-auto px-8 pb-8 xl:gap-12 xl:px-12">
           <div className="flex min-h-0 w-full flex-1 flex-col items-stretch gap-8 md:flex-row">
             <div
               aria-hidden
@@ -247,13 +247,13 @@ const Home = () => {
               <TransitMap stops={TIMELINE_SCRIPT} count={visibleCount} />
             </div>
 
-            <div className="flex flex-1 flex-col items-start justify-center gap-6 text-left xl:gap-8">
-              <div className="flex flex-col items-start gap-4">
+            <div className="short:justify-start short:gap-3 flex flex-1 flex-col items-start justify-center gap-6 text-left xl:gap-8">
+              <div className="short:gap-2 flex flex-col items-start gap-4">
                 <div>
-                  <h1 className="hero mb-3 xl:text-8xl">
+                  <h1 className="hero mb-3 xl:text-[clamp(3rem,9vh,6rem)]">
                     Welcome to <span className="text-action">Architect</span>
                   </h1>
-                  <p className="lead my-0 max-w-xl">
+                  <p className="lead short:hidden my-0 max-w-xl">
                     Architect is the protocol designer for Network Canvas.
                     Compose name generators, capture ordinal and categorical
                     data, map connections, and explore narratives.

--- a/apps/architect-web/src/styles/tailwind.css
+++ b/apps/architect-web/src/styles/tailwind.css
@@ -6,6 +6,11 @@
    because their classes never make it into the generated stylesheet. */
 @source '../../node_modules/@codaco/fresco-ui/dist/**/*.js';
 
+/* Height-based variant for the Home hero, which must yield vertical space to the
+   templates/resume panel when the viewport is short. Width breakpoints can't
+   express this. */
+@custom-variant short (@media (max-height: 760px));
+
 @layer base {
   :root {
     /* UI Colors */
@@ -616,7 +621,10 @@
 }
 
 @utility hero {
-  @apply font-heading text-7xl leading-tight font-bold tracking-tight;
+  @apply font-heading leading-tight font-bold tracking-tight;
+  /* Scale with viewport height so the heading yields space on short screens.
+     8vh hits 4.5rem (the former text-7xl) at ~900px tall, floored at 2.75rem. */
+  font-size: clamp(2.75rem, 8vh, 4.5rem);
 }
 
 @utility lead {


### PR DESCRIPTION
## Problem

On the architect-web start screen, when the browser height is constrained (e.g. ~1366×768 laptops and shorter), the large fixed hero heading and its description consumed the available vertical space and squeezed the **Recent / Templates (resume)** panel until it was too short to be usable.

## Changes

- **Fluid hero heading.** The `hero` utility's font-size now scales with viewport height via `clamp(2.75rem, 8vh, 4.5rem)`, and the `xl` override uses `clamp(3rem, 9vh, 6rem)`. On tall and xl-wide displays the heading is unchanged (4.5rem / 6rem ceilings); on short screens it shrinks smoothly instead of dominating. Because it keys off *height*, a wide-but-short window no longer gets an oversized heading.
- **New `short` height variant.** Added `@custom-variant short (@media (max-height: 760px))` — Tailwind's `sm/md/lg/xl` are width-based and can't express this. Below 760px tall: the description is hidden (`short:hidden`), vertical gaps tighten, and the hero column top-aligns (`short:justify-start`) so the heading can't be clipped by flex centering inside the scroll container.

Net effect: as the window shortens, the heading scales down, the description drops away, gaps tighten, and the Recent/Templates panel keeps a usable height throughout. The decorative `TransitMap` (width-gated) is untouched.

## Verification

Typecheck passes (via turbo). Verified visually in-browser at viewport heights **1000 / 800 / 700 / 650 / 600px** and at mobile width (414px): the panel stays usable at every height, with no top-clipping of the heading.

### Note (pre-existing, out of scope)
At the md–lg width band (~1024px and on mobile widths), the two large action buttons overflow the half-width hero column, producing a horizontal scrollbar. This reproduces on `main` independent of height (confirmed at 1024×900 where none of these changes apply), so it's left for a separate width-focused fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined home page layout spacing with responsive adjustments tailored for displays with constrained vertical height
  * Enhanced hero section heading typography with fluid font sizing that adapts dynamically based on viewport dimensions
  * Modified lead paragraph visibility on compact display heights to optimize layout presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->