### PR TITLE
fix(docs): download links

### DIFF
--- a/apps/documentation/components/DownloadLink.tsx
+++ b/apps/documentation/components/DownloadLink.tsx
@@ -1,0 +1,22 @@
+import { type ComponentProps, forwardRef } from 'react';
+
+import { LinkLabel, linkRootClass } from './linkStyles';
+
+// Renders a static download (protocol bundle, roster) as a plain <a download>.
+// Authors reach for this explicitly in content
+// (<DownloadLink href="/protocols/Example.netcanvas">…</DownloadLink>) when a
+// link points at a file in /public rather than an app route — next/link would
+// client-side route to a non-existent page and bounce to the not-found
+// fallback. Forwards all anchor props (title, onClick, aria-*, data-*); only
+// `download` and the shared className are imposed.
+const DownloadLink = forwardRef<HTMLAnchorElement, ComponentProps<'a'>>(
+  ({ className, children, ...props }, ref) => (
+    <a ref={ref} className={linkRootClass(className)} {...props} download>
+      <LinkLabel>{children}</LinkLabel>
+    </a>
+  ),
+);
+
+DownloadLink.displayName = 'DownloadLink';
+
+export default DownloadLink;

--- a/apps/documentation/components/Link.tsx
+++ b/apps/documentation/components/Link.tsx
@@ -1,27 +1,20 @@
 import NextLink from 'next/link';
 import { type ComponentProps, forwardRef, type ReactNode } from 'react';
 
-import { cn } from '~/lib/utils';
+import { LinkLabel, linkRootClass } from './linkStyles';
 
+// An inline link to an app route, rendered via next/link for client-side
+// navigation. This is what every markdown link compiles to; static-asset
+// downloads are not handled here — authors mark those explicitly with
+// DownloadLink.
 const Link = forwardRef<
   HTMLAnchorElement,
   ComponentProps<typeof NextLink> & { children: ReactNode; className?: string }
->((props, ref) => {
-  return (
-    <NextLink
-      ref={ref}
-      className={cn(
-        'focusable group text-link font-semibold transition-[background-size] duration-300 ease-in-out',
-        props.className,
-      )}
-      {...props}
-    >
-      <span className="from-link to-link bg-linear-to-r bg-size-[0%_2px] bg-left-bottom bg-no-repeat pb-0.5 transition-[background-size] duration-200 ease-out group-hover:bg-size-[100%_2px]">
-        {props.children}
-      </span>
-    </NextLink>
-  );
-});
+>(({ className, children, ...props }, ref) => (
+  <NextLink ref={ref} className={linkRootClass(className)} {...props}>
+    <LinkLabel>{children}</LinkLabel>
+  </NextLink>
+));
 
 Link.displayName = 'Link';
 

--- a/apps/documentation/components/linkStyles.tsx
+++ b/apps/documentation/components/linkStyles.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '~/lib/utils';
+
+// Shared visual treatment for inline links. Both Link (app routes, via
+// next/link) and DownloadLink (static assets, via a plain <a download>) render
+// with these so the two stay pixel-identical — the styling lives here, not
+// duplicated in each component.
+
+// The focusable root that establishes the hover group.
+export function linkRootClass(className?: string) {
+  return cn(
+    'focusable group text-link font-semibold transition-[background-size] duration-300 ease-in-out',
+    className,
+  );
+}
+
+// The label whose underline grows from the left on hover.
+export function LinkLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="from-link to-link bg-linear-to-r bg-size-[0%_2px] bg-left-bottom bg-no-repeat pb-0.5 transition-[background-size] duration-200 ease-out group-hover:bg-size-[100%_2px]">
+      {children}
+    </span>
+  );
+}

--- a/apps/documentation/docs/desktop/key-concepts/resources.en.mdx
+++ b/apps/documentation/docs/desktop/key-concepts/resources.en.mdx
@@ -57,7 +57,7 @@ Interviewer supports MP4 and MOV video file formats. Take special care when usin
 
 ### Network
 
