### PR TITLE
fix: make bundled Sample & Development protocols valid against schema 8

### DIFF
--- a/.changeset/bundled-protocols-schema8-fixup.md
+++ b/.changeset/bundled-protocols-schema8-fixup.md
@@ -1,0 +1,9 @@
+---
+'@codaco/sample-protocol': patch
+'@codaco/development-protocol': patch
+---
+
+Bring the bundled protocols into conformance with the current schema 8 so they open in Architect without a "Protocol Validation Failed" dialog. These protocols are tagged schema version 8, so the open path skips migration and stale legacy keys are never stripped.
+
+- Sample Protocol: removed `size` from Information **text** items (schema 8 only allows `size` on asset items).
+- Development Protocol: removed `size` from text items, dropped the no-longer-supported `form.title` on the ego/alter/alter-edge forms, removed the unused `loop` flag on the `withSound` asset, dropped the `highlight` block from the Sociogram prompt that also created edges (the two are mutually exclusive), and renamed the venue node type's `name_variable` to `venue_name_variable` so variable record keys are unique across entity types.

--- a/apps/architect-web/README.md
+++ b/apps/architect-web/README.md
@@ -128,4 +128,5 @@ This app depends on other packages in the monorepo:
 
 - `@codaco/protocol-validation` - Protocol schema validation and migration
 - `@codaco/shared-consts` - Shared constants and type definitions
-- `@codaco/development-protocol` - Sample protocol for testing (dev dependency)
+- `@codaco/sample-protocol` - Sample protocol bundled as the "Sample Protocol" template
+- `@codaco/development-protocol` - Development protocol bundled as the dev-only "Development Protocol" template

--- a/apps/architect-web/package.json
+++ b/apps/architect-web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@base-ui/react": "catalog:",
     "@codaco/art": "workspace:*",
+    "@codaco/development-protocol": "workspace:*",
     "@codaco/fresco-ui": "workspace:*",
     "@codaco/interface-images": "workspace:*",
     "@codaco/interview": "workspace:*",

