### PR TITLE
feat(interview): add server-safe @codaco/interview/contract entry

### DIFF
--- a/.changeset/interview-server-safe-contract.md
+++ b/.changeset/interview-server-safe-contract.md
@@ -1,0 +1,17 @@
+---
+'@codaco/interview': minor
+---
+
+Add a server-safe `@codaco/interview/contract` entry point.
+
+Importing anything from the package root evaluates the React component graph
+(`Shell` and its module-level `createContext` calls), which throws when pulled
+into a server / React Server Component build. The new `@codaco/interview/contract`
+subpath is bundled separately and re-exports only the React-free contract — the
+`createInitialNetwork` and `isValidAssetType` utilities and the public payload /
+handler types — so host servers can import them without evaluating any React
+code.
+
+`createInitialNetwork` now lives in `src/contract/` alongside `isValidAssetType`
+(a single definition, still re-exported from the package root for existing
+consumers). No runtime behaviour changes for existing imports.

--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,7 @@
     },
     "packages/interview": {
       "entry": [
+        "src/contract/index.ts",
         "src/**/*.stories.tsx",
         "e2e/specs/**/*.ts",
         "e2e/host/src/main.tsx",

--- a/packages/interview/e2e/host/src/mockCallbacks.test.ts
+++ b/packages/interview/e2e/host/src/mockCallbacks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { createInitialNetwork } from '../../../src/contract/network';
 import type { SessionPayload } from '../../../src/contract/types';
-import { createInitialNetwork } from '../../../src/store/modules/session';
 import { makeMockAssetRequest, mockFinish, mockSync } from './mockCallbacks';
 
 function makeSession(): SessionPayload {

--- a/packages/interview/e2e/host/src/testHooks.ts
+++ b/packages/interview/e2e/host/src/testHooks.ts
@@ -1,10 +1,10 @@
 import { v4 as uuid } from 'uuid';
 
+import { createInitialNetwork } from '../../../src/contract/network';
 import type {
   ProtocolPayload,
   SessionPayload,
 } from '../../../src/contract/types';
-import { createInitialNetwork } from '../../../src/store/modules/session';
 
 const STORAGE_KEY = '__e2e_test_state';
 

--- a/packages/interview/package.json
+++ b/packages/interview/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./contract": {
+      "types": "./dist/contract.d.ts",
+      "default": "./dist/contract.js"
+    },
     "./styles.css": "./dist/styles.css"
   },
   "publishConfig": {

--- a/packages/interview/src/contract/index.ts
+++ b/packages/interview/src/contract/index.ts
@@ -1,0 +1,26 @@
+// Server-safe contract surface for @codaco/interview.
+//
+// Everything re-exported here is React-free, so this entry point can be
+// imported from server (React Server Component) code without evaluating the
+// package's component graph — importing the main entry pulls in `Shell` and
+// its module-level `createContext` calls, which throw in an RSC build.
+//
+// Runtime exports must come from React-free modules only (no `Shell`, no
+// `contexts`). Types are erased at compile time and are safe to re-export.
+
+export { isValidAssetType } from './assets';
+export { createInitialNetwork } from './network';
+
+export type {
+  AssetRequestHandler,
+  FinishHandler,
+  InterviewAnalyticsMetadata,
+  InterviewerFlags,
+  InterviewPayload,
+  ProtocolPayload,
+  ResolvedAsset,
+  SessionPayload,
+  StepChangeHandler,
+  StepChangeMeta,
+  SyncHandler,
+} from './types';

--- a/packages/interview/src/contract/network.ts
+++ b/packages/interview/src/contract/network.ts
@@ -1,0 +1,23 @@
+import { v4 as uuid } from 'uuid';
+
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcNetwork,
+} from '@codaco/shared-consts';
+
+/**
+ * The empty network a host assigns to a freshly created interview.
+ *
+ * Lives in `contract/` (not the store) so it can be re-exported from the
+ * React-free `@codaco/interview/contract` entry point and imported by server
+ * (RSC) code without evaluating the package's React component graph.
+ */
+export const createInitialNetwork = (): NcNetwork => ({
+  ego: {
+    [entityPrimaryKeyProperty]: uuid(),
+    [entityAttributesProperty]: {},
+  },
+  nodes: [],
+  edges: [],
+});

--- a/packages/interview/src/index.ts
+++ b/packages/interview/src/index.ts
@@ -21,7 +21,7 @@ export type {
 // Runtime
 export { default as Shell, type NavigationOrientation } from './Shell';
 
-export { createInitialNetwork } from './store/modules/session';
+export { createInitialNetwork } from './contract/network';
 // Public utilities (consumed by sibling monorepo packages, e.g. network-exporters)
 export { getInterviewProgress } from './selectors/utils';
 export { getNodeLabelAttribute } from './utils/getNodeLabelAttribute';

--- a/packages/interview/src/interfaces/FamilyPedigree/__tests__/store.test.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/__tests__/store.test.ts
@@ -7,7 +7,8 @@ import {
   type NcEdge,
   type NcNode,
 } from '@codaco/shared-consts';
-import sessionReducer, { createInitialNetwork } from '~/store/modules/session';
+import { createInitialNetwork } from '~/contract/network';
+import sessionReducer from '~/store/modules/session';
 import type { useAppDispatch } from '~/store/store';
 
 import { createFamilyPedigreeStore, type VariableConfig } from '../store';

--- a/packages/interview/src/selectors/__tests__/session.test.ts
+++ b/packages/interview/src/selectors/__tests__/session.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest';
 import type { NodeDefinition } from '@codaco/protocol-validation';
 import type { DyadCensusMetadataItem } from '@codaco/shared-consts';
 
+import { createInitialNetwork } from '../../contract/network';
 import protocolReducer from '../../store/modules/protocol';
 import sessionReducer, {
-  createInitialNetwork,
   updateStageMetadata,
 } from '../../store/modules/session';
 import uiReducer from '../../store/modules/ui';

--- a/packages/interview/src/store/modules/__tests__/session.test.ts
+++ b/packages/interview/src/store/modules/__tests__/session.test.ts
@@ -8,11 +8,11 @@ import type {
   StageMetadata,
 } from '@codaco/shared-consts';
 
+import { createInitialNetwork } from '../../../contract/network';
 import sessionReducer, {
   addEdge,
   addNode,
   addNodeToPrompt,
-  createInitialNetwork,
   deleteNode,
   removeNodeFromPrompt,
   updateEdge,

--- a/packages/interview/src/store/modules/session.ts
+++ b/packages/interview/src/store/modules/session.ts
@@ -141,15 +141,6 @@ const actionTypes = {
   updateEgo: 'NETWORK/UPDATE_EGO' as const,
 };
 
-export const createInitialNetwork = (): NcNetwork => ({
-  ego: {
-    [entityPrimaryKeyProperty]: uuid(),
-    [entityAttributesProperty]: {},
-  },
-  nodes: [],
-  edges: [],
-});
-
 const initialState = {} as SessionState;
 
 type AddNodeArgs = {

--- a/packages/interview/vite.config.ts
+++ b/packages/interview/vite.config.ts
@@ -60,18 +60,25 @@ export default defineConfig({
     __PACKAGE_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
-    // Bundle to a single ESM entry rather than `preserveModules`. rolldown's
+    // Bundle to ESM entries rather than `preserveModules`. rolldown's
     // preserveModules rewrites inter-module specifiers from the emitted file
     // paths, and on Windows that leaks source extensions / mismatched paths
     // (e.g. `./Shell.tsx`, unresolved `./Shell.js`), breaking any consumer that
-    // bundles `dist/`. A single bundle has no inter-module specifiers to rewrite
-    // and so builds identically across platforms. CSS is unaffected — no JS here
-    // imports `.css`; `src/styles.css` is copied verbatim by cssCopyPlugin and
-    // consumed via the `./styles.css` export.
+    // bundles `dist/`. Bundled entries build identically across platforms. CSS
+    // is unaffected — no JS here imports `.css`; `src/styles.css` is copied
+    // verbatim by cssCopyPlugin and consumed via the `./styles.css` export.
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      // Two entries: the main (React) public API, and a server-safe `contract`
+      // bundle re-exporting only React-free utilities/types. The React code
+      // (`Shell`, contexts) is reachable only from `index`, so it never lands
+      // in the `contract` bundle — letting server (RSC) code import the
+      // contract without evaluating any module-level `createContext`.
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        contract: resolve(__dirname, 'src/contract/index.ts'),
+      },
       formats: ['es'],
-      fileName: 'index',
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
       // Bundle only this package's own files; externalize everything else —


### PR DESCRIPTION
## Problem

`@codaco/interview` builds to a single ESM bundle (`src/index.ts` → `dist/index.js`) that exports `Shell` alongside React-free utilities. That bundle evaluates React `createContext` at module top level (`AnalyticsContext`, `CurrentStepContext`, `StageMetadataContext`). As a result, importing **anything** from the package root — even the pure `createInitialNetwork` / `isValidAssetType` helpers — into a server / React Server Component module throws at build time:

```
TypeError: (0 , l.createContext) is not a function
```

In the RSC graph, `react` resolves to the server build which has no `createContext`. This blocks hosts (e.g. Fresco) from using these contract utilities in server actions / server components.

## Fix

Add a second, separately-bundled entry point `@codaco/interview/contract` that re-exports **only** the React-free contract:

- `createInitialNetwork` and `isValidAssetType` (runtime)
- the public payload / handler types (`InterviewPayload`, `ResolvedAsset`, `SyncHandler`, …)

Because the React code (`Shell`, contexts) is reachable only from the `index` entry, it never lands in the `contract` bundle. The emitted closure imports only `uuid` and `@codaco/shared-consts` — verified to contain no `createContext` / `react` reference.

`createInitialNetwork` moves from `store/modules/session.ts` into `src/contract/network.ts` (next to `isValidAssetType`), so it stays a **single definition**. The package root still re-exports it, so existing consumers are unaffected.

### Changes
- `src/contract/network.ts` — new home for `createInitialNetwork`
- `src/contract/index.ts` — server-safe entry
- `vite.config.ts` — two library entries (`index`, `contract`)
- `package.json` — `./contract` export
- internal `createInitialNetwork` imports repointed to `~/contract/network`

## Verification
- `pnpm --filter @codaco/interview build` → emits `dist/contract.js` + `dist/contract.d.ts`; the contract closure (`contract.js` + shared `network-*.js`) imports only `uuid` / `@codaco/shared-consts`, **no** `createContext`/`react`.
- `pnpm --filter @codaco/interview test` → 539 passed.
- `pnpm --filter @codaco/interview typecheck` → clean.

## Consumer follow-up
Fresco (complexdatacollective/Fresco#803) will import `createInitialNetwork` / `isValidAssetType` from `@codaco/interview/contract` once this releases, removing its temporary local shims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new server-safe import path for contract utilities and types, allowing server-side environments to use them without loading UI code.
  * Split the package build so the main app bundle and contract-only bundle are available separately.

* **Bug Fixes**
  * Improved compatibility with server and React Server Component builds by avoiding errors when importing contract-related code.
  * Kept existing imports working as before for current consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->