### PR TITLE
fix(architect-web): small UI/UX issues from #685

### DIFF
--- a/apps/architect-web/src/components/AssignAttributes/AssignAttributes.tsx
+++ b/apps/architect-web/src/components/AssignAttributes/AssignAttributes.tsx
@@ -1,6 +1,7 @@
 import type { FieldArrayFieldsProps } from 'redux-form';
 
 import Button from '~/lib/legacy-ui/components/Button';
+import { cx } from '~/utils/cva';
 
 import Attribute from './Attribute';
 import withAssignAttributesHandlers from './withAssignAttributesHandlers';
@@ -65,7 +66,9 @@ const AssignAttributes = ({
         })}
       </div>
     )}
-    <div className="mt-(--space-md) [&_button]:m-0">
+    <div
+      className={cx(fields.length > 0 && 'mt-(--space-md)', '[&_button]:m-0')}
+    >
       <Button color="sea-green" icon="add" onClick={handleAddNew}>
         Add new variable to assign
       </Button>

--- a/apps/architect-web/src/components/Codebook/EntityTypeDialog.tsx
+++ b/apps/architect-web/src/components/Codebook/EntityTypeDialog.tsx
@@ -129,7 +129,10 @@ const EntityTypeDialog = ({
   );
 
   const handleCancel = useCallback(() => {
-    if (!hasUnsavedChanges) {
+    // Abandoning a not-yet-created type loses nothing, so close immediately for
+    // new node and edge types. Editing an existing type still confirms, since
+    // discarding real edits is more consequential.
+    if (isNew || !hasUnsavedChanges) {
       onClose();
       return;
     }
@@ -147,7 +150,7 @@ const EntityTypeDialog = ({
         },
       }),
     ).unwrap();
-  }, [hasUnsavedChanges, onClose, dispatch]);
+  }, [isNew, hasUnsavedChanges, onClose, dispatch]);
 
   if (!entity) {
     return null;

--- a/apps/architect-web/src/components/EditorLayout/Section.tsx
+++ b/apps/architect-web/src/components/EditorLayout/Section.tsx
@@ -1,12 +1,21 @@
 import type React from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 
 import { cx } from '~/utils/cva';
 
 import Switch from '../NewComponents/Switch';
+import SectionDepthContext from './SectionDepthContext';
 
 const containerClasses =
   'p-6 shadow-md rounded bg-(--current-surface) text-(--current-surface-foreground) relative';
+
+// Surface tokens by nesting level (capped at surface-3). Class strings are
+// written out in full so Tailwind's scanner picks up the arbitrary properties.
+const surfaceClassesByLevel: Record<number, string> = {
+  1: '[--current-surface-foreground:var(--color-surface-1-foreground)] [--current-surface:var(--color-surface-1)]',
+  2: '[--current-surface-foreground:var(--color-surface-2-foreground)] [--current-surface:var(--color-surface-2)]',
+  3: '[--current-surface-foreground:var(--color-surface-3-foreground)] [--current-surface:var(--color-surface-3)]',
+};
 
 type SectionProps = {
   id?: string | null;
@@ -39,6 +48,9 @@ const Section = ({
   layout = 'horizontal',
   required = true,
 }: SectionProps) => {
+  const depth = useContext(SectionDepthContext);
+  const surfaceLevel = Math.min(depth + 1, 3);
+
   const [isOpen, setIsOpen] = useState(startExpanded);
 
   // If the startExpanded prop changes, update the state.
@@ -69,78 +81,81 @@ const Section = ({
   );
 
   return (
-    <div
-      id={id ?? undefined}
-      data-name={typeof title === 'string' ? title : undefined}
-      className={cx(
-        '[--input-background:var(--color-surface-1)] [--slider-color:hsl(var(--charcoal))]',
-        'relative [--current-surface-foreground:var(--color-surface-1-foreground)] [--current-surface:var(--color-surface-1)]',
-        'w-full max-w-7xl',
-        layout === 'horizontal' &&
-          'max-lg:mb-4 max-lg:flex max-lg:flex-col max-lg:gap-(--space-md) max-lg:rounded max-lg:bg-(--current-surface) max-lg:p-6 max-lg:text-(--current-surface-foreground) max-lg:shadow-md lg:grid lg:grid-cols-[20rem_auto] lg:gap-8',
-        layout === 'vertical' && 'mb-4 flex flex-col gap-(--space-md)',
-        layout === 'vertical' && containerClasses,
-        className,
-      )}
-    >
-      {title != null && (
-        <div>
-          <div
-            className={cx(
-              'flex items-center gap-4 text-right',
-              layout === 'vertical' && 'text-xl font-semibold tracking-tight',
-              // `lg:top-(--space-4xl)` (6rem) pins the heading just below the
-              // sticky top menu bar so it never overlaps it; `z-(--z-fx)` keeps
-              // it above the section content but below the nav.
-              layout === 'horizontal' &&
-                'lg:small-heading lg:bg-border max-lg:text-xl max-lg:font-semibold max-lg:tracking-tight lg:sticky lg:top-(--space-4xl) lg:z-(--z-fx) lg:flex-row-reverse lg:items-center lg:justify-between lg:rounded lg:px-6 lg:py-2',
-            )}
-          >
-            <span>
-              {title}
-              {!toggleable && required && (
-                <span className="text-error ms-1">*</span>
-              )}
-            </span>
-            {toggleable && (
-              <Switch
-                title="Turn this feature on or off"
-                checked={isOpen}
-                onCheckedChange={changeToggleState}
-                disabled={disabled}
-                className={cx(
-                  'shrink-0 grow-0',
-                  disabled && 'cursor-not-allowed opacity-50',
-                )}
-              />
-            )}
-          </div>
-          <div className="text-current/70">{summary}</div>
-        </div>
-      )}
-      <fieldset className={classes}>
-        {disabled ? (
-          layout === 'horizontal' ? (
-            <div className="bg-border/75 text-foreground/70 flex items-center justify-center font-semibold italic max-lg:rounded max-lg:p-8 max-lg:text-center lg:absolute lg:inset-0 lg:h-full lg:w-full">
-              {disabledMessage}
-            </div>
-          ) : (
-            <div className="bg-border/75 text-foreground/70 flex items-center justify-center rounded p-8 text-center font-semibold italic">
-              {disabledMessage}
-            </div>
-          )
-        ) : (
-          <>
-            {isOpen && children}
-            {toggleable && !isOpen && layout !== 'vertical' && (
-              <div className="bg-border/75 text-foreground/70 absolute inset-0 flex h-full w-full items-center justify-center font-semibold italic max-lg:hidden">
-                Click the toggle to enable this feature...
-              </div>
-            )}
-          </>
+    <SectionDepthContext.Provider value={depth + 1}>
+      <div
+        id={id ?? undefined}
+        data-name={typeof title === 'string' ? title : undefined}
+        className={cx(
+          '[--input-background:var(--color-surface-1)] [--slider-color:hsl(var(--charcoal))]',
+          'relative',
+          surfaceClassesByLevel[surfaceLevel],
+          'w-full max-w-7xl',
+          layout === 'horizontal' &&
+            'max-lg:mb-4 max-lg:flex max-lg:flex-col max-lg:gap-(--space-md) max-lg:rounded max-lg:bg-(--current-surface) max-lg:p-6 max-lg:text-(--current-surface-foreground) max-lg:shadow-md lg:grid lg:grid-cols-[20rem_auto] lg:gap-8',
+          layout === 'vertical' && 'mb-4 flex flex-col gap-(--space-md)',
+          layout === 'vertical' && containerClasses,
+          className,
         )}
-      </fieldset>
-    </div>
+      >
+        {title != null && (
+          <div>
+            <div
+              className={cx(
+                'flex items-center gap-4 text-right',
+                layout === 'vertical' && 'text-xl font-semibold tracking-tight',
+                // `lg:top-(--space-4xl)` (6rem) pins the heading just below the
+                // sticky top menu bar so it never overlaps it; `z-(--z-fx)` keeps
+                // it above the section content but below the nav.
+                layout === 'horizontal' &&
+                  'lg:small-heading lg:bg-border max-lg:text-xl max-lg:font-semibold max-lg:tracking-tight lg:sticky lg:top-(--space-4xl) lg:z-(--z-fx) lg:flex-row-reverse lg:items-center lg:justify-between lg:rounded lg:px-6 lg:py-2',
+              )}
+            >
+              <span>
+                {title}
+                {!toggleable && required && (
+                  <span className="text-error ms-1">*</span>
+                )}
+              </span>
+              {toggleable && (
+                <Switch
+                  title="Turn this feature on or off"
+                  checked={isOpen}
+                  onCheckedChange={changeToggleState}
+                  disabled={disabled}
+                  className={cx(
+                    'shrink-0 grow-0',
+                    disabled && 'cursor-not-allowed opacity-50',
+                  )}
+                />
+              )}
+            </div>
+            <div className="text-current/70">{summary}</div>
+          </div>
+        )}
+        <fieldset className={classes}>
+          {disabled ? (
+            layout === 'horizontal' ? (
+              <div className="bg-border/75 text-foreground/70 flex items-center justify-center font-semibold italic max-lg:rounded max-lg:p-8 max-lg:text-center lg:absolute lg:inset-0 lg:h-full lg:w-full">
+                {disabledMessage}
+              </div>
+            ) : (
+              <div className="bg-border/75 text-foreground/70 flex items-center justify-center rounded p-8 text-center font-semibold italic">
+                {disabledMessage}
+              </div>
+            )
+          ) : (
+            <>
+              {isOpen && children}
+              {toggleable && !isOpen && layout !== 'vertical' && (
+                <div className="bg-border/75 text-foreground/70 absolute inset-0 flex h-full w-full items-center justify-center font-semibold italic max-lg:hidden">
+                  Click the toggle to enable this feature...
+                </div>
+              )}
+            </>
+          )}
+        </fieldset>
+      </div>
+    </SectionDepthContext.Provider>
   );
 };
 

--- a/apps/architect-web/src/components/EditorLayout/SectionDepthContext.ts
+++ b/apps/architect-web/src/components/EditorLayout/SectionDepthContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+/**
+ * Tracks how deeply a Section is nested inside other Sections so each level can
+ * step to a more contrasting surface colour. Defaults to 0 (top level). Dialogs
+ * reset this to 0 because an overlay is a fresh surface, not a visual descendant
+ * of the Section it was opened from.
+ */
+const SectionDepthContext = createContext(0);
+
+export default SectionDepthContext;

--- a/apps/architect-web/src/components/EditorLayout/Subsection.tsx
+++ b/apps/architect-web/src/components/EditorLayout/Subsection.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+
+import { cx } from '~/utils/cva';
+
+type SubsectionProps = {
+  /** Used as the scroll-to-error anchor (see utils/issues getFieldId). */
+  id?: string;
+  title: ReactNode;
+  summary?: ReactNode;
+  /** Optional control shown to the right of the heading (e.g. a toggle). */
+  action?: ReactNode;
+  disabled?: boolean;
+  disabledMessage?: string;
+  children?: ReactNode;
+  className?: string;
+};
+
+/**
+ * A headed subsection within a single Section card. Used to group related
+ * fields under a heading instead of giving each group its own card.
+ */
+const Subsection = ({
+  id,
+  title,
+  summary = null,
+  action = null,
+  disabled = false,
+  disabledMessage = 'Complete the required options above to enable this section.',
+  children,
+  className = '',
+}: SubsectionProps) => (
+  <section
+    id={id}
+    className={cx(
+      'flex flex-col gap-(--space-md)',
+      'not-first:border-border not-first:border-t not-first:pt-(--space-lg)',
+      className,
+    )}
+  >
+    <div className="flex items-start justify-between gap-(--space-md)">
+      <div>
+        <h3 className="m-0 text-lg font-semibold tracking-tight">{title}</h3>
+        {summary && <div className="text-sm text-current/70">{summary}</div>}
+      </div>
+      {action}
+    </div>
+    {disabled ? (
+      <div className="bg-border/75 text-foreground/70 flex items-center justify-center rounded p-8 text-center font-semibold italic">
+        {disabledMessage}
+      </div>
+    ) : (
+      children
+    )}
+  </section>
+);
+
+export default Subsection;

--- a/apps/architect-web/src/components/EditorLayout/index.tsx
+++ b/apps/architect-web/src/components/EditorLayout/index.tsx
@@ -1,3 +1,4 @@
 export { default, default as Layout } from './Layout';
 export { default as Row } from './Row';
 export { default as Section } from './Section';
+export { default as Subsection } from './Subsection';

--- a/apps/architect-web/src/components/Form/Fields/NativeSelect.tsx
+++ b/apps/architect-web/src/components/Form/Fields/NativeSelect.tsx
@@ -287,13 +287,13 @@ const NativeSelect: React.FC<NativeSelectProps> = ({
             <select
               className={cx(
                 'm-0 block min-h-(--space-md) w-full max-w-full px-(--space-md) py-(--space-sm)',
-                'appearance-none rounded-sm border-0 shadow-none',
+                'border-border appearance-none rounded-sm border shadow-none',
                 'text-input-foreground bg-surface-1 text-base font-normal',
-                'focus:shadow-none focus:outline-none',
+                'focus:border-primary focus:shadow-none focus:outline-none',
                 'disabled:cursor-not-allowed',
                 '[&_option:disabled]:text-surface-2-foreground [&_option:disabled]:italic',
                 hasError &&
-                  'border-error mb-0 rounded-b-none border-(length:--space-xs) border-solid',
+                  'border-error mb-0 rounded-b-none border-2 border-solid',
               )}
               style={{
                 backgroundImage: CHEVRON_BACKGROUND_IMAGE,

--- a/apps/architect-web/src/components/Form/Fields/Text.tsx
+++ b/apps/architect-web/src/components/Form/Fields/Text.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 
-import { memo, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 
 import Icon from '~/lib/legacy-ui/components/Icon';
@@ -43,13 +43,23 @@ const TextInput = ({
   className = '',
   variant = 'default',
   type = 'text',
-  autoFocus: _autoFocus = false,
+  autoFocus = false,
   hidden = false,
   adornmentLeft = null,
   adornmentRight = null,
 }: TextInputProps) => {
   const { error, invalid, touched } = meta;
   const id = useRef(uuid());
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus on mount when requested (e.g. the variable spotlight search) so the
+  // user can type immediately. A ref/effect is used instead of the native
+  // `autoFocus` attribute to focus reliably after a dialog's focus trap settles.
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+    }
+  }, [autoFocus]);
 
   const hasLeftAdornment = !!adornmentLeft;
   const hasRightAdornment = !!adornmentRight;
@@ -66,6 +76,7 @@ const TextInput = ({
       )}
       <div className={cx('group relative', className)}>
         <input
+          ref={inputRef}
           id={id.current}
           name={input.name}
           className={cx(

--- a/apps/architect-web/src/components/Form/Fields/Toggle.tsx
+++ b/apps/architect-web/src/components/Form/Fields/Toggle.tsx
@@ -1,9 +1,7 @@
-/* eslint-disable react/jsx-props-no-spreading */
-
 import { isBoolean } from 'es-toolkit/compat';
-import { useEffect, useRef } from 'react';
-import { v4 as uuid } from 'uuid';
+import { useEffect } from 'react';
 
+import Switch from '~/components/NewComponents/Switch';
 import Icon from '~/lib/legacy-ui/components/Icon';
 import { cx } from '~/utils/cva';
 
@@ -37,13 +35,8 @@ const Toggle = ({
   disabled = false,
   input,
   meta = {},
-  ...rest
 }: ToggleProps) => {
-  const id = useRef(uuid());
-
-  // Because redux forms will just not pass on this
-  // field if it was never touched and we need it to
-  // return `false`.
+  // redux-form omits an untouched field's value, so default it to `false`.
   useEffect(() => {
     if (!isBoolean(input.value)) {
       input.onChange(false);
@@ -53,51 +46,28 @@ const Toggle = ({
   const { error, invalid, touched } = meta;
   const hasError = !!(invalid && touched && error);
 
-  const { name, value, onChange, ...inputRest } = input;
+  const { name, value, onChange } = input;
 
   return (
     <div className="m-0 [&>h4]:m-0">
       {fieldLabel && <MarkdownLabel label={fieldLabel} />}
-      <label
+      <div
         className={cx(
-          'form-field flex cursor-pointer flex-row items-center justify-start',
-          hasError && 'border-error mb-0 rounded-b-none border-2',
+          'flex flex-row items-center justify-start gap-(--space-md)',
           className,
         )}
-        htmlFor={id.current}
         title={title}
       >
-        <input
-          className="hidden"
-          id={id.current}
+        <Switch
           name={name}
           checked={!!value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            onChange(e.target.checked)
-          }
+          onCheckedChange={(checked) => onChange(checked)}
           disabled={disabled}
-          type="checkbox"
-          value="true"
-          {...(inputRest as Record<string, unknown>)}
-          {...(rest as Record<string, unknown>)}
+          className={cx(
+            'shrink-0',
+            disabled && 'cursor-not-allowed opacity-50',
+          )}
         />
-        <div className="relative mr-(--space-md) inline-block h-(--space-xl) w-(--space-3xl)">
-          <span
-            data-state={value ? 'checked' : 'unchecked'}
-            className={cx(
-              'absolute inset-0 overflow-hidden',
-              'bg-primary rounded-(--space-xl)',
-              'transition-colors duration-(--animation-duration-fast) ease-(--animation-easing)',
-              'data-[state=checked]:bg-active',
-              'before:absolute before:top-0 before:left-0',
-              "before:rounded-full before:content-['']",
-              'before:bg-border before:size-(--space-xl)',
-              'before:transition-[left] before:duration-(--animation-duration-fast) before:ease-(--animation-easing)',
-              'data-[state=checked]:before:left-[calc(100%-var(--space-xl))]',
-              disabled && 'opacity-50',
-            )}
-          />
-        </div>
         {label && (
           <MarkdownLabel
             inline
@@ -105,7 +75,7 @@ const Toggle = ({
             className="[&>:first-child]:mt-0 [&>:last-child]:mb-0"
           />
         )}
-      </label>
+      </div>
       {hasError && (
         <div className="bg-error text-error-foreground flex items-center rounded-b-sm px-(--space-xs) py-(--space-sm) [&_svg]:max-h-(--space-md)">
           <Icon name="warning" />

--- a/apps/architect-web/src/components/Form/Fields/Toggle.tsx
+++ b/apps/architect-web/src/components/Form/Fields/Toggle.tsx
@@ -1,5 +1,5 @@
 import { isBoolean } from 'es-toolkit/compat';
-import { useEffect } from 'react';
+import { useEffect, useId } from 'react';
 
 import Switch from '~/components/NewComponents/Switch';
 import Icon from '~/lib/legacy-ui/components/Icon';
@@ -47,13 +47,18 @@ const Toggle = ({
   const hasError = !!(invalid && touched && error);
 
   const { name, value, onChange } = input;
+  const labelId = useId();
 
   return (
     <div className="m-0 [&>h4]:m-0">
       {fieldLabel && <MarkdownLabel label={fieldLabel} />}
-      <div
+      {/* Native <label> wrap: clicking the label toggles base-ui's hidden
+          input (its span onClick preventDefaults, so there is no double toggle),
+          and aria-labelledby gives the switch its accessible name. */}
+      <label
         className={cx(
           'flex flex-row items-center justify-start gap-(--space-md)',
+          !disabled && 'cursor-pointer',
           className,
         )}
         title={title}
@@ -63,19 +68,21 @@ const Toggle = ({
           checked={!!value}
           onCheckedChange={(checked) => onChange(checked)}
           disabled={disabled}
+          aria-labelledby={label ? labelId : undefined}
           className={cx(
             'shrink-0',
             disabled && 'cursor-not-allowed opacity-50',
           )}
         />
         {label && (
-          <MarkdownLabel
-            inline
-            label={label}
+          <span
+            id={labelId}
             className="[&>:first-child]:mt-0 [&>:last-child]:mb-0"
-          />
+          >
+            <MarkdownLabel inline label={label} />
+          </span>
         )}
-      </div>
+      </label>
       {hasError && (
         <div className="bg-error text-error-foreground flex items-center rounded-b-sm px-(--space-xs) py-(--space-sm) [&_svg]:max-h-(--space-md)">
           <Icon name="warning" />

--- a/apps/architect-web/src/components/Form/Fields/VariablePicker/VariableSpotlight.tsx
+++ b/apps/architect-web/src/components/Form/Fields/VariablePicker/VariableSpotlight.tsx
@@ -28,7 +28,7 @@ type ListItemProps = {
 };
 
 const LIST_ITEM_BASE =
-  'flex w-full items-center justify-between px-(--space-lg) py-(--space-xs)';
+  'flex w-full items-center justify-between rounded-md px-(--space-md) py-(--space-sm)';
 
 // When `data-selected`, the row sets the foreground to white (so descendant
 // text reads on the primary background) and overrides the cascade variable
@@ -113,13 +113,9 @@ type DividerProps = {
 };
 
 const Divider = ({ legend }: DividerProps) => (
-  <ListItem>
-    <fieldset className="border-surface-3 w-full border-t-2">
-      <legend className="px-(--space-md) py-(--space-xs) text-center">
-        {legend}
-      </legend>
-    </fieldset>
-  </ListItem>
+  <li className="px-(--space-md) pt-(--space-md) pb-(--space-xs) first:pt-(--space-xs)">
+    <span className="small-heading text-muted-foreground">{legend}</span>
+  </li>
 );
 
 const CREATE_NEW_CLASSES =
@@ -227,7 +223,7 @@ const VariableSpotlight = ({
 
   const renderResults = () => (
     <Scroller>
-      <ol className="m-0 list-none p-0">
+      <ol className="m-0 flex list-none flex-col gap-(--space-xs) p-(--space-xs)">
         {filterTerm &&
           options.filter((item) => item.label === filterTerm).length !== 1 && (
             <>
@@ -408,9 +404,11 @@ const VariableSpotlight = ({
   const containerVariants = {
     visible: {
       y: 0,
+      opacity: 1,
     },
     hidden: {
       y: -50,
+      opacity: 0,
     },
   };
 

--- a/apps/architect-web/src/components/Form/Fields/VariablePicker/__tests__/VariableSpotlight.test.tsx
+++ b/apps/architect-web/src/components/Form/Fields/VariablePicker/__tests__/VariableSpotlight.test.tsx
@@ -67,10 +67,12 @@ describe('VariableSpotlight', () => {
       '[data-testid="spotlight-list-item"]',
     );
 
-    expect(items[0]).toHaveTextContent('Existing Variables');
-    expect(items[1]).toHaveTextContent('Just a number');
+    // The "Existing Variables" divider is a section header, not a selectable row.
+    expect(baseElement).toHaveTextContent('Existing Variables');
+    // Rows are sorted by label: "Just a number" before "Name".
+    expect(items[0]).toHaveTextContent('Just a number');
+    expect(items[0]?.querySelector('.icon')).toBeInTheDocument();
+    expect(items[1]).toHaveTextContent('Name');
     expect(items[1]?.querySelector('.icon')).toBeInTheDocument();
-    expect(items[2]).toHaveTextContent('Name');
-    expect(items[2]?.querySelector('.icon')).toBeInTheDocument();
   });
 });

--- a/apps/architect-web/src/components/InlineEditScreen/Form.tsx
+++ b/apps/architect-web/src/components/InlineEditScreen/Form.tsx
@@ -1,12 +1,41 @@
 import type React from 'react';
 import { reduxForm, type SubmitHandler } from 'redux-form';
 
+import { candidateIdsFor, flattenIssues } from '~/utils/issues';
+import scrollTo from '~/utils/scrollTo';
 import stopPropagationFromHandler from '~/utils/stopPropagationFromHandler';
 
 type FormProps = {
   handleSubmit: SubmitHandler;
   children?: React.ReactNode;
   id?: string;
+};
+
+// On a failed save, scroll the dialog body to the first invalid field. Each
+// field path is resolved to its anchor element (the same getFieldId anchors the
+// stage-form Issues list uses), and the one highest on screen is chosen so we
+// land on the visually-first error regardless of error object key order.
+const scrollToFirstError = (errors: Record<string, unknown>) => {
+  let target: HTMLElement | null = null;
+  let targetTop = Number.POSITIVE_INFINITY;
+
+  for (const { field } of flattenIssues(errors)) {
+    for (const id of candidateIdsFor(field)) {
+      const element = document.getElementById(id);
+      if (element instanceof HTMLElement) {
+        const { top } = element.getBoundingClientRect();
+        if (top < targetTop) {
+          targetTop = top;
+          target = element;
+        }
+        break;
+      }
+    }
+  }
+
+  if (target) {
+    scrollTo(target);
+  }
 };
 
 // Props that the wrapped component will accept
@@ -33,4 +62,9 @@ export default reduxForm({
   touchOnBlur: false,
   touchOnChange: true,
   enableReinitialize: false,
+  onSubmitFail: (errors) => {
+    if (errors) {
+      scrollToFirstError(errors as Record<string, unknown>);
+    }
+  },
 })(Form) as unknown as React.ComponentType<WrappedFormProps>;

--- a/apps/architect-web/src/components/NewComponents/Dialog.tsx
+++ b/apps/architect-web/src/components/NewComponents/Dialog.tsx
@@ -4,6 +4,7 @@ import { Dialog as BaseDialog } from '@base-ui/react/dialog';
 import { motion } from 'motion/react';
 import type { ComponentProps, ReactNode } from 'react';
 
+import SectionDepthContext from '~/components/EditorLayout/SectionDepthContext';
 import Button from '~/lib/legacy-ui/components/Button';
 import Modal from '~/lib/legacy-ui/components/Modal';
 import { cx } from '~/utils/cva';
@@ -63,7 +64,9 @@ function DialogPopup({
             </div>
           )}
           <div className="flex-1 overflow-y-auto px-(--space-lg) py-(--space-md)">
-            {children}
+            <SectionDepthContext.Provider value={0}>
+              {children}
+            </SectionDepthContext.Provider>
           </div>
           {footer && (
             <div className="bg-accent text-accent-foreground sticky bottom-0 flex justify-end gap-(--space-sm) px-(--space-lg) py-(--space-md) [&>*:first-child:not(:only-child)]:mr-auto">

--- a/apps/architect-web/src/components/NewVariableWindow/NewVariableWindow.tsx
+++ b/apps/architect-web/src/components/NewVariableWindow/NewVariableWindow.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { Field, formValueSelector } from 'redux-form';
 
 import type { Variable, VariableOptions } from '@codaco/protocol-validation';
-import { Section } from '~/components/EditorLayout';
+import { Section, Subsection } from '~/components/EditorLayout';
 import { Text } from '~/components/Form/Fields';
 import Select from '~/components/Form/Fields/Select';
 import ValidatedField from '~/components/Form/ValidatedField';
@@ -118,83 +118,84 @@ export default function NewVariableWindow({
       initialValues={mergedInitialValues ?? undefined}
       title="Create New Variable"
     >
-      <Section
-        title="Variable Name"
-        summary={
-          <p>
-            Enter a name for this variable. The variable name is how you will
-            reference the variable elsewhere, including in exported data.
-          </p>
-        }
-        layout="vertical"
-      >
-        <div id={getFieldId('name')} />
-        <Field
-          name="name"
-          component={Text}
-          placeholder="e.g. Nickname"
-          validate={[isRequired, validateName, isAllowedVariableName]}
-          normalize={safeName}
-        />
-      </Section>
-      <Section
-        title="Variable Type"
-        summary={<p>Choose a variable type</p>}
-        layout="vertical"
-      >
-        <div id={getFieldId('type')} />
-        <ValidatedField
-          name="type"
-          component={Select}
-          validation={{ required: true }}
-          componentProps={{
-            placeholder: 'Select variable type',
-            options: filteredVariableOptions,
-            isDisabled: !!initialValues?.type,
-          }}
-        />
-      </Section>
-      {isOrdinalOrCategoricalType(variableType) && (
-        <Section
-          title="Options"
+      <Section layout="vertical">
+        <Subsection
+          id={getFieldId('name')}
+          title="Variable Name"
           summary={
-            lockedOptions ? (
-              <p>
-                These options are automatically configured by the interface and
-                cannot be modified.
-              </p>
-            ) : (
-              <p>Create some options for this input control</p>
-            )
+            <p>
+              Enter a name for this variable. The variable name is how you will
+              reference the variable elsewhere, including in exported data.
+            </p>
           }
-          layout="vertical"
         >
-          <div id={getFieldId('options')} />
-          {lockedOptions ? (
-            <div className="bg-platinum relative rounded p-4 opacity-50">
-              <Lock className="text-charcoal absolute top-4 right-4 h-4 w-4" />
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-left">
-                    <th className="pb-2 font-bold">Label</th>
-                    <th className="pb-2 font-bold">Value</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {lockedOptions.map((option) => (
-                    <tr key={String(option.value)}>
-                      <td className="py-1">{option.label}</td>
-                      <td className="py-1 font-mono">{String(option.value)}</td>
+          <Field
+            name="name"
+            component={Text}
+            placeholder="e.g. Nickname"
+            validate={[isRequired, validateName, isAllowedVariableName]}
+            normalize={safeName}
+          />
+        </Subsection>
+        <Subsection
+          id={getFieldId('type')}
+          title="Variable Type"
+          summary={<p>Choose a variable type</p>}
+        >
+          <ValidatedField
+            name="type"
+            component={Select}
+            validation={{ required: true }}
+            componentProps={{
+              placeholder: 'Select variable type',
+              options: filteredVariableOptions,
+              isDisabled: !!initialValues?.type,
+            }}
+          />
+        </Subsection>
+        {isOrdinalOrCategoricalType(variableType) && (
+          <Subsection
+            id={getFieldId('options')}
+            title="Options"
+            summary={
+              lockedOptions ? (
+                <p>
+                  These options are automatically configured by the interface
+                  and cannot be modified.
+                </p>
+              ) : (
+                <p>Create some options for this input control</p>
+              )
+            }
+          >
+            {lockedOptions ? (
+              <div className="bg-platinum relative rounded p-4 opacity-50">
+                <Lock className="text-charcoal absolute top-4 right-4 h-4 w-4" />
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left">
+                      <th className="pb-2 font-bold">Label</th>
+                      <th className="pb-2 font-bold">Value</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <Options name="options" label="Options" />
-          )}
-        </Section>
-      )}
+                  </thead>
+                  <tbody>
+                    {lockedOptions.map((option) => (
+                      <tr key={String(option.value)}>
+                        <td className="py-1">{option.label}</td>
+                        <td className="py-1 font-mono">
+                          {String(option.value)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <Options name="options" label="Options" />
+            )}
+          </Subsection>
+        )}
+      </Section>
     </InlineEditScreen>
   );
 }

--- a/apps/architect-web/src/components/ProjectNav/ProjectLayout.tsx
+++ b/apps/architect-web/src/components/ProjectNav/ProjectLayout.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useLocation } from 'wouter';
 
 import ProjectNav from '~/components/ProjectNav/ProjectNav';
+import StorageUnavailableBanner from '~/components/StorageUnavailableBanner';
 import { cx } from '~/utils/cva';
 import { getScrollPosition, setScrollPosition } from '~/utils/scrollPositions';
 
@@ -43,6 +44,7 @@ const ProjectLayout = ({ children, className }: ProjectLayoutProps) => {
       )}
     >
       <ProjectNav />
+      <StorageUnavailableBanner />
       {children}
       <ProjectActions
         readOnly={isSummary}

--- a/apps/architect-web/src/components/StorageUnavailableBanner.tsx
+++ b/apps/architect-web/src/components/StorageUnavailableBanner.tsx
@@ -1,0 +1,42 @@
+import { TriangleAlert } from 'lucide-react';
+
+import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
+import { getStorageUnavailable } from '~/ducks/modules/app';
+import { exportNetcanvas } from '~/ducks/modules/userActions/userActions';
+import { Button } from '~/lib/legacy-ui/components';
+
+// Shown across the protocol editor when a protocol was opened from an in-memory
+// copy because the browser's storage is unavailable (e.g. private browsing).
+// Non-blocking: the user can keep editing, but their work won't persist, so we
+// keep a download action close at hand.
+const StorageUnavailableBanner = () => {
+  const dispatch = useAppDispatch();
+  const storageUnavailable = useAppSelector(getStorageUnavailable);
+
+  if (!storageUnavailable) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      className="bg-warning/20 text-foreground flex items-center justify-between gap-(--space-md) px-(--space-lg) py-(--space-sm) text-sm"
+    >
+      <span className="flex items-center gap-(--space-sm)">
+        <TriangleAlert className="size-4 shrink-0" aria-hidden />
+        This protocol isn&apos;t being saved on this device — your
+        browser&apos;s storage is unavailable, which is common in private
+        browsing. Download a copy to keep your work.
+      </span>
+      <Button
+        size="small"
+        color="sea-green"
+        onClick={() => void dispatch(exportNetcanvas())}
+      >
+        Download .netcanvas
+      </Button>
+    </div>
+  );
+};
+
+export default StorageUnavailableBanner;

--- a/apps/architect-web/src/components/Tip.tsx
+++ b/apps/architect-web/src/components/Tip.tsx
@@ -24,7 +24,7 @@ const Tip = ({ type = 'info', icon = true, children = null }: TipProps) => {
   return (
     <div
       className={cx(
-        'bg-surface-2 my-(--space-lg) flex w-full items-center gap-(--space-md) rounded px-(--space-xl) py-(--space-xs) text-sm',
+        'bg-surface-2 my-(--space-lg) flex w-full items-center gap-(--space-md) rounded px-(--space-xl) py-(--space-xs) text-sm first:mt-0 last:mb-0',
         typeClasses[type],
       )}
     >

--- a/apps/architect-web/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect-web/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -204,7 +204,7 @@ const ShapeVariableMapping = ({
           </button>
         </label>
         <p className="text-muted-foreground mt-(--space-xs) text-sm">
-          Override the default shape based on a variable's value.
+          Override the default shape based on the value of a node's attribute.
         </p>
       </div>
 

--- a/apps/architect-web/src/components/sections/Background/Background.tsx
+++ b/apps/architect-web/src/components/sections/Background/Background.tsx
@@ -50,6 +50,9 @@ class Background extends PureComponent<BackgroundProps> {
       >
         {imageAllowed && (
           <Row>
+            <h4 className="small-heading text-muted-foreground m-0">
+              Choose a background type
+            </h4>
             <DetachedField
               component={
                 BooleanField as React.ComponentType<Record<string, unknown>>
@@ -86,7 +89,6 @@ class Background extends PureComponent<BackgroundProps> {
                 _currentValue: unknown,
                 _name: string | null,
               ) => handleChooseBackgroundType(nextValue as boolean)}
-              label="Choose a background type"
               noReset
             />
           </Row>

--- a/apps/architect-web/src/components/sections/Form/FieldFields.tsx
+++ b/apps/architect-web/src/components/sections/Form/FieldFields.tsx
@@ -232,7 +232,10 @@ const PromptFields = ({
         </Subsection>
       )}
       {isBooleanWithOptions(component) && (
-        <Subsection id={getFieldId('parameters')} title="BooleanChoice Options">
+        // BooleanChoice writes to the `options` field, so anchor it there (it is
+        // mutually exclusive with the Categorical/Ordinal options subsection
+        // above, so the shared id never collides at runtime).
+        <Subsection id={getFieldId('options')} title="BooleanChoice Options">
           <BooleanChoice form={form} />
         </Subsection>
       )}

--- a/apps/architect-web/src/components/sections/Form/FieldFields.tsx
+++ b/apps/architect-web/src/components/sections/Form/FieldFields.tsx
@@ -1,11 +1,14 @@
+import type { UnknownAction } from '@reduxjs/toolkit';
 import { omit } from 'es-toolkit/compat';
 import type { ComponentType } from 'react';
-import { Field } from 'redux-form';
+import { useSelector } from 'react-redux';
+import { change, Field, formValueSelector } from 'redux-form';
 
-import { Row, Section } from '~/components/EditorLayout';
+import { Section, Subsection } from '~/components/EditorLayout';
 import NativeSelect from '~/components/Form/Fields/NativeSelect';
 import { Field as RichText } from '~/components/Form/Fields/RichText';
 import ValidatedField from '~/components/Form/ValidatedField';
+import Switch from '~/components/NewComponents/Switch';
 import Options from '~/components/Options';
 import Parameters from '~/components/Parameters';
 import {
@@ -13,6 +16,8 @@ import {
   isOrdinalOrCategoricalType,
   isVariableTypeWithParameters,
 } from '~/config/variables';
+import { useAppDispatch } from '~/ducks/hooks';
+import type { RootState } from '~/ducks/modules/root';
 import { getFieldId } from '~/utils/issues';
 
 import BooleanChoice from '../../BooleanChoice';
@@ -34,6 +39,8 @@ const PromptFields = ({
   entity = null,
   type = null,
 }: PromptFieldsProps) => {
+  const dispatch = useAppDispatch();
+
   const {
     variable,
     variableType,
@@ -52,45 +59,50 @@ const PromptFields = ({
     type: type ?? '',
   });
 
+  const showValidationHints = useSelector(
+    (state: RootState) =>
+      formValueSelector(form)(state, 'showValidationHints') as
+        | boolean
+        | undefined,
+  );
+
   return (
-    <>
-      <Section id={getFieldId('variable')} title="Variable" layout="vertical">
-        <Row>
-          {variable && !isNewVariable && (
-            <Tip>
-              <p>
-                When selecting an existing variable, changes you make to the
-                input control or validation options will also change other uses
-                of this variable.
-              </p>
-            </Tip>
-          )}
-          <ValidatedField
-            name="variable"
-            component={VariablePicker as ComponentType<Record<string, unknown>>}
-            validation={{ required: true }}
-            componentProps={{
-              entity: entity ?? undefined,
-              type: type ?? undefined,
-              options: variableOptions,
-              onCreateOption: handleNewVariable,
-              onChange: handleChangeVariable,
-            }}
-          />
-        </Row>
-      </Section>
-      <Section
-        title="Question"
+    <Section layout="vertical">
+      <Subsection id={getFieldId('variable')} title="Variable">
+        {variable && !isNewVariable && (
+          <Tip>
+            <p>
+              When selecting an existing variable, changes you make to the input
+              control or validation options will also change other uses of this
+              variable.
+            </p>
+          </Tip>
+        )}
+        <ValidatedField
+          name="variable"
+          component={VariablePicker as ComponentType<Record<string, unknown>>}
+          validation={{ required: true }}
+          componentProps={{
+            entity: entity ?? undefined,
+            type: type ?? undefined,
+            options: variableOptions,
+            onCreateOption: handleNewVariable,
+            onChange: handleChangeVariable,
+          }}
+        />
+      </Subsection>
+
+      <Subsection
         id={getFieldId('prompt')}
+        title="Question"
         summary={
           <p>
             Configure the question prompt and optional hints for the
             participant.
           </p>
         }
-        layout="vertical"
       >
-        <Row>
+        <div>
           <h4>Prompt Text</h4>
           <p className="mb-(--space-sm) text-sm text-current/70">
             Enter the question to display to the participant. Supports markdown
@@ -105,8 +117,8 @@ const PromptFields = ({
               placeholder: "What is this person's name?",
             }}
           />
-        </Row>
-        <Row>
+        </div>
+        <div>
           <h4>Hint Text</h4>
           <p className="mb-(--space-sm) text-sm text-current/70">
             Optionally display a markdown-formatted hint below the question to
@@ -118,12 +130,32 @@ const PromptFields = ({
             inline
             placeholder="e.g. Select all that apply..."
           />
-        </Row>
-      </Section>
-      <Section
-        disabled={!variable}
-        title="Input Control"
+        </div>
+        <div className="flex items-center justify-between gap-(--space-md)">
+          <div>
+            <h4 className="text-base font-semibold">Show validation hints?</h4>
+            <p className="text-sm text-current/70">
+              Automatically display hints derived from this field&apos;s
+              validation rules, helping participants understand input
+              requirements.
+            </p>
+          </div>
+          <Switch
+            checked={!!showValidationHints}
+            onCheckedChange={(checked) =>
+              dispatch(
+                change(form, 'showValidationHints', checked) as UnknownAction,
+              )
+            }
+            className="shrink-0"
+          />
+        </div>
+      </Subsection>
+
+      <Subsection
         id={getFieldId('component')}
+        title="Input Control"
+        disabled={!variable}
         summary={
           <p>
             Choose an input control that should be used to collect the answer.
@@ -134,60 +166,58 @@ const PromptFields = ({
             .
           </p>
         }
-        layout="vertical"
       >
-        <Row>
-          <ValidatedField
-            name="component"
-            component={NativeSelect as ComponentType<Record<string, unknown>>}
-            validation={{ required: true }}
-            componentProps={{
-              placeholder: 'Select an input control',
-              options: componentOptions,
-              sortOptionsByLabel: !isNewVariable,
-              onChange: handleChangeComponent,
-            }}
-          />
-          {isNewVariable && variableType && (
-            <Tip>
+        <ValidatedField
+          name="component"
+          component={NativeSelect as ComponentType<Record<string, unknown>>}
+          validation={{ required: true }}
+          componentProps={{
+            placeholder: 'Select an input control',
+            options: componentOptions,
+            sortOptionsByLabel: !isNewVariable,
+            onChange: handleChangeComponent,
+          }}
+        />
+        {isNewVariable && variableType && (
+          <Tip>
+            <p>
+              The selected input control will cause this variable to be defined
+              as type <strong>{String(variableType)}</strong>. Once set, this
+              cannot be changed (although you may change the input control
+              within this type).
+            </p>
+          </Tip>
+        )}
+        {!isNewVariable && variableType && (
+          <Tip type="warning">
+            <div>
               <p>
-                The selected input control will cause this variable to be
-                defined as type <strong>{String(variableType)}</strong>. Once
-                set, this cannot be changed (although you may change the input
-                control within this type).
+                A pre-existing variable is currently selected. You cannot change
+                a variable type after it has been created, so only{' '}
+                <strong>{String(variableType)}</strong> compatible input
+                controls can be selected above. If you would like to use a
+                different input control type, you will need to create a new
+                variable.
               </p>
-            </Tip>
-          )}
-          {!isNewVariable && variableType && (
-            <Tip type="warning">
-              <div>
-                <p>
-                  A pre-existing variable is currently selected. You cannot
-                  change a variable type after it has been created, so only{' '}
-                  <strong>{String(variableType)}</strong> compatible input
-                  controls can be selected above. If you would like to use a
-                  different input control type, you will need to create a new
-                  variable.
-                </p>
-              </div>
-            </Tip>
-          )}
-        </Row>
+            </div>
+          </Tip>
+        )}
         {variableType &&
           metaForType &&
           typeof metaForType.label === 'string' && (
-            <Row>
+            <div>
               <h4>Preview</h4>
               <InputPreview
                 label={metaForType.label}
                 description={metaForType.description}
                 image={metaForType.image}
               />
-            </Row>
+            </div>
           )}
-      </Section>
+      </Subsection>
+
       {isOrdinalOrCategoricalType(variableType) && (
-        <Section
+        <Subsection
           id={getFieldId('options')}
           title="Categorical/Ordinal options"
           summary={
@@ -197,40 +227,26 @@ const PromptFields = ({
               values for the participant to choose between.
             </p>
           }
-          layout="vertical"
         >
-          <Row>
-            <Options name="options" label="Options" />
-          </Row>
-        </Section>
+          <Options name="options" label="Options" />
+        </Subsection>
       )}
       {isBooleanWithOptions(component) && (
-        <Section
-          layout="vertical"
-          id={getFieldId('parameters')}
-          title="BooleanChoice Options"
-        >
-          <Row>
-            <BooleanChoice form={form} />
-          </Row>
-        </Section>
+        <Subsection id={getFieldId('parameters')} title="BooleanChoice Options">
+          <BooleanChoice form={form} />
+        </Subsection>
       )}
       {isVariableTypeWithParameters(variableType) && (
-        <Section
-          layout="vertical"
-          title="Input Options"
-          id={getFieldId('parameters')}
-        >
-          <Row>
-            <Parameters
-              type={String(variableType)}
-              component={component ?? ''}
-              name="parameters"
-              form={form}
-            />
-          </Row>
-        </Section>
+        <Subsection id={getFieldId('parameters')} title="Input Options">
+          <Parameters
+            type={String(variableType)}
+            component={component ?? ''}
+            name="parameters"
+            form={form}
+          />
+        </Subsection>
       )}
+
       <ValidationSection
         form={form}
         disabled={!variableType}
@@ -240,7 +256,7 @@ const PromptFields = ({
         }
         existingVariables={omit(existingVariables, variable)}
       />
-    </>
+    </Section>
   );
 };
 

--- a/apps/architect-web/src/components/sections/Form/Form.tsx
+++ b/apps/architect-web/src/components/sections/Form/Form.tsx
@@ -57,7 +57,7 @@ const Form = ({
       />
     )}
     <EditableList
-      label="Form Fields"
+      label={disableFormTitle ? undefined : 'Form Fields'}
       editComponent={FieldFields}
       editProps={{
         type,

--- a/apps/architect-web/src/components/sections/QuickAdd/QuickAdd.tsx
+++ b/apps/architect-web/src/components/sections/QuickAdd/QuickAdd.tsx
@@ -12,6 +12,12 @@ import Tip from '../../Tip';
 import withOptions from './withOptions';
 import withQuickAddVariable from './withQuickAddVariable';
 
+type VariableOption = {
+  label: string;
+  value: string;
+  type?: string;
+};
+
 type QuickAddProps = StageEditorSectionProps & {
   disabled?: boolean;
   entity: string;
@@ -20,7 +26,7 @@ type QuickAddProps = StageEditorSectionProps & {
     variableType: string,
     fieldName: string,
   ) => void;
-  options?: Array<Record<string, unknown>>;
+  options?: VariableOption[];
   type?: string | null;
   quickAdd?: string | null;
 };
@@ -32,8 +38,19 @@ const QuickAdd = ({
   options = [],
   type = null,
   quickAdd = null,
-}: QuickAddProps) =>
-  type && (
+}: QuickAddProps) => {
+  if (!type) {
+    return null;
+  }
+
+  // The Tip nudges the user to store the quick-add value in a variable named
+  // "name". Once they've done so, the recommendation is satisfied — hide it.
+  const selectedOption = options.find(
+    (option) => option.value === quickAdd || option.label === quickAdd,
+  );
+  const hasNameVariable = selectedOption?.label.toLowerCase() === 'name';
+
+  return (
     <Section
       disabled={disabled}
       group
@@ -45,13 +62,15 @@ const QuickAdd = ({
         </p>
       }
     >
-      <Tip type="info">
-        <p>
-          Use a variable called &quot;name&quot; here, unless you have a good
-          reason not to. Interviewer will then automatically use this variable
-          as the label for the node in the interview.
-        </p>
-      </Tip>
+      {!hasNameVariable && (
+        <Tip type="info">
+          <p>
+            Use a variable called &quot;name&quot; here, unless you have a good
+            reason not to. Interviewer will then automatically use this variable
+            as the label for the node in the interview.
+          </p>
+        </Tip>
+      )}
       <ValidatedField
         name="quickAdd"
         component={VariablePicker}
@@ -67,6 +86,7 @@ const QuickAdd = ({
       />
     </Section>
   );
+};
 
 export default compose<QuickAddProps, StageEditorSectionProps>(
   withSubject,

--- a/apps/architect-web/src/components/sections/SociogramPrompts/PromptFieldsTapBehaviour.tsx
+++ b/apps/architect-web/src/components/sections/SociogramPrompts/PromptFieldsTapBehaviour.tsx
@@ -211,54 +211,56 @@ const TapBehaviour = ({ form, type, entity }: TapBehaviourProps) => {
           noReset
         />
       </Row>
-      <Row>
-        {tapBehaviour === TAP_BEHAVIOURS.HIGHLIGHT_ATTRIBUTES && (
-          <ValidatedField
-            name="highlight.variable"
-            component={VariablePicker}
-            validation={{ required: true }}
-            componentProps={{
-              entity,
-              type,
-              label: 'Boolean Attribute to Toggle',
-              placeholder: 'Select or create a boolean variable',
-              onCreateOption: (value: string) =>
-                handleCreateVariable(value, 'boolean', 'highlight.variable'),
-              options: highlightVariablesForSubject,
-              variable: highlightVariable,
-            }}
-          />
-        )}
-        {tapBehaviour === TAP_BEHAVIOURS.CREATE_EDGES && (
-          <>
-            {showNetworkFilterWarning && (
-              <Tip type="warning">
-                <p>
-                  Stage level network filtering is enabled, but the edge type
-                  you want to create on this prompt is not currently included in
-                  the filter. This means that these edges may not be displayed.
-                  Either remove the stage-level network filtering, or add these
-                  edge types to the filter to resolve this issue.
-                </p>
-              </Tip>
-            )}
-
+      {tapBehaviour && (
+        <Row>
+          {tapBehaviour === TAP_BEHAVIOURS.HIGHLIGHT_ATTRIBUTES && (
             <ValidatedField
-              name="edges.create"
-              component={
-                EntitySelectField as React.ComponentType<
-                  Record<string, unknown>
-                >
-              }
+              name="highlight.variable"
+              component={VariablePicker}
               validation={{ required: true }}
               componentProps={{
-                entityType: 'edge',
-                label: 'Create edges of the following type',
+                entity,
+                type,
+                label: 'Boolean Attribute to Toggle',
+                placeholder: 'Select or create a boolean variable',
+                onCreateOption: (value: string) =>
+                  handleCreateVariable(value, 'boolean', 'highlight.variable'),
+                options: highlightVariablesForSubject,
+                variable: highlightVariable,
               }}
             />
-          </>
-        )}
-      </Row>
+          )}
+          {tapBehaviour === TAP_BEHAVIOURS.CREATE_EDGES && (
+            <>
+              {showNetworkFilterWarning && (
+                <Tip type="warning">
+                  <p>
+                    Stage level network filtering is enabled, but the edge type
+                    you want to create on this prompt is not currently included
+                    in the filter. This means that these edges may not be
+                    displayed. Either remove the stage-level network filtering,
+                    or add these edge types to the filter to resolve this issue.
+                  </p>
+                </Tip>
+              )}
+
+              <ValidatedField
+                name="edges.create"
+                component={
+                  EntitySelectField as React.ComponentType<
+                    Record<string, unknown>
+                  >
+                }
+                validation={{ required: true }}
+                componentProps={{
+                  entityType: 'edge',
+                  label: 'Create edges of the following type',
+                }}
+              />
+            </>
+          )}
+        </Row>
+      )}
     </Section>
   );
 };

--- a/apps/architect-web/src/components/sections/ValidationSection.tsx
+++ b/apps/architect-web/src/components/sections/ValidationSection.tsx
@@ -1,16 +1,17 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { createSelector } from '@reduxjs/toolkit';
 import { get, pickBy } from 'es-toolkit/compat';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 
 import type { Variable } from '@codaco/protocol-validation';
-import { Row, Section } from '~/components/EditorLayout';
+import { Subsection } from '~/components/EditorLayout';
 import Switch from '~/components/NewComponents/Switch';
 import Validations from '~/components/Validations';
 import { useAppDispatch } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/modules/root';
+import { cx } from '~/utils/cva';
 
 import { getFieldId } from '../../utils/issues';
 
@@ -42,19 +43,21 @@ const ValidationSection = ({
 
   const hasValidation = useSelector(hasValidationSelector);
 
-  const showValidationHints = useSelector(
-    (state: RootState) =>
-      formValueSelector(form)(state, 'showValidationHints') as
-        | boolean
-        | undefined,
-  );
+  const [isEnabled, setIsEnabled] = useState(!!hasValidation);
 
-  const handleToggleValidation = (nextState: boolean) => {
+  // Keep the toggle in sync when the underlying validation is set/cleared
+  // elsewhere (e.g. a form reset). Adding a rule sets hasValidation, removing
+  // the last rule clears it; enabling the toggle before adding a rule keeps
+  // hasValidation false, so this only fires on an actual change.
+  useEffect(() => {
+    setIsEnabled(!!hasValidation);
+  }, [hasValidation]);
+
+  const handleToggle = (nextState: boolean) => {
+    setIsEnabled(nextState);
     if (!nextState) {
       dispatch(change(form, 'validation', null) as UnknownAction);
     }
-
-    return true;
   };
 
   const existingVariablesForType = useMemo(
@@ -65,18 +68,27 @@ const ValidationSection = ({
       ),
     [existingVariables, variableType],
   );
+
   return (
-    <Section
-      disabled={disabled}
+    <Subsection
       id={getFieldId('validation')}
-      toggleable
       title="Validation"
       summary={<p>Add one or more validation rules to this form field.</p>}
-      startExpanded={!!hasValidation}
-      handleToggleChange={handleToggleValidation}
-      layout="vertical"
+      disabled={disabled}
+      action={
+        <Switch
+          title="Turn validation on or off"
+          checked={isEnabled}
+          onCheckedChange={handleToggle}
+          disabled={disabled}
+          className={cx(
+            'shrink-0',
+            disabled && 'cursor-not-allowed opacity-50',
+          )}
+        />
+      }
     >
-      <Row>
+      {isEnabled && (
         <Validations
           form={form}
           name="validation"
@@ -84,27 +96,8 @@ const ValidationSection = ({
           entity={entity}
           existingVariables={existingVariablesForType}
         />
-      </Row>
-      <div className="mt-(--space-sm) flex items-center justify-between gap-(--space-md)">
-        <div>
-          <h4 className="text-base font-semibold">Show validation hints?</h4>
-          <p className="text-sm text-current/70">
-            Automatically display hints derived from this field&apos;s
-            validation rules, helping participants understand input
-            requirements.
-          </p>
-        </div>
-        <Switch
-          checked={!!showValidationHints}
-          onCheckedChange={(checked) =>
-            dispatch(
-              change(form, 'showValidationHints', checked) as UnknownAction,
-            )
-          }
-          className="shrink-0"
-        />
-      </div>
-    </Section>
+      )}
+    </Subsection>
   );
 };
 

--- a/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -144,7 +144,7 @@ const EntitySelectField = ({
         Create new {entityType} type
       </Button>
       {invalid && touched && (
-        <div className="bg-error text-error-foreground mb-(--space-lg) flex items-center p-(--space-xs) [&_svg]:max-h-(--space-md)">
+        <div className="bg-error text-error-foreground flex items-center p-(--space-xs) [&_svg]:max-h-(--space-md)">
           <Icon name="warning" />
           {error}
         </div>

--- a/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -125,15 +125,16 @@ const EntitySelectField = ({
     <div className="flex flex-col items-start gap-(--space-md)">
       {label && <h4>{label}</h4>}
 
-      <div
-        className={cx(
-          'flex flex-row flex-wrap justify-start gap-(--space-sm) p-(--space-sm)',
-          hasError && 'border-error border-solid border-(--space-xs)',
-        )}
-      >
-        {renderOptions()}
-      </div>
-      {options.length === 0 && (
+      {options.length > 0 ? (
+        <div
+          className={cx(
+            'flex flex-row flex-wrap justify-start gap-(--space-sm) p-(--space-sm)',
+            hasError && 'border-error border-solid border-(--space-xs)',
+          )}
+        >
+          {renderOptions()}
+        </div>
+      ) : (
         <p>
           No {entityType} types currently defined. Use the button below to
           create one.

--- a/apps/architect-web/src/components/sections/fields/EntitySelectField/PreviewEdge.tsx
+++ b/apps/architect-web/src/components/sections/fields/EntitySelectField/PreviewEdge.tsx
@@ -37,7 +37,7 @@ const PreviewEdge = ({
       : 'bg-surface-1 text-surface-1-foreground';
 
   const baseClasses =
-    'relative m-(--space-sm) flex flex-row items-center rounded-full border-4 border-transparent px-(--space-md) py-(--space-sm) transition-[border-color] duration-(--animation-duration-standard) ease-(--animation-easing) [&_.icon]:mr-(--space-sm)';
+    'relative flex flex-row items-center rounded-full border-4 border-transparent px-(--space-md) py-(--space-sm) transition-[border-color] duration-(--animation-duration-standard) ease-(--animation-easing) [&_.icon]:mr-(--space-sm)';
 
   if (onClick && !selected) {
     return (

--- a/apps/architect-web/src/ducks/middleware/protocolLibraryListener.ts
+++ b/apps/architect-web/src/ducks/middleware/protocolLibraryListener.ts
@@ -10,7 +10,7 @@ import {
   setActiveProtocol,
   updateLastModified,
 } from '../modules/activeProtocol';
-import { getActiveProtocolId } from '../modules/app';
+import { getActiveProtocolId, getStorageUnavailable } from '../modules/app';
 import type { RootState } from '../modules/root';
 import { generalErrorDialog } from '../modules/userActions/dialogs';
 import type { AppDispatch } from '../store';
@@ -101,6 +101,12 @@ startAppListening({
     }
     // The initial library row is written by the opening thunk.
     if (setActiveProtocol.match(action)) {
+      return false;
+    }
+
+    // Nothing was persisted for an in-memory (storage-unavailable) protocol, so
+    // skip autosave entirely rather than failing on every edit.
+    if (getStorageUnavailable(currentState)) {
       return false;
     }
 

--- a/apps/architect-web/src/ducks/modules/app.ts
+++ b/apps/architect-web/src/ducks/modules/app.ts
@@ -54,6 +54,19 @@ export function getActiveProtocolId(
   return typeof raw === 'string' ? raw : null;
 }
 
+const STORAGE_UNAVAILABLE_KEY = 'storageUnavailable';
+
+// Set when a protocol had to be opened from an in-memory copy because persistent
+// storage (IndexedDB) was unavailable — e.g. Safari private browsing. Drives the
+// "won't be saved" banner and disables autosave for the session.
+export function setStorageUnavailable(value: boolean) {
+  return setProperty({ key: STORAGE_UNAVAILABLE_KEY, value });
+}
+
+export function getStorageUnavailable(state: Pick<RootState, 'app'>): boolean {
+  return Boolean(get(state, ['app', STORAGE_UNAVAILABLE_KEY]));
+}
+
 const PREVIEW_IGNORE_SKIP_LOGIC_KEY = 'previewIgnoreSkipLogic';
 
 export function setPreviewIgnoreSkipLogic(value: boolean) {

--- a/apps/architect-web/src/ducks/modules/userActions/userActions.ts
+++ b/apps/architect-web/src/ducks/modules/userActions/userActions.ts
@@ -144,6 +144,10 @@ const instantiateProtocol = async (
     return;
   }
 
+  // The protocol persisted successfully, so clear any earlier storage-unavailable
+  // flag (it is persisted to localStorage) to re-enable autosave for this and
+  // subsequent opens.
+  dispatch(setStorageUnavailable(false));
   dispatch(setActiveProtocolId(protocolId));
   dispatch(setActiveProtocol(protocol));
 

--- a/apps/architect-web/src/ducks/modules/userActions/userActions.ts
+++ b/apps/architect-web/src/ducks/modules/userActions/userActions.ts
@@ -19,7 +19,10 @@ import {
   validationErrorDialog,
 } from '~/ducks/modules/userActions/dialogs';
 import type { RootState } from '~/ducks/store';
-import { saveProtocolAssets } from '~/utils/assetUtils';
+import {
+  saveProtocolAssets,
+  saveProtocolAssetsToMemory,
+} from '~/utils/assetUtils';
 import { downloadProtocolAsNetcanvas } from '~/utils/bundleProtocol';
 import { ensureError } from '~/utils/ensureError';
 import {
@@ -30,9 +33,36 @@ import {
 import { reportError } from '~/utils/reportError';
 
 import { clearActiveProtocol, setActiveProtocol } from '../activeProtocol';
-import { getActiveProtocolId, setActiveProtocolId } from '../app';
+import {
+  getActiveProtocolId,
+  setActiveProtocolId,
+  setStorageUnavailable,
+} from '../app';
 
 type ImportSource = 'local' | 'remote' | 'bundled';
+
+// Error names thrown when IndexedDB is unavailable or over quota — the common
+// case being Safari private browsing, whose per-origin quota is too small for
+// the bundled sample media. Used to decide when to fall back to an in-memory
+// copy rather than failing the open outright.
+const STORAGE_ERROR_NAMES = new Set([
+  'QuotaExceededError',
+  'InvalidStateError',
+  'UnknownError',
+  'SecurityError',
+  'AbortError',
+  'DatabaseClosedError',
+  'OpenFailedError',
+  'VersionError',
+]);
+
+const isStorageUnavailableError = (error: unknown): boolean => {
+  if (error instanceof Error && STORAGE_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /quota|indexeddb|idbdatabase|object ?store|storage/i.test(message);
+};
 
 // A protocol failed schema validation during import. This is an expected
 // outcome for an old or malformed file, so we record an analytics event
@@ -86,14 +116,32 @@ const instantiateProtocol = async (
 ): Promise<void> => {
   const protocolId = crypto.randomUUID();
 
-  await putStoredProtocol({ id: protocolId, protocol, name, description });
   try {
-    await saveProtocolAssets(assets, protocolId);
+    await putStoredProtocol({ id: protocolId, protocol, name, description });
+    try {
+      await saveProtocolAssets(assets, protocolId);
+    } catch (error) {
+      // Don't leave a library row whose assetManifest points at assets that
+      // were never persisted; remove the orphaned row before surfacing.
+      await deleteStoredProtocol(protocolId);
+      throw error;
+    }
   } catch (error) {
-    // Don't leave a library row whose assetManifest points at assets that were
-    // never persisted; remove the orphaned row before surfacing the failure.
-    await deleteStoredProtocol(protocolId);
-    throw error;
+    // Persistent storage is unavailable (e.g. Safari private browsing, whose
+    // quota is too small for the bundled media). Open the protocol from an
+    // in-memory copy so it stays usable this session, and flag it so the UI can
+    // warn that it won't be saved on this device. Other errors are real bugs and
+    // are rethrown for the caller's import-error handling.
+    if (!isStorageUnavailableError(error)) {
+      throw error;
+    }
+
+    saveProtocolAssetsToMemory(assets, protocolId);
+    dispatch(setStorageUnavailable(true));
+    dispatch(setActiveProtocolId(protocolId));
+    dispatch(setActiveProtocol(protocol));
+    navigate('/protocol');
+    return;
   }
 
   dispatch(setActiveProtocolId(protocolId));

--- a/apps/architect-web/src/utils/assetUtils.ts
+++ b/apps/architect-web/src/utils/assetUtils.ts
@@ -2,6 +2,7 @@ import type { ExtractedAsset } from '@codaco/protocol-validation';
 
 import { getActiveProtocolScope } from './activeProtocolScope';
 import { assetDb, assetKey, type StoredAsset } from './assetDB';
+import { getMemoryAsset, putMemoryAsset } from './inMemoryAssetStore';
 
 // Resolve the protocol to operate on: an explicit id wins, otherwise fall back
 // to the active editing scope. Reads tolerate a missing scope (return empty);
@@ -53,6 +54,21 @@ export const saveProtocolAssets = async (
   await Promise.all(assetPromises);
 };
 
+// Fallback used when IndexedDB writes fail (e.g. Safari private browsing). Keeps
+// the protocol's assets in memory so they still render and can be exported this
+// session. apikey assets are plain strings, not files, so they're skipped.
+export const saveProtocolAssetsToMemory = (
+  assets: ExtractedAsset[],
+  protocolId: string,
+): void => {
+  for (const asset of assets) {
+    if (typeof asset.data === 'string') {
+      continue;
+    }
+    putMemoryAsset(asset, protocolId);
+  }
+};
+
 export const getAssetById = async (
   assetId: string,
   protocolId?: string,
@@ -61,8 +77,16 @@ export const getAssetById = async (
   if (!scope) {
     return undefined;
   }
-  const row = await assetDb.assets.get(assetKey(scope, assetId));
-  return row ? toExtractedAsset(row) : undefined;
+  try {
+    const row = await assetDb.assets.get(assetKey(scope, assetId));
+    if (row) {
+      return toExtractedAsset(row);
+    }
+  } catch {
+    // IndexedDB unavailable (e.g. private browsing) — fall back to memory below.
+  }
+  const memoryRow = getMemoryAsset(scope, assetId);
+  return memoryRow ? toExtractedAsset(memoryRow) : undefined;
 };
 
 export const deleteProtocolAssets = async (

--- a/apps/architect-web/src/utils/inMemoryAssetStore.ts
+++ b/apps/architect-web/src/utils/inMemoryAssetStore.ts
@@ -1,0 +1,25 @@
+import type { ExtractedAsset } from '@codaco/protocol-validation';
+
+import { assetKey, type StoredAsset } from './assetDB';
+
+// Holds protocol assets when IndexedDB is unavailable (e.g. Safari private
+// browsing, where the quota is too small for the bundled sample media). Keyed by
+// the same compound `${protocolId}::${assetId}` as the durable store. Lives only
+// for the session — nothing here survives a reload.
+const memoryAssets = new Map<string, StoredAsset>();
+
+export const putMemoryAsset = (asset: ExtractedAsset, scope: string): void => {
+  const key = assetKey(scope, asset.id);
+  memoryAssets.set(key, {
+    id: key,
+    assetId: asset.id,
+    protocolId: scope,
+    name: asset.name,
+    data: asset.data,
+  });
+};
+
+export const getMemoryAsset = (
+  scope: string,
+  assetId: string,
+): StoredAsset | undefined => memoryAssets.get(assetKey(scope, assetId));


### PR DESCRIPTION
Addresses the batch of small architect-web issues in #685.

## What changed

**Copy / small CSS**
- Shape-override helper text now reads "…the value of a node's attribute."
- Tip boxes collapse their top/bottom margin when they're the first/last child.
- Sociogram "Choose a background type" renders as a `small-heading` subheading.
- "Form Fields" heading is hidden when the form-title field is hidden.
- The "use a variable called name" tip is hidden once a variable named "name" is selected for Quick Add.

**Shared components**
- Subject selector: removed the doubled edge-chip margin and the empty options box so node/edge spacing is consistent.
- `NativeSelect` (input control) now has a visible border + focus state, matching text inputs.
- The oversized legacy `Toggle` switch now renders the modern `NewComponents/Switch`, so all switches are one size.
- `Section` is nesting-aware via context and steps the surface colour (surface-1 → 2 → 3) so nested panels contrast; dialogs reset the nesting depth.
- Create-type dialog no longer prompts "unsaved changes" when **creating** a new node/edge type (it still confirms when **editing** an existing type, where losing edits matters).

**Variable spotlight**
- The search field now autofocuses on open (the shared `Text` field was silently dropping `autoFocus`).
- Modernised the list: muted section headers instead of fieldset/legend rules, rounded inset selection, roomier rows.
- Fixed the exit animation so the input fades out with the container instead of lingering.

**Field editor**
- The field edit/create form and the create-variable window are now a single card with sub-headings (new `Subsection` component) instead of a stack of cards.
- "Show validation hints?" moved out of the Validation section to sit with the hint configuration under Hint Text.
- The prompt-creator dialog now scrolls to the first error on a failed save.

**Open protocol when storage is unavailable (Safari private browsing)**
- If the IndexedDB write fails (e.g. private-mode quota), the protocol now opens from an in-memory copy so it stays usable for the session, with a non-blocking banner ("won't be saved — download as .netcanvas") and autosave errors suppressed.

## Verification
- `typecheck`, `lint:fix` + `oxfmt`, `knip` (0 issues), unit tests (385 passed).
- Live in the running app: create-type close-without-confirm, subject-selector spacing, spotlight autofocus + restyle, nested dialog surfaces, single-card field editor, validation-hints placement, input-control border (confirmed 1px via inspect), modern switches, and the storage banner staying hidden when storage works. No console errors.

## Reviewer notes
- All changes are confined to `apps/architect-web` (a `private` app), so no changeset is included.
- ⚠️ **Separate, pre-existing issue (not introduced here):** the bundled Sample and Development protocols currently fail schema validation (`packages/sample-protocol/protocol.json` has `"size"` keys the schema rejects; `openBundledTemplate` skips migration). This blocks the sample protocol from opening end-to-end even in a normal tab, independent of the storage fix above. Flagged for a separate session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-blocking storage warning banner with a download option when local storage isn’t available.
  * Introduced richer section/subsection layout styling and reusable subsection blocks across editor forms.
  * Added automatic scrolling to the first invalid field after a failed save.

* **Bug Fixes**
  * Closing a new-item dialog no longer triggers an unsaved-changes prompt.
  * Improved autofocusing for text fields.
  * Refined toggle, select, and picker interactions and spacing for a smoother form experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->