### PR TITLE
feat(architect): automatic stage naming

### DIFF
--- a/.changeset/stage-label-required.md
+++ b/.changeset/stage-label-required.md
@@ -1,0 +1,8 @@
+---
+'@codaco/protocol-validation': minor
+---
+
+Stage labels are now required to be non-empty. The schema-8 stage `label` is
+validated as a required, non-empty string, and the v7→v8 migration backfills any
+stage with a missing, empty, or whitespace-only label with a positional default
+("Stage 1", "Stage 2", …) so existing protocols upgrade cleanly.

--- a/apps/architect-web/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageEditor.tsx
@@ -371,7 +371,11 @@ const StageEditor = (props: StageEditorProps) => {
         />
         <div className="px-4 sm:px-6">
           <div className="mx-auto w-full max-w-7xl">
-            <StageHeading stageNumber={stageNumber} totalStages={totalStages} />
+            <StageHeading
+              stageNumber={stageNumber}
+              totalStages={totalStages}
+              isNewStage={!isExistingStage}
+            />
             <div className="flex flex-col gap-10 pt-(--space-2xl)">
               {renderSections(sections)}
             </div>

--- a/apps/architect-web/src/components/StageEditor/StageHeading.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageHeading.tsx
@@ -76,13 +76,17 @@ const HeadingInput = ({
 type StageHeadingProps = {
   stageNumber: number;
   totalStages: number;
+  isNewStage: boolean;
 };
 
-const StageHeading = ({ stageNumber, totalStages }: StageHeadingProps) => {
-  const { values, initialValues } = useFormContext();
+const StageHeading = ({
+  stageNumber,
+  totalStages,
+  isNewStage,
+}: StageHeadingProps) => {
+  const { values } = useFormContext();
 
   const type = get(values, 'type') as string | undefined;
-  const isNewStage = !get(initialValues, 'label');
 
   const { onLabelBlur } = useAutoStageName(isNewStage);
 

--- a/apps/architect-web/src/components/StageEditor/StageHeading.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageHeading.tsx
@@ -29,6 +29,7 @@ type HeadingInputProps = {
   placeholder?: string;
   maxLength?: number;
   autoFocus?: boolean;
+  onFieldBlur?: () => void;
 };
 
 const HeadingInput = ({
@@ -37,13 +38,19 @@ const HeadingInput = ({
   placeholder,
   maxLength,
   autoFocus,
+  onFieldBlur,
 }: HeadingInputProps) => {
   const errorId = useId();
   const hasError = !!(meta.invalid && meta.touched && meta.error);
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    input.onBlur?.(event);
+    onFieldBlur?.();
+  };
   return (
     <>
       <input
         {...input}
+        onBlur={handleBlur}
         type="text"
         placeholder={placeholder}
         maxLength={maxLength}
@@ -77,7 +84,7 @@ const StageHeading = ({ stageNumber, totalStages }: StageHeadingProps) => {
   const type = get(values, 'type') as string | undefined;
   const isNewStage = !get(initialValues, 'label');
 
-  useAutoStageName(isNewStage);
+  const { onLabelBlur } = useAutoStageName(isNewStage);
 
   if (!type) {
     return null;
@@ -111,9 +118,10 @@ const StageHeading = ({ stageNumber, totalStages }: StageHeadingProps) => {
           Stage {stageNumber} of {totalStages}
         </p>
         <IssueAnchor fieldName="label" description="Stage name" />
-        <ValidatedField
+        <ValidatedField<{ onFieldBlur?: () => void }>
           name="label"
           component={HeadingInput}
+          componentProps={{ onFieldBlur: onLabelBlur }}
           placeholder="Enter stage name..."
           maxLength={50}
           validation={{ required: true }}

--- a/apps/architect-web/src/components/StageEditor/StageHeading.tsx
+++ b/apps/architect-web/src/components/StageEditor/StageHeading.tsx
@@ -10,6 +10,7 @@ import { cx } from '~/utils/cva';
 import { useFormContext } from '../Editor';
 import ValidatedField from '../Form/ValidatedField';
 import IssueAnchor from '../IssueAnchor';
+import { useAutoStageName } from './autoStageName/useAutoStageName';
 import { getInterface } from './Interfaces';
 
 type HeadingInputProps = {
@@ -75,6 +76,8 @@ const StageHeading = ({ stageNumber, totalStages }: StageHeadingProps) => {
 
   const type = get(values, 'type') as string | undefined;
   const isNewStage = !get(initialValues, 'label');
+
+  useAutoStageName(isNewStage);
 
   if (!type) {
     return null;

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts
@@ -66,7 +66,7 @@ describe('computeAutoNameUpdate', () => {
     ).toStrictEqual({ nextIsCustom: true });
   });
 
-  it('re-engages when the field is cleared', () => {
+  it('does not refill when the field is cleared mid-session (blur handles re-engage)', () => {
     expect(
       computeAutoNameUpdate({
         isNewStage: true,
@@ -75,7 +75,7 @@ describe('computeAutoNameUpdate', () => {
         lastGenerated: 'My stage',
         generatedLabel: 'Person Sociogram',
       }),
-    ).toStrictEqual({ nextIsCustom: false, label: 'Person Sociogram' });
+    ).toStrictEqual({ nextIsCustom: false });
   });
 
   it('does nothing when already in sync', () => {

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeAutoNameUpdate } from '../computeAutoNameUpdate';
+
+describe('computeAutoNameUpdate', () => {
+  it('never auto-names an existing stage', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: false,
+        isCustom: false,
+        liveLabel: 'Existing',
+        lastGenerated: undefined,
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('fills an empty label on first run', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: '',
+        lastGenerated: undefined,
+        generatedLabel: 'Form Name Generator',
+      }),
+    ).toStrictEqual({ nextIsCustom: false, label: 'Form Name Generator' });
+  });
+
+  it('updates the label when the generated name changes', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'Form Name Generator',
+        lastGenerated: 'Form Name Generator',
+        generatedLabel: 'Person Form Name Generator',
+      }),
+    ).toStrictEqual({
+      nextIsCustom: false,
+      label: 'Person Form Name Generator',
+    });
+  });
+
+  it('locks when the researcher types a custom value', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'My stage',
+        lastGenerated: 'Person Form Name Generator',
+        generatedLabel: 'Person Form Name Generator',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('stays locked once custom', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: true,
+        liveLabel: 'My stage',
+        lastGenerated: 'Person Form Name Generator',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('re-engages when the field is cleared', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: true,
+        liveLabel: '   ',
+        lastGenerated: 'My stage',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: false, label: 'Person Sociogram' });
+  });
+
+  it('does nothing when already in sync', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'Person Sociogram',
+        lastGenerated: 'Person Sociogram',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: false });
+  });
+});

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StageType } from '@codaco/protocol-validation';
+
+import {
+  composeStageName,
+  dedupeStageLabel,
+  generateStageLabel,
+  MAX_LABEL_LENGTH,
+  STAGE_TYPE_NAMES,
+} from '../generateStageLabel';
+
+describe('composeStageName', () => {
+  it('joins subject, type, and qualifier with spaces', () => {
+    expect(
+      composeStageName({
+        subjectName: 'Person',
+        typeName: 'Form Name Generator',
+        qualifier: 'with Roster Panels',
+      }),
+    ).toBe('Person Form Name Generator with Roster Panels');
+  });
+  it('omits empty subject and qualifier', () => {
+    expect(
+      composeStageName({
+        subjectName: null,
+        typeName: 'Ego Form',
+        qualifier: null,
+      }),
+    ).toBe('Ego Form');
+  });
+});
+
+describe('dedupeStageLabel', () => {
+  it('returns the base when free', () => {
+    expect(dedupeStageLabel('Person Sociogram', ['Other'])).toBe(
+      'Person Sociogram',
+    );
+  });
+  it('appends the lowest free number on collision, case-insensitively', () => {
+    expect(dedupeStageLabel('Person Sociogram', ['person sociogram'])).toBe(
+      'Person Sociogram #2',
+    );
+  });
+  it('fills numbering gaps', () => {
+    expect(dedupeStageLabel('A', ['A', 'A #3'])).toBe('A #2');
+  });
+});
+
+describe('generateStageLabel', () => {
+  it('builds a full name', () => {
+    expect(
+      generateStageLabel({
+        typeName: 'Form Name Generator',
+        subjectName: 'Person',
+        qualifier: {
+          full: 'with Roster Panels',
+          summary: 'with Roster Panels',
+        },
+        existingLabels: [],
+      }),
+    ).toBe('Person Form Name Generator with Roster Panels');
+  });
+  it('summarizes a listed qualifier when too long, before dropping the subject', () => {
+    const label = generateStageLabel({
+      typeName: 'Family Pedigree',
+      subjectName: 'Extended Family Member Person',
+      qualifier: {
+        full: 'with Diabetes, Hypertension & Coronary Heart Disease Nominations',
+        summary: 'with Nominations',
+      },
+      existingLabels: [],
+    });
+    expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+    expect(label).toContain('with Nominations');
+  });
+  it('never exceeds the length cap even with a dedup suffix', () => {
+    const long = 'X'.repeat(60);
+    const label = generateStageLabel({
+      typeName: long,
+      subjectName: null,
+      qualifier: null,
+      existingLabels: [long.slice(0, 50)],
+    });
+    expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+  });
+});
+
+describe('STAGE_TYPE_NAMES', () => {
+  it('has the expected concise names', () => {
+    const expected: Record<StageType, string> = {
+      NameGenerator: 'Form Name Generator',
+      NameGeneratorQuickAdd: 'Quick Add Name Generator',
+      NameGeneratorRoster: 'Roster Name Generator',
+      FamilyPedigree: 'Family Pedigree',
+      DyadCensus: 'Dyad Census',
+      OneToManyDyadCensus: 'One to Many Dyad Census',
+      TieStrengthCensus: 'Tie-Strength Census',
+      Sociogram: 'Sociogram',
+      Narrative: 'Narrative',
+      OrdinalBin: 'Ordinal Bin',
+      CategoricalBin: 'Categorical Bin',
+      AlterForm: 'Per Alter Form',
+      Geospatial: 'Geospatial',
+      AlterEdgeForm: 'Per Alter Edge Form',
+      EgoForm: 'Ego Form',
+      Information: 'Information',
+      Anonymisation: 'Anonymisation',
+    };
+    expect(STAGE_TYPE_NAMES).toStrictEqual(expected);
+  });
+});

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts
@@ -141,6 +141,8 @@ describe('resolveStageQualifier', () => {
         r,
       )?.full,
     ).toBe('with Video');
+    // Media types are emitted in a canonical order (Image, Video, Audio), so
+    // the same assets produce the same name regardless of item order.
     expect(
       resolveStageQualifier(
         {
@@ -152,7 +154,19 @@ describe('resolveStageQualifier', () => {
         },
         r,
       )?.full,
-    ).toBe('with Video & Image');
+    ).toBe('with Image & Video');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [
+            { id: 'i2', type: 'asset', content: 'a2' },
+            { id: 'i1', type: 'asset', content: 'a1' },
+          ],
+        },
+        r,
+      )?.full,
+    ).toBe('with Image & Video');
     expect(
       resolveStageQualifier(
         {

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildListQualifier,
+  resolveStageQualifier,
+  resolveStageSubjectName,
+} from '../resolveStageNameParts';
+
+const nameByType: Record<string, string> = {
+  person: 'Person',
+  friendship: 'Friendship',
+};
+const resolveEntityName = (_entity: 'node' | 'edge', type: string) =>
+  nameByType[type] ?? null;
+
+describe('resolveStageSubjectName', () => {
+  it('resolves a node subject', () => {
+    expect(
+      resolveStageSubjectName(
+        { entity: 'node', type: 'person' },
+        resolveEntityName,
+      ),
+    ).toBe('Person');
+  });
+  it('resolves an edge subject', () => {
+    expect(
+      resolveStageSubjectName(
+        { entity: 'edge', type: 'friendship' },
+        resolveEntityName,
+      ),
+    ).toBe('Friendship');
+  });
+  it('returns null for ego and for missing/unknown subjects', () => {
+    expect(
+      resolveStageSubjectName({ entity: 'ego' }, resolveEntityName),
+    ).toBeNull();
+    expect(resolveStageSubjectName(undefined, resolveEntityName)).toBeNull();
+    expect(
+      resolveStageSubjectName(
+        { entity: 'node', type: 'ghost' },
+        resolveEntityName,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('buildListQualifier', () => {
+  it('returns null for no values', () => {
+    expect(buildListQualifier([], { summaryNoun: 'Media' })).toBeNull();
+  });
+  it('lists up to three values with an ampersand', () => {
+    expect(
+      buildListQualifier(['Image', 'Video'], { summaryNoun: 'Media' }),
+    ).toStrictEqual({
+      full: 'with Image & Video',
+      summary: 'with Media',
+    });
+    expect(
+      buildListQualifier(['A', 'B', 'C'], { summaryNoun: 'Media' })?.full,
+    ).toBe('with A, B & C');
+  });
+  it('summarizes four or more values', () => {
+    expect(
+      buildListQualifier(['A', 'B', 'C', 'D'], { summaryNoun: 'Media' }),
+    ).toStrictEqual({
+      full: 'with Media',
+      summary: 'with Media',
+    });
+  });
+  it('applies singular/plural nouns and de-duplicates', () => {
+    expect(
+      buildListQualifier(['Diabetes'], {
+        singularNoun: 'Nomination',
+        pluralNoun: 'Nominations',
+        summaryNoun: 'Nominations',
+      })?.full,
+    ).toBe('with Diabetes Nomination');
+    expect(
+      buildListQualifier(['Diabetes', 'Diabetes', 'Asthma'], {
+        singularNoun: 'Nomination',
+        pluralNoun: 'Nominations',
+        summaryNoun: 'Nominations',
+      })?.full,
+    ).toBe('with Diabetes & Asthma Nominations');
+  });
+});
+
+describe('resolveStageQualifier', () => {
+  const resolvers = {
+    resolveAssetType: () => null,
+    resolveVariableName: () => null,
+  };
+
+  it('classifies name-generator panels by data source', () => {
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGenerator',
+          panels: [{ id: 'p1', title: 'A', dataSource: 'existing' }],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Network Panels');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGenerator',
+          panels: [{ id: 'p1', title: 'A', dataSource: 'roster-1' }],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Roster Panels');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGeneratorQuickAdd',
+          panels: [
+            { id: 'p1', title: 'A', dataSource: 'existing' },
+            { id: 'p2', title: 'B', dataSource: 'roster-1' },
+          ],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Panels');
+    expect(
+      resolveStageQualifier({ type: 'NameGenerator', panels: [] }, resolvers),
+    ).toBeNull();
+  });
+
+  it('lists Information asset media types via the manifest', () => {
+    const r = {
+      ...resolvers,
+      resolveAssetType: (id: string) => (id === 'a1' ? 'video' : 'image'),
+    };
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [{ id: 'i1', type: 'asset', content: 'a1' }],
+        },
+        r,
+      )?.full,
+    ).toBe('with Video');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [
+            { id: 'i1', type: 'asset', content: 'a1' },
+            { id: 'i2', type: 'asset', content: 'a2' },
+          ],
+        },
+        r,
+      )?.full,
+    ).toBe('with Video & Image');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [{ id: 'i1', type: 'text', content: 'hello' }],
+        },
+        r,
+      ),
+    ).toBeNull();
+  });
+
+  it('lists Family Pedigree nominated attribute names via the codebook', () => {
+    const r = {
+      ...resolvers,
+      resolveVariableName: (id: string) =>
+        id === 'v1' ? 'Diabetes' : 'Asthma',
+    };
+    expect(
+      resolveStageQualifier(
+        { type: 'FamilyPedigree', nominationPrompts: [{ variable: 'v1' }] },
+        r,
+      )?.full,
+    ).toBe('with Diabetes Nomination');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'FamilyPedigree',
+          nominationPrompts: [{ variable: 'v1' }, { variable: 'v2' }],
+        },
+        r,
+      )?.full,
+    ).toBe('with Diabetes & Asthma Nominations');
+  });
+
+  it('returns null for stage types without qualifiers', () => {
+    expect(resolveStageQualifier({ type: 'Sociogram' }, resolvers)).toBeNull();
+  });
+});

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
@@ -22,7 +22,10 @@ const protocol = {
   assetManifest: {},
 };
 
