### PR TITLE
feat(fresco-ui): make form fields a single unit of focus

### DIFF
--- a/.changeset/field-container-focus-unit.md
+++ b/.changeset/field-container-focus-unit.md
@@ -1,0 +1,12 @@
+---
+'@codaco/fresco-ui': minor
+---
+
+Make a form field a single unit of focus.
+
+- **Container-scoped validation**: validate-on-blur now fires when focus leaves the whole field, not the inner `<input>`. Moving focus to an in-field control (a prefix/suffix button, a number stepper, a sibling radio…) no longer counts as leaving the field, so it no longer leaves a stale validation error (e.g. a "Generate identifier" button populating a field that still showed "cannot be empty"). Single-control fields behave identically; multi-control fields (RadioGroup, Combobox, DatePicker…) get strictly better behaviour.
+- **Focus indication**: slot controls stay real tab stops and render their own design-system focus ring (`Button`/`IconButton` already do); the field shows one ring per focused element rather than double-ringing the wrapper around an already-focused control. The `InputField` wrapper also un-clips (`overflow-visible`) while a slot control is focus-visible, so the control's offset focus ring isn't clipped by the rounded container.
+- **Slot field controller**: `InputField`'s `prefixComponent`/`suffixComponent` now also accept a render function `(field) => ReactNode` that receives a `FieldSlotController` (`{ name, value, setValue, validate, focusInput }`), so a slot control can set and validate the value without importing the form store. Delivered via the new `useFieldController` hook / `FieldController` context. The plain `ReactNode` form is unchanged.
+- **Escape hatch**: `validateOnControlBlur` on `Field` restores validation when focus moves to an in-field control.
+
+Slot controls remain real tab stops with native button semantics.

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -264,6 +264,10 @@
       "types": "./dist/form/Field/Field.d.ts",
       "default": "./dist/form/Field/Field.js"
     },
+    "./form/Field/FieldController": {
+      "types": "./dist/form/Field/FieldController.d.ts",
+      "default": "./dist/form/Field/FieldController.js"
+    },
     "./form/Field/types": {
       "types": "./dist/form/Field/types.d.ts",
       "default": "./dist/form/Field/types.js"

--- a/packages/fresco-ui/src/form/Field/Field.stories.tsx
+++ b/packages/fresco-ui/src/form/Field/Field.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { action } from 'storybook/actions';
+import { expect, userEvent, within } from 'storybook/test';
 
+import Button from '../../Button';
 import InputField from '../fields/InputField';
 import ToggleField from '../fields/ToggleField';
 import Form from '../Form';
@@ -408,5 +410,137 @@ export const UsingMarkdown: Story = {
           'Field labels and hints are rendered with ReactMarkdown, supporting `*italic*` and `**bold**`. This story demonstrates markdown rendering in both.',
       },
     },
