### PR TITLE
a11y(interview): expose Narrative Pedigree per-node disease status to screen readers

### DIFF
--- a/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/FramingSelectionStep.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/FramingSelectionStep.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useId } from 'react';
+
 import RichSelectGroupField from '@codaco/fresco-ui/form/fields/RichSelectGroup';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import type { FramingId } from '@codaco/shared-consts';
@@ -33,14 +35,16 @@ const FRAMING_OPTIONS = [
 export function FramingSelectionStep() {
   const framing = useFamilyPedigreeStore((s) => s.framing);
   const setFraming = useFamilyPedigreeStore((s) => s.setFraming);
+  const promptId = useId();
 
   return (
     <>
-      <Paragraph>
+      <Paragraph id={promptId}>
         How would you like us to refer to the people you&apos;re biologically
         related to?
       </Paragraph>
       <RichSelectGroupField
+        aria-labelledby={promptId}
         options={FRAMING_OPTIONS}
         value={framing ?? undefined}
         onChange={(value) => {

--- a/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/FramingSelectionStep.test.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/FramingSelectionStep.test.tsx
@@ -64,6 +64,23 @@ describe('FramingSelectionStep', () => {
     expect(screen.getByText('Mother & father')).toBeTruthy();
   });
 
+  it('gives the selection group an accessible name from the prompt', () => {
+    const { Wrapper } = framingWrapper(null);
+    render(
+      <Wrapper>
+        <FramingSelectionStep />
+      </Wrapper>,
+    );
+
+    // The prompt is a sibling Paragraph, wired to the group via aria-labelledby
+    // so the group is not an anonymous control for screen-reader users.
+    expect(
+      screen.getByRole('listbox', {
+        name: /how would you like us to refer to the people/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('calls setFraming with "gendered" when the mother & father option is selected', () => {
     const { Wrapper, store } = framingWrapper(null);
 

--- a/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
@@ -593,3 +593,108 @@ describe('NarrativePedigreeView — at-risk-homozygous threading (sticker mode)'
     ).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-node disease-status summary exposed to assistive technology.
+//
+// The visual status markers (stickers / classic notation) are aria-hidden, so
+// the only way a screen-reader user can learn who is affected/carrier/at-risk
+// is the visually-hidden summary referenced by the focal container's
+// aria-describedby. These tests assert that accessibility outcome directly via
+// the computed accessible name/description rather than DOM attributes.
+// ---------------------------------------------------------------------------
+
+function focalMember(nodeId: string): HTMLElement {
+  const el = document.querySelector(`[data-node-id="${nodeId}"]`);
+  if (!(el instanceof HTMLElement)) {
+    throw new Error(`No focal member for node "${nodeId}"`);
+  }
+  return el;
+}
+
+describe('NarrativePedigreeView — per-node status summary (a11y)', () => {
+  it("exposes each member's disease status via the focal container's accessible description", async () => {
+    renderView();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-node-id="mother"]')).toBeTruthy(),
+    );
+
+    const mother = focalMember('mother');
+    // The name conveys the focal action + person; the description conveys the
+    // disease status. Mother has Disease A (autosomal dominant) → affected.
+    expect(mother).toHaveAccessibleName(/^Focus on /);
+    expect(mother).toHaveAccessibleDescription(/Disease A: Affected/);
+  });
+
+  it('summarises every shown disease in sticker (all-diseases) mode', async () => {
+    renderView();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-sticker-status]')).toBeTruthy(),
+    );
+
+    const mother = focalMember('mother');
+    expect(mother).toHaveAccessibleDescription(/Disease A:/);
+    expect(mother).toHaveAccessibleDescription(/Disease B:/);
+  });
+
+  it('narrows the summary to the selected disease in classic mode', async () => {
+    renderView();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-sticker-status]')).toBeTruthy(),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Disease A' }));
+    await waitFor(() =>
+      expect(document.querySelector('[data-notation-status]')).toBeTruthy(),
+    );
+
+    const mother = focalMember('mother');
+    expect(mother).toHaveAccessibleDescription('Disease A: Affected');
+  });
+
+  it('references the summary via a non-aria-hidden, reachable element', async () => {
+    renderView();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-node-id="mother"]')).toBeTruthy(),
+    );
+
+    const mother = focalMember('mother');
+    const summaryId = mother.getAttribute('aria-describedby');
+    expect(summaryId).toBeTruthy();
+
+    const summary = summaryId ? document.getElementById(summaryId) : null;
+    expect(summary).toBeInTheDocument();
+
+    // Walk every ancestor to confirm the summary is not suppressed by an
+    // aria-hidden subtree (the regression these tests guard against).
+    let el: Element | null = summary;
+    while (el) {
+      expect(el.getAttribute('aria-hidden')).not.toBe('true');
+      el = el.parentElement;
+    }
+  });
+});
+
+describe('NarrativePedigreeView — at-risk-homozygous reaches the description (a11y)', () => {
+  it("includes the at-risk-homozygous note in the flagged member's accessible description", async () => {
+    renderCousinView('classic');
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-notation-status]')).toBeTruthy(),
+    );
+
+    const sharedChild = focalMember('sharedChild');
+    expect(sharedChild).toHaveAccessibleDescription(
+      /At risk of being affected \(homozygous\)/,
+    );
+
+    const unrelated = focalMember('unrelated');
+    expect(unrelated).not.toHaveAccessibleDescription(
+      /At risk of being affected \(homozygous\)/,
+    );
+  });
+});

