### PR TITLE
fix(architect-web): clip summary section headings and scale print text

### DIFF
--- a/apps/architect-web/src/lib/ProtocolSummary/components/Stage/SectionFrame.tsx
+++ b/apps/architect-web/src/lib/ProtocolSummary/components/Stage/SectionFrame.tsx
@@ -18,7 +18,7 @@ const SectionFrame = ({
   <div className={cx('mb-(--space-xl) last:mb-0', wrapperClassName)}>
     <div
       className={cx(
-        'border-platinum relative rounded border-2 px-(--space-md) pt-(--space-xl) pb-(--space-sm)',
+        'border-platinum relative overflow-hidden rounded border-2 px-(--space-md) pt-(--space-xl) pb-(--space-sm)',
         contentClassName,
       )}
     >

--- a/apps/architect-web/src/lib/ProtocolSummary/styles/protocol-summary.css
+++ b/apps/architect-web/src/lib/ProtocolSummary/styles/protocol-summary.css
@@ -20,7 +20,14 @@
 }
 
 @media print {
+  /* Scale the printed document to the summary's intended 12px base. The
+     surface's `--base-font-size` only re-bases inherited text; the summary's
+     headings/labels use rem-based Tailwind utilities tied to the root font
+     size, so overriding it here on the <html> element (which already reads
+     `font-size: var(--base-font-size)`) shrinks the whole document uniformly.
+     The app chrome is `print:hidden`, so this only affects the printed page. */
   .summary-view {
+    --base-font-size: 12px;
     overflow: visible;
     height: auto;
     width: auto;


### PR DESCRIPTION
## What changed

Two fixes to the **protocol summary page** in `architect-web`:

1. **Section headings no longer overflow the card's rounded corners.** The section heading bar is an `absolute top-0 left-0 w-full` element with square corners; its `rounded` container did not clip overflow, so the bar's corners poked past the card's rounded corners (see before screenshot). Added `overflow-hidden` to the container so the bar traces the card's curve. Because the bar's `bg-platinum` matches the card's `border-platinum`, the clipped result reads as a single seamless rounded header.

2. **Printed summary text scaled down to its intended base.** The summary surface already declared `--base-font-size: 12px`, but that variable only re-bases *inherited* text. The headings and labels use rem-based Tailwind utilities (`text-3xl`, `text-base`, …) tied to the root `<html>` font size (16px), so they never shrank — print came out larger than intended. `.summary-view` is the `<html>` element and `html { font-size: var(--base-font-size) }`, so overriding `--base-font-size` there inside `@media print` scales the whole printed document uniformly (text, spacing, and radii are all rem) to the intended 12px base — a ~25% reduction.

## Why

Reported visual bug: section headings overflowing the rounded section container, plus print text reading too large.

## Notes for reviewers

- **Print-scoped by design.** The font-size override lives in `@media print`. The app nav/chrome is `print:hidden`, so the printed page is the only thing affected; the on-screen editor nav keeps its normal scale (scaling the root on screen would shrink the global nav on just this route). Trade-off: the on-screen paper-card preview still renders at editor scale rather than the smaller print scale — easy to extend to screen too if WYSIWYG preview is preferred.
- The 12px value reuses the base the surface already declared, rather than introducing a new magic number; it's a single number to tune if a gentler reduction is wanted.
- No changeset: `@codaco/architect-web` is `private` and in the changeset `ignore` list.

Best verified via the browser's **print preview** (⌘P) on the protocol summary page.