### PR TITLE
fix(architect-web): enlarge interface-type picker to fill the screen

### DIFF
--- a/apps/architect-web/src/components/Screens/NewStageScreen/NewStageScreen.tsx
+++ b/apps/architect-web/src/components/Screens/NewStageScreen/NewStageScreen.tsx
@@ -296,7 +296,7 @@ const NewStageScreen = ({
           render={<Button color="platinum">Cancel</Button>}
         />
       }
-      className="h-[80%]"
+      className="h-[calc(100vh-4rem)] max-h-[64rem] w-[calc(100vw-4rem)] max-w-[100rem]"
     >
       <InterfaceList
         items={filteredInterfaces}


### PR DESCRIPTION
## Summary

The **Select an Interface Type** dialog (shown when adding a new stage in Architect) was capped at a fixed \`3xl\` width (~48rem) and 80% height, which left it small relative to the viewport.

This change overrides the shared \`Dialog\` sizing **for this instance only** so it:

- **Fills the screen by default**, with a symmetric ~2rem margin on every edge (`w-[calc(100vw-4rem)] h-[calc(100vh-4rem)]`).
- **Caps at a high max width/height** (`max-w-[100rem]` / `max-h-[64rem]`) so on very large/4K monitors it stays centred rather than sprawling edge-to-edge.

The dialog is centred (`fixed top-1/2 left-1/2 -translate-*-1/2`), so subtracting `4rem` from each dimension yields the even 2rem gap on all four edges. Because the shared `Dialog` merges `className` through `twMerge`, these utilities cleanly override the base `w-3xl` / `max-w` / `max-h` for this dialog without affecting the smaller confirm/alert/asset dialogs that reuse the same component.

## Change

\`apps/architect-web/src/components/Screens/NewStageScreen/NewStageScreen.tsx\`:

\`\`\`diff
-      className="h-[80%]"
+      className="h-[calc(100vh-4rem)] max-h-[64rem] w-[calc(100vw-4rem)] max-w-[100rem]"
\`\`\`

## Verification

Ran architect-web locally and opened the dialog at three viewport sizes:

- **1440×900 (laptop):** fills the screen with an even margin on every edge.
- **2560×1440 (large monitor):** caps at ~1600×1024 and stays centred — does not go edge-to-edge.
- **1024×600 (small/short):** still fills with the same margin; search/filter header and Cancel footer stay visible, only the card list scrolls — no off-screen overflow.

No changeset added — \`@codaco/architect-web\` is \`private\` and in the changeset \`ignore\` list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the New Stage screen’s dialog sizing so it adapts more reliably to different viewport sizes.
  * Replaced the fixed height behavior with viewport- and maximum-size constraints for a more consistent layout on larger and smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->