+  },
+};
+
+/**
+ * A control rendered in a field's prefix/suffix slot is part of the field: the
+ * **field container** is the unit of focus for validation, not the `<input>`.
+ *
+ * A function slot receives a `FieldSlotController` so it can set the value
+ * without importing the form store. Because `setValue` routes through the
+ * field's change handler, a generated value clears any pre-existing error.
+ *
+ * The play function reproduces the original bug (a "Generate" button leaving a
+ * stale "cannot be empty" error) and proves it no longer happens — for the
+ * keyboard path: tabbing input → button does not validate, and there is no
+ * error flash.
+ */
+export const SlotControllerNoStaleError: Story = {
+  name: 'Slot controller — no stale validation error',
+  render: () => (
+    <div className="max-w-lg">
+      <Form
+        onSubmit={(data) => {
+          action('form-submitted')(data);
+          return { success: true };
+        }}
+      >
+        <Field
+          name="identifier"
+          label="Identifier"
+          hint="Generate an identifier, or type your own."
+          component={InputField}
+          required="Identifier cannot be empty"
+          suffixComponent={(field) => (
+            <Button
+              size="sm"
+              variant="text"
+              onClick={() => field.setValue('p-generated')}
+            >
+              Generate
+            </Button>
+          )}
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </Form>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox');
+    const generate = canvas.getByRole('button', { name: 'Generate' });
+
+    // Touch the required field, then leave it empty.
+    await userEvent.click(input);
+    await userEvent.type(input, 'x');
+    await userEvent.clear(input);
+
+    // Tab from the input to the in-field Generate button. Focus is still
+    // inside the field, so no validation fires — no error flash.
+    await userEvent.tab();
+    await expect(generate).toHaveFocus();
+    await expect(
+      canvas.queryByText('Identifier cannot be empty'),
+    ).not.toBeInTheDocument();
+
+    // Activate Generate from the keyboard → the value is set.
+    await userEvent.keyboard('{Enter}');
+    await expect(input).toHaveValue('p-generated');
+
+    // Tab out of the field → validates the now-valid value, still no error.
+    await userEvent.tab();
+    await expect(
+      canvas.queryByText('Identifier cannot be empty'),
+    ).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Slot controls (Generate buttons, clear, the number steppers) are real tab stops with native button semantics — no `tabindex=-1`, no `mousedown` preventDefault. With container-scoped validation, tabbing from the input to a slot control no longer mis-fires validation, and a function slot can set + validate the value via the injected `FieldSlotController`.',
+      },
+    },
+  },
+};
+
+/**
+ * `<input type="number">` already supports ArrowUp/ArrowDown stepping while
+ * focused, so the keyboard story is covered natively. The +/- buttons are
+ * redundant pointer affordances (`tabIndex=-1`), and because they are in-field
+ * controls, clicking them does not fire premature validation.
+ */
+export const NumberStepperKeyboard: Story = {
+  name: 'Number steppers — keyboard + no premature validation',
+  render: () => (
+    <div className="max-w-lg">
+      <Form
+        onSubmit={(data) => {
+          action('form-submitted')(data);
+          return { success: true };
+        }}
+      >
+        <Field
+          name="count"
+          label="Count"
+          component={InputField}
+          type="number"
+          required
+          min={0}
+          max={10}
+          initialValue="5"
+        />
+        <SubmitButton>Submit</SubmitButton>
+      </Form>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton');
+
+    // ArrowUp/ArrowDown step the value while the input is focused.
+    await userEvent.click(input);
+    await userEvent.keyboard('{ArrowUp}');
+    await expect(input).toHaveValue(6);
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}');
+    await expect(input).toHaveValue(4);
+
+    // The +/- buttons step the value too; being in-field controls, the focus
+    // move does not trigger premature validation.
+    await userEvent.click(canvas.getByLabelText('Increase value'));
+    await expect(input).toHaveValue(5);
+    await expect(
+      canvas.queryByText('You must answer this question before continuing.'),
+    ).not.toBeInTheDocument();
   },
 };

--- a/packages/fresco-ui/src/form/Field/Field.tsx
+++ b/packages/fresco-ui/src/form/Field/Field.tsx
@@ -6,6 +6,7 @@ import { useField } from '../hooks/useField';
 import type { FieldValue } from '../store/types';
 import { filterValidationProps } from '../validation/helpers';
 import { BaseField } from './BaseField';
+import { FieldControllerProvider } from './FieldController';
 import type { FieldProps, ValidFieldComponent } from './types';
 
 /**
@@ -27,18 +28,27 @@ export default function Field<C extends ValidFieldComponent>({
   validationContext,
   validateOnChange,
   validateOnChangeDelay,
+  validateOnControlBlur,
   component,
   disabled,
   readOnly,
   ...componentProps
 }: FieldProps<C>) {
-  const { id, containerProps, fieldProps, meta, validationSummary } = useField({
+  const {
+    id,
+    containerProps,
+    fieldProps,
+    meta,
+    controller,
+    validationSummary,
+  } = useField({
     name,
     initialValue: initialValue as FieldValue,
     showValidationHints,
     validationContext,
     validateOnChange,
     validateOnChangeDelay,
+    validateOnControlBlur,
     disabled,
     readOnly,
     // Pass validation props
@@ -70,7 +80,9 @@ export default function Field<C extends ValidFieldComponent>({
       showErrors={meta.shouldShowError}
       containerProps={containerProps}
     >
-      {createElement(component, mergedProps)}
+      <FieldControllerProvider controller={controller}>
+        {createElement(component, mergedProps)}
+      </FieldControllerProvider>
     </BaseField>
   );
 }

--- a/packages/fresco-ui/src/form/Field/FieldController.tsx
+++ b/packages/fresco-ui/src/form/Field/FieldController.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, type ReactNode, useContext } from 'react';
+
+import type { FieldSlotController } from './types';
+
+const FieldControllerContext = createContext<FieldSlotController | null>(null);
+
+/**
+ * Access the controller for the enclosing Field from a control rendered in one
+ * of its slots. Returns `null` when used outside a Field (e.g. a field
+ * component rendered standalone), so function slots can no-op gracefully.
+ */
+export function useFieldController(): FieldSlotController | null {
+  return useContext(FieldControllerContext);
+}
+
+export function FieldControllerProvider({
+  controller,
+  children,
+}: {
+  controller: FieldSlotController;
+  children: ReactNode;
+}) {
+  return (
+    <FieldControllerContext.Provider value={controller}>
+      {children}
+    </FieldControllerContext.Provider>
+  );
+}