-Interviewer supports network data in CSV format. The heading row will be used to set [variable](/en/desktop/key-concepts/variables) names for any nodes brought into the interview. Ensure that you have a column called `name` to take advantage of automatic [node labelling](/en/desktop/advanced-topics/node-labelling). Download a simple example CSV file from [here](/assets/previousInterview.csv).
+Interviewer supports network data in CSV format. The heading row will be used to set [variable](/en/desktop/key-concepts/variables) names for any nodes brought into the interview. Ensure that you have a column called `name` to take advantage of automatic [node labelling](/en/desktop/advanced-topics/node-labelling). Download a simple example CSV file from <DownloadLink href="/assets/previousInterview.csv">here</DownloadLink>.
 
 ## Related concepts
 

--- a/apps/documentation/docs/desktop/tutorials/building-a-protocol.en.mdx
+++ b/apps/documentation/docs/desktop/tutorials/building-a-protocol.en.mdx
@@ -11,8 +11,8 @@ This tutorial will guide you through the process of creating a
 Network Canvas protocol using Architect. We will be rebuilding the sample
 protocol that is available to install within Interviewer, which was discussed
 extensively in the tutorial on [using Interviewer](/en/desktop/tutorials/using-interviewer). If
-you would like to download and open the finished protocol, you can do so [from
-here](</protocols/Sample Protocol v4.netcanvas>).
+you would like to download and open the finished protocol, you can do so <DownloadLink href="/protocols/Sample Protocol v4.netcanvas">from
+here</DownloadLink>.
 
 </SummarySection>
 <PrerequisitesSection>
@@ -259,7 +259,7 @@ Next we will develop a name generator that uses a roster brought in as an extern
 
 As we did in prior name generators above, we will first select the interface we want to configure (Name Generator for Roster Data), add a stage name, and create a new node type for "Classmate".
 
-Next we will select the external data source to bring into the protocol that will populate the nodes on the roster. For this example, we have used a fictitious classroom roster. To use the same roster as the sample protocol, please [click here](/assets/class-roster.csv) to download our CSV file. Alternatively, use any other roster you have on hand.
+Next we will select the external data source to bring into the protocol that will populate the nodes on the roster. For this example, we have used a fictitious classroom roster. To use the same roster as the sample protocol, please <DownloadLink href="/assets/class-roster.csv">click here</DownloadLink> to download our CSV file. Alternatively, use any other roster you have on hand.
 
 Just as you added resources to the Information Interface above, you will also browse for your external data source from the protocol resource library if you saved it there or else from another location on your device.
 

--- a/apps/documentation/docs/desktop/tutorials/using-interviewer.en.mdx
+++ b/apps/documentation/docs/desktop/tutorials/using-interviewer.en.mdx
@@ -94,7 +94,7 @@ provider to distribute protocol files to multiple devices.
 
 ### Import the Sample Protocol
 
-For the purposes of this tutorial, we will proceed using the built-in sample protocol. To follow along on your own device, **click the "install sample protocol" button in the welcome section of the app** to install the protocol that we will be using. Alternatively, [click here](</protocols/Sample Protocol v4.netcanvas>) to download the file, and then import it into Interviewer using the import from file method described above.
+For the purposes of this tutorial, we will proceed using the built-in sample protocol. To follow along on your own device, **click the "install sample protocol" button in the welcome section of the app** to install the protocol that we will be using. Alternatively, <DownloadLink href="/protocols/Sample Protocol v4.netcanvas">click here</DownloadLink> to download the file, and then import it into Interviewer using the import from file method described above.
 
 Once a protocol has been imported, a new section will appear on the start screen: the **new interview section**. Inside this section will be a protocol card, representing the protocol you imported.
 

--- a/apps/documentation/docs/desktop/tutorials/working-with-rosters.en.md
+++ b/apps/documentation/docs/desktop/tutorials/working-with-rosters.en.md
@@ -83,7 +83,7 @@ Once you are satisfied with your roster, you can add it to a Network Canvas prot
 
 ![Resource library button](/assets/img/roster-tutorial/resource-button.png 'The resource library button from within a protocol in Architect')
 
