### PR TITLE
fix(interview): contain Geospatial map init failures and surface real error

### DIFF
--- a/.changeset/interview-geospatial-map-init-fallback.md
+++ b/.changeset/interview-geospatial-map-init-fallback.md
@@ -1,0 +1,15 @@
+---
+'@codaco/interview': patch
+---
+
+Contain Geospatial map initialisation failures instead of crashing the whole
+stage. `mapbox-gl`'s `Map` constructor throws synchronously when the
+environment can't host a map (most commonly "Failed to initialize WebGL" on
+devices or browsers without working WebGL). That throw previously escaped the
+effect and was caught by `StageErrorBoundary`, taking down the entire stage
+with an opaque reconciler stack. The map creation is now wrapped in a
+`try/catch` that captures the real error and renders a contained fallback
+message, so participants can continue. `StageErrorBoundary`'s copyable debug
+info also now leads with the error name and message — Firefox's `Error.stack`
+omits the message, which was silently dropping the most useful detail from
+bug reports.

--- a/packages/interview/src/components/StageErrorBoundary.tsx
+++ b/packages/interview/src/components/StageErrorBoundary.tsx
@@ -8,6 +8,18 @@ import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { useCaptureException } from '../analytics/useTrack';
 import CopyDebugInfoButton from './CopyDebugInfoButton';
 
+// Build the copyable debug string. The stack alone is not enough: Firefox's
+// Error.stack contains only call frames, not the error message, so copying
+// `error.stack` there silently drops the single most useful piece of
+// information (e.g. "Failed to initialize WebGL"). Always lead with the
+// name/message so reports are actionable regardless of browser.
+function formatDebugInfo(error: Error): string {
+  const heading = error.message
+    ? `${error.name}: ${error.message}`
+    : error.name;
+  return error.stack ? `${heading}\n\n${error.stack}` : heading;
+}
+
 type StageErrorBoundaryInnerProps = {
   children: ReactNode;
   captureException: (error: Error, props?: Record<string, unknown>) => void;
@@ -57,7 +69,7 @@ class StageErrorBoundaryInner extends Component<
             </div>
           </div>
           <div className="mt-4 flex justify-end">
-            <CopyDebugInfoButton debugInfo={error.stack ?? error.message} />
+            <CopyDebugInfoButton debugInfo={formatDebugInfo(error)} />
           </div>
         </Surface>
       );