--- a/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
@@ -698,3 +698,101 @@ describe('NarrativePedigreeView — at-risk-homozygous reaches the description (
     );
   });
 });
+
+// An affected recessive individual trivially has two carrier parents, so
+// computeAtRiskHomozygous flags them too. The visual still draws the triangle,
+// but the spoken summary must not say "Affected, at risk of being affected".
+describe('NarrativePedigreeView — affected nodes omit the contradictory homozygous note (a11y)', () => {
+  const AR2_VAR = 'ar2';
+  const SRC_TRIO = 'source-fp-trio';
+
+  function renderAffectedTrioView() {
+    const trioSource = { ...sourceStage, id: SRC_TRIO };
+    const trioNodes: NcNode[] = [
+      makeNode('p1', { [NAME_VAR]: 'Pat', [BIO_SEX_VAR]: 'female' }),
+      makeNode('p2', { [NAME_VAR]: 'Sam', [BIO_SEX_VAR]: 'male' }),
+      makeNode('kid', {
+        [NAME_VAR]: 'Kit',
+        [BIO_SEX_VAR]: 'male',
+        [AR2_VAR]: true,
+      }),
+    ];
+    const trioEdges: NcEdge[] = [
+      makeEdge('p1', 'kid'),
+      makeEdge('p2', 'kid'),
+      {
+        [entityPrimaryKeyProperty]: 'p1-p2',
+        type: EDGE_TYPE,
+        from: 'p1',
+        to: 'p2',
+        [entityAttributesProperty]: {
+          [REL_TYPE_VAR]: ['partner'],
+          [IS_ACTIVE_VAR]: true,
+        },
+      },
+    ];
+    const stage: NarrativeStage = {
+      id: 'np-trio',
+      type: 'NarrativePedigree',
+      label: 'Recessive Trio Pedigree',
+      sourceStageId: SRC_TRIO,
+      diseases: [
+        {
+          id: 'ar2',
+          label: 'Recessive Disease',
+          color: '#ff0000',
+          variable: asEntityAttributeReference(AR2_VAR),
+          inheritancePattern: 'autosomalRecessive',
+        },
+      ],
+    };
+    const store = configureStore({
+      reducer: { protocol, session },
+      preloadedState: {
+        protocol: {
+          codebook,
+          stages: [trioSource, stage],
+          assets: [],
+        } as never,
+        session: {
+          id: 'trio-session',
+          network: {
+            nodes: trioNodes,
+            edges: trioEdges,
+            ego: { [entityAttributesProperty]: {} },
+          },
+          stageMetadata: {},
+        } as never,
+      },
+      middleware: (g) => g({ serializableCheck: false }),
+    });
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <Provider store={store}>
+          <CurrentStepProvider currentStep={1} onStepChange={() => undefined}>
+            {children}
+          </CurrentStepProvider>
+        </Provider>
+      );
+    }
+    return render(<NarrativePedigreeView stage={stage} />, {
+      wrapper: Wrapper,
+    });
+  }
+
+  it('does not append the homozygous note to an already-affected member', async () => {
+    renderAffectedTrioView();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-node-id="kid"]')).toBeTruthy(),
+    );
+
+    const kid = focalMember('kid');
+    // The homozygous flag IS set (the triangle renders) — without it this test
+    // would not exercise the guard.
+    expect(kid.querySelector('[data-atrisk-homozygous-notation]')).toBeTruthy();
+    // ...but the spoken summary must stay coherent: affected, full stop.
+    expect(kid).toHaveAccessibleDescription('Recessive Disease: Affected');
+    expect(kid).not.toHaveAccessibleDescription(/homozygous/i);
+  });
+});

