### PR TITLE
fix(architect-web): wrap long protocol names on the summary cover card

### DIFF
--- a/apps/architect-web/src/lib/ProtocolSummary/components/ProtocolCard.tsx
+++ b/apps/architect-web/src/lib/ProtocolSummary/components/ProtocolCard.tsx
@@ -32,9 +32,15 @@ const ProtocolCard = ({
           gradient's dark top, mirroring the timeline card's controls row. */}
       <div className="min-h-(--space-2xl)" aria-hidden />
 
-      <h2 className="m-0 hyphens-auto">{name}</h2>
+      {/* break-words so a long name with no spaces (or an over-long word)
+          wraps instead of overflowing the overflow-hidden card and being
+          clipped; hyphens-auto adds nicer breaks where the browser supports
+          it. The timeline card sidesteps this via a soft-wrapping textarea. */}
+      <h2 className="m-0 wrap-break-word hyphens-auto">{name}</h2>
 
-      {description && <div className="text-sm">{description}</div>}
+      {description && (
+        <div className="text-sm wrap-break-word">{description}</div>
+      )}
 
       <div className="text-navy-taupe/70 font-monospace mt-(--space-sm) flex flex-col gap-(--space-xs) text-xs tracking-widest uppercase">
         <span>Last Modified: {formatDate(lastModified)}</span>


### PR DESCRIPTION
Follow-up to #691 (already merged). This commit was pushed to the branch *after* #691 merged, so it never made it into `main` — opening it as its own PR.

## Problem

On the printable protocol summary cover, a very long protocol name with no break opportunities (e.g. a single long token) overflowed the `overflow-hidden` card and was clipped. `hyphens-auto` alone cannot break an otherwise-unbreakable string.

## Fix

Add `overflow-wrap: break-word` (`wrap-break-word`) to the name and description so they wrap to fit. Normal multi-word names still break at spaces; only over-long unbreakable tokens are force-wrapped. The timeline `ProtocolInfoCard` never hit this because it renders the name in a soft-wrapping `<textarea>`.

## Verification

Reproduced in the running app with a 97-character single-token name on `/protocol/summary`:
- `overflow-wrap: break-word` applied; heading and card report zero horizontal overflow.
- The long name wraps cleanly across multiple lines inside the card; pattern, description and metadata all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)