### PR TITLE
fix(protocol-utilities): keep manual node attributes neutral instead of random

### DIFF
--- a/packages/interview/src/interfaces/NarrativePedigree/NarrativePedigree.stories.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/NarrativePedigree.stories.tsx
@@ -179,20 +179,11 @@ export function buildPedigreeInterview(seed: number) {
   // Using stable UIDs that match the edge wiring below.
   const fpId = fpStage.id;
 
-  // SyntheticInterview.getNetwork() fills any attribute NOT explicitly set on a
-  // manual node with a random faker value. For boolean variables that would
-  // randomise ego identity and disease status across the pedigree, so every
-  // person seeds the full flag set to a deterministic default and overrides only
-  // what is intentionally true.
-  const PERSON_DEFAULTS: Record<string, unknown> = {
-    [EGO_VAR]: false,
-    [HUNTINGTONS_VAR]: false,
-    [HAEMOPHILIA_VAR]: false,
-    [MITO_VAR]: false,
-    [REL_TO_EGO_VAR]: '',
-  };
+  // addManualNode leaves unset attributes neutral (boolean -> false, text ->
+  // ''), so each person only needs to declare the flags that are intentionally
+  // true; ego identity and disease status stay deterministic.
   const person = (uid: string, attrs: Record<string, unknown>) =>
-    si.addManualNode(fpId, nodeType.id, uid, { ...PERSON_DEFAULTS, ...attrs });
+    si.addManualNode(fpId, nodeType.id, uid, attrs);
 
   // Maternal grandparents: grandmother has mitochondrial myopathy
   person('gm', {

--- a/packages/protocol-utilities/src/SyntheticInterview.ts
+++ b/packages/protocol-utilities/src/SyntheticInterview.ts
@@ -1347,9 +1347,13 @@ export class SyntheticInterview {
               varId
             ] as VariableValue;
           } else {
-            attributes[varId] = valueGen.generateForVariable(
-              variable,
-              index,
+            // Procedurally-generated nodes get random synthetic values;
+            // manually-seeded nodes keep unset attributes neutral so the
+            // caller's scenario isn't corrupted by random data.
+            attributes[varId] = (
+              nodeEntry.manual
+                ? valueGen.neutralForVariable(variable)
+                : valueGen.generateForVariable(variable, index)
             ) as VariableValue;
           }
         }
@@ -1656,6 +1660,7 @@ export class SyntheticInterview {
       stageId,
       promptIDs: [],
       explicitAttributes: attributes,
+      manual: true,
     });
   }
 

--- a/packages/protocol-utilities/src/ValueGenerator.ts
+++ b/packages/protocol-utilities/src/ValueGenerator.ts
@@ -56,6 +56,25 @@ export class ValueGenerator {
     }
   }
 
+  /**
+   * Type-appropriate "unanswered" value for a variable. Used for manually
+   * seeded nodes, where unset attributes must stay neutral rather than being
+   * filled with random data that would corrupt a deliberately-constructed
+   * scenario (e.g. a random ego or random disease flags in a pedigree).
+   */
+  neutralForVariable(variable: VariableEntry): unknown {
+    switch (variable.type) {
+      case 'boolean':
+        return false;
+      case 'text':
+        return '';
+      case 'categorical':
+        return [];
+      default:
+        return null;
+    }
+  }
+
   generateName(): string {
     return this.faker.person.firstName();
   }

--- a/packages/protocol-utilities/src/__tests__/SyntheticInterview.test.ts
+++ b/packages/protocol-utilities/src/__tests__/SyntheticInterview.test.ts
@@ -401,6 +401,61 @@ describe('SyntheticInterview', () => {
     });
   });
 
