### PR TITLE
fix(interview): Name generator panel layout 

### DIFF
--- a/.changeset/name-generator-panel-layout.md
+++ b/.changeset/name-generator-panel-layout.md
@@ -1,0 +1,11 @@
+---
+'@codaco/interview': patch
+---
+
+Fix two layout bugs in name-generator side panels:
+
+- When two panels are open they now share the rail evenly (~50/50) instead of
+  the panel with more content taking almost all the space and leaving its
+  sibling a sliver.
+- A collapsed panel now keeps its full title bar visible instead of shrinking to
+  nothing and hiding the title.

--- a/packages/interview/src/components/Panel.tsx
+++ b/packages/interview/src/components/Panel.tsx
@@ -39,10 +39,13 @@ const Panel = ({
 
   const panelClasses = cx(
     'elevation-high shadow-none',
-    'flex min-h-0 grow flex-col overflow-hidden rounded border-b-10',
+    'flex min-h-0 grow basis-0 flex-col overflow-hidden rounded border-b-10',
     'transition-all duration-500 ease-in-out',
     minimize && 'mb-0 grow-0 basis-0 border-b-0 opacity-0',
-    collapsed && !minimize && 'grow-0',
+    // Restore an auto basis while collapsed so the panel sizes to its title bar
+    // instead of shrinking to the base `basis-0`; `shrink-0` keeps the title from
+    // being compressed (and clipped by `overflow-hidden`) when the rail is short.
+    collapsed && !minimize && 'shrink-0 grow-0 basis-auto',
     panelNumber === 0 && 'border-b-cat-1',
     panelNumber === 1 && 'border-b-cat-2',
     panelNumber === 2 && 'border-b-cat-3',

--- a/packages/interview/src/components/Panels.stories.tsx
+++ b/packages/interview/src/components/Panels.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import Panel from './Panel';
+import Panels from './Panels';
+
+/**
+ * Isolated harness for the side-panel collapse/expand behaviour, decoupled from
+ * the interview store, external data, and drag-and-drop. Each `Panel` owns its
+ * own collapsed state and toggles it when its title bar is clicked; `Panels` is
+ * the `flex flex-col` vertical container they stack inside.
+ *
+ * Use the `TwoFullPanels` story to reproduce the reported glitch where, with two
+ * fully-populated panels, collapsing one does not let the sibling expand to fill
+ * the freed space (and vice versa).
+ */
+
+const FillerList = ({ count }: { count: number }) => (
+  <div className="flex flex-col gap-2 overflow-auto p-4">
+    {Array.from({ length: count }, (_, i) => (
+      <div
+        key={i}
+        className="bg-surface-1 flex h-12 shrink-0 items-center rounded px-3"
+      >
+        Item {i + 1}
+      </div>
+    ))}
+  </div>
+);
+
+const meta: Meta<typeof Panels> = {
+  title: 'Components/Panels',
+  component: Panels,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  // Constrain height so collapse/expand is observable: panels grow to fill the
+  // available column height, mirroring the Name Generator side rail.
+  decorators: [
+    (Story) => (
+      <div className="bg-background flex h-dvh w-80 flex-col p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Two stacked, fully-populated panels. Click either header to collapse it; the
+ * sibling should expand to fill the freed space.
+ */
+export const TwoFullPanels: Story = {
+  render: () => (
+    <Panels>
+      <Panel title="in progress interview" panelNumber={0}>
+        <FillerList count={12} />
+      </Panel>
+      <Panel title="previous interview" panelNumber={1}>
+        <FillerList count={12} />
+      </Panel>
+    </Panels>
+  ),
+};
+
+/**
+ * Two stacked panels holding *different* amounts of content. Both should still
+ * take ~50% of the column: each `Panel` grows from a zero `flex-basis` (`basis-0`)
+ * so the split ignores content height. Before that fix they grew from a
+ * content-derived `flex-basis: auto`, so the fuller panel kept most of the space
+ * and the sibling collapsed to a sliver — the asymmetry `TwoFullPanels` masks by
+ * giving both panels identical content.
+ */
+export const UnequalPanels: Story = {
+  render: () => (
+    <Panels>
+      <Panel title="in progress interview" panelNumber={0} testId="panel-0">
+        <FillerList count={12} />
+      </Panel>
+      <Panel title="previous interview" panelNumber={1} testId="panel-1">
+        <FillerList count={1} />
+      </Panel>
+    </Panels>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Deterministic isolated mirror of NameGenerator's `TwoPanels` even-split
+    // guard: no store, external data, or entrance animation to settle.
+    const [tall, short] = await waitFor(
+      async () => {
+        const heights = ['panel-0', 'panel-1'].map(
+          (id) => canvas.getByTestId(id).getBoundingClientRect().height,
+        );
+        for (const h of heights) await expect(h).toBeGreaterThan(0);
+        return heights;
+      },
+      { timeout: 2000 },
+    );
+
+    const ratio = Math.min(tall!, short!) / Math.max(tall!, short!);
+    await expect(
+      ratio,
+      `Open panels should split ~evenly despite unequal content, got ${tall!.toFixed(0)}px vs ${short!.toFixed(0)}px`,
+    ).toBeGreaterThan(0.85);
+  },
+};
+
+/**
+ * Clicking a panel's title bar collapses it. The collapsed panel must shrink to
+ * just its title bar — the whole title stays visible — rather than collapsing to
+ * zero height and clipping the title behind `overflow-hidden`. Regression guard
+ * for the `basis-0` interaction: a collapsed `grow-0` panel with a zero basis
+ * shrinks all the way to nothing, so `Panel` must restore an auto basis while
+ * collapsed.
+ */
+export const CollapseKeepsTitle: Story = {
+  render: () => (
+    <Panels>
+      <Panel title="in progress interview" panelNumber={0} testId="panel-0">
+        <FillerList count={12} />
+      </Panel>
+      <Panel title="previous interview" panelNumber={1} testId="panel-1">
+        <FillerList count={12} />
+      </Panel>
+    </Panels>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const panel = canvas.getByTestId('panel-0');
+    const header = within(panel).getByRole('button', {
+      name: /in progress interview/i,
+    });
+    const fullHeight = panel.getBoundingClientRect().height;
+    // Capture the header's natural height while the panel is still open — once
+    // collapsed a buggy panel would clip the header too, so measuring it
+    // afterwards could read a misleadingly small value.
+    const headerHeight = header.getBoundingClientRect().height;
+
+    // Collapse the panel via its title bar.
+    await userEvent.click(header);
+
+    // Collapse runs a 500ms transition — wait for the height to stop changing
+    // before measuring so we don't read a mid-animation value.
+    let prev = -1;
+    await waitFor(
+      async () => {
+        const h = panel.getBoundingClientRect().height;
+        const settled = h < fullHeight && Math.abs(h - prev) < 1;
+        prev = h;
+        await expect(settled).toBe(true);
+      },
+      { timeout: 3000, interval: 150 },
+    );
+
+    // A correctly collapsed panel stays at least as tall as its title bar,
+    // keeping the whole title visible; the bug shrinks it to ~0 (just the
+    // bottom border). Guard both against the header height and an absolute floor
+    // so the assertion can't be satisfied by a degenerate near-zero panel.
+    const collapsedHeight = panel.getBoundingClientRect().height;
+    await expect(
+      collapsedHeight,
+      `Collapsed panel should still show its full title bar (>= ${headerHeight.toFixed(0)}px), got ${collapsedHeight.toFixed(0)}px`,
+    ).toBeGreaterThanOrEqual(headerHeight - 1);
+    await expect(collapsedHeight).toBeGreaterThan(20);
+  },
+};
+
+/**
+ * Single panel baseline — collapse/expand of one panel in isolation works as a
+ * reference for the two-panel case.
+ */
+export const SinglePanel: Story = {
+  render: () => (
+    <Panels>
+      <Panel title="in progress interview" panelNumber={0}>
+        <FillerList count={12} />
+      </Panel>
+    </Panels>
+  ),
+};

--- a/packages/interview/src/interfaces/NameGenerator/NameGenerator.stories.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/NameGenerator.stories.tsx
@@ -17,7 +17,7 @@ type StoryArgs = {
   minNodes: number;
   maxNodes: number;
   /**
-   * Panel 1 content. `0` keeps it an existing-network panel; any value `> N`
+   * Panel 1 content. `0` keeps it an existing-network panel; any value `> 0`
    * makes it an external-data panel pre-loaded with that many nodes. Set this
    * unequal to {@link panel2NodeCount} to reproduce the lopsided split where one
    * open panel takes nearly all the space and its sibling collapses to a sliver.
@@ -271,18 +271,31 @@ export const TwoPanels: Story = {
     panelTitles: ['in progress interview', 'previous interview'],
   },
   render: (args) => <NameGeneratorStoryWrapper {...args} />,
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
+    const [title0 = '', title1 = ''] = args.panelTitles ?? [];
 
     // Wait until both panels have rendered and their external data has loaded,
-    // so measured heights reflect real content (12 vs 2 nodes).
+    // so measured heights reflect real content. Match each panel by its title
+    // (via its header button) rather than DOM order, so the test is independent
+    // of render order; assert the configured per-panel node counts.
     const panels = await waitFor(
       async () => {
         const found = canvas.getAllByTestId('node-panel');
         await expect(found.length).toBe(2);
-        await expect(within(found[0]!).getAllByRole('option').length).toBe(12);
-        await expect(within(found[1]!).getAllByRole('option').length).toBe(2);
-        return found;
+        const byTitle = (title: string) =>
+          found.find((p) => within(p).queryByRole('button', { name: title }));
+        const fuller = byTitle(title0);
+        const sparser = byTitle(title1);
+        await expect(fuller).toBeDefined();
+        await expect(sparser).toBeDefined();
+        await expect(within(fuller!).getAllByRole('option').length).toBe(
+          args.panel1NodeCount,
+        );
+        await expect(within(sparser!).getAllByRole('option').length).toBe(
+          args.panel2NodeCount,
+        );
+        return [fuller!, sparser!];
       },
       { timeout: 10000 },
     );

--- a/packages/interview/src/interfaces/NameGenerator/NameGenerator.stories.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/NameGenerator.stories.tsx
@@ -16,7 +16,62 @@ type StoryArgs = {
   panelCount: number;
   minNodes: number;
   maxNodes: number;
+  /**
+   * Panel 1 content. `0` keeps it an existing-network panel; any value `> N`
+   * makes it an external-data panel pre-loaded with that many nodes. Set this
+   * unequal to {@link panel2NodeCount} to reproduce the lopsided split where one
+   * open panel takes nearly all the space and its sibling collapses to a sliver.
+   */
+  panel1NodeCount: number;
+  /** Panel 2 content; see {@link panel1NodeCount}. */
+  panel2NodeCount: number;
+  /** Per-panel title overrides (index-aligned); falls back to `Panel N`. */
+  panelTitles?: string[];
 };
+
+type PanelHost = {
+  addPanel: (config: { title: string; dataSource?: string }) => void;
+};
+
+/**
+ * Add `args.panelCount` side panels to a stage. A panel whose per-index node
+ * count (`panel1NodeCount` / `panel2NodeCount`) is `> 0` becomes an
+ * external-data panel loaded with exactly that many nodes, giving each panel an
+ * independently controllable content height; a count of `0` leaves it as a
+ * plain existing-network panel.
+ */
+function addConfiguredPanels(
+  interview: SyntheticInterview,
+  stage: PanelHost,
+  args: StoryArgs,
+) {
+  const nodeCounts = [args.panel1NodeCount, args.panel2NodeCount];
+
+  for (let i = 0; i < args.panelCount; i++) {
+    const title = args.panelTitles?.[i] ?? `Panel ${i + 1}`;
+    const nodeCount = nodeCounts[i] ?? 0;
+
+    if (nodeCount <= 0) {
+      stage.addPanel({ title });
+      continue;
+    }
+
+    const assetId = `panel-${i}-data`;
+    const names = Array.from(
+      { length: nodeCount },
+      (_, n) => `${title} ${n + 1}`,
+    );
+    interview.addAsset({
+      key: assetId,
+      assetId,
+      name: `${assetId}.json`,
+      type: 'network',
+      url: buildExternalDataUrl(names),
+      size: 0,
+    });
+    stage.addPanel({ title, dataSource: assetId });
+  }
+}
 
 /**
  * When `initialNodeCount > 0`, prepend a one-prompt "Setup" NameGenerator stage
@@ -78,9 +133,7 @@ function buildInterview(args: StoryArgs): {
       });
     }
 
-    for (let i = 0; i < args.panelCount; i++) {
-      stage.addPanel({ title: `Panel ${i + 1}` });
-    }
+    addConfiguredPanels(interview, stage, args);
   } else {
     const stage = interview.addStage('NameGeneratorQuickAdd', {
       label: 'Name Generator',
@@ -95,9 +148,7 @@ function buildInterview(args: StoryArgs): {
       });
     }
 
-    for (let i = 0; i < args.panelCount; i++) {
-      stage.addPanel({ title: `Panel ${i + 1}` });
-    }
+    addConfiguredPanels(interview, stage, args);
   }
 
   interview.addInformationStage({
@@ -153,7 +204,18 @@ const meta: Meta<StoryArgs> = {
     },
     panelCount: {
       control: { type: 'range', min: 0, max: 2 },
-      description: 'Side panels (dataSource: existing)',
+      description:
+        'Number of side panels (per-panel data source set by panel1/2NodeCount)',
+    },
+    panel1NodeCount: {
+      control: { type: 'range', min: 0, max: 20 },
+      description:
+        'Panel 1 nodes: 0 = existing-network panel; >0 = external-data panel with N nodes. Set unequal to panel 2 to reproduce the lopsided split.',
+    },
+    panel2NodeCount: {
+      control: { type: 'range', min: 0, max: 20 },
+      description:
+        'Panel 2 nodes: 0 = existing-network panel; >0 = external-data panel with N nodes.',
     },
     minNodes: {
       control: 'number',
@@ -169,6 +231,8 @@ const meta: Meta<StoryArgs> = {
     initialNodeCount: 3,
     promptCount: 2,
     panelCount: 1,
+    panel1NodeCount: 0,
+    panel2NodeCount: 0,
     minNodes: 0,
     maxNodes: 0,
   },
@@ -179,6 +243,75 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {
   render: (args) => <NameGeneratorStoryWrapper {...args} />,
+};
+
+/**
+ * Two stacked side panels with *unequal* content (12 nodes vs 2). When both
+ * panels are open they should each take ~50% of the column regardless of how
+ * much content each holds. This is the regression guard for the lopsided-split
+ * bug: because `Panel` grows from a content-derived `flex-basis: auto` (rather
+ * than `basis-0`) the fuller panel keeps nearly all the space and its sibling
+ * collapses to a sliver — the `play` below fails until `components/Panel.tsx`
+ * gives panels a zero basis.
+ *
+ * Use the `panel1NodeCount` / `panel2NodeCount` controls to vary the imbalance,
+ * or set both to the same value. Setting a count to `0` reverts that panel to an
+ * existing-network panel.
+ */
+export const TwoPanels: Story = {
+  args: {
+    stageType: 'NameGenerator',
+    initialNodeCount: 0,
+    promptCount: 1,
+    panelCount: 2,
+    panel1NodeCount: 12,
+    panel2NodeCount: 2,
+    minNodes: 0,
+    maxNodes: 0,
+    panelTitles: ['in progress interview', 'previous interview'],
+  },
+  render: (args) => <NameGeneratorStoryWrapper {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Wait until both panels have rendered and their external data has loaded,
+    // so measured heights reflect real content (12 vs 2 nodes).
+    const panels = await waitFor(
+      async () => {
+        const found = canvas.getAllByTestId('node-panel');
+        await expect(found.length).toBe(2);
+        await expect(within(found[0]!).getAllByRole('option').length).toBe(12);
+        await expect(within(found[1]!).getAllByRole('option').length).toBe(2);
+        return found;
+      },
+      { timeout: 10000 },
+    );
+
+    // Surface (the panel root) mounts with its own entrance animation that
+    // drives the node-panel element's opacity 0 → 1; measuring before it settles
+    // reports transient zero heights, so wait for it to finish. (The ratio below
+    // is scale-invariant, but the height read itself is not reliable mid-anim.)
+    await waitFor(
+      async () => {
+        for (const p of panels) {
+          await expect(getComputedStyle(p).opacity).toBe('1');
+        }
+      },
+      { timeout: 5000 },
+    );
+
+    const [tall, short] = panels.map((p) => p.getBoundingClientRect().height);
+    const ratio = Math.min(tall!, short!) / Math.max(tall!, short!);
+
+    // Two open panels should split the rail evenly irrespective of content.
+    // Pre-fix (`grow` + content-derived `basis-auto`) the fuller panel keeps
+    // almost all the height and this ratio collapses toward 0; post-fix
+    // (`basis-0`) both grow from a zero baseline and it sits near 1.
+    await expect(
+      ratio,
+      `Open panels should be within 15% of each other in height, got ${tall!.toFixed(0)}px vs ${short!.toFixed(0)}px`,
+    ).toBeGreaterThan(0.85);
+  },
 };
 
 export const MinNodesValidation: Story = {


### PR DESCRIPTION
Make panels each take 50% of container when expanded and keep titles visible for collapsed panels

Update stories to reproduce, and add test coverage for these bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new panel layout examples showing stacked panels, collapse/expand behavior, and uneven content sizing.
  * Introduced configurable side-panel content in the Name Generator experience, including panel counts and optional panel titles.

* **Bug Fixes**
  * Improved collapsed panel sizing so title bars stay visible and don’t get clipped.
  * Updated panel flex behavior so adjacent panels share space more consistently, even with different content heights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->