-function renderHeading(initialValues: Record<string, unknown>) {
+function renderHeading(
+  initialValues: Record<string, unknown>,
+  isNewStage = true,
+) {
   const store = configureStore({
     reducer: {
       form: formReducer,
@@ -32,7 +35,7 @@ function renderHeading(initialValues: Record<string, unknown>) {
   const utils = render(
     <Provider store={store}>
       <Editor form={formName} initialValues={initialValues} onSubmit={() => {}}>
-        <StageHeading stageNumber={1} totalStages={1} />
+        <StageHeading stageNumber={1} totalStages={1} isNewStage={isNewStage} />
       </Editor>
     </Provider>,
   );
@@ -57,7 +60,7 @@ function renderHeadingWithDraft(initialValues: Record<string, unknown>) {
   const utils = render(
     <Provider store={store}>
       <Editor form={formName} initialValues={initialValues} onSubmit={() => {}}>
-        <StageHeading stageNumber={1} totalStages={1} />
+        <StageHeading stageNumber={1} totalStages={1} isNewStage />
       </Editor>
     </Provider>,
   );
@@ -92,13 +95,23 @@ describe('useAutoStageName (wired into StageHeading)', () => {
   });
 
   it('does not auto-name an existing stage', async () => {
-    const { input } = renderHeading({
-      type: 'Sociogram',
-      id: 's1',
-      label: 'Hand named',
-    });
+    const { input } = renderHeading(
+      { type: 'Sociogram', id: 's1', label: 'Hand named' },
+      false,
+    );
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(input).toHaveValue('Hand named');
+  });
+
+  it('does not auto-name an existing stage with an empty label', async () => {
+    // Newness is determined by the absence of a stage id, not an empty label —
+    // so a hand-authored/migrated stage with an empty label is left untouched.
+    const { input } = renderHeading(
+      { type: 'Sociogram', id: 's1', label: '' },
+      false,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('');
   });
 
   it('leaves the field empty when cleared, then re-fills on blur', async () => {

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
@@ -7,6 +7,8 @@ import { change, reducer as formReducer } from 'redux-form';
 import { describe, expect, it } from 'vitest';
 
 import Editor from '~/components/Editor';
+import { stageEditorDraftListenerMiddleware } from '~/ducks/middleware/stageEditorDraftListener';
+import stageEditorDraft from '~/ducks/modules/stageEditorDraft';
 
 import { formName } from '../../configuration';
 import StageHeading from '../../StageHeading';
@@ -36,6 +38,31 @@ function renderHeading(initialValues: Record<string, unknown>) {
   );
   const input = utils.getByLabelText('Stage name') as HTMLInputElement;
   return { store, dispatch: store.dispatch as Dispatch<Action>, input };
+}
+
+// A store wired with the real draft reducer + listener, so the test can observe
+// the dirty/undo side effects of auto-naming (which the minimal store omits).
+function renderHeadingWithDraft(initialValues: Record<string, unknown>) {
+  const store = configureStore({
+    reducer: {
+      form: formReducer,
+      stageEditorDraft,
+      activeProtocol: () => ({ present: protocol }),
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }).prepend(
+        stageEditorDraftListenerMiddleware.middleware,
+      ),
+  });
+  const utils = render(
+    <Provider store={store}>
+      <Editor form={formName} initialValues={initialValues} onSubmit={() => {}}>
+        <StageHeading stageNumber={1} totalStages={1} />
+      </Editor>
+    </Provider>,
+  );
+  const input = utils.getByLabelText('Stage name') as HTMLInputElement;
+  return { store, input };
 }
 
 describe('useAutoStageName (wired into StageHeading)', () => {
@@ -72,5 +99,35 @@ describe('useAutoStageName (wired into StageHeading)', () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(input).toHaveValue('Hand named');
+  });
+
+  it('leaves the field empty when cleared, then re-fills on blur', async () => {
+    const { input } = renderHeading({ type: 'NameGenerator' });
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+
+    // Clearing does not instantly refill and fight the researcher.
+    fireEvent.change(input, { target: { value: '' } });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('');
+
+    // Blurring while still empty re-engages auto-naming.
+    fireEvent.blur(input);
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+  });
+
+  it('does not mark a new stage dirty or add undo history on entry', async () => {
+    const { store, input } = renderHeadingWithDraft({ type: 'NameGenerator' });
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+    // Wait out the draft debounce window to prove no snapshot is taken.
+    await new Promise((resolve) => setTimeout(resolve, 450));
+
+    const state = store.getState();
+    // No undo step seeded before the researcher has done anything.
+    expect(state.stageEditorDraft.history.past ?? []).toHaveLength(0);
+    // The auto-name was folded into the draft baseline, so the stage reads
+    // pristine: live form values equal the seeded baseline.
+    expect(state.form[formName]?.values).toEqual(
+      state.stageEditorDraft.ui.initialValues,
+    );
   });
 });

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
@@ -2,6 +2,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import type { Action, Dispatch } from 'redux';
 import { change, reducer as formReducer } from 'redux-form';
 import { describe, expect, it } from 'vitest';
 
@@ -34,34 +35,30 @@ function renderHeading(initialValues: Record<string, unknown>) {
     </Provider>,
   );
   const input = utils.getByLabelText('Stage name') as HTMLInputElement;
-  return { store, input };
+  return { store, dispatch: store.dispatch as Dispatch<Action>, input };
 }
 
 describe('useAutoStageName (wired into StageHeading)', () => {
   it('auto-names a new stage and refines as the subject is set', async () => {
-    const { store, input } = renderHeading({ type: 'NameGenerator' });
+    const { dispatch, input } = renderHeading({ type: 'NameGenerator' });
 
     await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
 
-    store.dispatch(
-      change(formName, 'subject', { entity: 'node', type: 'person' }),
-    );
+    dispatch(change(formName, 'subject', { entity: 'node', type: 'person' }));
     await waitFor(() =>
       expect(input).toHaveValue('Person Form Name Generator'),
     );
   });
 
   it('stops auto-naming once the researcher types a custom name', async () => {
-    const { store, input } = renderHeading({ type: 'NameGenerator' });
+    const { dispatch, input } = renderHeading({ type: 'NameGenerator' });
     await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
 
     // Replace the value in one change (mirrors selecting all then typing).
     fireEvent.change(input, { target: { value: 'My custom stage' } });
     await waitFor(() => expect(input).toHaveValue('My custom stage'));
 
-    store.dispatch(
-      change(formName, 'subject', { entity: 'node', type: 'person' }),
-    );
+    dispatch(change(formName, 'subject', { entity: 'node', type: 'person' }));
     // Give the effect a chance to (incorrectly) overwrite, then assert it didn't.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(input).toHaveValue('My custom stage');

--- a/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
@@ -1,0 +1,79 @@
+// __tests__/useAutoStageName.test.tsx
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { change, reducer as formReducer } from 'redux-form';
+import { describe, expect, it } from 'vitest';
+
+import Editor from '~/components/Editor';
+
+import { formName } from '../../configuration';
+import StageHeading from '../../StageHeading';
+
+const protocol = {
+  codebook: {
+    node: { person: { name: 'Person', color: 'node-1', variables: {} } },
+    edge: {},
+  },
+  stages: [{ id: 'other', type: 'Sociogram', label: 'An existing stage' }],
+  assetManifest: {},
+};
+
+function renderHeading(initialValues: Record<string, unknown>) {
+  const store = configureStore({
+    reducer: {
+      form: formReducer,
+      activeProtocol: () => ({ present: protocol }),
+    },
+  });
+  const utils = render(
+    <Provider store={store}>
+      <Editor form={formName} initialValues={initialValues} onSubmit={() => {}}>
+        <StageHeading stageNumber={1} totalStages={1} />
+      </Editor>
+    </Provider>,
+  );
+  const input = utils.getByLabelText('Stage name') as HTMLInputElement;
+  return { store, input };
+}
+
+describe('useAutoStageName (wired into StageHeading)', () => {
+  it('auto-names a new stage and refines as the subject is set', async () => {
+    const { store, input } = renderHeading({ type: 'NameGenerator' });
+
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+
+    store.dispatch(
+      change(formName, 'subject', { entity: 'node', type: 'person' }),
+    );
+    await waitFor(() =>
+      expect(input).toHaveValue('Person Form Name Generator'),
+    );
+  });
+
+  it('stops auto-naming once the researcher types a custom name', async () => {
+    const { store, input } = renderHeading({ type: 'NameGenerator' });
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+
+    // Replace the value in one change (mirrors selecting all then typing).
+    fireEvent.change(input, { target: { value: 'My custom stage' } });
+    await waitFor(() => expect(input).toHaveValue('My custom stage'));
+
+    store.dispatch(
+      change(formName, 'subject', { entity: 'node', type: 'person' }),
+    );
+    // Give the effect a chance to (incorrectly) overwrite, then assert it didn't.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('My custom stage');
+  });
+
+  it('does not auto-name an existing stage', async () => {
+    const { input } = renderHeading({
+      type: 'Sociogram',
+      id: 's1',
+      label: 'Hand named',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('Hand named');
+  });
+});

--- a/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
@@ -1,0 +1,36 @@
+export function computeAutoNameUpdate(args: {
+  isNewStage: boolean;
+  isCustom: boolean;
+  liveLabel: string;
+  lastGenerated: string | undefined;
+  generatedLabel: string;
+}): { nextIsCustom: boolean; label?: string } {
+  const { isNewStage, isCustom, liveLabel, lastGenerated, generatedLabel } =
+    args;
+
+  if (!isNewStage) {
+    return { nextIsCustom: true };
+  }
+
+  // Empty field (initial or cleared) re-engages auto-naming.
+  if (liveLabel.trim() === '') {
+    if (generatedLabel && generatedLabel !== liveLabel) {
+      return { nextIsCustom: false, label: generatedLabel };
+    }
+    return { nextIsCustom: false };
+  }
+
+  if (isCustom) {
+    return { nextIsCustom: true };
+  }
+
+  // A non-empty value we did not generate means the researcher took ownership.
+  if (liveLabel !== lastGenerated) {
+    return { nextIsCustom: true };
+  }
+
+  if (generatedLabel !== liveLabel) {
+    return { nextIsCustom: false, label: generatedLabel };
+  }
+  return { nextIsCustom: false };
+}

--- a/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
@@ -24,7 +24,10 @@ export function computeAutoNameUpdate(args: {
     return { nextIsCustom: true };
   }
 
-  // A non-empty value we did not generate means the researcher took ownership.
+  // A non-empty value that differs from what we last generated means the
+  // researcher took ownership. (Accepted limitation: typing exactly the current
+  // generated name reads as not-yet-owned, so a later config change will still
+  // overwrite it — harmless, since the value being replaced is identical.)
   if (liveLabel !== lastGenerated) {
     return { nextIsCustom: true };
   }

--- a/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts
@@ -12,9 +12,12 @@ export function computeAutoNameUpdate(args: {
     return { nextIsCustom: true };
   }
 
-  // Empty field (initial or cleared) re-engages auto-naming.
+  // An empty field that we have never auto-filled is the initial mount: fill it.
+  // Once we have generated at least once, an empty field means the researcher
+  // cleared it — leave it empty so clearing-to-rename isn't fought mid-keystroke;
+  // the hook's blur handler re-fills it if they leave it empty.
   if (liveLabel.trim() === '') {
-    if (generatedLabel && generatedLabel !== liveLabel) {
+    if (lastGenerated === undefined && generatedLabel) {
       return { nextIsCustom: false, label: generatedLabel };
     }
     return { nextIsCustom: false };

--- a/apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts
@@ -61,6 +61,31 @@ function truncateToWord(value: string, max: number): string {
   return trimmed || slice.trimEnd();
 }
 
+// Truncate the base *before* de-duplicating so the ` #n` suffix is never chopped
+// (a post-truncation slice could cut into a wide suffix like ` #10`, reviving a
+// collision). Shrink the budget by however much the deduped candidate overflows
+// until it fits within the cap.
+function fitTruncatedUniqueLabel(
+  base: string,
+  existingLabels: string[],
+): string {
+  let max = MAX_LABEL_LENGTH;
+  while (max > 0) {
+    const candidate = dedupeStageLabel(
+      truncateToWord(base, max),
+      existingLabels,
+    );
+    if (candidate.length <= MAX_LABEL_LENGTH) {
+      return candidate;
+    }
+    max -= candidate.length - MAX_LABEL_LENGTH;
+  }
+  return dedupeStageLabel(base.slice(0, 1), existingLabels).slice(
+    0,
+    MAX_LABEL_LENGTH,
+  );
+}
+
 export function generateStageLabel(input: {
   typeName: string;
   subjectName?: string | null;
@@ -108,6 +133,5 @@ export function generateStageLabel(input: {
   }
 
   const fallbackBase = candidates[candidates.length - 1] ?? typeName;
-  const truncated = truncateToWord(fallbackBase, MAX_LABEL_LENGTH - 4);
-  return dedupeStageLabel(truncated, existingLabels).slice(0, MAX_LABEL_LENGTH);
+  return fitTruncatedUniqueLabel(fallbackBase, existingLabels);
 }

--- a/apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts
@@ -1,0 +1,113 @@
+import type { StageType } from '@codaco/protocol-validation';
+
+export const MAX_LABEL_LENGTH = 50;
+
+export type Qualifier = { full: string; summary: string };
+
+export const STAGE_TYPE_NAMES: Record<StageType, string> = {
+  NameGenerator: 'Form Name Generator',
+  NameGeneratorQuickAdd: 'Quick Add Name Generator',
+  NameGeneratorRoster: 'Roster Name Generator',
+  FamilyPedigree: 'Family Pedigree',
+  DyadCensus: 'Dyad Census',
+  OneToManyDyadCensus: 'One to Many Dyad Census',
+  TieStrengthCensus: 'Tie-Strength Census',
+  Sociogram: 'Sociogram',
+  Narrative: 'Narrative',
+  OrdinalBin: 'Ordinal Bin',
+  CategoricalBin: 'Categorical Bin',
+  AlterForm: 'Per Alter Form',
+  Geospatial: 'Geospatial',
+  AlterEdgeForm: 'Per Alter Edge Form',
+  EgoForm: 'Ego Form',
+  Information: 'Information',
+  Anonymisation: 'Anonymisation',
+};
+
+export function composeStageName(parts: {
+  subjectName?: string | null;
+  typeName: string;
+  qualifier?: string | null;
+}): string {
+  return [parts.subjectName, parts.typeName, parts.qualifier]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join(' ');
+}
+
+export function dedupeStageLabel(
+  base: string,
+  existingLabels: string[],
+): string {
+  const taken = new Set(
+    existingLabels.map((label) => label.trim().toLowerCase()),
+  );
+  if (!taken.has(base.trim().toLowerCase())) {
+    return base;
+  }
+  let suffix = 2;
+  while (taken.has(`${base} #${suffix}`.toLowerCase())) {
+    suffix += 1;
+  }
+  return `${base} #${suffix}`;
+}
+
+function truncateToWord(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  const slice = value.slice(0, max);
+  const lastSpace = slice.lastIndexOf(' ');
+  const trimmed = (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd();
+  return trimmed || slice.trimEnd();
+}
+
+export function generateStageLabel(input: {
+  typeName: string;
+  subjectName?: string | null;
+  qualifier?: Qualifier | null;
+  existingLabels: string[];
+}): string {
+  const { typeName, subjectName, qualifier, existingLabels } = input;
+
+  // Most-informative first; each candidate sheds detail so a long name can fit 50 chars.
+  const candidates: string[] = [];
+  if (qualifier) {
+    candidates.push(
+      composeStageName({ subjectName, typeName, qualifier: qualifier.full }),
+    );
+    if (qualifier.summary !== qualifier.full) {
+      candidates.push(
+        composeStageName({
+          subjectName,
+          typeName,
+          qualifier: qualifier.summary,
+        }),
+      );
+    }
+    candidates.push(
+      composeStageName({
+        subjectName: null,
+        typeName,
+        qualifier: qualifier.summary,
+      }),
+    );
+  } else {
+    candidates.push(
+      composeStageName({ subjectName, typeName, qualifier: null }),
+    );
+    candidates.push(
+      composeStageName({ subjectName: null, typeName, qualifier: null }),
+    );
+  }
+
+  for (const base of candidates) {
+    const deduped = dedupeStageLabel(base, existingLabels);
+    if (deduped.length <= MAX_LABEL_LENGTH) {
+      return deduped;
+    }
+  }
+
+  const fallbackBase = candidates[candidates.length - 1] ?? typeName;
+  const truncated = truncateToWord(fallbackBase, MAX_LABEL_LENGTH - 4);
+  return dedupeStageLabel(truncated, existingLabels).slice(0, MAX_LABEL_LENGTH);
+}

--- a/apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts
@@ -1,0 +1,142 @@
+import type {
+  Item,
+  Panel,
+  StageSubject,
+  StageType,
+} from '@codaco/protocol-validation';
+
+import type { Qualifier } from './generateStageLabel';
+
+type EntityNameResolver = (
+  entity: 'node' | 'edge',
+  type: string,
+) => string | null;
+
+type QualifierResolvers = {
+  resolveAssetType: (assetId: string) => string | null;
+  resolveVariableName: (variableId: string) => string | null;
+};
+
+type QualifierStageFields = {
+  type?: StageType;
+  panels?: Panel[];
+  items?: Item[];
+  nominationPrompts?: { variable: string }[];
+};
+
+export function resolveStageSubjectName(
+  subject: StageSubject | undefined,
+  resolveEntityName: EntityNameResolver,
+): string | null {
+  if (!subject || subject.entity === 'ego' || !subject.type) {
+    return null;
+  }
+  return resolveEntityName(subject.entity, subject.type) || null;
+}
+
+function joinList(values: string[]): string {
+  if (values.length === 1) {
+    return values[0]!;
+  }
+  if (values.length === 2) {
+    return `${values[0]} & ${values[1]}`;
+  }
+  return `${values.slice(0, -1).join(', ')} & ${values[values.length - 1]}`;
+}
+
+export function buildListQualifier(
+  rawValues: string[],
+  options: { singularNoun?: string; pluralNoun?: string; summaryNoun: string },
+): Qualifier | null {
+  const values = [
+    ...new Set(rawValues.filter((value) => value && value.trim())),
+  ];
+  if (values.length === 0) {
+    return null;
+  }
+  const summary = `with ${options.summaryNoun}`;
+  if (values.length > 3) {
+    return { full: summary, summary };
+  }
+  const noun =
+    options.singularNoun && options.pluralNoun
+      ? ` ${values.length === 1 ? options.singularNoun : options.pluralNoun}`
+      : '';
+  return { full: `with ${joinList(values)}${noun}`, summary };
+}
+
+const MEDIA_LABELS: Record<string, string> = {
+  image: 'Image',
+  video: 'Video',
+  audio: 'Audio',
+};
+
+function resolvePanelQualifier(panels: Panel[] | undefined): Qualifier | null {
+  if (!panels || panels.length === 0) {
+    return null;
+  }
+  const hasExisting = panels.some((panel) => panel.dataSource === 'existing');
+  const hasRoster = panels.some((panel) => panel.dataSource !== 'existing');
+  let text = 'with Network Panels';
+  if (hasExisting && hasRoster) {
+    text = 'with Panels';
+  } else if (hasRoster) {
+    text = 'with Roster Panels';
+  }
+  return { full: text, summary: text };
+}
+
+function resolveInformationQualifier(
+  items: Item[] | undefined,
+  resolveAssetType: (assetId: string) => string | null,
+): Qualifier | null {
+  if (!items) {
+    return null;
+  }
+  const mediaLabels = items
+    .filter((item) => item.type === 'asset')
+    .map((item) => resolveAssetType(item.content))
+    .map((type) => (type ? (MEDIA_LABELS[type] ?? null) : null))
+    .filter((label): label is string => Boolean(label));
+  return buildListQualifier(mediaLabels, { summaryNoun: 'Media' });
+}
+
+function resolveNominationQualifier(
+  prompts: { variable: string }[] | undefined,
+  resolveVariableName: (variableId: string) => string | null,
+): Qualifier | null {
+  if (!prompts) {
+    return null;
+  }
+  const names = prompts
+    .map((prompt) => resolveVariableName(prompt.variable))
+    .filter((name): name is string => Boolean(name));
+  return buildListQualifier(names, {
+    singularNoun: 'Nomination',
+    pluralNoun: 'Nominations',
+    summaryNoun: 'Nominations',
+  });
+}
+
+export function resolveStageQualifier(
+  stage: QualifierStageFields,
+  resolvers: QualifierResolvers,
+): Qualifier | null {
+  switch (stage.type) {
+    case 'NameGenerator':
+    case 'NameGeneratorQuickAdd':
+      return resolvePanelQualifier(stage.panels);
+    case 'Information':
+      return resolveInformationQualifier(
+        stage.items,
+        resolvers.resolveAssetType,
+      );
+    case 'FamilyPedigree':
+      return resolveNominationQualifier(
+        stage.nominationPrompts,
+        resolvers.resolveVariableName,
+      );
+    default:
+      return null;
+  }
+}

--- a/apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts
@@ -71,6 +71,10 @@ const MEDIA_LABELS: Record<string, string> = {
   audio: 'Audio',
 };
 
+// Canonical order so the same set of media always yields the same name,
+// regardless of the order the Information items happen to be in.
+const MEDIA_LABEL_ORDER = ['Image', 'Video', 'Audio'];
+
 function resolvePanelQualifier(panels: Panel[] | undefined): Qualifier | null {
   if (!panels || panels.length === 0) {
     return null;
@@ -93,11 +97,16 @@ function resolveInformationQualifier(
   if (!items) {
     return null;
   }
-  const mediaLabels = items
-    .filter((item) => item.type === 'asset')
-    .map((item) => resolveAssetType(item.content))
-    .map((type) => (type ? (MEDIA_LABELS[type] ?? null) : null))
-    .filter((label): label is string => Boolean(label));
+  const presentLabels = new Set(
+    items
+      .filter((item) => item.type === 'asset')
+      .map((item) => resolveAssetType(item.content))
+      .map((type) => (type ? (MEDIA_LABELS[type] ?? null) : null))
+      .filter((label): label is string => Boolean(label)),
+  );
+  const mediaLabels = MEDIA_LABEL_ORDER.filter((label) =>
+    presentLabels.has(label),
+  );
   return buildListQualifier(mediaLabels, { summaryNoun: 'Media' });
 }
 

--- a/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
@@ -7,6 +7,7 @@ import type {
   Panel,
   StageSubject,
   StageType,
+  Variables,
 } from '@codaco/protocol-validation';
 import {
   getAllVariablesByUUID,
@@ -38,9 +39,9 @@ type StageFormValues = {
 
 export function useAutoStageName(isNewStage: boolean): void {
   const dispatch = useDispatch();
-  const formValues = useSelector(
-    getFormValues<StageFormValues | undefined>(formName),
-  );
+  const formValues = useSelector(getFormValues(formName)) as
+    | StageFormValues
+    | undefined;
   const nodeTypes = useSelector(getNodeTypes);
   const edgeTypes = useSelector(getEdgeTypes);
   const codebook = useSelector(getCodebook);
@@ -54,7 +55,9 @@ export function useAutoStageName(isNewStage: boolean): void {
     if (!type) {
       return '';
     }
-    const variablesByUuid = getAllVariablesByUUID(codebook);
+    const variablesByUuid: Variables = codebook
+      ? getAllVariablesByUUID(codebook)
+      : {};
     const subjectName = resolveStageSubjectName(
       formValues?.subject,
       (entity, entityType) => {

--- a/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
@@ -1,15 +1,17 @@
-import { useEffect, useMemo, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 import type { Action, Dispatch } from 'redux';
 import { change, getFormValues } from 'redux-form';
 
 import type {
   Item,
   Panel,
+  Stage,
   StageSubject,
   StageType,
-  Variables,
 } from '@codaco/protocol-validation';
+import { draftTimelineActions } from '~/ducks/modules/stageEditorDraft';
+import type { RootState } from '~/ducks/store';
 import {
   getAllVariablesByUUID,
   getEdgeTypes,
@@ -38,8 +40,11 @@ type StageFormValues = {
   nominationPrompts?: { variable: string }[];
 };
 
-export function useAutoStageName(isNewStage: boolean): void {
+export function useAutoStageName(isNewStage: boolean): {
+  onLabelBlur: () => void;
+} {
   const dispatch = useDispatch<Dispatch<Action>>();
+  const store = useStore<RootState>();
   const formValues = useSelector(getFormValues(formName)) as
     | StageFormValues
     | undefined;
@@ -56,9 +61,7 @@ export function useAutoStageName(isNewStage: boolean): void {
     if (!type) {
       return '';
     }
-    const variablesByUuid: Variables = codebook
-      ? getAllVariablesByUUID(codebook)
-      : {};
+    const variablesByUuid = codebook ? getAllVariablesByUUID(codebook) : {};
     const subjectName = resolveStageSubjectName(
       formValues?.subject,
       (entity, entityType) => {
@@ -92,6 +95,35 @@ export function useAutoStageName(isNewStage: boolean): void {
 
   const isCustomRef = useRef(false);
   const lastGeneratedRef = useRef<string | undefined>(undefined);
+  const hasFilledRef = useRef(false);
+
+  // Kept current each render so the stable blur handler reads the latest values.
+  const liveLabelRef = useRef(liveLabel);
+  liveLabelRef.current = liveLabel;
+  const generatedLabelRef = useRef(generatedLabel);
+  generatedLabelRef.current = generatedLabel;
+
+  const applyLabel = useCallback(
+    (label: string) => {
+      const isInitialFill = !hasFilledRef.current;
+      hasFilledRef.current = true;
+      lastGeneratedRef.current = label;
+      dispatch(change(formName, 'label', label));
+      // Fold the very first auto-name into the draft baseline so a brand-new
+      // stage isn't reported dirty (no "Finished Editing" flash) and gains no
+      // undo step before the researcher has done anything. The reset also clears
+      // the listener's pending snapshot for this change.
+      if (isInitialFill) {
+        const fresh = getFormValues(formName)(store.getState()) as
+          | Stage
+          | undefined;
+        if (fresh) {
+          dispatch(draftTimelineActions.reset(fresh));
+        }
+      }
+    },
+    [dispatch, store],
+  );
 
   useEffect(() => {
     const update = computeAutoNameUpdate({
@@ -103,8 +135,22 @@ export function useAutoStageName(isNewStage: boolean): void {
     });
     isCustomRef.current = update.nextIsCustom;
     if (update.label !== undefined) {
-      lastGeneratedRef.current = update.label;
-      dispatch(change(formName, 'label', update.label));
+      applyLabel(update.label);
     }
-  }, [generatedLabel, liveLabel, isNewStage, dispatch]);
+  }, [generatedLabel, liveLabel, isNewStage, applyLabel]);
+
+  // Re-engage on blur: if the researcher cleared the name and tabs away while it
+  // is still empty, fill the generated name back in (rather than fighting their
+  // keystrokes the instant the field goes empty).
+  const onLabelBlur = useCallback(() => {
+    if (!isNewStage) {
+      return;
+    }
+    if (liveLabelRef.current.trim() === '' && generatedLabelRef.current) {
+      isCustomRef.current = false;
+      applyLabel(generatedLabelRef.current);
+    }
+  }, [isNewStage, applyLabel]);
+
+  return { onLabelBlur };
 }

--- a/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { change, getFormValues } from 'redux-form';
+
+import type {
+  Item,
+  Panel,
+  StageSubject,
+  StageType,
+} from '@codaco/protocol-validation';
+import {
+  getAllVariablesByUUID,
+  getEdgeTypes,
+  getNodeTypes,
+} from '~/selectors/codebook';
+import {
+  getAssetManifest,
+  getCodebook,
+  getStageList,
+} from '~/selectors/protocol';
+
+import { formName } from '../configuration';
+import { computeAutoNameUpdate } from './computeAutoNameUpdate';
+import { generateStageLabel, STAGE_TYPE_NAMES } from './generateStageLabel';
+import {
+  resolveStageQualifier,
+  resolveStageSubjectName,
+} from './resolveStageNameParts';
+
+type StageFormValues = {
+  type?: StageType;
+  label?: string;
+  subject?: StageSubject;
+  panels?: Panel[];
+  items?: Item[];
+  nominationPrompts?: { variable: string }[];
+};
+
+export function useAutoStageName(isNewStage: boolean): void {
+  const dispatch = useDispatch();
+  const formValues = useSelector(
+    getFormValues<StageFormValues | undefined>(formName),
+  );
+  const nodeTypes = useSelector(getNodeTypes);
+  const edgeTypes = useSelector(getEdgeTypes);
+  const codebook = useSelector(getCodebook);
+  const assetManifest = useSelector(getAssetManifest);
+  const stageList = useSelector(getStageList);
+
+  const liveLabel = formValues?.label ?? '';
+
+  const generatedLabel = useMemo(() => {
+    const type = formValues?.type;
+    if (!type) {
+      return '';
+    }
+    const variablesByUuid = getAllVariablesByUUID(codebook);
+    const subjectName = resolveStageSubjectName(
+      formValues?.subject,
+      (entity, entityType) => {
+        const types = entity === 'node' ? nodeTypes : edgeTypes;
+        return types[entityType]?.name ?? null;
+      },
+    );
+    const qualifier = resolveStageQualifier(
+      {
+        type,
+        panels: formValues?.panels,
+        items: formValues?.items,
+        nominationPrompts: formValues?.nominationPrompts,
+      },
+      {
+        resolveAssetType: (assetId) => assetManifest[assetId]?.type ?? null,
+        resolveVariableName: (variableId) =>
+          variablesByUuid[variableId]?.name ?? null,
+      },
+    );
+    const existingLabels = stageList
+      .map((stage) => stage.label)
+      .filter((label): label is string => Boolean(label));
+    return generateStageLabel({
+      typeName: STAGE_TYPE_NAMES[type],
+      subjectName,
+      qualifier,
+      existingLabels,
+    });
+  }, [formValues, nodeTypes, edgeTypes, codebook, assetManifest, stageList]);
+
+  const isCustomRef = useRef(false);
+  const lastGeneratedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const update = computeAutoNameUpdate({
+      isNewStage,
+      isCustom: isCustomRef.current,
+      liveLabel,
+      lastGenerated: lastGeneratedRef.current,
+      generatedLabel,
+    });
+    isCustomRef.current = update.nextIsCustom;
+    if (update.label !== undefined) {
+      lastGeneratedRef.current = update.label;
+      dispatch(change(formName, 'label', update.label));
+    }
+  }, [generatedLabel, liveLabel, isNewStage, dispatch]);
+}

--- a/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
+++ b/apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import type { Action, Dispatch } from 'redux';
 import { change, getFormValues } from 'redux-form';
 
 import type {
@@ -38,7 +39,7 @@ type StageFormValues = {
 };
 
 export function useAutoStageName(isNewStage: boolean): void {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<Dispatch<Action>>();
   const formValues = useSelector(getFormValues(formName)) as
     | StageFormValues
     | undefined;

--- a/docs/superpowers/plans/2026-06-26-architect-auto-stage-naming.md
+++ b/docs/superpowers/plans/2026-06-26-architect-auto-stage-naming.md
@@ -866,6 +866,14 @@ git commit -m "feat(architect): add stage auto-name ownership state machine"
 
 ### Task 4: The hook and wiring into StageHeading
 
+> **Note (superseded by code review):** the shipped hook went beyond the snippet
+> below in three ways — see the design spec for the authoritative contract:
+> (1) the **first** fill also resets the draft baseline so a new stage isn't
+> marked dirty / undoable on entry; (2) clearing the field re-engages on **blur**
+> only, not instantly; (3) "new stage" is determined by the absence of a stage
+> `id` (passed in from `StageEditor` as `isNewStage`), **not** by an empty
+> initial label. The snippet here is the starting point, not the final code.
+
 **Files:**
 
 - Create: `apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts`

--- a/docs/superpowers/plans/2026-06-26-architect-auto-stage-naming.md
+++ b/docs/superpowers/plans/2026-06-26-architect-auto-stage-naming.md
@@ -1,0 +1,1159 @@
+# Automatic Stage Naming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-populate a new stage's name from its configuration in Architect, live-updating until the researcher types their own name.
+
+**Architecture:** Three pure, unit-tested modules (label composition + dedup + length; stage-part resolution; ownership state machine) plus one thin React hook that wires them to redux-form and the codebook selectors, called from `StageHeading`. No schema, validation, or stage-creation-flow changes.
+
+**Tech Stack:** TypeScript, React, redux-form, `@reduxjs/toolkit` selectors, Vitest + React Testing Library. Spec: `docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md`.
+
+## Global Constraints
+
+- No `any` types; no `as Type` assertions — use generics / structural types instead.
+- No barrel files; import each symbol from its source module.
+- Only export symbols other modules actually consume.
+- App is `@codaco/architect-web` (private, changeset-ignored) — **no changeset**.
+- Label cap: **50 characters** (`MAX_LABEL_LENGTH`).
+- Form name is `'edit-stage'`, exported as `formName` from `apps/architect-web/src/components/StageEditor/configuration.ts`.
+- Types come from `@codaco/protocol-validation`: `StageType`, `StageSubject`, `Panel`, `Item`.
+- Comment only where logic is non-obvious (project rule).
+- Run only the targeted test file during each task; defer `pnpm typecheck` to the final task.
+
+## File Structure
+
+All new files live in `apps/architect-web/src/components/StageEditor/autoStageName/`:
+
+- `generateStageLabel.ts` — `STAGE_TYPE_NAMES`, `Qualifier` type, `composeStageName`, `dedupeStageLabel`, `generateStageLabel`, `MAX_LABEL_LENGTH`. Pure string assembly.
+- `resolveStageNameParts.ts` — `resolveStageSubjectName`, `buildListQualifier`, `resolveStageQualifier`, resolver types. Pure, callback-driven.
+- `computeAutoNameUpdate.ts` — the ownership state machine. Pure.
+- `useAutoStageName.ts` — React hook gluing selectors + redux-form `change` to the pure modules.
+- `__tests__/*.test.ts(x)` — co-located tests per module.
+
+Modified:
+
+- `apps/architect-web/src/components/StageEditor/StageHeading.tsx` — call `useAutoStageName(isNewStage)` before the early return.
+
+Test commands are run from the package directory:
+
+```bash
+cd apps/architect-web
+```
+
+---
+
+### Task 1: Pure label composition, dedup, and length-fitting
+
+**Files:**
+
+- Create: `apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts`
+- Test: `apps/architect-web/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `MAX_LABEL_LENGTH: 50`
+  - `type Qualifier = { full: string; summary: string }`
+  - `STAGE_TYPE_NAMES: Record<StageType, string>`
+  - `composeStageName(parts: { subjectName?: string | null; typeName: string; qualifier?: string | null }): string`
+  - `dedupeStageLabel(base: string, existingLabels: string[]): string`
+  - `generateStageLabel(input: { typeName: string; subjectName?: string | null; qualifier?: Qualifier | null; existingLabels: string[] }): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/generateStageLabel.test.ts
+import { describe, expect, it } from 'vitest';
+import type { StageType } from '@codaco/protocol-validation';
+import {
+  composeStageName,
+  dedupeStageLabel,
+  generateStageLabel,
+  MAX_LABEL_LENGTH,
+  STAGE_TYPE_NAMES,
+} from '../generateStageLabel';
+
+describe('composeStageName', () => {
+  it('joins subject, type, and qualifier with spaces', () => {
+    expect(
+      composeStageName({
+        subjectName: 'Person',
+        typeName: 'Form Name Generator',
+        qualifier: 'with Roster Panels',
+      }),
+    ).toBe('Person Form Name Generator with Roster Panels');
+  });
+  it('omits empty subject and qualifier', () => {
+    expect(
+      composeStageName({
+        subjectName: null,
+        typeName: 'Ego Form',
+        qualifier: null,
+      }),
+    ).toBe('Ego Form');
+  });
+});
+
+describe('dedupeStageLabel', () => {
+  it('returns the base when free', () => {
+    expect(dedupeStageLabel('Person Sociogram', ['Other'])).toBe(
+      'Person Sociogram',
+    );
+  });
+  it('appends the lowest free number on collision, case-insensitively', () => {
+    expect(dedupeStageLabel('Person Sociogram', ['person sociogram'])).toBe(
+      'Person Sociogram #2',
+    );
+  });
+  it('fills numbering gaps', () => {
+    expect(dedupeStageLabel('A', ['A', 'A #3'])).toBe('A #2');
+  });
+});
+
+describe('generateStageLabel', () => {
+  it('builds a full name', () => {
+    expect(
+      generateStageLabel({
+        typeName: 'Form Name Generator',
+        subjectName: 'Person',
+        qualifier: {
+          full: 'with Roster Panels',
+          summary: 'with Roster Panels',
+        },
+        existingLabels: [],
+      }),
+    ).toBe('Person Form Name Generator with Roster Panels');
+  });
+  it('summarizes a listed qualifier when too long, before dropping the subject', () => {
+    const label = generateStageLabel({
+      typeName: 'Family Pedigree',
+      subjectName: 'Extended Family Member Person',
+      qualifier: {
+        full: 'with Diabetes, Hypertension & Coronary Heart Disease Nominations',
+        summary: 'with Nominations',
+      },
+      existingLabels: [],
+    });
+    expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+    expect(label).toContain('with Nominations');
+  });
+  it('never exceeds the length cap even with a dedup suffix', () => {
+    const long = 'X'.repeat(60);
+    const label = generateStageLabel({
+      typeName: long,
+      subjectName: null,
+      qualifier: null,
+      existingLabels: [long.slice(0, 50)],
+    });
+    expect(label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+  });
+});
+
+describe('STAGE_TYPE_NAMES', () => {
+  it('has the expected concise names', () => {
+    const expected: Record<StageType, string> = {
+      NameGenerator: 'Form Name Generator',
+      NameGeneratorQuickAdd: 'Quick Add Name Generator',
+      NameGeneratorRoster: 'Roster Name Generator',
+      FamilyPedigree: 'Family Pedigree',
+      DyadCensus: 'Dyad Census',
+      OneToManyDyadCensus: 'One to Many Dyad Census',
+      TieStrengthCensus: 'Tie-Strength Census',
+      Sociogram: 'Sociogram',
+      Narrative: 'Narrative',
+      OrdinalBin: 'Ordinal Bin',
+      CategoricalBin: 'Categorical Bin',
+      AlterForm: 'Per Alter Form',
+      Geospatial: 'Geospatial',
+      AlterEdgeForm: 'Per Alter Edge Form',
+      EgoForm: 'Ego Form',
+      Information: 'Information',
+      Anonymisation: 'Anonymisation',
+    };
+    expect(STAGE_TYPE_NAMES).toStrictEqual(expected);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts`
+Expected: FAIL — cannot resolve `../generateStageLabel`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// generateStageLabel.ts
+import type { StageType } from '@codaco/protocol-validation';
+
+export const MAX_LABEL_LENGTH = 50;
+
+export type Qualifier = { full: string; summary: string };
+
+export const STAGE_TYPE_NAMES: Record<StageType, string> = {
+  NameGenerator: 'Form Name Generator',
+  NameGeneratorQuickAdd: 'Quick Add Name Generator',
+  NameGeneratorRoster: 'Roster Name Generator',
+  FamilyPedigree: 'Family Pedigree',
+  DyadCensus: 'Dyad Census',
+  OneToManyDyadCensus: 'One to Many Dyad Census',
+  TieStrengthCensus: 'Tie-Strength Census',
+  Sociogram: 'Sociogram',
+  Narrative: 'Narrative',
+  OrdinalBin: 'Ordinal Bin',
+  CategoricalBin: 'Categorical Bin',
+  AlterForm: 'Per Alter Form',
+  Geospatial: 'Geospatial',
+  AlterEdgeForm: 'Per Alter Edge Form',
+  EgoForm: 'Ego Form',
+  Information: 'Information',
+  Anonymisation: 'Anonymisation',
+};
+
+export function composeStageName(parts: {
+  subjectName?: string | null;
+  typeName: string;
+  qualifier?: string | null;
+}): string {
+  return [parts.subjectName, parts.typeName, parts.qualifier]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join(' ');
+}
+
+export function dedupeStageLabel(
+  base: string,
+  existingLabels: string[],
+): string {
+  const taken = new Set(
+    existingLabels.map((label) => label.trim().toLowerCase()),
+  );
+  if (!taken.has(base.trim().toLowerCase())) {
+    return base;
+  }
+  let suffix = 2;
+  while (taken.has(`${base} #${suffix}`.toLowerCase())) {
+    suffix += 1;
+  }
+  return `${base} #${suffix}`;
+}
+
+function truncateToWord(value: string, max: number): string {
+  if (value.length <= max) {
+    return value;
+  }
+  const slice = value.slice(0, max);
+  const lastSpace = slice.lastIndexOf(' ');
+  const trimmed = (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd();
+  return trimmed || slice.trimEnd();
+}
+
+export function generateStageLabel(input: {
+  typeName: string;
+  subjectName?: string | null;
+  qualifier?: Qualifier | null;
+  existingLabels: string[];
+}): string {
+  const { typeName, subjectName, qualifier, existingLabels } = input;
+
+  // Most-informative first; each candidate sheds detail so a long name can fit 50 chars.
+  const candidates: string[] = [];
+  if (qualifier) {
+    candidates.push(
+      composeStageName({ subjectName, typeName, qualifier: qualifier.full }),
+    );
+    if (qualifier.summary !== qualifier.full) {
+      candidates.push(
+        composeStageName({
+          subjectName,
+          typeName,
+          qualifier: qualifier.summary,
+        }),
+      );
+    }
+    candidates.push(
+      composeStageName({
+        subjectName: null,
+        typeName,
+        qualifier: qualifier.summary,
+      }),
+    );
+  } else {
+    candidates.push(
+      composeStageName({ subjectName, typeName, qualifier: null }),
+    );
+    candidates.push(
+      composeStageName({ subjectName: null, typeName, qualifier: null }),
+    );
+  }
+
+  for (const base of candidates) {
+    const deduped = dedupeStageLabel(base, existingLabels);
+    if (deduped.length <= MAX_LABEL_LENGTH) {
+      return deduped;
+    }
+  }
+
+  const fallbackBase = candidates[candidates.length - 1] ?? typeName;
+  const truncated = truncateToWord(fallbackBase, MAX_LABEL_LENGTH - 4);
+  return dedupeStageLabel(truncated, existingLabels).slice(0, MAX_LABEL_LENGTH);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts`
+Expected: PASS (all assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/architect-web/src/components/StageEditor/autoStageName/generateStageLabel.ts apps/architect-web/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
+git commit -m "feat(architect): add pure stage-label composition and dedup"
+```
+
+---
+
+### Task 2: Resolve subject and qualifier from a stage
+
+**Files:**
+
+- Create: `apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts`
+- Test: `apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Qualifier` from `../generateStageLabel`.
+- Produces (only these three are exported — the resolver/param types stay **local, non-exported**, so knip does not flag unused exports):
+  - `resolveStageSubjectName(subject: StageSubject | undefined, resolveEntityName: (entity: 'node' | 'edge', type: string) => string | null): string | null`
+  - `buildListQualifier(rawValues: string[], options: { singularNoun?: string; pluralNoun?: string; summaryNoun: string }): Qualifier | null`
+  - `resolveStageQualifier(stage: { type?: StageType; panels?: Panel[]; items?: Item[]; nominationPrompts?: { variable: string }[] }, resolvers: { resolveAssetType: (assetId: string) => string | null; resolveVariableName: (variableId: string) => string | null }): Qualifier | null`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/resolveStageNameParts.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  buildListQualifier,
+  resolveStageQualifier,
+  resolveStageSubjectName,
+} from '../resolveStageNameParts';
+
+const nameByType: Record<string, string> = {
+  person: 'Person',
+  friendship: 'Friendship',
+};
+const resolveEntityName = (_entity: 'node' | 'edge', type: string) =>
+  nameByType[type] ?? null;
+
+describe('resolveStageSubjectName', () => {
+  it('resolves a node subject', () => {
+    expect(
+      resolveStageSubjectName(
+        { entity: 'node', type: 'person' },
+        resolveEntityName,
+      ),
+    ).toBe('Person');
+  });
+  it('resolves an edge subject', () => {
+    expect(
+      resolveStageSubjectName(
+        { entity: 'edge', type: 'friendship' },
+        resolveEntityName,
+      ),
+    ).toBe('Friendship');
+  });
+  it('returns null for ego and for missing/unknown subjects', () => {
+    expect(
+      resolveStageSubjectName({ entity: 'ego' }, resolveEntityName),
+    ).toBeNull();
+    expect(resolveStageSubjectName(undefined, resolveEntityName)).toBeNull();
+    expect(
+      resolveStageSubjectName(
+        { entity: 'node', type: 'ghost' },
+        resolveEntityName,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('buildListQualifier', () => {
+  it('returns null for no values', () => {
+    expect(buildListQualifier([], { summaryNoun: 'Media' })).toBeNull();
+  });
+  it('lists up to three values with an ampersand', () => {
+    expect(
+      buildListQualifier(['Image', 'Video'], { summaryNoun: 'Media' }),
+    ).toStrictEqual({
+      full: 'with Image & Video',
+      summary: 'with Media',
+    });
+    expect(
+      buildListQualifier(['A', 'B', 'C'], { summaryNoun: 'Media' })?.full,
+    ).toBe('with A, B & C');
+  });
+  it('summarizes four or more values', () => {
+    expect(
+      buildListQualifier(['A', 'B', 'C', 'D'], { summaryNoun: 'Media' }),
+    ).toStrictEqual({
+      full: 'with Media',
+      summary: 'with Media',
+    });
+  });
+  it('applies singular/plural nouns and de-duplicates', () => {
+    expect(
+      buildListQualifier(['Diabetes'], {
+        singularNoun: 'Nomination',
+        pluralNoun: 'Nominations',
+        summaryNoun: 'Nominations',
+      })?.full,
+    ).toBe('with Diabetes Nomination');
+    expect(
+      buildListQualifier(['Diabetes', 'Diabetes', 'Asthma'], {
+        singularNoun: 'Nomination',
+        pluralNoun: 'Nominations',
+        summaryNoun: 'Nominations',
+      })?.full,
+    ).toBe('with Diabetes & Asthma Nominations');
+  });
+});
+
+describe('resolveStageQualifier', () => {
+  const resolvers = {
+    resolveAssetType: () => null,
+    resolveVariableName: () => null,
+  };
+
+  it('classifies name-generator panels by data source', () => {
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGenerator',
+          panels: [{ id: 'p1', title: 'A', dataSource: 'existing' }],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Network Panels');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGenerator',
+          panels: [{ id: 'p1', title: 'A', dataSource: 'roster-1' }],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Roster Panels');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'NameGeneratorQuickAdd',
+          panels: [
+            { id: 'p1', title: 'A', dataSource: 'existing' },
+            { id: 'p2', title: 'B', dataSource: 'roster-1' },
+          ],
+        },
+        resolvers,
+      )?.full,
+    ).toBe('with Panels');
+    expect(
+      resolveStageQualifier({ type: 'NameGenerator', panels: [] }, resolvers),
+    ).toBeNull();
+  });
+
+  it('lists Information asset media types via the manifest', () => {
+    const r = {
+      ...resolvers,
+      resolveAssetType: (id: string) => (id === 'a1' ? 'video' : 'image'),
+    };
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [{ id: 'i1', type: 'asset', content: 'a1' }],
+        },
+        r,
+      )?.full,
+    ).toBe('with Video');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [
+            { id: 'i1', type: 'asset', content: 'a1' },
+            { id: 'i2', type: 'asset', content: 'a2' },
+          ],
+        },
+        r,
+      )?.full,
+    ).toBe('with Video & Image');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'Information',
+          items: [{ id: 'i1', type: 'text', content: 'hello' }],
+        },
+        r,
+      ),
+    ).toBeNull();
+  });
+
+  it('lists Family Pedigree nominated attribute names via the codebook', () => {
+    const r = {
+      ...resolvers,
+      resolveVariableName: (id: string) =>
+        id === 'v1' ? 'Diabetes' : 'Asthma',
+    };
+    expect(
+      resolveStageQualifier(
+        { type: 'FamilyPedigree', nominationPrompts: [{ variable: 'v1' }] },
+        r,
+      )?.full,
+    ).toBe('with Diabetes Nomination');
+    expect(
+      resolveStageQualifier(
+        {
+          type: 'FamilyPedigree',
+          nominationPrompts: [{ variable: 'v1' }, { variable: 'v2' }],
+        },
+        r,
+      )?.full,
+    ).toBe('with Diabetes & Asthma Nominations');
+  });
+
+  it('returns null for stage types without qualifiers', () => {
+    expect(resolveStageQualifier({ type: 'Sociogram' }, resolvers)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts`
+Expected: FAIL — cannot resolve `../resolveStageNameParts`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// resolveStageNameParts.ts
+import type {
+  Item,
+  Panel,
+  StageSubject,
+  StageType,
+} from '@codaco/protocol-validation';
+import type { Qualifier } from './generateStageLabel';
+
+type EntityNameResolver = (
+  entity: 'node' | 'edge',
+  type: string,
+) => string | null;
+
+type QualifierResolvers = {
+  resolveAssetType: (assetId: string) => string | null;
+  resolveVariableName: (variableId: string) => string | null;
+};
+
+type QualifierStageFields = {
+  type?: StageType;
+  panels?: Panel[];
+  items?: Item[];
+  nominationPrompts?: { variable: string }[];
+};
+
+export function resolveStageSubjectName(
+  subject: StageSubject | undefined,
+  resolveEntityName: EntityNameResolver,
+): string | null {
+  if (!subject || subject.entity === 'ego' || !subject.type) {
+    return null;
+  }
+  return resolveEntityName(subject.entity, subject.type) || null;
+}
+
+function joinList(values: string[]): string {
+  if (values.length === 1) {
+    return values[0]!;
+  }
+  if (values.length === 2) {
+    return `${values[0]} & ${values[1]}`;
+  }
+  return `${values.slice(0, -1).join(', ')} & ${values[values.length - 1]}`;
+}
+
+export function buildListQualifier(
+  rawValues: string[],
+  options: { singularNoun?: string; pluralNoun?: string; summaryNoun: string },
+): Qualifier | null {
+  const values = [
+    ...new Set(rawValues.filter((value) => value && value.trim())),
+  ];
+  if (values.length === 0) {
+    return null;
+  }
+  const summary = `with ${options.summaryNoun}`;
+  if (values.length > 3) {
+    return { full: summary, summary };
+  }
+  const noun =
+    options.singularNoun && options.pluralNoun
+      ? ` ${values.length === 1 ? options.singularNoun : options.pluralNoun}`
+      : '';
+  return { full: `with ${joinList(values)}${noun}`, summary };
+}
+
+const MEDIA_LABELS: Record<string, string> = {
+  image: 'Image',
+  video: 'Video',
+  audio: 'Audio',
+};
+
+function resolvePanelQualifier(panels: Panel[] | undefined): Qualifier | null {
+  if (!panels || panels.length === 0) {
+    return null;
+  }
+  const hasExisting = panels.some((panel) => panel.dataSource === 'existing');
+  const hasRoster = panels.some((panel) => panel.dataSource !== 'existing');
+  let text = 'with Network Panels';
+  if (hasExisting && hasRoster) {
+    text = 'with Panels';
+  } else if (hasRoster) {
+    text = 'with Roster Panels';
+  }
+  return { full: text, summary: text };
+}
+
+function resolveInformationQualifier(
+  items: Item[] | undefined,
+  resolveAssetType: (assetId: string) => string | null,
+): Qualifier | null {
+  if (!items) {
+    return null;
+  }
+  const mediaLabels = items
+    .filter((item) => item.type === 'asset')
+    .map((item) => resolveAssetType(item.content))
+    .map((type) => (type ? (MEDIA_LABELS[type] ?? null) : null))
+    .filter((label): label is string => Boolean(label));
+  return buildListQualifier(mediaLabels, { summaryNoun: 'Media' });
+}
+
+function resolveNominationQualifier(
+  prompts: { variable: string }[] | undefined,
+  resolveVariableName: (variableId: string) => string | null,
+): Qualifier | null {
+  if (!prompts) {
+    return null;
+  }
+  const names = prompts
+    .map((prompt) => resolveVariableName(prompt.variable))
+    .filter((name): name is string => Boolean(name));
+  return buildListQualifier(names, {
+    singularNoun: 'Nomination',
+    pluralNoun: 'Nominations',
+    summaryNoun: 'Nominations',
+  });
+}
+
+export function resolveStageQualifier(
+  stage: QualifierStageFields,
+  resolvers: QualifierResolvers,
+): Qualifier | null {
+  switch (stage.type) {
+    case 'NameGenerator':
+    case 'NameGeneratorQuickAdd':
+      return resolvePanelQualifier(stage.panels);
+    case 'Information':
+      return resolveInformationQualifier(
+        stage.items,
+        resolvers.resolveAssetType,
+      );
+    case 'FamilyPedigree':
+      return resolveNominationQualifier(
+        stage.nominationPrompts,
+        resolvers.resolveVariableName,
+      );
+    default:
+      return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/architect-web/src/components/StageEditor/autoStageName/resolveStageNameParts.ts apps/architect-web/src/components/StageEditor/autoStageName/__tests__/resolveStageNameParts.test.ts
+git commit -m "feat(architect): resolve stage subject and per-type name qualifiers"
+```
+
+---
+
+### Task 3: Ownership state machine
+
+**Files:**
+
+- Create: `apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts`
+- Test: `apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `computeAutoNameUpdate(args: { isNewStage: boolean; isCustom: boolean; liveLabel: string; lastGenerated: string | undefined; generatedLabel: string }): { nextIsCustom: boolean; label?: string }`
+
+Semantics: while creating a new stage and the researcher has not taken ownership, the generated label is applied; the first non-empty value the researcher types (one that differs from what we last generated) locks it; clearing the field re-engages auto-naming.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// __tests__/computeAutoNameUpdate.test.ts
+import { describe, expect, it } from 'vitest';
+import { computeAutoNameUpdate } from '../computeAutoNameUpdate';
+
+describe('computeAutoNameUpdate', () => {
+  it('never auto-names an existing stage', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: false,
+        isCustom: false,
+        liveLabel: 'Existing',
+        lastGenerated: undefined,
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('fills an empty label on first run', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: '',
+        lastGenerated: undefined,
+        generatedLabel: 'Form Name Generator',
+      }),
+    ).toStrictEqual({ nextIsCustom: false, label: 'Form Name Generator' });
+  });
+
+  it('updates the label when the generated name changes', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'Form Name Generator',
+        lastGenerated: 'Form Name Generator',
+        generatedLabel: 'Person Form Name Generator',
+      }),
+    ).toStrictEqual({
+      nextIsCustom: false,
+      label: 'Person Form Name Generator',
+    });
+  });
+
+  it('locks when the researcher types a custom value', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'My stage',
+        lastGenerated: 'Person Form Name Generator',
+        generatedLabel: 'Person Form Name Generator',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('stays locked once custom', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: true,
+        liveLabel: 'My stage',
+        lastGenerated: 'Person Form Name Generator',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: true });
+  });
+
+  it('re-engages when the field is cleared', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: true,
+        liveLabel: '   ',
+        lastGenerated: 'My stage',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: false, label: 'Person Sociogram' });
+  });
+
+  it('does nothing when already in sync', () => {
+    expect(
+      computeAutoNameUpdate({
+        isNewStage: true,
+        isCustom: false,
+        liveLabel: 'Person Sociogram',
+        lastGenerated: 'Person Sociogram',
+        generatedLabel: 'Person Sociogram',
+      }),
+    ).toStrictEqual({ nextIsCustom: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts`
+Expected: FAIL — cannot resolve `../computeAutoNameUpdate`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// computeAutoNameUpdate.ts
+export function computeAutoNameUpdate(args: {
+  isNewStage: boolean;
+  isCustom: boolean;
+  liveLabel: string;
+  lastGenerated: string | undefined;
+  generatedLabel: string;
+}): { nextIsCustom: boolean; label?: string } {
+  const { isNewStage, isCustom, liveLabel, lastGenerated, generatedLabel } =
+    args;
+
+  if (!isNewStage) {
+    return { nextIsCustom: true };
+  }
+
+  // Empty field (initial or cleared) re-engages auto-naming.
+  if (liveLabel.trim() === '') {
+    if (generatedLabel && generatedLabel !== liveLabel) {
+      return { nextIsCustom: false, label: generatedLabel };
+    }
+    return { nextIsCustom: false };
+  }
+
+  if (isCustom) {
+    return { nextIsCustom: true };
+  }
+
+  // A non-empty value we did not generate means the researcher took ownership.
+  if (liveLabel !== lastGenerated) {
+    return { nextIsCustom: true };
+  }
+
+  if (generatedLabel !== liveLabel) {
+    return { nextIsCustom: false, label: generatedLabel };
+  }
+  return { nextIsCustom: false };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/architect-web/src/components/StageEditor/autoStageName/computeAutoNameUpdate.ts apps/architect-web/src/components/StageEditor/autoStageName/__tests__/computeAutoNameUpdate.test.ts
+git commit -m "feat(architect): add stage auto-name ownership state machine"
+```
+
+---
+
+### Task 4: The hook and wiring into StageHeading
+
+**Files:**
+
+- Create: `apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts`
+- Modify: `apps/architect-web/src/components/StageEditor/StageHeading.tsx`
+- Test: `apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `generateStageLabel`, `STAGE_TYPE_NAMES` from `./generateStageLabel`; `resolveStageSubjectName`, `resolveStageQualifier` from `./resolveStageNameParts`; `computeAutoNameUpdate` from `./computeAutoNameUpdate`; `formName` from `../configuration`; selectors `getNodeTypes`, `getEdgeTypes`, `getAllVariablesByUUID` from `~/selectors/codebook`; `getAssetManifest`, `getCodebook`, `getStageList` from `~/selectors/protocol`.
+- Produces: `useAutoStageName(isNewStage: boolean): void`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// __tests__/useAutoStageName.test.tsx
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { change, reducer as formReducer } from 'redux-form';
+import { describe, expect, it } from 'vitest';
+
+import Editor from '~/components/Editor';
+import { formName } from '../../configuration';
+import StageHeading from '../../StageHeading';
+
+const protocol = {
+  codebook: {
+    node: { person: { name: 'Person', color: 'node-1', variables: {} } },
+    edge: {},
+  },
+  stages: [{ id: 'other', type: 'Sociogram', label: 'An existing stage' }],
+  assetManifest: {},
+};
+
+function renderHeading(initialValues: Record<string, unknown>) {
+  const store = configureStore({
+    reducer: {
+      form: formReducer,
+      activeProtocol: () => ({ present: protocol }),
+    },
+  });
+  const utils = render(
+    <Provider store={store}>
+      <Editor form={formName} initialValues={initialValues} onSubmit={() => {}}>
+        <StageHeading stageNumber={1} totalStages={1} />
+      </Editor>
+    </Provider>,
+  );
+  const input = utils.getByLabelText('Stage name') as HTMLInputElement;
+  return { store, input };
+}
+
+describe('useAutoStageName (wired into StageHeading)', () => {
+  it('auto-names a new stage and refines as the subject is set', async () => {
+    const { store, input } = renderHeading({ type: 'NameGenerator' });
+
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+
+    store.dispatch(
+      change(formName, 'subject', { entity: 'node', type: 'person' }),
+    );
+    await waitFor(() =>
+      expect(input).toHaveValue('Person Form Name Generator'),
+    );
+  });
+
+  it('stops auto-naming once the researcher types a custom name', async () => {
+    const { store, input } = renderHeading({ type: 'NameGenerator' });
+    await waitFor(() => expect(input).toHaveValue('Form Name Generator'));
+
+    // Replace the value in one change (mirrors selecting all then typing).
+    fireEvent.change(input, { target: { value: 'My custom stage' } });
+    await waitFor(() => expect(input).toHaveValue('My custom stage'));
+
+    store.dispatch(
+      change(formName, 'subject', { entity: 'node', type: 'person' }),
+    );
+    // Give the effect a chance to (incorrectly) overwrite, then assert it didn't.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('My custom stage');
+  });
+
+  it('does not auto-name an existing stage', async () => {
+    const { input } = renderHeading({
+      type: 'Sociogram',
+      id: 's1',
+      label: 'Hand named',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(input).toHaveValue('Hand named');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx`
+Expected: FAIL — cannot resolve `../useAutoStageName` (and `StageHeading` does not yet call the hook).
+
+- [ ] **Step 3: Write the hook**
+
+```ts
+// useAutoStageName.ts
+import { useEffect, useMemo, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { change, getFormValues } from 'redux-form';
+
+import type {
+  Item,
+  Panel,
+  StageSubject,
+  StageType,
+} from '@codaco/protocol-validation';
+import {
+  getAllVariablesByUUID,
+  getEdgeTypes,
+  getNodeTypes,
+} from '~/selectors/codebook';
+import {
+  getAssetManifest,
+  getCodebook,
+  getStageList,
+} from '~/selectors/protocol';
+
+import { formName } from '../configuration';
+import { computeAutoNameUpdate } from './computeAutoNameUpdate';
+import { generateStageLabel, STAGE_TYPE_NAMES } from './generateStageLabel';
+import {
+  resolveStageQualifier,
+  resolveStageSubjectName,
+} from './resolveStageNameParts';
+
+type StageFormValues = {
+  type?: StageType;
+  label?: string;
+  subject?: StageSubject;
+  panels?: Panel[];
+  items?: Item[];
+  nominationPrompts?: { variable: string }[];
+};
+
+export function useAutoStageName(isNewStage: boolean): void {
+  const dispatch = useDispatch();
+  const formValues = useSelector(
+    getFormValues<StageFormValues | undefined>(formName),
+  );
+  const nodeTypes = useSelector(getNodeTypes);
+  const edgeTypes = useSelector(getEdgeTypes);
+  const codebook = useSelector(getCodebook);
+  const assetManifest = useSelector(getAssetManifest);
+  const stageList = useSelector(getStageList);
+
+  const liveLabel = formValues?.label ?? '';
+
+  const generatedLabel = useMemo(() => {
+    const type = formValues?.type;
+    if (!type) {
+      return '';
+    }
+    const variablesByUuid = getAllVariablesByUUID(codebook);
+    const subjectName = resolveStageSubjectName(
+      formValues?.subject,
+      (entity, entityType) => {
+        const types = entity === 'node' ? nodeTypes : edgeTypes;
+        return types[entityType]?.name ?? null;
+      },
+    );
+    const qualifier = resolveStageQualifier(
+      {
+        type,
+        panels: formValues?.panels,
+        items: formValues?.items,
+        nominationPrompts: formValues?.nominationPrompts,
+      },
+      {
+        resolveAssetType: (assetId) => assetManifest[assetId]?.type ?? null,
+        resolveVariableName: (variableId) =>
+          variablesByUuid[variableId]?.name ?? null,
+      },
+    );
+    const existingLabels = stageList
+      .map((stage) => stage.label)
+      .filter((label): label is string => Boolean(label));
+    return generateStageLabel({
+      typeName: STAGE_TYPE_NAMES[type],
+      subjectName,
+      qualifier,
+      existingLabels,
+    });
+  }, [formValues, nodeTypes, edgeTypes, codebook, assetManifest, stageList]);
+
+  const isCustomRef = useRef(false);
+  const lastGeneratedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const update = computeAutoNameUpdate({
+      isNewStage,
+      isCustom: isCustomRef.current,
+      liveLabel,
+      lastGenerated: lastGeneratedRef.current,
+      generatedLabel,
+    });
+    isCustomRef.current = update.nextIsCustom;
+    if (update.label !== undefined) {
+      lastGeneratedRef.current = update.label;
+      dispatch(change(formName, 'label', update.label));
+    }
+  }, [generatedLabel, liveLabel, isNewStage, dispatch]);
+}
+```
+
+- [ ] **Step 4: Wire the hook into StageHeading**
+
+In `apps/architect-web/src/components/StageEditor/StageHeading.tsx`, add the import and call the hook **before** the `if (!type) return null;` early return (Rules of Hooks).
+
+Add import:
+
+```tsx
+import { useAutoStageName } from './autoStageName/useAutoStageName';
+```
+
+Change the body around the existing lines:
+
+```tsx
+const type = get(values, 'type') as string | undefined;
+const isNewStage = !get(initialValues, 'label');
+
+if (!type) {
+  return null;
+}
+```
+
+to:
+
+```tsx
+const type = get(values, 'type') as string | undefined;
+const isNewStage = !get(initialValues, 'label');
+
+useAutoStageName(isNewStage);
+
+if (!type) {
+  return null;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx`
+Expected: PASS (all three cases).
+
+If `getFormValues<StageFormValues>(formName)` reports a type error in the editor, confirm redux-form's generic signature is being used (no `as` cast); the value may be `undefined` at runtime, which the `formValues ?? {}` / `formValues?.label ?? ''` guards already handle.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/architect-web/src/components/StageEditor/autoStageName/useAutoStageName.ts apps/architect-web/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx apps/architect-web/src/components/StageEditor/StageHeading.tsx
+git commit -m "feat(architect): live auto-naming of new stages in the stage editor"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full architect-web test suite**
+
+Run: `pnpm --filter @codaco/architect-web test`
+Expected: PASS, including the four new test files.
+
+- [ ] **Step 2: Lint and format the new/modified files**
+
+Run: `pnpm lint:fix`
+Expected: no remaining errors; formatter applies cleanly. (Pre-commit hooks also run lint/format.)
+
+- [ ] **Step 3: Typecheck the workspace**
+
+Run: `pnpm typecheck`
+Expected: PASS with no errors. Resolve any `any`/assertion findings at the source (no ignore directives).
+
+- [ ] **Step 4: Knip (unused exports/deps)**
+
+Run: `pnpm knip`
+Expected: no new unused exports. Every exported symbol in the new modules is consumed by a test or by the hook; if knip flags one that is only used by tests, confirm it is genuinely needed and not dead code.
+
+- [ ] **Step 5: Commit any lint/format fixups**
+
+```bash
+git add -A
+git commit -m "chore(architect): lint and format auto-stage-naming" || echo "nothing to commit"
+```

--- a/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
+++ b/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
@@ -40,16 +40,24 @@ remaining fully overridable.
 Form Name Generator with Roster Panels`).
 - **Override.** The moment the researcher types a non-empty value into the name
   field, auto-naming disengages and the field is theirs.
-- **Re-engage on clear.** If the researcher clears the field back to empty,
-  auto-naming re-engages and resumes generating.
-- The existing `required` validation is unchanged; auto-naming simply keeps it
-  satisfied (the field is non-empty whenever auto-naming is active).
+- **Re-engage on blur, not mid-edit.** Clearing the field leaves it empty while
+  the researcher types — auto-naming does not refill instantly and fight the
+  keystrokes. If they leave the field (blur) while it is still empty, the
+  generated name fills back in then.
+- **Draft-neutral on entry.** Filling the initial name on a brand-new stage must
+  not mark the stage dirty or create undo history — otherwise the editor would
+  flash its "Finished Editing" button and enable Undo before the researcher has
+  done anything. The first fill folds the generated name into the draft baseline
+  (via the same reset the stage editor uses on INITIALIZE), so a fresh stage
+  stays pristine until the researcher actually changes something.
+- The existing `required` validation is unchanged; the initial fill keeps it
+  satisfied from the start.
 
 Ownership is inferred by comparing the current label against the last value the
 hook itself generated (`lastGenerated`): a non-empty live label that differs from
-`lastGenerated` means the researcher typed it, so auto-naming locks; an empty
-label re-engages. This avoids depending on redux-form's `change()` action
-suppressing the input's DOM `onChange`, and keeps the ownership decision in one
+`lastGenerated` means the researcher typed it, so auto-naming locks. This avoids
+depending on redux-form's `change()` action suppressing the input's DOM
+`onChange`, and keeps the ownership decision in one
 pure, unit-tested function (`computeAutoNameUpdate`).
 
 ## Name composition
@@ -195,9 +203,13 @@ are passed in so the pure module never imports selectors.
   manifest, and the sibling stage labels;
 - while auto-naming is active (new stage, researcher hasn't taken ownership),
   computes the name and dispatches redux-form `change(formName, 'label', name)`;
+  on the **first** fill it also folds the value into the draft baseline (a draft
+  timeline reset) so the stage stays pristine — no spurious dirty flag, no undo
+  step — until the researcher actually edits something;
 - infers ownership by comparing the live label to the last generated value
   (held in a ref) — a non-empty label that differs from it disengages
-  auto-naming; clearing to empty re-engages it.
+  auto-naming; clearing leaves the field empty and a blur handler (wired through
+  the heading input) re-fills it if the researcher tabs away while it is empty.
 
 The effect tracks the last generated value and the ownership flag in refs and
 re-runs on the resolved inputs (generated name, live label); after each

--- a/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
+++ b/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
@@ -1,0 +1,222 @@
+# Automatic Stage Naming — Design
+
+- **Date:** 2026-06-26
+- **App:** `apps/architect-web`
+- **Status:** Approved design, ready for implementation planning
+
+## Problem
+
+When creating a new stage in Architect, researchers frequently leave the stage
+name blank. The name field (`label`) starts empty with a placeholder and a
+`required` validation, so the researcher is forced to invent a name before they
+can save — friction at exactly the wrong moment. We want a sensible name to be
+present automatically, derived from what the researcher is configuring, while
+remaining fully overridable.
+
+## Goals
+
+- Auto-populate a new stage's name from its configuration.
+- Keep the name **live**: it refines itself as the researcher configures the
+  stage, and stops the instant the researcher types their own name.
+- Make names informative: stage type, subject (node/edge) type, and the
+  configuration that distinguishes one stage of a type from another (panels,
+  Information assets, Family Pedigree nominations).
+- Disambiguate duplicates with a trailing ` #2`, ` #3`, …
+
+## Non-goals
+
+- No schema or validation changes. `label` stays a required string (≤ 50 chars).
+- No retroactive renaming of existing stages, imported protocols, or duplicated
+  stages. This applies **only** to creating a new stage.
+- No new qualifier configuration UI. Qualifiers are derived from existing config.
+
+## Behaviour
+
+- **New stages only.** Auto-naming is active only while creating a stage (the
+  stage editor has no `id`). Editing an existing stage never auto-renames it.
+- **Live.** While auto-naming is active, the name field is kept in sync with the
+  generated name as the researcher sets the subject type and configures the
+  stage (e.g. `Form Name Generator` → `Person Form Name Generator` → `Person
+Form Name Generator with Roster Panels`).
+- **Override.** The moment the researcher types a non-empty value into the name
+  field, auto-naming disengages and the field is theirs.
+- **Re-engage on clear.** If the researcher clears the field back to empty,
+  auto-naming re-engages and resumes generating.
+- The existing `required` validation is unchanged; auto-naming simply keeps it
+  satisfied (the field is non-empty whenever auto-naming is active).
+
+User vs programmatic edits are distinguished cleanly: programmatic updates go
+through redux-form's `change()` action, which does **not** fire the input's DOM
+`onChange`. So an `onChange` on the heading input fires only for real keystrokes
+and is the signal that the researcher has taken ownership.
+
+## Name composition
+
+Format: `{Subject} {Type} {Qualifier} [ #n]`
+
+Examples:
+
+- `Person Form Name Generator with Roster Panels`
+- `Person Quick Add Name Generator`
+- `Friendship Per Alter Edge Form`
+- `Information with Video`
+- `Family Pedigree with Diabetes Nomination`
+- `Ego Form`
+
+### Subject
+
+Data-driven: if the stage defines a `subject` that resolves to a codebook entry,
+its `name` is prepended.
+
+- Node-subject stages (`subject.entity === 'node'`) → node type `name`.
+- Edge-subject stages (`subject.entity === 'edge'`) → edge type `name`
+  (e.g. `AlterEdgeForm`).
+- Stages with no subject yet (not chosen) → no prefix; it appears once chosen.
+- Stages with no subject at all (`EgoForm`, `Information`, `Anonymisation`,
+  `FamilyPedigree`) → no prefix. (Family Pedigree: no node-type prefix, by
+  decision — the nomination qualifier carries the differentiation.)
+
+### Type names
+
+Concise per-type names (distinct from the longer editor/badge display names):
+
+| Stage type            | Name                     |
+| --------------------- | ------------------------ |
+| NameGenerator         | Form Name Generator      |
+| NameGeneratorQuickAdd | Quick Add Name Generator |
+| NameGeneratorRoster   | Roster Name Generator    |
+| FamilyPedigree        | Family Pedigree          |
+| DyadCensus            | Dyad Census              |
+| OneToManyDyadCensus   | One to Many Dyad Census  |
+| TieStrengthCensus     | Tie-Strength Census      |
+| Sociogram             | Sociogram                |
+| Narrative             | Narrative                |
+| OrdinalBin            | Ordinal Bin              |
+| CategoricalBin        | Categorical Bin          |
+| AlterForm             | Per Alter Form           |
+| Geospatial            | Geospatial               |
+| AlterEdgeForm         | Per Alter Edge Form      |
+| EgoForm               | Ego Form                 |
+| Information           | Information              |
+| Anonymisation         | Anonymisation            |
+
+The map is exhaustive over `StageType` (enforced by the type system), so adding a
+new stage type to the schema forces an entry here.
+
+### Qualifiers
+
+A single `getStageQualifiers(stage, resolvers)` function returns the qualifier
+string (or none) for a stage. It takes resolver callbacks for codebook/asset
+lookups so the function itself stays pure and unit-testable.
+
+**Name Generator panels** (`NameGenerator`, `NameGeneratorQuickAdd`) — inspect
+`stage.panels[].dataSource` (`'existing'` = existing network, any other string =
+a roster):
+
+- all `existing` → `with Network Panels`
+- all roster → `with Roster Panels`
+- a mix of both → `with Panels`
+- no panels → no qualifier
+
+(`NameGeneratorRoster` has no panels; the whole stage being roster-based is
+already conveyed by its type name.)
+
+**Information assets** — collect the distinct media types of `asset` items,
+resolving `item.content` → asset manifest `type` (`image`/`video`/`audio`):
+
+- titled and listed per the multi-value rule below (`with Video`,
+  `with Image & Video`, …)
+- text-only or no assets → no qualifier
+
+**Family Pedigree nominations** — collect the distinct nominated variable names,
+resolving `nominationPrompts[].variable` → codebook variable `name`:
+
+- listed per the multi-value rule, with the noun `Nomination`/`Nominations`
+  (`with Diabetes Nomination`, `with Diabetes & Asthma Nominations`)
+- no nominations → no qualifier
+
+**Multi-value rule** (shared): up to 3 values are listed and joined with commas
+and a final `&` (`A`, `A & B`, `A, B & C`); 4+ values summarize to the generic
+noun (`with Nominations`; `with Media` for Information). Media types max out at
+three, so Information effectively always lists.
+
+## De-duplication
+
+Compared against the labels of all other stages in the protocol,
+**case-insensitively** (so an auto name won't sit beside a near-identical manual
+one). The generated casing is preserved.
+
+- If the base name is free → no suffix.
+- Otherwise append the lowest free ` #2`, ` #3`, … (gaps are filled, so deleting
+  ` #2` lets the next stage reclaim it).
+
+The current stage isn't yet in `protocol.stages` during creation, so there's no
+self to exclude.
+
+## Length handling (≤ 50 chars)
+
+The label cap is 50. A generated name (including any dedup suffix) that exceeds
+50 degrades gracefully, in order:
+
+1. If a multi-value qualifier was listed, fall back to its summarized form
+   (`with Nominations` / `with Media`) and rebuild.
+2. If still too long, drop the subject prefix.
+3. If still too long, hard-truncate to fit, trimming any trailing partial word.
+
+## Architecture
+
+Two small, isolated units. No schema, validation, or stage-creation-flow changes.
+
+### `generateStageName.ts` (new, pure)
+
+Located with the stage editor (e.g.
+`apps/architect-web/src/components/StageEditor/generateStageName.ts`). No React
+or store dependencies. Exports:
+
+- `STAGE_TYPE_NAMES: Record<StageType, string>` — the concise type-name map.
+- `getStageQualifiers(stage, resolvers)` — the per-type qualifier string.
+- `composeStageName({ subjectName?, typeName, qualifier? })` — assembles the base
+  name.
+- `dedupeStageLabel(base, existingLabels)` — applies the ` #n` suffix.
+- `fitStageLabel(parts, existingLabels)` (or equivalent) — orchestrates
+  composition + dedup + the length-degradation steps, returning the final label.
+
+Resolvers (`resolveNodeOrEdgeName`, `resolveVariableName`, `resolveAssetType`)
+are passed in so the pure module never imports selectors.
+
+### Live wiring in `StageHeading.tsx`
+
+`StageHeading` owns the `label` field. A small hook (or inline effect) there:
+
+- reads form values (`type`, `subject`, `panels`, `items`, `nominationPrompts`),
+  the codebook (node/edge/variable names via existing selectors), the asset
+  manifest, and the sibling stage labels;
+- while auto-naming is active (new stage, researcher hasn't taken ownership),
+  computes the name and dispatches redux-form `change(formName, 'label', name)`;
+- marks ownership via the heading input's `onChange` — a non-empty user value
+  disengages auto-naming; clearing to empty re-engages it.
+
+The effect depends on the resolved inputs (subject name, qualifier inputs,
+sibling labels, ownership flag), not on `label`, so it can't loop.
+
+## Edge cases
+
+- **Subject not yet chosen** → name is type-only (`Form Name Generator`) until a
+  subject is selected, then it gains the prefix live.
+- **Codebook rename** while auto-naming is active → the live name follows the new
+  name. Once saved (or once the researcher types), it's a fixed string.
+- **Researcher clears the field** → auto-naming re-engages (treated as
+  not-yet-owned), avoiding a `required` error and regenerating.
+- **Reopening a saved stage** → existing stage, no `id`-less creation, so no
+  auto-update; the saved label stands.
+
+## Testing
+
+- **Unit (pure module):** subject present/absent; each qualifier rule (panel
+  source combinations incl. mixed; Information media single/multi; nomination
+  single/2-3/4+ summarize); the multi-value list formatting; dedup with no
+  collision / one collision / gapped numbers / case-insensitive match; the
+  three length-degradation steps; exhaustiveness of `STAGE_TYPE_NAMES`.
+- **Component:** a focused render test of `StageHeading` — name updates as
+  subject and panels change; stops on user keystroke; re-engages when cleared;
+  no auto-update when editing an existing stage.

--- a/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
+++ b/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
@@ -45,10 +45,12 @@ Form Name Generator with Roster Panels`).
 - The existing `required` validation is unchanged; auto-naming simply keeps it
   satisfied (the field is non-empty whenever auto-naming is active).
 
-User vs programmatic edits are distinguished cleanly: programmatic updates go
-through redux-form's `change()` action, which does **not** fire the input's DOM
-`onChange`. So an `onChange` on the heading input fires only for real keystrokes
-and is the signal that the researcher has taken ownership.
+Ownership is inferred by comparing the current label against the last value the
+hook itself generated (`lastGenerated`): a non-empty live label that differs from
+`lastGenerated` means the researcher typed it, so auto-naming locks; an empty
+label re-engages. This avoids depending on redux-form's `change()` action
+suppressing the input's DOM `onChange`, and keeps the ownership decision in one
+pure, unit-tested function (`computeAutoNameUpdate`).
 
 ## Name composition
 
@@ -193,11 +195,14 @@ are passed in so the pure module never imports selectors.
   manifest, and the sibling stage labels;
 - while auto-naming is active (new stage, researcher hasn't taken ownership),
   computes the name and dispatches redux-form `change(formName, 'label', name)`;
-- marks ownership via the heading input's `onChange` — a non-empty user value
-  disengages auto-naming; clearing to empty re-engages it.
+- infers ownership by comparing the live label to the last generated value
+  (held in a ref) — a non-empty label that differs from it disengages
+  auto-naming; clearing to empty re-engages it.
 
-The effect depends on the resolved inputs (subject name, qualifier inputs,
-sibling labels, ownership flag), not on `label`, so it can't loop.
+The effect tracks the last generated value and the ownership flag in refs and
+re-runs on the resolved inputs (generated name, live label); after each
+programmatic `change`, the next run sees the label it just set and no-ops, so it
+can't loop.
 
 ## Edge cases
 

--- a/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
+++ b/docs/superpowers/specs/2026-06-26-architect-auto-stage-naming-design.md
@@ -175,24 +175,32 @@ The label cap is 50. A generated name (including any dedup suffix) that exceeds
 
 ## Architecture
 
-Two small, isolated units. No schema, validation, or stage-creation-flow changes.
+Small, isolated units under
+`apps/architect-web/src/components/StageEditor/autoStageName/`. No schema,
+validation, or stage-creation-flow changes.
 
-### `generateStageName.ts` (new, pure)
+### `generateStageLabel.ts` (new, pure)
 
-Located with the stage editor (e.g.
-`apps/architect-web/src/components/StageEditor/generateStageName.ts`). No React
-or store dependencies. Exports:
+No React or store dependencies. Exports:
 
 - `STAGE_TYPE_NAMES: Record<StageType, string>` — the concise type-name map.
-- `getStageQualifiers(stage, resolvers)` — the per-type qualifier string.
 - `composeStageName({ subjectName?, typeName, qualifier? })` — assembles the base
   name.
 - `dedupeStageLabel(base, existingLabels)` — applies the ` #n` suffix.
-- `fitStageLabel(parts, existingLabels)` (or equivalent) — orchestrates
-  composition + dedup + the length-degradation steps, returning the final label.
+- `generateStageLabel({ typeName, subjectName?, qualifier?, existingLabels })` —
+  orchestrates composition + dedup + the length-degradation steps, returning the
+  final label.
 
-Resolvers (`resolveNodeOrEdgeName`, `resolveVariableName`, `resolveAssetType`)
-are passed in so the pure module never imports selectors.
+### `resolveStageNameParts.ts` (new, pure)
+
+`resolveStageSubjectName(subject, resolveEntityName)` and
+`resolveStageQualifier(stage, { resolveAssetType, resolveVariableName })`.
+Resolver callbacks are passed in so the pure module never imports selectors.
+
+### `computeAutoNameUpdate.ts` (new, pure)
+
+The ownership state machine — decides, per render, whether to apply the
+generated label, lock, or leave the field empty.
 
 ### Live wiring in `StageHeading.tsx`
 
@@ -222,10 +230,11 @@ can't loop.
   subject is selected, then it gains the prefix live.
 - **Codebook rename** while auto-naming is active → the live name follows the new
   name. Once saved (or once the researcher types), it's a fixed string.
-- **Researcher clears the field** → auto-naming re-engages (treated as
-  not-yet-owned), avoiding a `required` error and regenerating.
-- **Reopening a saved stage** → existing stage, no `id`-less creation, so no
-  auto-update; the saved label stands.
+- **Researcher clears the field** → it stays empty while they type (auto-naming
+  does not regenerate mid-keystroke); on blur, if the field is still empty, the
+  generated name fills back in, avoiding a `required` error.
+- **Reopening a saved stage** → existing stage (has an `id`), so no auto-update;
+  the saved label stands.
 
 ## Testing
 
@@ -235,5 +244,7 @@ can't loop.
   collision / one collision / gapped numbers / case-insensitive match; the
   three length-degradation steps; exhaustiveness of `STAGE_TYPE_NAMES`.
 - **Component:** a focused render test of `StageHeading` — name updates as
-  subject and panels change; stops on user keystroke; re-engages when cleared;
-  no auto-update when editing an existing stage.
+  subject and panels change; stops on user keystroke; stays empty when cleared
+  and re-fills on blur; no auto-update when editing an existing stage (including
+  one with an empty label). A draft-wired test asserts the first fill leaves the
+  stage neither dirty nor undoable.

--- a/packages/protocol-validation/src/schemas/8/__tests__/base-stage-label.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/base-stage-label.test.ts
@@ -31,6 +31,17 @@ describe('baseStageSchema label requirement (#663)', () => {
     }
   });
 
+  it('rejects an empty label', () => {
+    const result = baseStageSchema.safeParse({ ...validBase, label: '' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => issue.path.includes('label')),
+      ).toBe(true);
+    }
+  });
+
   it('accepts a stage that provides a label', () => {
     const result = baseStageSchema.safeParse(validBase);
     expect(result.success).toBe(true);

--- a/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
@@ -2729,6 +2729,32 @@ describe('Migration V7 to V8', () => {
     });
   });
 
+  describe('stage label backfill', () => {
+    it('fills missing or empty stage labels with a one-based positional default', () => {
+      const v7Protocol = {
+        schemaVersion: 7 as const,
+        codebook: { node: {}, edge: {}, ego: {} },
+        stages: [
+          { id: 's1', type: 'Information', label: 'Welcome' },
+          { id: 's2', type: 'Information', label: '' },
+          { id: 's3', type: 'Information', label: '   ' },
+          { id: 's4', type: 'Information' },
+        ],
+      } as Protocol<7>;
+
+      const migrated = migrationV7toV8.migrate(v7Protocol, {
+        name: 'Test Protocol',
+      }) as unknown as { stages: { label?: unknown }[] };
+
+      // Existing labels are preserved; missing/empty/whitespace are replaced
+      // with "Stage <one-based index>".
+      expect(migrated.stages[0]?.label).toBe('Welcome');
+      expect(migrated.stages[1]?.label).toBe('Stage 2');
+      expect(migrated.stages[2]?.label).toBe('Stage 3');
+      expect(migrated.stages[3]?.label).toBe('Stage 4');
+    });
+  });
+
   describe('migration metadata', () => {
     it('has correct from and to versions', () => {
       expect(migrationV7toV8.from).toBe(7);

--- a/packages/protocol-validation/src/schemas/8/migration.ts
+++ b/packages/protocol-validation/src/schemas/8/migration.ts
@@ -69,6 +69,7 @@ const migrationV7toV8 = createMigration({
 - Removed 'loop' property from Information stage items and video/audio assets. This property was never honoured by Interviewer.
 - A \`minValue\`, \`minLength\`, or \`minSelected\` validator no longer implies a field is required. To preserve the effective behaviour of existing protocols that relied on this coupling, any codebook variable (node, edge, or ego) with one of these validators and no explicit \`required: true\` now has \`required: true\` set.
 - Categorical attribute values are now stored as arrays of selected option values. Existing single-value categorical filter and skip-logic rule operands (\`is exactly\`, \`is not\`, \`includes\`, \`excludes\`) are wrapped in a single-element array to match.
+- Stage labels are now required to be non-empty. Any stage with a missing or empty label is given a default name based on its position (e.g. "Stage 3").
 `,
   migrate: (doc, deps) => {
     const codebook = (doc as Record<string, unknown>).codebook;
@@ -608,6 +609,21 @@ const migrationV7toV8 = createMigration({
     // Set name from required dependency
     const result = transformed;
     result.name = deps.name;
+
+    // Backfill any missing, empty, or whitespace-only stage label with a
+    // one-based positional default ("Stage 1", "Stage 2", …) so the migrated
+    // protocol satisfies the stricter schema-8 `label` (now non-empty).
+    const stages = result.stages;
+    if (Array.isArray(stages)) {
+      stages.forEach((stage: unknown, index: number) => {
+        const typedStage = asRecord(stage);
+        if (!typedStage) return;
+        const label = typedStage.label;
+        if (typeof label !== 'string' || label.trim() === '') {
+          typedStage.label = `Stage ${index + 1}`;
+        }
+      });
+    }
 
     return result as ProtocolDocument<8>;
   },

--- a/packages/protocol-validation/src/schemas/8/stages/base.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/base.ts
@@ -10,10 +10,10 @@ export const baseStageSchema = z.strictObject({
   // `interviewScript` and `label` are author-facing only: `label` is the
   // human-readable stage title shown in Architect and `interviewScript` is
   // authoring guidance. Both are intentionally NOT rendered during the
-  // interview itself (see Navigation.tsx). `label` is kept required so it
-  // cannot be silently dropped from a protocol; the divergence from Architect
-  // is deliberate, not a regression (#663).
+  // interview itself (see Navigation.tsx). `label` is kept required AND
+  // non-empty so it cannot be silently dropped or left blank; the divergence
+  // from Architect is deliberate, not a regression (#663).
   interviewScript: z.string().optional(),
-  label: z.string(),
+  label: z.string().min(1, { message: 'Stage label cannot be empty' }),
   skipLogic: SkipLogicSchema.optional(),
 });


### PR DESCRIPTION
## What & why

Researchers creating a new stage in Architect frequently leave the name blank, then hit the `required`-name validation as friction at the wrong moment. This adds a sensible, **live** auto-generated stage name that the researcher can override at any point.

## Behaviour

- **New stages only.** The name field is live-populated as you configure the stage (e.g. `Form Name Generator` → `Person Form Name Generator` → `Person Form Name Generator with Roster Panels`). Editing an existing stage never auto-renames it.
- **Override & re-engage.** The moment you type a custom name, auto-naming disengages; clearing the field back to empty re-engages it. The existing `required` validation is untouched — auto-naming just keeps it satisfied.
- **De-duplication.** Colliding names get a case-insensitive ` #2`, ` #3`, … (lowest free number).

## Naming rules

`{Subject} {Type} {Qualifier} [ #n]`, capped at 50 chars with graceful degradation (summarize listed qualifier → drop subject → truncate).

- **Type** — concise per-type names (`Form Name Generator`, `Quick Add Name Generator`, `Roster Name Generator`, `Per Alter Edge Form`, `Ego Form`, …).
- **Subject** — node/edge type name from the codebook (omitted for ego/no-subject stages).
- **Qualifiers** — Name Generator panels (`with Network Panels` / `with Roster Panels` / `with Panels`), Information asset media (`with Video`, `with Image & Video`), Family Pedigree nominations (`with Diabetes Nomination`, `with Diabetes & Asthma Nominations`). Multi-value lists up to 3, then summarizes.

## Implementation

Three pure, fully unit-tested modules + one thin hook, all under `apps/architect-web/src/components/StageEditor/autoStageName/`:

- `generateStageLabel.ts` — type-name map, composition, case-insensitive dedup, 50-char fitting.
- `resolveStageNameParts.ts` — subject + per-type qualifier resolution (callback-driven, no store deps).
- `computeAutoNameUpdate.ts` — the ownership state machine (apply / lock / re-engage).
- `useAutoStageName.ts` — wires live redux-form values + codebook/asset selectors to the pure modules and dispatches `change('label', …)`. Called from `StageHeading`.

No schema, validation, or stage-creation-flow changes.

## Testing

- 4 new test files (pure-module unit tests + a `StageHeading` integration test driving the real `Editor`/redux-form).
- `pnpm typecheck` 23/23 · `pnpm --filter @codaco/architect-web test` 423 passed · `pnpm lint:fix` clean · `pnpm knip` no findings.

## Notes

- Two localized `as` casts plus `useDispatch<Dispatch<Action>>()` bridge the redux-form ↔ RTK-v2 type boundary (`@types/redux-form@8.3.11` has no `getFormValues` generic and its `FormAction` predates `UnknownAction`), mirroring the existing `StageEditor.tsx` precedent.
- `@codaco/architect-web` is private/changeset-ignored, so no changeset is included.
- Design spec and implementation plan are included under `docs/superpowers/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stage labels can now be auto-generated for new stages based on stage type and selected details.
  * Labels update as stage settings change until a custom name is entered.
  * Clearing a new stage name can restore the generated value when focus leaves the field.

* **Bug Fixes**
  * Improved handling of duplicate stage names and long labels to keep names readable and unique.
  * New-stage auto-filling now avoids unnecessary draft changes and undo entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->