+  describe('manual nodes', () => {
+    it('defaults unset attributes on manual nodes to neutral values instead of randomising', () => {
+      const si = new SyntheticInterview();
+      const nt = si.addNodeType();
+      const isEgo = nt.addVariable({ type: 'boolean', name: 'isEgo' });
+      const affected = nt.addVariable({ type: 'boolean', name: 'affected' });
+      const relationship = nt.addVariable({
+        type: 'text',
+        name: 'relationship',
+      });
+      const tags = nt.addVariable({
+        type: 'categorical',
+        name: 'tags',
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ],
+      });
+
+      const stage = si.addStage('Narrative', {
+        subject: { entity: 'node', type: nt.id },
+      });
+      si.addManualNode(stage.id, nt.id, 'person-1', { [isEgo.id]: true });
+
+      const network = si.getNetwork();
+      const node = network.nodes.find(
+        (n) => n[entityPrimaryKeyProperty] === 'person-1',
+      )!;
+      const attrs = node[entityAttributesProperty];
+
+      // Explicitly-seeded attribute is preserved.
+      expect(attrs[isEgo.id]).toBe(true);
+      // Unset attributes get type-appropriate neutrals, never random values.
+      expect(attrs[affected.id]).toBe(false);
+      expect(attrs[relationship.id]).toBe('');
+      expect(attrs[tags.id]).toEqual([]);
+    });
+
+    it('still randomises unset attributes on procedurally-generated nodes', () => {
+      const si = new SyntheticInterview();
+      const nt = si.addNodeType();
+      const label = nt.addVariable({ type: 'text', name: 'label' });
+
+      si.addStage('Narrative', {
+        initialNodes: { count: 1 },
+        subject: { entity: 'node', type: nt.id },
+      });
+
+      const node = si.getNetwork().nodes[0]!;
+      const value = node[entityAttributesProperty][label.id];
+      expect(typeof value).toBe('string');
+      expect(value).not.toBe('');
+    });
+  });
+
   describe('edge generation', () => {
     it('creates edges between initial nodes', () => {
       const si = new SyntheticInterview();

--- a/packages/protocol-utilities/src/types.ts
+++ b/packages/protocol-utilities/src/types.ts
@@ -297,6 +297,9 @@ export type NodeEntry = {
   // getNetwork() time, since prompts are added after the stage is created.
   promptIndices?: number[];
   explicitAttributes: Record<string, unknown>;
+  // Manually seeded nodes (addManualNode) take full control of their
+  // attributes: unset attributes are left neutral rather than randomised.
+  manual?: boolean;
 };
 
 export type EdgeEntry = {


### PR DESCRIPTION
## Problem

`SyntheticInterview.addManualNode` is used to seed **deliberate** scenarios — most notably the NarrativePedigree stories' pedigree, where node identity matters. But `getNetwork()` filled every attribute *not* explicitly set on a node with a random faker value. For manually-seeded nodes that meant boolean flags like `isEgo` and the disease variables were randomised on every render — producing a random ego and random "affected" family members each time.

The NarrativePedigree story had worked around this with a `PERSON_DEFAULTS` object spread into every node, but that only neutralised the handful of flags the author remembered; any other unset boolean/text var would still randomise.

## Fix

- `getNetwork()` now distinguishes **procedurally-generated** nodes (`initialNodes`) from **manually-seeded** ones. Procedural nodes still randomise unset attributes (that's their purpose); manual nodes fill unset attributes with type-appropriate neutrals.
- New `ValueGenerator.neutralForVariable`: `boolean → false`, `text → ''`, `categorical → []` (arrays-always), everything else `→ null`. Neutrals (rather than leaving attrs absent) preserve the existing invariant that every node carries every codebook variable.
- `NodeEntry` gains an optional `manual` flag, set by `addManualNode`.
- Edges were already passed through verbatim, so only the node path changed.

## Story simplification

The NarrativePedigree story drops the `PERSON_DEFAULTS` workaround — each `person()` now declares only its intentionally-true flags. The neutrals exactly match the values `PERSON_DEFAULTS` provided, and `getNetwork()` orders attributes by `nodeType.variables` (not insertion order), so **the produced network is byte-identical** and the capture/view images do not change.

## Tests

- TDD: added a failing test first (unset `relationship` came back as a random `'Annie'`), then implemented to green.
- `@codaco/protocol-utilities`: 64/64 pass, including a contrast test asserting procedural nodes still randomise.
- `turbo typecheck` clean for `@codaco/protocol-utilities` and `@codaco/interview`.

No changeset — `addManualNode` is itself new and unreleased on the parent branch, so tuning its behaviour before it ships doesn't warrant one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manually added interview nodes now keep unset attributes neutral instead of filling them with random values.
  * Explicitly set attributes on manually added nodes continue to be preserved.

* **Bug Fixes**
  * Improved consistency when building interview networks so seeded nodes no longer receive unexpected default data.
  * Procedurally generated nodes still randomize unset attributes as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->