--- a/packages/interview/src/interfaces/NarrativePedigree/components/ClassicNotationNode.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/ClassicNotationNode.tsx
@@ -4,7 +4,7 @@ import Node from '@codaco/fresco-ui/Node';
 import type { NodeShape } from '@codaco/fresco-ui/Node';
 import type { NcNode } from '@codaco/shared-consts';
 
-import type { Status } from '../genetics/status';
+import { AT_RISK_HOMOZYGOUS_LABEL, type Status } from '../genetics/status';
 import { StatusMarker } from './StatusMarker';
 
 export type ClassicDisease = {
@@ -21,8 +21,6 @@ type ClassicNotationNodeProps = {
   selected?: boolean;
 };
 
-const AT_RISK_LABEL = 'At risk of being affected (homozygous)';
-
 /**
  * Small upward-pointing triangle positioned at the bottom-right corner of the
  * node symbol. Signals that the person may be homozygous-affected for this
@@ -34,7 +32,7 @@ const AT_RISK_LABEL = 'At risk of being affected (homozygous)';
 function AtRiskHomozygousNotation({ color }: { color: string }) {
   return (
     <span
-      aria-label={AT_RISK_LABEL}
+      aria-label={AT_RISK_HOMOZYGOUS_LABEL}
       data-atrisk-homozygous-notation
       className="pointer-events-none absolute right-0 bottom-0 flex items-center justify-center"
       style={{ width: 10, height: 10 }}

--- a/packages/interview/src/interfaces/NarrativePedigree/components/ClassicNotationNode.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/ClassicNotationNode.tsx
@@ -4,7 +4,7 @@ import Node from '@codaco/fresco-ui/Node';
 import type { NodeShape } from '@codaco/fresco-ui/Node';
 import type { NcNode } from '@codaco/shared-consts';
 
-import { AT_RISK_HOMOZYGOUS_LABEL, type Status } from '../genetics/status';
+import type { Status } from '../genetics/status';
 import { StatusMarker } from './StatusMarker';
 
 export type ClassicDisease = {
@@ -23,16 +23,16 @@ type ClassicNotationNodeProps = {
 
 /**
  * Small upward-pointing triangle positioned at the bottom-right corner of the
- * node symbol. Signals that the person may be homozygous-affected for this
- * disease — a second signal distinct from all primary-status markers.
+ * node symbol. Visually signals that the person may be homozygous-affected for
+ * this disease — a second signal distinct from all primary-status markers.
  *
- * Rendered as a sibling to the notation-status span (not inside it) so its
- * aria-label is not suppressed by the overlay's aria-hidden ancestor.
+ * Decorative (aria-hidden): the status it conveys is announced as text by the
+ * per-node summary in NarrativePedigreeView.
  */
 function AtRiskHomozygousNotation({ color }: { color: string }) {
   return (
     <span
-      aria-label={AT_RISK_HOMOZYGOUS_LABEL}
+      aria-hidden
       data-atrisk-homozygous-notation
       className="pointer-events-none absolute right-0 bottom-0 flex items-center justify-center"
       style={{ width: 10, height: 10 }}

--- a/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
@@ -274,7 +274,13 @@ export default function NarrativePedigreeView({
       const atRiskHomozygous =
         statusesByDiseaseHomozygous.get(disease.id)?.get(node.id) ?? false;
       const statusText = STATUS_LABELS[status];
-      return atRiskHomozygous
+      // An affected recessive individual trivially has two carrier parents, so
+      // the homozygous flag is set for them too — but announcing "Affected, at
+      // risk of being affected" is contradictory. Drop the note once the person
+      // is already affected so the spoken summary stays coherent.
+      const alreadyAffected =
+        status === 'affected' || status === 'obligateAffected';
+      return atRiskHomozygous && !alreadyAffected
         ? `${disease.label}: ${statusText}, ${AT_RISK_HOMOZYGOUS_LABEL}`
         : `${disease.label}: ${statusText}`;
     });

--- a/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
@@ -35,7 +35,12 @@ import {
 } from '../genetics/computeStatuses';
 import { buildGeneticGraph } from '../genetics/geneticGraph';
 import { resolveSex } from '../genetics/resolveSex';
-import { affectedSet, type Status } from '../genetics/status';
+import {
+  affectedSet,
+  AT_RISK_HOMOZYGOUS_LABEL,
+  STATUS_LABELS,
+  type Status,
+} from '../genetics/status';
 import { computeContributors } from '../highlight';
 import {
   ClassicNotationNode,
@@ -255,6 +260,27 @@ export default function NarrativePedigreeView({
     return displayLabels.get(node.id) ?? '';
   };
 
+  // Plain-text per-node disease-status summary for screen readers. The visual
+  // status markers (stickers / classic notation) are aria-hidden, so this is the
+  // only way a screen-reader user learns who is affected/carrier/at-risk. It
+  // mirrors whatever is currently shown (all diseases, or a single selected one)
+  // and is announced via aria-describedby on the focal container. Returns null
+  // when there are no diseases to describe.
+  const statusSummaryFor = (node: RenderableNode): string | null => {
+    if (shownDiseases.length === 0) return null;
+    const parts = shownDiseases.map((disease) => {
+      const status =
+        statusesByDisease.get(disease.id)?.get(node.id) ?? 'unknown';
+      const atRiskHomozygous =
+        statusesByDiseaseHomozygous.get(disease.id)?.get(node.id) ?? false;
+      const statusText = STATUS_LABELS[status];
+      return atRiskHomozygous
+        ? `${disease.label}: ${statusText}, ${AT_RISK_HOMOZYGOUS_LABEL}`
+        : `${disease.label}: ${statusText}`;
+    });
+    return parts.join('. ');
+  };
+
   const handleSnapshot = () => {
     if (!viewRef.current) return;
     void exportSnapshot(viewRef.current, `${stage.label || 'pedigree'}.png`);
@@ -272,6 +298,9 @@ export default function NarrativePedigreeView({
       ? renderClassic(node, shape, label, singleDisease, isSelected)
       : renderSticker(node, shape, label, isSelected);
 
+    const statusSummary = statusSummaryFor(node);
+    const statusSummaryId = statusSummary ? `np-status-${node.id}` : undefined;
+
     const handleClick = () => {
       setFocalId(node.id);
     };
@@ -280,10 +309,15 @@ export default function NarrativePedigreeView({
     // the fresco-ui Node is itself a <button>, and a <button> inside a <button>
     // is invalid HTML. role="button" + key handling keeps it accessible while
     // the inner Node button stays tabIndex=-1.
+    //
+    // aria-describedby points at the visually-hidden status summary so the
+    // person's disease status is announced after their name. The container's
+    // aria-label provides the name, so the summary need not repeat it.
     const focalProps: ComponentPropsWithoutRef<'div'> = {
       'role': 'button',
       'tabIndex': 0,
       'aria-label': `Focus on ${label || node.id}`,
+      'aria-describedby': statusSummaryId,
       'onClick': handleClick,
       'onKeyDown': (event) => {
         if (event.key === 'Enter' || event.key === ' ') {
@@ -302,6 +336,11 @@ export default function NarrativePedigreeView({
         style={{ opacity: dimmed ? 0.3 : 1 }}
         {...focalProps}
       >
+        {statusSummary && (
+          <span id={statusSummaryId} className="sr-only">
+            {statusSummary}
+          </span>
+        )}
         {inner}
       </div>
     );

--- a/packages/interview/src/interfaces/NarrativePedigree/components/StickerNode.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/StickerNode.tsx
@@ -1,11 +1,7 @@
 import Node from '@codaco/fresco-ui/Node';
 import type { NodeColorSequence, NodeShape } from '@codaco/fresco-ui/Node';
 
-import {
-  AT_RISK_HOMOZYGOUS_LABEL,
-  STATUS_LABELS,
-  type Status,
-} from '../genetics/status';
+import { STATUS_LABELS, type Status } from '../genetics/status';
 import { StatusMarker } from './StatusMarker';
 import { stickerPositions } from './stickerPositions';
 
@@ -39,12 +35,14 @@ const STATUS_CLASS: Record<Status, string> = {
 
 /**
  * Small upward-pointing triangle placed at the bottom-right corner of its
- * parent sticker. Signals that a person may be homozygous-affected for this
- * disease — distinct from the primary-status marker shape.
+ * parent sticker. Visually signals that a person may be homozygous-affected for
+ * this disease — distinct from the primary-status marker shape.
  *
- * Rendered as a sibling to the sticker overlay (not inside it) so that:
- * - its aria-label is not suppressed by the overlay's aria-hidden ancestor, and
- * - the overflow-hidden / rounded-full clip on the sticker span does not trim it.
+ * Decorative: the status it conveys is announced as text by the per-node
+ * summary in NarrativePedigreeView, so the triangle is hidden from assistive
+ * technology (its aria-hidden overlay). It is still rendered as a sibling to
+ * the sticker overlay so the overflow-hidden / rounded-full clip on the sticker
+ * span does not trim the triangle.
  */
 function AtRiskHomozygousMarker({
   color,
@@ -57,7 +55,6 @@ function AtRiskHomozygousMarker({
 }) {
   return (
     <span
-      aria-label={AT_RISK_HOMOZYGOUS_LABEL}
       data-atrisk-homozygous-marker
       className="pointer-events-none absolute flex items-center justify-center"
       style={{
@@ -200,10 +197,11 @@ export function StickerNode({
         })}
       </span>
 
-      {/* At-risk-homozygous markers — rendered outside the aria-hidden overlay so
-          their labels are reachable by assistive technology, and outside the
-          overflow-hidden sticker span so the triangle is not clipped. */}
-      <span className="pointer-events-none absolute inset-0">
+      {/* At-risk-homozygous markers — decorative (aria-hidden); the status is
+          announced as text by the per-node summary in NarrativePedigreeView.
+          Kept in their own overlay (not the sticker overlay) so the
+          overflow-hidden sticker span does not clip the triangle. */}
+      <span aria-hidden className="pointer-events-none absolute inset-0">
         {visibleStickers.map((sticker, i) => {
           if (sticker.atRiskHomozygous !== true) return null;
           const pos = positions[i];

--- a/packages/interview/src/interfaces/NarrativePedigree/components/StickerNode.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/StickerNode.tsx
@@ -1,7 +1,11 @@
 import Node from '@codaco/fresco-ui/Node';
 import type { NodeColorSequence, NodeShape } from '@codaco/fresco-ui/Node';
 
-import type { Status } from '../genetics/status';
+import {
+  AT_RISK_HOMOZYGOUS_LABEL,
+  STATUS_LABELS,
+  type Status,
+} from '../genetics/status';
 import { StatusMarker } from './StatusMarker';
 import { stickerPositions } from './stickerPositions';
 
@@ -24,24 +28,14 @@ const STICKER_SIZE_PX = 22;
 /** Half-sticker offset so the marker is centred on the perimeter point. */
 const STICKER_HALF = STICKER_SIZE_PX / 2;
 
-type StatusStyleInfo = {
-  className: string;
-  label: string;
+const STATUS_CLASS: Record<Status, string> = {
+  affected: 'sticker-solid',
+  obligateAffected: 'sticker-double-ring',
+  obligateCarrier: 'sticker-ring-dot',
+  atRiskAffected: 'sticker-half',
+  atRiskCarrier: 'sticker-dot',
+  unknown: 'sticker-question',
 };
-
-const STATUS_STYLE: Record<Status, StatusStyleInfo> = {
-  affected: { className: 'sticker-solid', label: 'Affected' },
-  obligateAffected: {
-    className: 'sticker-double-ring',
-    label: 'Obligate affected',
-  },
-  obligateCarrier: { className: 'sticker-ring-dot', label: 'Obligate carrier' },
-  atRiskAffected: { className: 'sticker-half', label: 'At risk (affected)' },
-  atRiskCarrier: { className: 'sticker-dot', label: 'At risk (carrier)' },
-  unknown: { className: 'sticker-question', label: 'Status unknown' },
-};
-
-const AT_RISK_LABEL = 'At risk of being affected (homozygous)';
 
 /**
  * Small upward-pointing triangle placed at the bottom-right corner of its
@@ -63,7 +57,7 @@ function AtRiskHomozygousMarker({
 }) {
   return (
     <span
-      aria-label={AT_RISK_LABEL}
+      aria-label={AT_RISK_HOMOZYGOUS_LABEL}
       data-atrisk-homozygous-marker
       className="pointer-events-none absolute flex items-center justify-center"
       style={{
@@ -88,7 +82,8 @@ type StickerMarkerProps = {
 };
 
 function StickerMarker({ sticker, x, y, onSelectDisease }: StickerMarkerProps) {
-  const { className, label } = STATUS_STYLE[sticker.status];
+  const className = STATUS_CLASS[sticker.status];
+  const label = STATUS_LABELS[sticker.status];
 
   const handlePointerClick =
     onSelectDisease !== undefined

--- a/packages/interview/src/interfaces/NarrativePedigree/components/__tests__/ClassicNotationNode.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/__tests__/ClassicNotationNode.test.tsx
@@ -357,7 +357,7 @@ describe('ClassicNotationNode', () => {
       expect(marker).toBeInTheDocument();
     });
 
-    it('[data-atrisk-homozygous-notation] is not nested inside any aria-hidden subtree', () => {
+    it('[data-atrisk-homozygous-notation] is decorative — aria-hidden with no accessible label', () => {
       render(
         <ClassicNotationNode
           node={mockNode}
@@ -370,21 +370,27 @@ describe('ClassicNotationNode', () => {
           label="Alice"
         />,
       );
-      // Verify the marker exists and carries an accessible name.
       const marker = document.querySelector(
         '[data-atrisk-homozygous-notation]',
       );
       expect(marker).not.toBeNull();
-      expect(marker).toHaveAttribute('aria-label');
 
-      // Walk every ancestor to confirm none carries aria-hidden="true".
-      // getByLabelText does NOT filter by aria-hidden, so this explicit walk is
-      // the only reliable guard that the marker is outside any aria-hidden subtree.
+      // The status is announced as text by the per-node summary in
+      // NarrativePedigreeView; the triangle carries no accessible label and is
+      // hidden from the accessibility tree.
+      expect(marker).not.toHaveAttribute('aria-label');
+
+      // Confirm an aria-hidden ancestor (or the marker itself) hides it from AT.
       let el: Element | null = marker;
+      let hidden = false;
       while (el) {
-        expect(el.getAttribute('aria-hidden')).not.toBe('true');
+        if (el.getAttribute('aria-hidden') === 'true') {
+          hidden = true;
+          break;
+        }
         el = el.parentElement;
       }
+      expect(hidden).toBe(true);
     });
 
     it.each(['square', 'circle', 'diamond'] as const)(

--- a/packages/interview/src/interfaces/NarrativePedigree/components/__tests__/StickerNode.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/__tests__/StickerNode.test.tsx
@@ -216,23 +216,7 @@ describe('StickerNode', () => {
       expect(statusMarker).not.toBe(atRiskMarker);
     });
 
-    it('[data-atrisk-homozygous-marker] accessible label is reachable via the accessibility tree', () => {
-      const disease: DiseaseSticker = {
-        id: 'dx',
-        color: '#ff0000',
-        status: 'obligateCarrier',
-        atRiskHomozygous: true,
-      };
-      render(<StickerNode label="Test" shape="square" diseases={[disease]} />);
-      // getByLabelText searches the accessibility tree and honours aria-hidden
-      // ancestors — if the marker were inside an aria-hidden container this
-      // query would throw, catching the suppression bug.
-      expect(
-        screen.getByLabelText(/risk of being affected/i),
-      ).toBeInTheDocument();
-    });
-
-    it('[data-atrisk-homozygous-marker] has no aria-hidden ancestor', () => {
+    it('[data-atrisk-homozygous-marker] is decorative — aria-hidden with no accessible label', () => {
       const disease: DiseaseSticker = {
         id: 'dx',
         color: '#ff0000',
@@ -242,11 +226,27 @@ describe('StickerNode', () => {
       render(<StickerNode label="Test" shape="square" diseases={[disease]} />);
       const marker = document.querySelector('[data-atrisk-homozygous-marker]');
       expect(marker).toBeInTheDocument();
-      let node = marker?.parentElement;
+
+      // The status is announced as text by the per-node summary in
+      // NarrativePedigreeView; the triangle itself carries no accessible label
+      // and is hidden from the accessibility tree (so getByLabelText can't find
+      // it).
+      expect(marker).not.toHaveAttribute('aria-label');
+      expect(
+        screen.queryByLabelText(/risk of being affected/i),
+      ).not.toBeInTheDocument();
+
+      // Confirm an aria-hidden ancestor (or the marker itself) hides it from AT.
+      let node: Element | null = marker;
+      let hidden = false;
       while (node) {
-        expect(node.getAttribute('aria-hidden')).not.toBe('true');
+        if (node.getAttribute('aria-hidden') === 'true') {
+          hidden = true;
+          break;
+        }
         node = node.parentElement;
       }
+      expect(hidden).toBe(true);
     });
   });
 

--- a/packages/interview/src/interfaces/NarrativePedigree/genetics/status.ts
+++ b/packages/interview/src/interfaces/NarrativePedigree/genetics/status.ts
@@ -9,6 +9,23 @@ export type Status =
   | 'atRiskCarrier'
   | 'unknown';
 
+// Human-readable labels for each genetic status. Single source of truth for the
+// text describing a status, shared by the (decorative) node markers and the
+// screen-reader status summary so they never drift apart.
+export const STATUS_LABELS: Record<Status, string> = {
+  affected: 'Affected',
+  obligateAffected: 'Obligate affected',
+  obligateCarrier: 'Obligate carrier',
+  atRiskAffected: 'At risk (affected)',
+  atRiskCarrier: 'At risk (carrier)',
+  unknown: 'Status unknown',
+};
+
+// Label for the secondary at-risk-homozygous marker (a person who may be
+// homozygous-affected), shown alongside their primary status.
+export const AT_RISK_HOMOZYGOUS_LABEL =
+  'At risk of being affected (homozygous)';
+
 // Lower index = higher precedence (affected is highest, unknown is lowest).
 const STATUS_PRECEDENCE: readonly Status[] = [
   'affected',


### PR DESCRIPTION
Stacked on **#713** (base branch `claude/kind-darwin-c34372`) — the files this touches only exist there, and this fixes an accessibility regression introduced by that PR's NarrativePedigree rework. Merge #713 first; this diff shows only the a11y changes.

## Problem

In the reworked NarrativePedigree interface the per-node disease status was not exposed to screen readers:

- Sticker status markers now sit inside an `aria-hidden` overlay (`StickerNode`).
- The single-disease classic node's symbol SVG is `aria-hidden` (`ClassicNotationNode` / `StatusMarker`).
- The focal member is a `role="button"` whose `aria-label="Focus on <name>"` replaces descendant naming, so any text inside it is ignored.

Net effect: a screen-reader user could not learn who is affected / carrier / at-risk in either view (only the at-risk-homozygous triangle kept a reachable label). The `aria-live` region only announces view/disease/focal **changes**, not per-node status. This is a regression versus the earlier build where each sticker carried `aria-label="<Status> (<hex>)"`.

## Changes

- **Per-node status summary** (`NarrativePedigreeView`): each focal member now has `aria-describedby` pointing at a visually-hidden (`sr-only`) summary listing every shown disease and its status — e.g. *"Disease A: Affected. Disease B: At risk (carrier)"* — plus the at-risk-homozygous note where it applies. The container's `aria-label` still supplies the name, so the description carries only status (no double-speaking the name). The summary mirrors the current view: all diseases in sticker mode, the single selected disease in classic mode. **Visual markers stay `aria-hidden`** (decorative duplicates of the text).
- **Single source of truth** (`genetics/status.ts`): added `STATUS_LABELS` and `AT_RISK_HOMOZYGOUS_LABEL`, now consumed by `StickerNode`, `ClassicNotationNode`, and the summary, removing duplicated label strings so visual and screen-reader text can't drift.
- **Framing group name** (`FramingSelectionStep`): the language step's `RichSelectGroup` gets an accessible name via `aria-labelledby` pointing at its prompt `Paragraph` (the component forwards the attribute; it does not accept a `label` prop).

## Accessibility standards

Restores **WCAG 1.1.1 / 1.3.3 / 1.4.1** (status no longer conveyed by shape/colour alone) and **4.1.2 Name, Role, Value** (focal control exposes state; framing group has a name), using the recommended `aria-describedby` / `aria-labelledby` patterns.

## Verification

- New tests assert the **computed** accessible name/description (`toHaveAccessibleName` / `toHaveAccessibleDescription`), that the summary is reachable (no `aria-hidden` ancestor), that it narrows to the selected disease in classic mode, that the at-risk-homozygous note reaches the description, and that the framing group has an accessible name.
- Targeted vitest: 79 passed across the touched files; full NarrativePedigree suite: 385 passed.
- `turbo run typecheck --filter=@codaco/interview`: clean. `oxfmt` / `oxlint`: clean. `knip` (interview workspace): no findings.

No separate changeset: this refines the still-unreleased NarrativePedigree / FamilyPedigree-language work already covered by `family-pedigree-redesign` and `pedigree-refinements` in #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)