--- a/packages/fresco-ui/src/form/Field/types.ts
+++ b/packages/fresco-ui/src/form/Field/types.ts
@@ -182,8 +182,9 @@ export type CreateFormFieldProps<
  * two usage patterns:
  *
  * 1. **Within Field** (primary pattern): Field always provides these props
- *    via useField hook. Components receive id, name, onBlur, aria-describedby,
- *    etc. automatically.
+ *    via useField hook. Components receive id, name, aria-describedby, etc.
+ *    automatically. (Validation-on-blur is handled at the field container,
+ *    so onBlur is not injected.)
  *
  * 2. **Standalone** (secondary pattern): Components like InputField, SelectField,
  *    and ToggleField are sometimes used outside of Field for simple controlled
@@ -198,6 +199,12 @@ export type CreateFormFieldProps<
 export type InjectedFieldProps = {
   'id'?: string;
   'name'?: string;
+  /**
+   * Validate-on-blur is now container-scoped: Field listens for focusout on
+   * the field container, so components no longer need to forward a blur to
+   * their focusable element to drive validation. This remains available for
+   * standalone use (a native blur passed by a consumer outside Field).
+   */
   'onBlur'?: (e: React.FocusEvent) => void;
   'aria-required'?: boolean;
   'aria-invalid'?: boolean;
@@ -215,6 +222,28 @@ export type InjectedFieldProps = {
 export type FieldValueProps<V extends FieldValue> = {
   value?: V | undefined;
   onChange?: (value: V | undefined) => void;
+};
+
+/**
+ * Handle a control rendered inside a field's slot (e.g. a prefix/suffix
+ * "Generate" button) can use to read and set the field's value without
+ * importing the form store or knowing the field name. Delivered to function
+ * slots via FieldController context.
+ */
+export type FieldSlotController = {
+  /** Fully-resolved field name (including any namespace prefix). */
+  name: string;
+  /** Current field value. */
+  value: FieldValue;
+  /**
+   * Set the field value. Routes through the field's change handler, so a
+   * pre-existing error clears immediately once the field has been blurred.
+   */
+  setValue: (value: FieldValue) => void;
+  /** Validate the field now. */
+  validate: () => void;
+  /** Move DOM focus to the field's primary input. */
+  focusInput: () => void;
 };
 
 /**
@@ -262,6 +291,12 @@ type FieldOwnProps<C extends ValidFieldComponent> = {
    * @default 300
    */
   validateOnChangeDelay?: number;
+  /**
+   * Escape hatch: validate when focus moves to an in-field control instead of
+   * only when focus leaves the whole field.
+   * @default false
+   */
+  validateOnControlBlur?: boolean;
 };
 
 /**

--- a/packages/fresco-ui/src/form/fields/DatePicker.tsx
+++ b/packages/fresco-ui/src/form/fields/DatePicker.tsx
@@ -149,8 +149,6 @@ export default function DatePickerField(props: DatePickerFieldProps) {
     }
   };
 
-  const onBlur = rest.onBlur;
-
   if (resolutionType === 'month') {
     return (
       <div className="flex gap-2">
@@ -163,7 +161,6 @@ export default function DatePickerField(props: DatePickerFieldProps) {
           onChange={(selectValue) =>
             handleChange(String(selectValue), undefined)
           }
-          onBlur={onBlur}
           disabled={disabled ?? readOnly}
           aria-invalid={rest['aria-invalid']}
           className="w-fit"
@@ -177,7 +174,6 @@ export default function DatePickerField(props: DatePickerFieldProps) {
           onChange={(selectValue) =>
             handleChange(undefined, String(selectValue))
           }
-          onBlur={onBlur}
           disabled={disabled ?? readOnly ?? !selectedYear}
           aria-invalid={rest['aria-invalid']}
           className="w-fit"
@@ -194,7 +190,6 @@ export default function DatePickerField(props: DatePickerFieldProps) {
         placeholder="Year"
         value={value}
         onChange={(v) => onChange?.(String(v))}
-        onBlur={onBlur}
         name={name ?? 'year'}
         disabled={disabled ?? readOnly}
         aria-invalid={rest['aria-invalid']}
@@ -211,7 +206,6 @@ export default function DatePickerField(props: DatePickerFieldProps) {
       max={max}
       value={value}
       onChange={(v) => onChange?.(String(v))}
-      onBlur={onBlur}
       name={name ?? ''}
       placeholder={placeholder}
       className={cx(

--- a/packages/fresco-ui/src/form/fields/InputField.tsx
+++ b/packages/fresco-ui/src/form/fields/InputField.tsx
@@ -15,8 +15,17 @@ import {
   wrapperPaddingVariants,
 } from '../../styles/controlVariants';
 import { compose, cva, cx, type VariantProps } from '../../utils/cva';
-import type { CreateFormFieldProps } from '../Field/types';
+import { useFieldController } from '../Field/FieldController';
+import type { CreateFormFieldProps, FieldSlotController } from '../Field/types';
 import { getInputState } from '../utils/getInputState';
+
+/**
+ * A prefix/suffix slot is either static content or a render function that
+ * receives the enclosing Field's controller (so a "Generate" button can set
+ * the value without importing the form store). Function slots no-op when
+ * InputField is used standalone, outside a Field.
+ */
+type InputFieldSlot = ReactNode | ((field: FieldSlotController) => ReactNode);
 
 const inputWrapperVariants = compose(
   heightVariants,
@@ -42,6 +51,21 @@ const inputWrapperVariants = compose(
       // `<input>` (see `inputVariants` below), text is clipped inside
       // a container-sized field instead of blowing out the layout.
       'w-auto shrink-0',
+      // Focus indication is one ring per focused element: the wrapper's
+      // `focus-styles` ring (from the composed `interactiveStateVariants`) is
+      // the inner <input>'s proxy — the input sets `focus:ring-0` and has none
+      // of its own. Slot controls render their own design-system focus ring
+      // (`Button`/`IconButton` use `focusable`), so the wrapper deliberately
+      // does NOT add a second ring on slot focus, which would double-ring.
+      //
+      // The wrapper clips to its rounded corners (`overflow-hidden` from
+      // `controlVariants`, needed for child backgrounds such as the number
+      // steppers). A focused slot button's offset ring (outline-offset-3 +
+      // outline-2 = 5px) exceeds the ~4px vertical clearance and would be
+      // clipped, so un-clip while a slot control is focus-visible — the ring
+      // then paints in full. Steppers are `tabIndex={-1}` so they never match
+      // `:focus-visible`, and number fields keep their clipped corners.
+      'has-[button:focus-visible]:overflow-visible',
       // Child buttons should have reduced height, but their icons should stay the same size
       '[&_button]:h-10',
     ),
@@ -89,8 +113,8 @@ type InputFieldProps = CreateFormFieldProps<
   'input',
   {
     size?: VariantProps<typeof textSizeVariants>['size'];
-    prefixComponent?: ReactNode;
-    suffixComponent?: ReactNode;
+    prefixComponent?: InputFieldSlot;
+    suffixComponent?: InputFieldSlot;
     // Forwards the native React ChangeEvent to the caller. Needed when
     // InputField is used as a base-ui `render` prop (e.g. Combobox.Input),
     // because base-ui's internal onChange handler expects the full event
@@ -103,8 +127,8 @@ type InputFieldProps = CreateFormFieldProps<
 const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
   function InputField(props, ref) {
     const {
-      prefixComponent: prefix,
-      suffixComponent: suffix,
+      prefixComponent,
+      suffixComponent,
       size = 'md',
       className,
       value,
@@ -115,6 +139,18 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       readOnly,
       ...inputProps
     } = props;
+
+    // Function slots resolve against the enclosing Field's controller; outside
+    // a Field there is no controller, so they render nothing.
+    const fieldController = useFieldController();
+    const resolveSlot = (slot: InputFieldSlot): ReactNode =>
+      typeof slot === 'function'
+        ? fieldController
+          ? slot(fieldController)
+          : null
+        : slot;
+    const prefix = resolveSlot(prefixComponent);
+    const suffix = resolveSlot(suffixComponent);
 
     const internalRef = useRef<HTMLInputElement>(null);
     const isNumber = type === 'number';

--- a/packages/fresco-ui/src/form/fields/RelativeDatePicker.tsx
+++ b/packages/fresco-ui/src/form/fields/RelativeDatePicker.tsx
@@ -55,7 +55,6 @@ export default function RelativeDatePickerField(
       max={maxYmd}
       value={value}
       onChange={(inputValue) => onChange?.(String(inputValue))}
-      onBlur={rest.onBlur}
       name={name ?? ''}
       placeholder={placeholder}
       className={cx(

--- a/packages/fresco-ui/src/form/fields/RichTextEditor.tsx
+++ b/packages/fresco-ui/src/form/fields/RichTextEditor.tsx
@@ -237,7 +237,6 @@ export default function RichTextEditorField({
   name,
   value,
   onChange,
-  onBlur,
   disabled,
   readOnly,
   toolbarOptions,
@@ -358,11 +357,7 @@ export default function RichTextEditorField({
         state: getInputState({ disabled, readOnly, ...props }),
       })}
     >
-      <EditorContent
-        editor={editor}
-        className={editorContentStyles}
-        onBlur={onBlur}
-      />
+      <EditorContent editor={editor} className={editorContentStyles} />
       {hasToolbar && (
         <Toolbar.Root className={toolbarStyles}>
           {showTextFormatting && (

--- a/packages/fresco-ui/src/form/fields/SegmentedCodeField.tsx
+++ b/packages/fresco-ui/src/form/fields/SegmentedCodeField.tsx
@@ -110,7 +110,6 @@ function SegmentedCodeField(props: SegmentedCodeFieldProps) {
     disabled,
     readOnly,
     className,
-    onBlur,
     id,
     autoFocus,
     name: _name,
@@ -121,7 +120,6 @@ function SegmentedCodeField(props: SegmentedCodeFieldProps) {
   void _name;
 
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
-  const groupRef = useRef<HTMLFieldSetElement>(null);
   const { pattern, inputMode } = CHARACTER_SETS[characterSet];
 
   const chars = value.split('').slice(0, segments);
@@ -262,7 +260,6 @@ function SegmentedCodeField(props: SegmentedCodeFieldProps) {
 
   return (
     <fieldset
-      ref={groupRef}
       className={cx(segmentGroupVariants({ size }), className)}
       aria-label={rest['aria-describedby'] ? undefined : 'Code input'}
     >
@@ -301,16 +298,6 @@ function SegmentedCodeField(props: SegmentedCodeFieldProps) {
             onKeyDown={(e) => handleKeyDown(i, e)}
             onPaste={(e) => handlePaste(i, e)}
             onFocus={handleFocus}
-            onBlur={(e) => {
-              // Only report blur to the form (which validates) when focus
-              // leaves the whole group — not on the automatic focus moves
-              // between segments, which would validate the half-typed code.
-              const next = e.relatedTarget;
-              if (next instanceof Node && groupRef.current?.contains(next)) {
-                return;
-              }
-              onBlur?.(e);
-            }}
           />
           {separatorSet.has(i) && (
             <span className={separatorVariants({ size })} aria-hidden="true">

--- a/packages/fresco-ui/src/form/fields/TextArea.tsx
+++ b/packages/fresco-ui/src/form/fields/TextArea.tsx
@@ -39,8 +39,7 @@ type TextAreaFieldProps = CreateFormFieldProps<string, 'textarea'> &
 
 const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
   function TextAreaField(props, ref) {
-    const { className, value, onChange, onBlur, disabled, readOnly, ...rest } =
-      props;
+    const { className, value, onChange, disabled, readOnly, ...rest } = props;
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       onChange?.(e.target.value);
@@ -57,7 +56,6 @@ const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
           ref={ref}
           {...rest}
           value={value ?? ''}
-          onBlur={onBlur}
           disabled={disabled}
           readOnly={readOnly}
           onChange={handleChange}

--- a/packages/fresco-ui/src/form/fields/ToggleField.tsx
+++ b/packages/fresco-ui/src/form/fields/ToggleField.tsx
@@ -121,7 +121,6 @@ export default function ToggleField(props: ToggleFieldProps) {
     onChange,
     disabled,
     readOnly,
-    onBlur,
     'aria-required': ariaRequired,
     'aria-invalid': ariaInvalid,
     'aria-describedby': ariaDescribedBy,
@@ -146,7 +145,6 @@ export default function ToggleField(props: ToggleFieldProps) {
       aria-describedby={ariaDescribedBy}
       aria-disabled={ariaDisabled}
       aria-readonly={ariaReadonly}
-      onBlur={onBlur}
       id={id}
       name={name}
       nativeButton

--- a/packages/fresco-ui/src/form/fields/__tests__/InputFieldContainerValidation.test.tsx
+++ b/packages/fresco-ui/src/form/fields/__tests__/InputFieldContainerValidation.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Field from '../../Field/Field';
+import type { FieldSlotController } from '../../Field/types';
+import FormStoreProvider from '../../store/formStoreProvider';
+import InputField from '../InputField';
+
+const EMPTY_ERROR = 'Identifier cannot be empty';
+
+function renderFieldWithGenerate() {
+  const utils = render(
+    <FormStoreProvider>
+      <Field
+        name="identifier"
+        label="Identifier"
+        component={InputField}
+        required={EMPTY_ERROR}
+        suffixComponent={(field: FieldSlotController) => (
+          <button type="button" onClick={() => field.setValue('p-123')}>
+            Generate
+          </button>
+        )}
+      />
+    </FormStoreProvider>,
+  );
+
+  const input = utils.container.querySelector('input[name="identifier"]');
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('identifier input not rendered');
+  }
+  const generate = screen.getByRole('button', { name: 'Generate' });
+  return { input, generate };
+}
+
+/** Type a character then clear it, leaving the field dirty and empty. */
+function touchThenEmpty(input: HTMLInputElement) {
+  fireEvent.change(input, { target: { value: 'x' } });
+  fireEvent.change(input, { target: { value: '' } });
+}
+
+describe('Field container-scoped validation with an in-field control', () => {
+  it('does not validate when focus moves from the input to a slot button', async () => {
+    const { input, generate } = renderFieldWithGenerate();
+
+    touchThenEmpty(input);
+    // Focus moves to the in-field Generate button — the field is still active.
+    fireEvent.blur(input, { relatedTarget: generate });
+
+    // Give any (unexpected) async validation a chance to surface an error.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(
+      screen.queryByTestId('identifier-field-error'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('setValue from the slot populates the field without leaving a stale error', async () => {
+    const { input, generate } = renderFieldWithGenerate();
+
+    touchThenEmpty(input);
+    fireEvent.blur(input, { relatedTarget: generate });
+    fireEvent.click(generate);
+
+    await waitFor(() => expect(input).toHaveValue('p-123'));
+    expect(
+      screen.queryByTestId('identifier-field-error'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('validates when focus leaves the whole field', async () => {
+    const { input } = renderFieldWithGenerate();
+    // An element outside the field container receives focus.
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    touchThenEmpty(input);
+    fireEvent.blur(input, { relatedTarget: outside });
+
+    const error = await screen.findByTestId('identifier-field-error');
+    expect(error).toHaveTextContent(EMPTY_ERROR);
+
+    outside.remove();
+  });
+
+  it('setValue clears a pre-existing error once the field has been blurred', async () => {
+    const { input, generate } = renderFieldWithGenerate();
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+
+    // Blur out of the field with an empty value → error appears.
+    touchThenEmpty(input);
+    fireEvent.blur(input, { relatedTarget: outside });
+    await screen.findByTestId('identifier-field-error');
+
+    // Generating a valid value routes through the change handler, which
+    // revalidates because the field was already blurred.
+    fireEvent.click(generate);
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('identifier-field-error'),
+      ).not.toBeInTheDocument(),
+    );
+    expect(input).toHaveValue('p-123');
+
+    outside.remove();
+  });
+});

--- a/packages/fresco-ui/src/form/hooks/useField.ts
+++ b/packages/fresco-ui/src/form/hooks/useField.ts
@@ -2,7 +2,11 @@ import { debounce } from 'es-toolkit';
 import { type ReactNode, useCallback, useEffect, useId, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-import type { FieldValue, ValidationPropsCatalogue } from '../Field/types';
+import type {
+  FieldSlotController,
+  FieldValue,
+  ValidationPropsCatalogue,
+} from '../Field/types';
 import { useFieldNamespace } from '../FieldNamespace';
 import type { FieldState, ValidationContext } from '../store/types';
 import { validationPropKeys } from '../validation/functions';
@@ -60,11 +64,14 @@ type UseFieldResult = {
   };
   containerProps: {
     'data-field-name': string; // Used for scrolling to field errors
+    // Validate-on-blur is scoped to the whole field: this fires on focusout
+    // bubbling from any descendant, so moving focus to an in-field control
+    // (a slot button, a sibling radio…) does not validate prematurely.
+    'onBlur': (e: React.FocusEvent<HTMLElement>) => void;
   };
   fieldProps: {
     'value': FieldValue;
     'onChange': (value: FieldValue) => void;
-    'onBlur': (e: React.FocusEvent) => void;
     'disabled': boolean;
     'readOnly': boolean;
     'aria-required': boolean; // Indicates if the field is required
@@ -73,6 +80,11 @@ type UseFieldResult = {
     'aria-disabled': boolean; // Indicates if the field is disabled
     'aria-readonly': boolean; // Indicates if the field is read-only
   };
+  /**
+   * Handle for controls rendered inside the field (slot buttons, etc.) to read
+   * and set the value. Field delivers this to function slots via context.
+   */
+  controller: FieldSlotController;
   validationSummary?: ReactNode;
 };
 
@@ -101,6 +113,12 @@ type UseFieldConfig = {
    * @default 300
    */
   validateOnChangeDelay?: number;
+  /**
+   * Escape hatch: validate when focus moves to an in-field control (a slot
+   * button, a sibling control…) instead of only when focus leaves the whole
+   * field. Off by default — the field is the unit of focus.
+   */
+  validateOnControlBlur?: boolean;
 } & Partial<ValidationPropsCatalogue>;
 
 export function useField(config: UseFieldConfig): UseFieldResult {
@@ -224,18 +242,26 @@ export function useField(config: UseFieldConfig): UseFieldResult {
     ],
   );
 
-  const handleBlur = useCallback(
-    (e: React.FocusEvent) => {
-      // Skip validation if clicking on a dialog close element
-      const relatedTarget = e.relatedTarget;
-      if (relatedTarget?.hasAttribute('data-dialog-close')) {
+  const handleContainerBlur = useCallback(
+    (e: React.FocusEvent<HTMLElement>) => {
+      // Focus moved to another control inside this field (a slot button, a
+      // stepper, a sibling radio…) → the field is still active; don't validate
+      // yet. The escape hatch validates on in-field focus moves anyway.
+      if (
+        !config.validateOnControlBlur &&
+        e.currentTarget.contains(e.relatedTarget)
+      ) {
         return;
       }
 
-      // Skip validation if this field is inside a dialog that's closing
-      const target = e.target as HTMLElement;
-      const parentDialog = target.closest('dialog');
-      if (parentDialog && !parentDialog.open) {
+      // Skip validation if focus is going to a dialog close affordance.
+      if (e.relatedTarget?.hasAttribute('data-dialog-close')) {
+        return;
+      }
+
+      // Skip validation if this field is inside a dialog that's closing.
+      const dialog = e.currentTarget.closest('dialog');
+      if (dialog && !dialog.open) {
         return;
       }
 
@@ -248,11 +274,37 @@ export function useField(config: UseFieldConfig): UseFieldResult {
         void validateField(resolvedName);
       }
     },
-    [resolvedName, config.validateOnChange, setFieldBlurred, validateField],
+    [
+      resolvedName,
+      config.validateOnChange,
+      config.validateOnControlBlur,
+      setFieldBlurred,
+      validateField,
+    ],
   );
 
   // Show invalid styling when showing error text - keep them in sync
   const showInvalid = shouldShowError;
+
+  // Fall back to initialValue only before the field is registered. Once
+  // registered, honour the stored value verbatim — including an explicit
+  // `undefined` from clearing the field.
+  const currentValue = fieldState ? fieldState.value : initialValue;
+
+  const controller = useMemo<FieldSlotController>(
+    () => ({
+      name: resolvedName,
+      value: currentValue,
+      setValue: handleChange,
+      validate: () => {
+        void validateField(resolvedName);
+      },
+      focusInput: () => {
+        document.getElementById(id)?.focus();
+      },
+    }),
+    [resolvedName, currentValue, handleChange, validateField, id],
+  );
 
   const result: UseFieldResult = {
     id,
@@ -267,16 +319,15 @@ export function useField(config: UseFieldConfig): UseFieldResult {
     },
     containerProps: {
       'data-field-name': resolvedName, // Used for scrolling to field errors
+      'onBlur': handleContainerBlur,
     },
     fieldProps: {
-      // Fall back to initialValue only before the field is registered. Once
-      // registered, honour the stored value verbatim — including an explicit
-      // `undefined` from clearing the field. Using `?? initialValue` here
-      // re-applied the initial value on every clear, so a field with an
+      // Honour the stored value verbatim once registered — including an
+      // explicit `undefined` from clearing the field. Using `?? initialValue`
+      // here re-applied the initial value on every clear, so a field with an
       // initialValue could never be cleared.
-      'value': fieldState ? fieldState.value : initialValue,
+      'value': currentValue,
       'onChange': handleChange,
-      'onBlur': handleBlur,
       'disabled': isDisabled ?? false,
       'readOnly': isReadOnly ?? false,
       'aria-required': !!validationProps.required,
@@ -293,6 +344,7 @@ export function useField(config: UseFieldConfig): UseFieldResult {
        */
       'aria-describedby': `${id}-hint ${id}-error`.trim(),
     },
+    controller,
     validationSummary,
   };
 


### PR DESCRIPTION
Closes complexdatacollective/network-canvas-monorepo#701

Controls in a field's prefix/suffix slot (Generate buttons, clear, the number steppers) are part of the field *conceptually* but were not *mechanically*: `useField`/`InputField` validate-on-blur keyed off the inner `<input>`'s blur, so moving focus to an in-field control was treated as "leaving the field" and left a **stale error** (e.g. *"Identifier cannot be empty"* on a field that was just populated). This makes the **field container the unit of focus** for both validation and styling, and gives slots a first-class way to set the value.

## Changes

- **Container-scoped validation** (`useField`): a `handleContainerBlur` on the field container skips validation when focus moves to a descendant control (`e.currentTarget.contains(e.relatedTarget)`); `onBlur` moved from `fieldProps` to `containerProps`. Single-control fields behave identically; multi-control fields (RadioGroup, Combobox, DatePicker…) get strictly better behaviour (intra-widget focus moves no longer mis-fire validation).
- **Slot field controller** (`InputField`): `prefixComponent`/`suffixComponent` now also accept a render function `(field) => ReactNode` receiving a `FieldSlotController` (`{ name, value, setValue, validate, focusInput }`), so a slot control can set + validate the value without importing the form store. Delivered via the new `useFieldController` hook / `FieldController` context. The plain `ReactNode` form is unchanged (additive, opt-in). Because `setValue` routes through the change handler, a generated value clears a pre-existing error.
- **Focus indication**: slot controls stay real tab stops with native button semantics and render their own design-system focus ring (`Button`/`IconButton` already do) — one ring per focused element, no double-ring. The `InputField` wrapper un-clips (`overflow-visible`) while a slot control is focus-visible so its offset ring isn't clipped by the rounded container.
- **Escape hatch**: `validateOnControlBlur` on `Field` restores validation when focus moves to an in-field control.
- **Audit**: removed now-dead injected `onBlur` forwarding from `TextArea`, `ToggleField`, `DatePicker`, `RelativeDatePicker`, `RichTextEditor`, and `SegmentedCodeField`'s hand-rolled blur containment (the container now owns it). `RichTextEditor` keeps tiptap's own value-commit `onBlur`.

## Tests

- **Unit** (`InputFieldContainerValidation.test.tsx`): touch-then-empty → focus a slot button → no stale error; `setValue` populates without a stale error; leaving the whole field validates; `setValue` clears a pre-existing error once blurred.
- **Storybook** (`Field.stories.tsx`): keyboard regression (Tab input→Generate→no error flash→activate→Tab out) and number-stepper keyboard; documents the keyboard model.

## Verification

`pnpm typecheck`, `pnpm knip`, lint/format, and the fresco-ui unit suite (671 passing) are green. The focus-ring clipping fix was verified in Storybook: simulating the ring under `overflow: hidden` shows it clipped top/bottom; `overflow: visible` shows it wrapping the button fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)