--- a/apps/architect-web/src/components/Home/Home.tsx
+++ b/apps/architect-web/src/components/Home/Home.tsx
@@ -16,7 +16,6 @@ import type {
 import Badge from '~/components/Badge';
 import NewProtocolDialog from '~/components/NewProtocolDialog';
 import NavShell from '~/components/ProjectNav/NavShell';
-import { DEVELOPMENT_PROTOCOL_URL } from '~/config';
 import { useAppDispatch } from '~/ducks/hooks';
 import { generalErrorDialog } from '~/ducks/modules/userActions/dialogs';
 import {
@@ -24,10 +23,13 @@ import {
   openBundledTemplate,
   openLibraryProtocol,
   openLocalNetcanvas,
-  openRemoteNetcanvas,
 } from '~/ducks/modules/userActions/userActions';
 import Button from '~/lib/legacy-ui/components/Button';
 import { BUNDLED_TEMPLATES, type BundledTemplate } from '~/templates';
+import {
+  developmentProtocol,
+  loadDevelopmentAssets,
+} from '~/templates/development-protocol';
 import { loadSampleAssets, sampleProtocol } from '~/templates/sample-protocol';
 import { appVersion } from '~/utils/appVersion';
 import { reportError } from '~/utils/reportError';
@@ -59,16 +61,11 @@ const Home = () => {
   const dispatch = useAppDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const [showNewDialog, setShowNewDialog] = useState(false);
-  const [pendingTemplate, setPendingTemplate] = useState<
-    | { kind: 'remote'; url: string; defaultName: string }
-    | {
-        kind: 'bundled';
-        protocol: CurrentProtocol;
-        defaultName: string;
-        loadAssets?: () => Promise<ExtractedAsset[]>;
-      }
-    | null
-  >(null);
+  const [pendingTemplate, setPendingTemplate] = useState<{
+    protocol: CurrentProtocol;
+    defaultName: string;
+    loadAssets?: () => Promise<ExtractedAsset[]>;
+  } | null>(null);
   const [visibleCount, setVisibleCount] = useState(3);
 
   useEffect(() => {
@@ -122,7 +119,6 @@ const Home = () => {
   // dialog; confirming it fetches and instantiates the protocol.
   const handleOpenSample = useCallback(() => {
     setPendingTemplate({
-      kind: 'bundled',
       protocol: sampleProtocol,
       loadAssets: loadSampleAssets,
       defaultName: 'Sample Protocol',
@@ -131,15 +127,14 @@ const Home = () => {
 
   const handleOpenDevProtocol = useCallback(() => {
     setPendingTemplate({
-      kind: 'remote',
-      url: DEVELOPMENT_PROTOCOL_URL,
+      protocol: developmentProtocol,
+      loadAssets: loadDevelopmentAssets,
       defaultName: 'Development Protocol',
     });
   }, []);
 
   const handleOpenTemplate = useCallback((template: BundledTemplate) => {
     setPendingTemplate({
-      kind: 'bundled',
       protocol: template.protocol,
       loadAssets: template.loadAssets,
       defaultName: template.name,
@@ -152,23 +147,19 @@ const Home = () => {
       setPendingTemplate(null);
       if (!template) return;
       void runAction(async () => {
-        if (template.kind === 'bundled') {
-          let assets: ExtractedAsset[] | undefined;
-          try {
-            assets = template.loadAssets
-              ? await template.loadAssets()
-              : undefined;
-          } catch (error) {
-            const { message } = reportError(error);
-            dispatch(generalErrorDialog('Protocol Import Error', message));
-            return;
-          }
-          await dispatch(
-            openBundledTemplate({ protocol: template.protocol, name, assets }),
-          );
-        } else {
-          await dispatch(openRemoteNetcanvas({ url: template.url, name }));
+        let assets: ExtractedAsset[] | undefined;
+        try {
+          assets = template.loadAssets
+            ? await template.loadAssets()
+            : undefined;
+        } catch (error) {
+          const { message } = reportError(error);
+          dispatch(generalErrorDialog('Protocol Import Error', message));
+          return;
         }
+        await dispatch(
+          openBundledTemplate({ protocol: template.protocol, name, assets }),
+        );
       });
     },
     [dispatch, pendingTemplate, runAction],

--- a/apps/architect-web/src/config/index.ts
+++ b/apps/architect-web/src/config/index.ts
@@ -14,8 +14,6 @@ export const COLOR_PALETTE_BY_ENTITY = {
 // Target protocol schema version. Used to determine compatibility & migration
 export const APP_SCHEMA_VERSION = 8 as const;
 
-export const DEVELOPMENT_PROTOCOL_URL =
-  'http://networkcanvas.com/downloads/Development.netcanvas';
 // Maps for supported asset types within the app. Used by asset chooser.
 export const SUPPORTED_EXTENSION_TYPE_MAP = {
   network: ['.csv', '.json'],

--- a/apps/architect-web/src/ducks/modules/userActions/userActions.ts
+++ b/apps/architect-web/src/ducks/modules/userActions/userActions.ts
@@ -32,7 +32,7 @@ import { reportError } from '~/utils/reportError';
 import { clearActiveProtocol, setActiveProtocol } from '../activeProtocol';
 import { getActiveProtocolId, setActiveProtocolId } from '../app';
 
-type ImportSource = 'local' | 'remote' | 'bundled';
+type ImportSource = 'local' | 'bundled';
 
 // A protocol failed schema validation during import. This is an expected
 // outcome for an old or malformed file, so we record an analytics event
@@ -333,92 +333,6 @@ export const exportNetcanvas = createAsyncThunk(
     );
 
     return true;
-  },
-);
-
-export const openRemoteNetcanvas = createAsyncThunk(
-  'webUserActions/openRemoteNetcanvas',
-  async ({ url, name }: { url: string; name?: string }, { dispatch }) => {
-    const controller = new AbortController();
-
-    try {
-      // Fetch the zipped .netcanvas file from the remote URL
-      const response = await fetch(url, {
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const buffer = await response.arrayBuffer();
-
-      // TODO: Remove duplicated code by reusing openLocalNetcanvas logic
-      const { protocol, assets } = await extractProtocol(
-        new Uint8Array(buffer),
-      );
-
-      // Get filename from URL
-      const fileName = decodeURIComponent(
-        url.split('/').pop() || 'remote_protocol.netcanvas',
-      );
-      const protocolName = fileName.replace(/\.netcanvas$/, '');
-
-      // Handle migration if needed
-      const migratedProtocol = await dispatch(
-        handleProtocolMigration({
-          protocol: protocol as CurrentProtocol,
-          name: protocolName,
-        }),
-      ).unwrap();
-
-      if (!migratedProtocol) {
-        // Migration was canceled or app upgrade is required; the migration
-        // step has already surfaced the appropriate dialog. Treat as a benign
-        // exit rather than a reportable exception.
-        dispatch(
-          generalErrorDialog(
-            'Protocol Import Error',
-            'Protocol migration failed or was canceled.',
-          ),
-        );
-        return;
-      }
-
-      // Validate the protocol
-      const validationResult = await validateProtocol(
-        migratedProtocol as CurrentProtocol,
-      );
-
-      if (!validationResult.success) {
-        trackImportValidationFailure('remote', validationResult.error);
-        const errorMessage = ensureError(validationResult.error).message;
-        dispatch(validationErrorDialog(errorMessage));
-        return;
-      }
-
-      // Opening a remote/template protocol instantiates a fresh library entry
-      // (new id), so templates can be opened repeatedly without overwriting. A
-      // caller-supplied `name` (the template-naming flow) overrides the
-      // protocol's own name so the library row and the editor agree.
-      const finalProtocol = migratedProtocol as CurrentProtocol;
-      const finalName = name ?? finalProtocol.name ?? protocolName;
-      await instantiateProtocol(
-        {
-          protocol: name ? { ...finalProtocol, name } : finalProtocol,
-          assets,
-          name: finalName,
-          description: finalProtocol.description,
-        },
-        dispatch,
-      );
-    } catch (error) {
-      trackImportException('remote', error);
-      const errorMessage = ensureError(error).message;
-      dispatch(generalErrorDialog('Protocol Import Error', errorMessage));
-    } finally {
-      controller.abort();
-    }
   },
 );
 

--- a/apps/architect-web/src/templates/__tests__/bundled-validation.test.ts
+++ b/apps/architect-web/src/templates/__tests__/bundled-validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CurrentProtocol,
+  validateProtocol,
+} from '@codaco/protocol-validation';
+import { BUNDLED_TEMPLATES } from '~/templates';
+import { developmentProtocol } from '~/templates/development-protocol';
+import { sampleProtocol } from '~/templates/sample-protocol';
+
+// Architect opens these via `openBundledTemplate`, which deliberately skips the
+// migration step (bundled protocols are assumed to already be at the current
+// schema version). A protocol that drifts from the schema therefore fails the
+// "Protocol Validation Failed" dialog before reaching the editor, so this test
+// guards every bundled protocol against the live schema.
+const bundledProtocols: { name: string; protocol: CurrentProtocol }[] = [
+  { name: 'Sample Protocol', protocol: sampleProtocol },
+  { name: 'Development Protocol', protocol: developmentProtocol },
+  ...BUNDLED_TEMPLATES.map((template) => ({
+    name: template.name,
+    protocol: template.protocol,
+  })),
+];
+
+describe('bundled protocols validate against the current schema', () => {
+  for (const { name, protocol } of bundledProtocols) {
+    it(`${name} passes validateProtocol`, async () => {
+      const result = await validateProtocol(protocol);
+      const issues = result.success
+        ? []
+        : result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+      expect(issues).toStrictEqual([]);
+    });
+  }
+});

--- a/apps/architect-web/src/templates/development-protocol.ts
+++ b/apps/architect-web/src/templates/development-protocol.ts
@@ -1,0 +1,57 @@
+import developmentProtocolJson from '@codaco/development-protocol';
+import type {
+  CurrentProtocol,
+  ExtractedAsset,
+} from '@codaco/protocol-validation';
+
+// The Development Protocol, vendored as `@codaco/development-protocol`, so the
+// dev-mode template opens from the bundled app rather than a remote URL. It
+// exercises every stage type and is only surfaced in development builds.
+export const developmentProtocol =
+  developmentProtocolJson as unknown as CurrentProtocol;
+
+// Vite emits each bundled asset file and gives us its URL. The file name matches
+// the `source` of the corresponding `assetManifest` entry in the protocol.
+const assetUrlByPath = import.meta.glob<string>(
+  '../../../../packages/development-protocol/assets/*',
+  { query: '?url', import: 'default', eager: true },
+);
+
+const urlBySource = new Map(
+  Object.entries(assetUrlByPath).map(([path, url]) => [
+    path.slice(path.lastIndexOf('/') + 1),
+    url,
+  ]),
+);
+
+type ManifestEntry = { id: string; name: string; source?: string };
+
+// Fetches each bundled asset into a Blob keyed by its `assetManifest` id, so the
+// Development protocol instantiates into the library with its media intact.
+// Called lazily, only when the Development template is actually opened.
+export const loadDevelopmentAssets = async (): Promise<ExtractedAsset[]> => {
+  const entries = Object.values(
+    developmentProtocol.assetManifest ?? {},
+  ) as ManifestEntry[];
+
+  return Promise.all(
+    entries
+      .filter((entry): entry is Required<ManifestEntry> =>
+        Boolean(entry.source),
+      )
+      .map(async (entry) => {
+        const url = urlBySource.get(entry.source);
+        if (!url) {
+          throw new Error(`Missing bundled Development asset: ${entry.source}`);
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch bundled Development asset ${entry.source}: ${response.status}`,
+          );
+        }
+        const data = await response.blob();
+        return { id: entry.id, name: entry.name, data };
+      }),
+  );
+};

--- a/packages/development-protocol/package.json
+++ b/packages/development-protocol/package.json
@@ -21,7 +21,8 @@
   "type": "module",
   "main": "./protocol.json",
   "exports": {
-    ".": "./protocol.json"
+    ".": "./protocol.json",
+    "./assets/*": "./assets/*"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/development-protocol/protocol.json
+++ b/packages/development-protocol/protocol.json
@@ -23,7 +23,6 @@
       "type": "EgoForm",
       "label": "Ego Form",
       "form": {
-        "title": "An example ego form",
         "fields": [
           {
             "variable": "3377af3f-3c79-41da-9b0b-6570fb519b93",
@@ -138,7 +137,6 @@
       "title": "Ego name contains Josh",
       "items": [
         {
-          "size": "SMALL",
           "id": "08964cf2-4c7b-4ecd-a6ef-9d68c2b13bf4",
           "content": "Hello fellow Josh!\n",
           "type": "text"
@@ -297,7 +295,7 @@
       "id": "namegen2",
       "type": "NameGeneratorQuickAdd",
       "label": "NG Quick add",
-      "quickAdd": "name_variable",
+      "quickAdd": "venue_name_variable",
       "subject": {
         "entity": "node",
         "type": "venue_node_type"
@@ -669,10 +667,6 @@
           "edges": {
             "display": ["friend_edge_type", "professional_edge_type"],
             "create": "friend_edge_type"
-          },
-          "highlight": {
-            "allowHighlighting": true,
-            "variable": "03b03617-46ae-41cb-9462-9acd8a17edd6"
           }
         }
       ],
@@ -904,7 +898,6 @@
         "type": "person_node_type"
       },
       "form": {
-        "title": "Modify a Person",
         "fields": [
           {
             "variable": "246c4d84-ebd7-41a6-8c1a-ef83938227ba",
@@ -964,7 +957,6 @@
         "type": "friend_edge_type"
       },
       "form": {
-        "title": "Modify an Edge",
         "fields": [
           {
             "variable": "e343a91f-628d-4175-870c-957beffa0002",
@@ -1017,7 +1009,6 @@
         "type": "professional_edge_type"
       },
       "form": {
-        "title": "Modify a Professional Edge",
         "fields": [
           {
             "variable": "d343a91f-628d-4175-870c-957beffa0002",
@@ -1107,8 +1098,7 @@
         {
           "id": "65192318-0ef0-454d-91b7-bbaf51380069",
           "type": "text",
-          "content": "The video below has sound and is set to loop. Some arbitrary text content that can _contain_ **formatting**.",
-          "size": "SMALL"
+          "content": "The video below has sound and is set to loop. Some arbitrary text content that can _contain_ **formatting**."
         },
         {
           "id": "27eee84a-52c0-440d-951c-5ac35bc75168",
@@ -1127,7 +1117,6 @@
         {
           "id": "d3e52e4b-0d22-42e3-a82f-7a150daf7b6b",
           "type": "text",
-          "size": "LARGE",
           "content": "# h1 Heading 8-)\n## h2 Heading\n### h3 Heading\n#### h4 Heading\n##### h5 Heading\n###### h6 Heading\n\n## Emphasis\n\n**This is bold text**\n\n__This is bold text__\n\n*This is italic text* \n\n_This is italic text_ \n# Emoji \n:blush: :heartpulse: :wave:"
         }
       ]
@@ -1141,8 +1130,7 @@
         {
           "id": "ffaf2249-00e7-4fdb-99fc-5757a24f5605",
           "type": "text",
-          "content": "...that is the question.",
-          "size": "LARGE"
+          "content": "...that is the question."
         }
       ],
       "skipLogic": {
@@ -1670,7 +1658,7 @@
         "icon": "add-a-place",
         "shape": { "default": "circle" },
         "variables": {
-          "name_variable": {
+          "venue_name_variable": {
             "name": "name",
             "type": "text"
           },
@@ -2134,8 +2122,7 @@
     "withSound": {
       "type": "video",
       "name": "withSound.mp4",
-      "source": "withSound.mp4",
-      "loop": true
+      "source": "withSound.mp4"
     },
     "quadrant-1": {
       "type": "image",

--- a/packages/development-protocol/protocol.json
+++ b/packages/development-protocol/protocol.json
@@ -660,7 +660,7 @@
         },
         {
           "id": "closeness3",
-          "text": "This prompt shows 3 concentric circles and has create edge and allow highlight specified (against the rules!)",
+          "text": "This prompt shows 3 concentric circles and creates friend edges.",
           "layout": {
             "layoutVariable": "layout_variable"
           },
@@ -1098,7 +1098,7 @@
         {
           "id": "65192318-0ef0-454d-91b7-bbaf51380069",
           "type": "text",
-          "content": "The video below has sound and is set to loop. Some arbitrary text content that can _contain_ **formatting**."
+          "content": "The video below has sound. Some arbitrary text content that can _contain_ **formatting**."
         },
         {
           "id": "27eee84a-52c0-440d-951c-5ac35bc75168",

--- a/packages/sample-protocol/protocol.json
+++ b/packages/sample-protocol/protocol.json
@@ -473,14 +473,12 @@
         {
           "id": "f12c365f-237b-49da-99d2-2eeacc817997",
           "type": "text",
-          "content": "We developed this sample interview protocol to provide an overview of the features of Interviewer, and give examples of the key tasks associated with conducting a personal network interview. Specifically, we will be discussing:\n\n* Options for name generation within Interviewer, including the use of existing roster data\n* Name interpreter functionality, including dedicated interfaces for certain types of data, and general purpose \"form\" interfaces for everything else\n* The use of the Sociogram Interface, and other methods of creating edges\n* The use of skip logic and network filtering on a stage to minimize response burden\n* The Narrative Interface as a tool for qualitative network interviewing",
-          "size": "MEDIUM"
+          "content": "We developed this sample interview protocol to provide an overview of the features of Interviewer, and give examples of the key tasks associated with conducting a personal network interview. Specifically, we will be discussing:\n\n* Options for name generation within Interviewer, including the use of existing roster data\n* Name interpreter functionality, including dedicated interfaces for certain types of data, and general purpose \"form\" interfaces for everything else\n* The use of the Sociogram Interface, and other methods of creating edges\n* The use of skip logic and network filtering on a stage to minimize response burden\n* The Narrative Interface as a tool for qualitative network interviewing"
         },
         {
           "id": "fd3a3fea-b094-4098-ac7a-d6e06722432d",
           "type": "text",
-          "content": "To move through this protocol, use the arrows on the left hand side of the screen. When you are ready to continue, click the down arrow.",
-          "size": "SMALL"
+          "content": "To move through this protocol, use the arrows on the left hand side of the screen. When you are ready to continue, click the down arrow."
         },
         {
           "id": "f275e48b-a614-4c06-b830-217d2b15a737",
@@ -499,8 +497,7 @@
         {
           "id": "176d0f5a-132c-45b9-b542-8f7b7a83e71b",
           "type": "text",
-          "content": "The screen you are currently viewing was built using the **Information Interface** within Architect.\n\nUnlike other interfaces, this interface captures no data from the participant. Instead, researchers are able to include explanatory **text** and **image**, **audio**, and **video** files to assist in the administration of Network Canvas Interviews.\n\nWhile these screens are helpful in guiding interviews, it should be noted that Interviewer has been designed to conduct interviews in a face-to-face setting, where tasks on each screen are able to be fully explained to the participant by the researcher.\n",
-          "size": "MEDIUM"
+          "content": "The screen you are currently viewing was built using the **Information Interface** within Architect.\n\nUnlike other interfaces, this interface captures no data from the participant. Instead, researchers are able to include explanatory **text** and **image**, **audio**, and **video** files to assist in the administration of Network Canvas Interviews.\n\nWhile these screens are helpful in guiding interviews, it should be noted that Interviewer has been designed to conduct interviews in a face-to-face setting, where tasks on each screen are able to be fully explained to the participant by the researcher.\n"
         },
         {
           "id": "74fab225-4b5d-42cb-b01b-d220d7158e8a",
@@ -519,8 +516,7 @@
         {
           "id": "8d5c5245-78d9-4fe5-86fb-bbc0f4063f8e",
           "type": "text",
-          "content": "Interviewer supports collecting arbitrary data from the participant, through the use of the **Ego Form** interface. This interface allows you to present as many questions as you wish to the participant. Answers given are stored separately from node and edge attribute data, and can be exported along with other data.\n\nThe next screen uses the Ego Form interface to create an example of a consent form.\n",
-          "size": "LARGE"
+          "content": "Interviewer supports collecting arbitrary data from the participant, through the use of the **Ego Form** interface. This interface allows you to present as many questions as you wish to the participant. Answers given are stored separately from node and edge attribute data, and can be exported along with other data.\n\nThe next screen uses the Ego Form interface to create an example of a consent form.\n"
         }
       ]
     },
@@ -599,8 +595,7 @@
         {
           "id": "45ca0997-c8cf-4d94-bc71-f2dccff41442",
           "type": "text",
-          "content": "The first key step within a social network interview is the generation of the network members - or nodes. On the next screen you will see an example of a Name Generator Interface using **Quick Add**, which asks you to enter the names of any individuals whom you have felt close to or have discussed important personal matters with. \n\nEnter the names of these individuals by pressing the **‘Add a Person’ Icon** at the bottom right corner of the screen. Type the name of the individual and press enter. Numerous individuals can be entered in rapid succession. \n\nResearchers are able to choose from four types of name generator interfaces based on their priorities and needs. A researcher might choose this 'quick add' name generator if they wish to prioritize the elicitation of many names as quickly as possible. If a mistake is made, nodes can be easily deleted by dragging them toward the bottom of the screen into the garbage bin that appears.",
-          "size": "MEDIUM"
+          "content": "The first key step within a social network interview is the generation of the network members - or nodes. On the next screen you will see an example of a Name Generator Interface using **Quick Add**, which asks you to enter the names of any individuals whom you have felt close to or have discussed important personal matters with. \n\nEnter the names of these individuals by pressing the **‘Add a Person’ Icon** at the bottom right corner of the screen. Type the name of the individual and press enter. Numerous individuals can be entered in rapid succession. \n\nResearchers are able to choose from four types of name generator interfaces based on their priorities and needs. A researcher might choose this 'quick add' name generator if they wish to prioritize the elicitation of many names as quickly as possible. If a mistake is made, nodes can be easily deleted by dragging them toward the bottom of the screen into the garbage bin that appears."
         },
         {
           "id": "96e56bee-cbdb-4933-9e00-783e7505c276",
@@ -635,8 +630,7 @@
         {
           "id": "8ad0af99-37cb-40c0-b2f1-8c482aab16d7",
           "type": "text",
-          "content": "Sometimes the individuals named within network interviews have multiple relationships with the interviewee that are important to the researcher. For example, someone might be a *close friend* but also a *co-worker*. Instead of having the research participant enter these names twice, researchers can use **Side Panels** to allow the participant to select and drag over nodes already entered from the in-progress interview. The use of Side Panels speeds data entry, and can be used for simple name interpreter functionality. \n\nSide panels can also be populated before the interview (when building the protocol within Architect) by adding a network data file containing a roster of individuals from which all participants would be able to select - such as a classroom. This is the first of three locations where roster data can be used in your protocol.\n\nOn the next screen - add individuals by clicking the ‘Add a Person' Icon or dragging individuals from the side panel. \n",
-          "size": "MEDIUM"
+          "content": "Sometimes the individuals named within network interviews have multiple relationships with the interviewee that are important to the researcher. For example, someone might be a *close friend* but also a *co-worker*. Instead of having the research participant enter these names twice, researchers can use **Side Panels** to allow the participant to select and drag over nodes already entered from the in-progress interview. The use of Side Panels speeds data entry, and can be used for simple name interpreter functionality. \n\nSide panels can also be populated before the interview (when building the protocol within Architect) by adding a network data file containing a roster of individuals from which all participants would be able to select - such as a classroom. This is the first of three locations where roster data can be used in your protocol.\n\nOn the next screen - add individuals by clicking the ‘Add a Person' Icon or dragging individuals from the side panel. \n"
         },
         {
           "id": "868da7cc-9dcb-43c9-a799-6d7ea3b19747",
@@ -684,8 +678,7 @@
         {
           "id": "bf1390c3-a703-4bae-831d-9ab78e4f0ad5",
           "type": "text",
-          "content": "The previous two name generator tasks have used the **Quick Add** version of our Name Generator, which means that the participant only needed to enter a name for the alter in order to add them to the interview.\n\nFor more in-depth data collection about alters as they are collected, we provide a version of the name generator that uses **Forms**. A form is a collection of one or more variables which is shown to the participant each time they click the 'Add a Person' Icon on the name generator. \n\nFor example, on the next screen, Clinics or Health Care Providers visited within the past 12 months are entered. Names are required, along with date of visit and a text description of the purpose of the visit. \n\nThe choice of name generation interface should depend on the priorities of the researcher. The *Quick Add* version back-loads the burden of name interpreter tasks, whereas the *Name Generator using Forms* front-loads some of that burden.",
-          "size": "MEDIUM"
+          "content": "The previous two name generator tasks have used the **Quick Add** version of our Name Generator, which means that the participant only needed to enter a name for the alter in order to add them to the interview.\n\nFor more in-depth data collection about alters as they are collected, we provide a version of the name generator that uses **Forms**. A form is a collection of one or more variables which is shown to the participant each time they click the 'Add a Person' Icon on the name generator. \n\nFor example, on the next screen, Clinics or Health Care Providers visited within the past 12 months are entered. Names are required, along with date of visit and a text description of the purpose of the visit. \n\nThe choice of name generation interface should depend on the priorities of the researcher. The *Quick Add* version back-loads the burden of name interpreter tasks, whereas the *Name Generator using Forms* front-loads some of that burden."
         },
         {
           "id": "0ff569f0-4fbc-40df-93a4-cfb23467040c",
@@ -736,8 +729,7 @@
         {
           "id": "e2937966-8e0f-4a48-b090-84fc078e1852",
           "type": "text",
-          "content": "Interviewer also supports the use of rosters containing pre\\-populated lists of names. The name generator you saw earlier featuring a side panel for &quot;people already mentioned&quot; is one place this roster data can be used, but the following two screens demonstrate our dedicated interface for this type of data.\n\nThe roster interface is split into two panels. One panel displays &#39;cards&#39; that represent each item in your roster. The other panel represents nodes in the interview, and will initially be empty. **To nominate an alter**, the participant must drag a card from the first panel, into the second. This card will then be removed from the card list, and a node will be created representing the roster member in the interview network.\n\nThe interface supports configurable options for sorting cards, searching for cards, and displaying cards.\n\nThe first screen you will see shows a smaller roster. Alters elicited on this stage will be used on a later stage (Dyad Census) which requires at _at least two nodes be nominated._ Please be sure to **nominate at least two classmates from the roster.**\n\nThe second screen shows a larger roster. Where the roster is above 100 members in size, the participant must use the search function before any cards are shown.\n",
-          "size": "LARGE"
+          "content": "Interviewer also supports the use of rosters containing pre\\-populated lists of names. The name generator you saw earlier featuring a side panel for &quot;people already mentioned&quot; is one place this roster data can be used, but the following two screens demonstrate our dedicated interface for this type of data.\n\nThe roster interface is split into two panels. One panel displays &#39;cards&#39; that represent each item in your roster. The other panel represents nodes in the interview, and will initially be empty. **To nominate an alter**, the participant must drag a card from the first panel, into the second. This card will then be removed from the card list, and a node will be created representing the roster member in the interview network.\n\nThe interface supports configurable options for sorting cards, searching for cards, and displaying cards.\n\nThe first screen you will see shows a smaller roster. Alters elicited on this stage will be used on a later stage (Dyad Census) which requires at _at least two nodes be nominated._ Please be sure to **nominate at least two classmates from the roster.**\n\nThe second screen shows a larger roster. Where the roster is above 100 members in size, the participant must use the search function before any cards are shown.\n"
         }
       ]
     },
@@ -853,8 +845,7 @@
         {
           "id": "dab3ed09-8b8b-4bd0-a9aa-550e29fac2c4",
           "type": "text",
-          "content": "The next interface we will introduce is the **Sociogram**. Participants use this interface to position their alters on the screen, create ties between them, and to nominate alters as having a given attribute. \n\nOn the next two screens you will be asked to position alters onto the Sociogram screen, first onto a default image of concentric circles, placing folks who know each other closer together and those who do not know each other farther away. On the second screen, you will see an example of a customized background image, using the political compass diagram. We included this image by adding it as a resource when we were building the protocol within Architect. This allows the researcher immense flexibility in how the Sociogram might be utilized. ",
-          "size": "MEDIUM"
+          "content": "The next interface we will introduce is the **Sociogram**. Participants use this interface to position their alters on the screen, create ties between them, and to nominate alters as having a given attribute. \n\nOn the next two screens you will be asked to position alters onto the Sociogram screen, first onto a default image of concentric circles, placing folks who know each other closer together and those who do not know each other farther away. On the second screen, you will see an example of a customized background image, using the political compass diagram. We included this image by adding it as a resource when we were building the protocol within Architect. This allows the researcher immense flexibility in how the Sociogram might be utilized. "
         },
         {
           "id": "6acf6657-b16a-4ac2-bca9-50a831ff83c3",
@@ -922,8 +913,7 @@
         {
           "id": "56717145-8fcc-44f7-913f-359a591b6766",
           "type": "text",
-          "content": "Once alters have been positioned on the screen, the *Sociogram Interface* can also be used to measure relationships between alters. \n\nOn the next screens you will be asked to create connections or **edges** between individuals who have a certain relationship with each other. To do this, you tap one node and then tap a second node. You can go through this process again to remove a tie. \n\nMultiple kinds of edges can be created. While on the first screen we ask you to connect any two people who might spend time together without you being there, on the second screen we ask you to connect individuals are have conflict or who do not get along with each other well. ",
-          "size": "MEDIUM"
+          "content": "Once alters have been positioned on the screen, the *Sociogram Interface* can also be used to measure relationships between alters. \n\nOn the next screens you will be asked to create connections or **edges** between individuals who have a certain relationship with each other. To do this, you tap one node and then tap a second node. You can go through this process again to remove a tie. \n\nMultiple kinds of edges can be created. While on the first screen we ask you to connect any two people who might spend time together without you being there, on the second screen we ask you to connect individuals are have conflict or who do not get along with each other well. "
         },
         {
           "id": "f835d765-e864-4197-b6bb-f703fadc7d5c",
@@ -1035,8 +1025,7 @@
         {
           "id": "85353555-72d0-49ef-aba9-75023648ead1",
           "type": "text",
-          "content": "The dyad census interface was not shown because you do not have any \"classmates\" in this interview network. \n\nTo see the dyad census interface:\n\n1. Click the timeline on the left to show the interview timeline\n2. Click on Stage \"10. Small Roster - Classroom\"\n3. Add two or more classmates\n4. Return to Stage \"19. Classmates Dyad Census\" ",
-          "size": "MEDIUM"
+          "content": "The dyad census interface was not shown because you do not have any \"classmates\" in this interview network. \n\nTo see the dyad census interface:\n\n1. Click the timeline on the left to show the interview timeline\n2. Click on Stage \"10. Small Roster - Classroom\"\n3. Add two or more classmates\n4. Return to Stage \"19. Classmates Dyad Census\" "
         }
       ]
     },
@@ -1049,8 +1038,7 @@
         {
           "id": "8b518105-17f1-4f95-91b4-f0d00a7bf5e5",
           "type": "text",
-          "content": "On the next series of screens, we will demonstrate several ways that information can be gathered about numerous alters at once using either the *Sociogram Interface* or by using various **Name Interpreter Interfaces**\n\nWhen a researcher wants to ask a question where the answer is either *Yes* or *No*, they may wish to utilize a sociogram screen so participants just select particular individuals. For example, on this screen we ask to select anyone whom you have asked for advice within the prior 6 months. \n\nFollowing the *Sociogram*, we demonstrate the **Ordinal Bin Interface**, where nodes appear at the top and can be quickly sorted into the correct category, and rearranged at any point. Next, the **Categorical Bin Interface** is demonstrated, where nodes can again be sorted into the most appropriate category. Bins can be clicked on to move nodes after they have been placed. \n",
-          "size": "MEDIUM"
+          "content": "On the next series of screens, we will demonstrate several ways that information can be gathered about numerous alters at once using either the *Sociogram Interface* or by using various **Name Interpreter Interfaces**\n\nWhen a researcher wants to ask a question where the answer is either *Yes* or *No*, they may wish to utilize a sociogram screen so participants just select particular individuals. For example, on this screen we ask to select anyone whom you have asked for advice within the prior 6 months. \n\nFollowing the *Sociogram*, we demonstrate the **Ordinal Bin Interface**, where nodes appear at the top and can be quickly sorted into the correct category, and rearranged at any point. Next, the **Categorical Bin Interface** is demonstrated, where nodes can again be sorted into the most appropriate category. Bins can be clicked on to move nodes after they have been placed. \n"
         },
         {
           "id": "407e60d2-a5ec-488b-a086-0f48a6d20396",
@@ -1154,20 +1142,17 @@
         {
           "id": "7043ca48-87e6-4517-a461-13957c71aa4c",
           "type": "text",
-          "content": "On the next screen, we have implemented both skip logic and network filtering for the stage. \n\nSkip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n\n",
-          "size": "SMALL"
+          "content": "On the next screen, we have implemented both skip logic and network filtering for the stage. \n\nSkip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n\n"
         },
         {
           "id": "828ce70c-c5d4-4e32-ab61-8e8cfca46fd4",
           "type": "text",
-          "content": "Skip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n",
-          "size": "SMALL"
+          "content": "Skip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n"
         },
         {
           "id": "7e33fc24-0899-4779-b523-01d5254671bd",
           "type": "text",
-          "content": "Network filtering refers to a feature that allows you to define rules that determine which nodes or edges should be shown on a given stage. It can be used to only show a subset of a network, based on node type, node attributes, and edge types. \n\nIn summary, _skip logic_ determines if a stage should be shown at all and _network filtering_ determines which nodes should be shown on a given stage. \n",
-          "size": "SMALL"
+          "content": "Network filtering refers to a feature that allows you to define rules that determine which nodes or edges should be shown on a given stage. It can be used to only show a subset of a network, based on node type, node attributes, and edge types. \n\nIn summary, _skip logic_ determines if a stage should be shown at all and _network filtering_ determines which nodes should be shown on a given stage. \n"
         },
         {
           "id": "0bcb1e4b-f9d1-4906-9682-6aa0a809ec89",
@@ -1245,8 +1230,7 @@
         {
           "id": "80806937-1630-4600-8212-4cf21de990dd",
           "type": "text",
-          "content": "While we've already demonstrated how the *Sociogram Interface* can be used to place nodes, draw edges, and select particular nodes, the **Narrative Interface** is able to display information on the sociogram in a way to elicit qualitative data from the participant about their network. \n\nResearchers are able to configure display presets that are then able to be toggled on and off to reveal colored convex hulls which represent group-level data, to highlight nodes of a certain type, or to display different edge types. \n\nParticipants can interact with this screen by drawing, freezing, and erasing lines. Unlike many other screens, no data is collected on this Interface.",
-          "size": "MEDIUM"
+          "content": "While we've already demonstrated how the *Sociogram Interface* can be used to place nodes, draw edges, and select particular nodes, the **Narrative Interface** is able to display information on the sociogram in a way to elicit qualitative data from the participant about their network. \n\nResearchers are able to configure display presets that are then able to be toggled on and off to reveal colored convex hulls which represent group-level data, to highlight nodes of a certain type, or to display different edge types. \n\nParticipants can interact with this screen by drawing, freezing, and erasing lines. Unlike many other screens, no data is collected on this Interface."
         }
       ]
     },

--- a/packages/sample-protocol/protocol.json
+++ b/packages/sample-protocol/protocol.json
@@ -1145,11 +1145,6 @@
           "content": "On the next screen, we have implemented both skip logic and network filtering for the stage. \n\nSkip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n\n"
         },
         {
-          "id": "828ce70c-c5d4-4e32-ab61-8e8cfca46fd4",
-          "type": "text",
-          "content": "Skip logic is a feature that allows you to conditionally skip or show a stage within an interview, based on information previously provided by a participant. By implementing skip logic, a participant will bypass information not relevant to them, thus making for a more streamlined interview process. Skip logic rules can be based on _ego, alter,_ or _edges_ and resolve to either **true** or **false** which determines whether the stage is shown.\n"
-        },
-        {
           "id": "7e33fc24-0899-4779-b523-01d5254671bd",
           "type": "text",
           "content": "Network filtering refers to a feature that allows you to define rules that determine which nodes or edges should be shown on a given stage. It can be used to only show a subset of a network, based on node type, node attributes, and edge types. \n\nIn summary, _skip logic_ determines if a stage should be shown at all and _network filtering_ determines which nodes should be shown on a given stage. \n"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
       '@codaco/art':
         specifier: workspace:*
         version: link:../../packages/art
+      '@codaco/development-protocol':
+        specifier: workspace:*
+        version: link:../../packages/development-protocol
       '@codaco/fresco-ui':
         specifier: workspace:*
         version: link:../../packages/fresco-ui


### PR DESCRIPTION
## Problem

Opening the bundled **Sample Protocol** in architect-web (Home → Templates → "Sample Protocol" → Create) failed schema validation and never reached the editor — you got a "Protocol Validation Failed" dialog (`unrecognized_keys: ["size"]` on stage items). The dev-mode **Development Protocol** failed too. This happens on normal tabs and is separate from the Safari-private-tab storage issue (which is handled elsewhere via an in-memory fallback) — this validation failure happens *before* the storage step.

## Root cause

The bundled protocols are tagged `schemaVersion: 8`, so `openBundledTemplate` deliberately skips migration and validates them directly. But they are **stale-v8 data** — tagged v8 *before* schema 8 was tightened and the v8 migration extended. The schema and migration are correct (schema 8 allows `size` only on Information *asset* items, drops `form.title` on ego/alter forms, etc.); the data just carries legacy keys the migration would otherwise strip. Because migration is skipped, those keys reach the validator and fail.

Running the real `validateProtocol` over every bundled protocol confirmed the 6 research templates were already valid; only Sample (16 errors) and Development (11 errors) were not.

## Changes

**Data fixes (the keys are legacy; schema/migration are correct):**
- **Sample Protocol** — remove `size` from the 16 Information *text* items; keep it on the 9 asset items where it's valid.
- **Development Protocol** — remove `size` from text items; drop `form.title` on the ego/alter/alter-edge forms (kept on NameGenerator forms, which still allow it); remove the unused `loop` flag on the `withSound` asset; drop the `highlight` block from the Sociogram prompt that also creates edges (mutually exclusive); rename the venue node type's `name_variable` → `venue_name_variable` so variable record keys are unique across entity types (the only cross-entity collision — person's `name_variable` is unchanged).

**Bundle the monorepo Development Protocol:**
- architect-web now bundles `@codaco/development-protocol` (with its assets) like the Sample Protocol, instead of fetching `networkcanvas.com/downloads/Development.netcanvas`.
- Removed the orphaned remote-open path (`DEVELOPMENT_PROTOCOL_URL`, `openRemoteNetcanvas`) since the dev protocol was its only consumer.

**Regression guard:**
- New `bundled-validation.test.ts` runs `validateProtocol` over all 8 protocols architect-web bundles, so a stale template can't silently ship again.

Plus a changeset (patch bump for the two published protocol packages) and a README dependency-list correction.

## Verification

- `validateProtocol`: all 8 bundled protocols pass (was 2 failing).
- Typecheck (architect-web graph), `knip` (exit 0), and `lint:fix` all clean.
- Full architect-web test suite: 393 passed, 13 todo, 1 skipped.

## Reviewer notes

- The protocol-data diffs are intentionally minimal (only the stale keys + the one rename) rather than a full reformat.
- `@codaco/architect-web` is changeset-ignored, so only the two protocol packages get a version bump.
- The dev-protocol **asset** loader is a line-for-line copy of the working Sample loader (lazy fetch); the import path resolves the 9 asset files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Development Protocol as an in-app template, including its bundled media assets.
  * Bundled protocol templates are now checked against the current schema before they open.

* **Bug Fixes**
  * Updated bundled protocol content to load cleanly without validation errors.
  * Removed outdated settings from forms, text screens, and asset playback so templates open reliably.
  * Renamed a venue field to avoid duplicate variable keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->