--- a/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
+++ b/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
@@ -194,6 +194,7 @@ export default function GeospatialInterface({
     accessToken,
     isStageReady,
     zoomLevel,
+    mapError,
     handleResetMapZoom,
     handleZoomIn,
     handleZoomOut,
@@ -384,6 +385,27 @@ export default function GeospatialInterface({
             data-testid="geospatial-stub-click-area"
             className="bg-accent/10 absolute inset-0 cursor-crosshair"
           />
+        )}
+
+        {/* The map failed to initialise (e.g. WebGL unavailable on this
+            device/browser). Show a contained message rather than crashing the
+            whole stage. Stub mode never constructs a real map, so skip it. */}
+        {mapError && !useStub && (
+          <div
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center"
+            data-testid="map-error-overlay"
+          >
+            <div className="bg-background absolute inset-0 opacity-90" />
+            <div className="relative z-20 flex w-2/3 max-w-xl flex-col items-center gap-4 text-center">
+              <h2>The map could not be displayed</h2>
+              <p>
+                This can happen if your browser or device does not support the
+                features the map requires (for example, WebGL). Try a different
+                browser or device, or contact the study organizer. You may be
+                able to continue your interview by selecting the next arrow.
+              </p>
+            </div>
+          </div>
         )}
 
         {/* if outside-selectable-areas, add an overlay */}

--- a/packages/interview/src/interfaces/Geospatial/useMapbox.ts
+++ b/packages/interview/src/interfaces/Geospatial/useMapbox.ts
@@ -11,6 +11,7 @@ import mapboxgl from 'mapbox-gl';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useCaptureException } from '~/analytics/useTrack';
 import { useContractFlags } from '~/contract/context';
 import { makeGetApiKeyAssetValue } from '~/selectors/protocol';
 
@@ -109,6 +110,7 @@ export const useMapbox = ({
   onSelectionChange,
 }: UseMapboxProps) => {
   const { isE2E } = useContractFlags();
+  const captureException = useCaptureException();
   const {
     center,
     initialZoom,
@@ -126,6 +128,7 @@ export const useMapbox = ({
   const [isGeoJsonLoaded, setIsGeoJsonLoaded] = useState(false);
   const [isTransitLoaded, setIsTransitLoaded] = useState(false);
   const [zoomLevel, setZoomLevel] = useState<number>(initialZoom);
+  const [mapError, setMapError] = useState<Error | null>(null);
 
   // Composite readiness flag exposed to e2e tests via `data-map-idle`.
   // Gates the stage as fully rendered: map idle + every async resource
@@ -177,15 +180,30 @@ export const useMapbox = ({
     setIsMapIdleEvent(false);
     setIsGeoJsonLoaded(false);
     setIsTransitLoaded(false);
+    setMapError(null);
 
     mapboxgl.accessToken = accessToken;
 
-    mapRef.current = new mapboxgl.Map({
-      container: mapContainerRef.current,
-      center,
-      zoom: initialZoom,
-      style,
-    });
+    try {
+      mapRef.current = new mapboxgl.Map({
+        container: mapContainerRef.current,
+        center,
+        zoom: initialZoom,
+        style,
+      });
+    } catch (err) {
+      // mapbox-gl's Map constructor throws synchronously when the environment
+      // can't host a map — most commonly "Failed to initialize WebGL" on
+      // devices/browsers without working WebGL (hardware acceleration off,
+      // locked-down or virtualised browsers). Without this guard the throw
+      // escapes the passive-effect flush and is caught by StageErrorBoundary,
+      // crashing the entire stage with an opaque stack. Capture the real
+      // error and surface a contained fallback instead.
+      const error = err instanceof Error ? err : new Error(String(err));
+      captureException(error, { feature: 'geospatial-map-init' });
+      setMapError(error);
+      return;
+    }
 
     // Expose the current map instance to e2e tests. The data-map-idle
     // attribute is a necessary but insufficient signal on webkit for
@@ -437,6 +455,7 @@ export const useMapbox = ({
     style,
     showTransit,
     isE2E,
+    captureException,
   ]);
 
   // handle selections
@@ -553,6 +572,7 @@ export const useMapbox = ({
     accessToken,
     isStageReady,
     zoomLevel,
+    mapError,
     handleResetMapZoom,
     handleZoomIn,
     handleZoomOut,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1146,8 +1146,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@capacitor/android':
-        specifier: ^8.3.4
-        version: 8.4.0(@capacitor/core@8.4.0)
+        specifier: ^8.4.1
+        version: 8.4.1(@capacitor/core@8.4.0)
       '@capacitor/app':
         specifier: ^8.1.0
         version: 8.1.0(@capacitor/core@8.4.0)
@@ -2829,6 +2829,11 @@ packages:
 
   '@capacitor/android@8.4.0':
     resolution: {integrity: sha512-K1ZPkQzvRzPEALz9nBdLx5p5nAPzp5fsTYWk7LRiKZeH/NXqjDvqfTv7lrLgrziQNoDeaL6ijg64oBREzXiV+g==}
+    peerDependencies:
+      '@capacitor/core': ^8.4.0
+
+  '@capacitor/android@8.4.1':
+    resolution: {integrity: sha512-igtDCJ7QQn0P2qHFD9p4KXaa6V1b2PRNt+MxjVwtjTm/BJvqmiazOJq6rPjwFSZnfHm6iFoZk8TfzHd44pyBGw==}
     peerDependencies:
       '@capacitor/core': ^8.4.0
 
@@ -7963,6 +7968,7 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
@@ -9250,7 +9256,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -9260,7 +9266,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -15042,6 +15048,10 @@ snapshots:
       css-tree: 3.2.1
 
   '@capacitor/android@8.4.0(@capacitor/core@8.4.0)':
+    dependencies:
+      '@capacitor/core': 8.4.0
+
+  '@capacitor/android@8.4.1(@capacitor/core@8.4.0)':
     dependencies:
       '@capacitor/core': 8.4.0
 


### PR DESCRIPTION
## Problem

A Fresco deployment reported a crash on the Geospatial (map) stage with an opaque, undecipherable stack trace:

```
Map@…/12gls946ma_lb.js:116:8207
@…/12gls946ma_lb.js:154:918779
iv@…/18b3_6wyfw757.js:1:103322
up@… ud@… up@… ud@…   ← repeated ~60×
```

### What the trace actually meant

Only the first frame carries information:

- `Map@…` is **mapbox-gl's own `Map` class constructor** (a vendor chunk), not one of our components. `GeospatialInterface` never renders a `<Map>`; it drives mapbox imperatively via `useMapbox`.
- The next anonymous frame is the `useEffect` body in `useMapbox.ts` that calls `new mapboxgl.Map(...)`.
- `iv` is React's `flushPassiveEffects`; the repeated `up`/`ud` ladder is React's recursive passive-effect tree-walk descending to the stage — pure noise whose length just reflects component-tree depth.

So `new mapboxgl.Map(...)` threw **synchronously**, the throw escaped the effect (no `try/catch`), and `StageErrorBoundary` caught it. The reason it was undecipherable: the boundary's "Copy Debug Info" button copied `error.stack`, but **Firefox stacks (note the `@` syntax) omit the message**, dropping the one useful line — most likely `Failed to initialize WebGL`.

**Most likely root cause:** WebGL unavailable/disabled on a participant's device or browser — the classic "works for us, breaks in deployment" mapbox failure.

## Changes

1. **`useMapbox.ts`** — wrap the `new mapboxgl.Map(...)` constructor in `try/catch`; on failure, capture the exception (`feature: geospatial-map-init`) and expose a `mapError` state instead of letting the throw crash the whole stage.
2. **`Geospatial.tsx`** — render a contained fallback message when `mapError` is set, so a map failure no longer takes down the stage and the participant can continue.
3. **`StageErrorBoundary.tsx`** — lead the copyable debug info with the error name/message, so the message is never lost again regardless of browser.

## Notes

- I could not run `typecheck`/`lint` to completion in the dev container — `pnpm install` fails on a `sharp` download through the proxy, leaving workspace `dist` outputs unbuilt. `tsc` shows only pre-existing `@codaco/*` module-resolution errors (whole package, unrelated to these edits); **zero** type errors in the three changed files. Worth a green CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013SLHee9K4pkkoud9Berbo5)_