-You can also add it when you are creating a roster name generator. Below we walk through the steps of adding it to a name generator and we will add the roster as we go along. We will use a simple roster which includes five members of the cartoon television show, "The Simpsons", but you should be able to follow by analogy for a roster of your own making. The example CSV is available [here](/assets/simpsons-roster.csv).
+You can also add it when you are creating a roster name generator. Below we walk through the steps of adding it to a name generator and we will add the roster as we go along. We will use a simple roster which includes five members of the cartoon television show, "The Simpsons", but you should be able to follow by analogy for a roster of your own making. The example CSV is available <DownloadLink href="/assets/simpsons-roster.csv">here</DownloadLink>.
 
 ### Selecting the Name Generator Interface
 
@@ -184,4 +184,4 @@ To collect this sort of data in Network Canvas we can use a roster and only coll
 3. Because roster items become nodes only once, ego will then not be listed on subsequent roster prompts.
 4. However, ego is still in the alter pool, so any time we want to do something with the alters, such as ask for data on frequency of communication, we need to filter our ego, which we can do with stage level filtering and our `is_ego` variable.
 
-You can find a protocol [here](</protocols/Roster Example Protocol v1.netcanvas> 'Name Generator Interface with side panel for roster and nodes already mentioned') which has all of these features included. It has the small roster with Alice, Bob, Cam, and Dot but you can replace this with your own roster and modify it for your needs.
+You can find a protocol <DownloadLink href="/protocols/Roster Example Protocol v1.netcanvas" title="Name Generator Interface with side panel for roster and nodes already mentioned">here</DownloadLink> which has all of these features included. It has the small roster with Alice, Bob, Cam, and Dot but you can replace this with your own roster and modify it for your needs.

--- a/apps/documentation/docs/fresco/using-fresco.en.mdx
+++ b/apps/documentation/docs/fresco/using-fresco.en.mdx
@@ -112,7 +112,7 @@ Either an identifier column **or** a label column **must be provided** for each 
 
 The identifier and label column headers must be lowercase.
 
-You can download a template CSV file to help you format your data correctly from [here](/assets/participants-template.csv).
+You can download a template CSV file to help you format your data correctly from <DownloadLink href="/assets/participants-template.csv">here</DownloadLink>.
 
 </TipBox>
 

--- a/apps/documentation/lib/docs.tsx
+++ b/apps/documentation/lib/docs.tsx
@@ -43,6 +43,7 @@ import {
 } from '~/components/customComponents/SummaryCard';
 import TipBox, { type TipBoxProps } from '~/components/customComponents/TipBox';
 import VideoIFrame from '~/components/customComponents/VideoIFrame';
+import DownloadLink from '~/components/DownloadLink';
 import Link from '~/components/Link';
 import { Button } from '~/components/ui/Button';
 import { Details, Summary } from '~/components/ui/typography/Details';
@@ -251,6 +252,11 @@ const markdownComponents = {
   ) => {
     return <Link {...props} />;
   },
+  // Static download (protocol bundle, roster, etc.). Authors mark a link as a
+  // download explicitly — <DownloadLink href="/protocols/Example.netcanvas">…</DownloadLink>
+  // — rather than relying on href sniffing; these render as a plain <a download>
+  // because next/link would route to a non-existent page.
+  downloadlink: DownloadLink,
   tipbox: (props: TipBoxProps) => {
     return (
       <TipBox danger={props.danger !== undefined}>{props.children}</TipBox>


### PR DESCRIPTION
Fixes broken protocol/roster downloads in the docs app.

Similar fix implemented in #586 for the docs refactor. 

Markdown links pointing at static files under `/assets` and `/protocols` (protocols, roster CSVs) were rendered through `next/link`. Because these are real files in `/public` rather than app routes, `next/link` client-side routes to a non-existent page and bounces to the not-found fallback instead of downloading the file.

This PR makes downloads an **explicit authoring choice** rather than something inferred from the href. Authors mark a download link with a dedicated `<DownloadLink>` component, which renders a plain `<a download>`; regular markdown links continue to render as routed `next/link` links. `<DownloadLink>` and `<Link>` share styles so that they look visually identical. 