### PR TITLE
refactor(interview,fresco-ui): Narrative controls use SegmentedToolbar

### DIFF
--- a/.changeset/narrative-segmented-toolbar.md
+++ b/.changeset/narrative-segmented-toolbar.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Narrative interface: the behaviours/drawing controls and the preset switcher now use the shared `SegmentedToolbar`, unifying them with the rest of the interview UI (toolbar semantics, roving focus, tooltips, and the interview-theme pressed state).

--- a/.changeset/segmented-toolbar.md
+++ b/.changeset/segmented-toolbar.md
@@ -2,4 +2,4 @@
 '@codaco/fresco-ui': minor
 ---
 
-Add `SegmentedToolbar`: a config-driven, accessible (`Surface`-backed) toolbar of button / toggle / exclusive-group / separator segments, built on the shared `Button` component. Each segment supports an icon, text, or both, and an optional `className` (e.g. for named theme colours like `bg-tomato text-white`). The toolbar offers enter/exit animation, horizontal or vertical orientation, and an optional draggable handle (with keyboard repositioning).
+Add `SegmentedToolbar`: a config-driven, accessible (`Surface`-backed) toolbar of button / toggle / exclusive-group / separator segments, built on the shared `Button` component. Each segment supports an icon, text, or both, and an optional `className` (e.g. for named theme colours like `bg-tomato text-white`). A button segment can also be hosted inside a caller-supplied element (`render`) — e.g. a Popover or Menu trigger — so its overlay wiring composes with the toolbar button and its roving focus. The toolbar offers enter/exit animation, horizontal or vertical orientation, and an optional draggable handle (with keyboard repositioning).

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
@@ -9,6 +9,7 @@ import {
   Trash2,
   Undo2,
 } from 'lucide-react';
+import { cloneElement, type ReactElement } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SegmentedToolbar, type ToolbarSegment } from './SegmentedToolbar';
@@ -114,6 +115,40 @@ describe('SegmentedToolbar — toggles', () => {
     render(<SegmentedToolbar label="Tools" items={items} />);
     await userEvent.click(screen.getByRole('button', { name: 'Freeze' }));
     expect(onPressedChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('SegmentedToolbar — hosted (render) button', () => {
+  it('hosts a button segment inside a caller-supplied element', async () => {
+    // Mirrors the Narrative preset switcher, whose label button lives inside a
+    // Popover trigger. The wrapper receives the styled toolbar button as its
+    // `render`, and its behaviour (here, an onClick) composes with the segment.
+    const onTriggerClick = vi.fn();
+    // A wrapper that *becomes* the styled toolbar button (as Base UI triggers
+    // do), attaching its own behaviour — here a click handler.
+    function TriggerWrapper({
+      render: target,
+    }: {
+      render?: ReactElement<{ onClick?: () => void }>;
+    }) {
+      return target ? cloneElement(target, { onClick: onTriggerClick }) : null;
+    }
+
+    const items: ToolbarSegment[] = [
+      {
+        type: 'button',
+        id: 'label',
+        label: 'Social Network',
+        showLabel: true,
+        render: <TriggerWrapper />,
+      },
+    ];
+    render(<SegmentedToolbar label="Presets" items={items} />);
+
+    const button = screen.getByRole('button', { name: 'Social Network' });
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(onTriggerClick).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -40,7 +40,15 @@ export type ButtonSegment = {
   type: 'button';
   id: string;
   disabled?: boolean;
-  onClick: () => void;
+  onClick?: () => void;
+  /**
+   * Host the segment inside a caller-supplied element — e.g. a Popover or Menu
+   * trigger. The element receives the styled toolbar button as its `render`, so
+   * the overlay's trigger wiring (focus return, `aria-expanded`) composes with
+   * the toolbar button and its roving focus. When set, the open/close behaviour
+   * comes from the wrapper rather than `onClick`.
+   */
+  render?: React.ReactElement<{ render?: unknown }>;
 } & SegmentContent;
 
 export type ToggleSegment = {
@@ -93,7 +101,7 @@ export type SegmentedToolbarProps = {
   onPositionChange?: (pos: Position) => void;
   /** Optional drag bounds. */
   dragConstraints?:
-    | React.RefObject<Element>
+    | React.RefObject<Element | null>
     | { top: number; left: number; right: number; bottom: number };
   /** Accessible name for the drag handle. @default 'Move toolbar' */
   dragHandleLabel?: string;
@@ -170,11 +178,19 @@ function ToolbarButtonSegment({
   segment: ButtonSegment;
   size: SegmentSize;
 }) {
+  const styledButton = segmentButton(segment, size);
+  // When a caller hosts the segment in their own element (e.g. a Popover
+  // trigger), the styled button becomes that element's render target so the
+  // overlay wiring composes with the toolbar button — mirroring the
+  // Toolbar.Button → Toggle → Button nesting used for toggle segments.
+  const control = segment.render
+    ? React.cloneElement(segment.render, { render: styledButton })
+    : styledButton;
   const button = (
     <Toolbar.Button
       disabled={segment.disabled}
       onClick={segment.onClick}
-      render={segmentButton(segment, size)}
+      render={control}
     />
   );
   return withTooltip(button, segment.label, isLabelVisible(segment));

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -48,7 +48,7 @@ export type ButtonSegment = {
    * the toolbar button and its roving focus. When set, the open/close behaviour
    * comes from the wrapper rather than `onClick`.
    */
-  render?: React.ReactElement<{ render?: unknown }>;
+  render?: React.ReactElement<{ render?: React.ReactElement }>;
 } & SegmentContent;
 
 export type ToggleSegment = {

--- a/packages/interview/src/interfaces/Narrative/BehavioursPanel.tsx
+++ b/packages/interview/src/interfaces/Narrative/BehavioursPanel.tsx
@@ -1,9 +1,9 @@
-import { Toggle } from '@base-ui/react/toggle';
 import { Pause, Pencil, Play, RotateCcw, Snowflake } from 'lucide-react';
 
-import { IconButton } from '@codaco/fresco-ui/Button';
-import { MotionSurface } from '@codaco/fresco-ui/layout/Surface';
-import { cx } from '@codaco/fresco-ui/utils/cva';
+import {
+  SegmentedToolbar,
+  type ToolbarSegment,
+} from '@codaco/fresco-ui/SegmentedToolbar';
 
 type BehavioursPanelProps = {
   // Auto-layout pause/resume. Shown whenever the automatic layout is active
@@ -21,7 +21,7 @@ type BehavioursPanelProps = {
   onReset: () => void;
 };
 
-// Floating bottom-left panel collecting the Narrative interface's behaviour
+// Floating bottom-left toolbar collecting the Narrative interface's behaviour
 // controls: the automatic-layout pause/resume toggle and (when enabled) the
 // free-draw annotation tools.
 export default function BehavioursPanel({
@@ -37,77 +37,58 @@ export default function BehavioursPanel({
 }: BehavioursPanelProps) {
   if (!showLayoutToggle && !showDrawingControls) return null;
 
+  const items: ToolbarSegment[] = [];
+
+  if (showLayoutToggle) {
+    items.push({
+      type: 'button',
+      id: 'layout',
+      label: simulationEnabled
+        ? 'Pause automatic layout'
+        : 'Resume automatic layout',
+      icon: simulationEnabled ? <Pause /> : <Play />,
+      onClick: onToggleSimulation,
+    });
+  }
+
+  if (showLayoutToggle && showDrawingControls) {
+    items.push({ type: 'separator', id: 'sep' });
+  }
+
+  if (showDrawingControls) {
+    items.push(
+      {
+        type: 'toggle',
+        id: 'draw',
+        label: isDrawingEnabled ? 'Disable drawing' : 'Enable drawing',
+        icon: <Pencil />,
+        pressed: isDrawingEnabled,
+        onPressedChange: onToggleDrawing,
+      },
+      {
+        type: 'toggle',
+        id: 'freeze',
+        label: isFrozen ? 'Unfreeze annotations' : 'Freeze annotations',
+        icon: <Snowflake />,
+        pressed: isFrozen,
+        onPressedChange: onToggleFreeze,
+      },
+      {
+        type: 'button',
+        id: 'reset',
+        label: 'Reset annotations',
+        icon: <RotateCcw />,
+        onClick: onReset,
+      },
+    );
+  }
+
   return (
-    <MotionSurface
-      noContainer
-      className="bg-surface/80 absolute bottom-10 left-10 z-10 flex items-center rounded-2xl backdrop-blur-md"
-      spacing="none"
-      shadow="none"
-      layout
-    >
-      {showLayoutToggle && (
-        <IconButton
-          icon={simulationEnabled ? <Pause /> : <Play />}
-          onClick={onToggleSimulation}
-          variant="text"
-          size="lg"
-          className="rounded-none"
-          aria-label={
-            simulationEnabled
-              ? 'Pause automatic layout'
-              : 'Resume automatic layout'
-          }
-        />
-      )}
-      {showDrawingControls && (
-        <>
-          <Toggle
-            pressed={isDrawingEnabled}
-            onPressedChange={onToggleDrawing}
-            render={
-              <IconButton
-                icon={<Pencil />}
-                variant="text"
-                size="lg"
-                className={cx(
-                  'rounded-none',
-                  isDrawingEnabled && 'bg-primary/40 text-primary',
-                )}
-                aria-label={
-                  isDrawingEnabled ? 'Disable drawing' : 'Enable drawing'
-                }
-              />
-            }
-          />
-          <Toggle
-            pressed={isFrozen}
-            onPressedChange={onToggleFreeze}
-            render={
-              <IconButton
-                icon={<Snowflake />}
-                variant="text"
-                size="lg"
-                className={cx(
-                  'hover:enabled:bg-sea-serpent/40 rounded-none',
-                  isFrozen &&
-                    'bg-sea-serpent/40 hover:enabled:bg-sea-serpent/40 text-sea-serpent',
-                )}
-                aria-label={
-                  isFrozen ? 'Unfreeze annotations' : 'Freeze annotations'
-                }
-              />
-            }
-          />
-          <IconButton
-            icon={<RotateCcw />}
-            onClick={onReset}
-            variant="text"
-            size="lg"
-            className="rounded-none"
-            aria-label="Reset annotations"
-          />
-        </>
-      )}
-    </MotionSurface>
+    <SegmentedToolbar
+      label="Layout and drawing tools"
+      items={items}
+      size="lg"
+      className="absolute bottom-10 left-10 z-10"
+    />
   );
 }

--- a/packages/interview/src/interfaces/Narrative/PresetSwitcher.tsx
+++ b/packages/interview/src/interfaces/Narrative/PresetSwitcher.tsx
@@ -1,8 +1,7 @@
 import { RadioGroup } from '@base-ui/react/radio-group';
 import { createSelector } from '@reduxjs/toolkit';
-import { ChevronLeft, ChevronRight, GripVertical } from 'lucide-react';
-import { LayoutGroup, useDragControls } from 'motion/react';
-import { type RefObject, useCallback, useMemo, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { type RefObject, useCallback, useMemo, useState } from 'react';
 
 import {
   Accordion,
@@ -11,15 +10,17 @@ import {
   AccordionPanel,
   AccordionTrigger,
 } from '@codaco/fresco-ui/Accordion';
-import { buttonVariants, IconButton } from '@codaco/fresco-ui/Button';
 import { RadioItem } from '@codaco/fresco-ui/form/fields/RadioGroup';
-import { MotionSurface } from '@codaco/fresco-ui/layout/Surface';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@codaco/fresco-ui/Popover';
 import { RenderMarkdown } from '@codaco/fresco-ui/RenderMarkdown';
+import {
+  SegmentedToolbar,
+  type ToolbarSegment,
+} from '@codaco/fresco-ui/SegmentedToolbar';
 import type {
   Stage,
   VariableOption,
@@ -197,158 +198,138 @@ export default function PresetSwitcher({
   );
 
   const [popoverOpen, setPopoverOpen] = useState(true);
-  const dragControls = useDragControls();
-
-  const switcherRef = useRef<HTMLDivElement>(null);
 
   if (!currentPreset) return null;
 
+  // The centre label is the Popover trigger that opens the legend: it is hosted
+  // inside the toolbar via the segment `render` escape hatch so its trigger
+  // wiring composes with the toolbar's roving focus. Prev/next are icon-only
+  // buttons (tooltip + aria-label).
+  const items: ToolbarSegment[] = [
+    {
+      type: 'button',
+      id: 'previous',
+      label: 'Previous preset',
+      icon: <ChevronLeft />,
+      disabled: activePreset === 0,
+      onClick: () => onChangePreset(activePreset - 1),
+    },
+    {
+      type: 'button',
+      id: 'label',
+      label: currentPreset.label,
+      showLabel: true,
+      render: <PopoverTrigger />,
+    },
+    {
+      type: 'button',
+      id: 'next',
+      label: 'Next preset',
+      icon: <ChevronRight />,
+      disabled: activePreset + 1 === presets.length,
+      onClick: () => onChangePreset(activePreset + 1),
+    },
+  ];
+
   return (
-    <LayoutGroup>
-      <Popover
-        open={popoverOpen}
-        onOpenChange={(open, event) => {
-          if (!open && event.reason !== 'trigger-press') return;
-          setPopoverOpen(open);
-        }}
-      >
-        <MotionSurface
-          noContainer
-          drag
-          dragConstraints={dragConstraints}
-          spacing="xs"
-          shadow="xs"
-          className="absolute right-10 bottom-10 z-10 flex items-center gap-2 rounded-full"
-          dragControls={dragControls}
-          dragListener={false}
-          ref={switcherRef}
+    <Popover
+      open={popoverOpen}
+      onOpenChange={(open, event) => {
+        if (!open && event.reason !== 'trigger-press') return;
+        setPopoverOpen(open);
+      }}
+    >
+      <SegmentedToolbar
+        label="Presets"
+        items={items}
+        size="lg"
+        draggable
+        dragConstraints={dragConstraints}
+        dragHandleLabel="Drag to reposition"
+        className="absolute right-10 bottom-10 z-10"
+      />
+      <PopoverContent align="center" sideOffset={14} className="min-w-2xs">
+        <Accordion
+          multiple
+          value={accordionValue}
+          onValueChange={handleAccordionValueChange}
         >
-          <IconButton
-            aria-label="Drag to reposition"
-            onPointerDown={(event) => {
-              event.stopPropagation();
-              dragControls.start(event);
-            }}
-            onClick={(event) => event.stopPropagation()}
-            className="cursor-grab active:cursor-grabbing"
-            icon={<GripVertical />}
-            variant="text"
-          />
-          <IconButton
-            disabled={activePreset === 0}
-            onClick={(event) => {
-              event.stopPropagation();
-              onChangePreset(activePreset - 1);
-            }}
-            aria-label="Previous preset"
-            icon={<ChevronLeft />}
-            variant="text"
-          />
-          <PopoverTrigger
-            nativeButton={false}
-            className={buttonVariants({ variant: 'text' })}
-          >
-            {currentPreset.label}
-          </PopoverTrigger>
-          <IconButton
-            icon={<ChevronRight />}
-            aria-label="Next preset"
-            disabled={activePreset + 1 === presets.length}
-            onClick={(event) => {
-              event.stopPropagation();
-              onChangePreset(activePreset + 1);
-            }}
-            variant="text"
-          />
-        </MotionSurface>
-        <PopoverContent
-          align="end"
-          sideOffset={14}
-          anchor={switcherRef}
-          className="min-w-2xs"
-        >
-          <Accordion
-            multiple
-            value={accordionValue}
-            onValueChange={handleAccordionValueChange}
-          >
-            {hasHighlights && (
-              <AccordionItem value={SECTION_ATTRIBUTES}>
-                <AccordionHeader>
-                  <AccordionTrigger>Attributes</AccordionTrigger>
-                </AccordionHeader>
-                <AccordionPanel>
-                  <RadioGroup
-                    value={String(highlightIndex)}
-                    onValueChange={(v) => onChangeHighlightIndex(Number(v))}
-                    className="flex flex-col gap-2"
-                  >
-                    {highlightLabels.map((label, index) => {
-                      const radioId = `highlight-radio-${index}`;
-                      return (
-                        <RadioItem
-                          key={index}
-                          id={radioId}
-                          value={String(index)}
-                          label={label}
-                        />
-                      );
-                    })}
-                  </RadioGroup>
-                </AccordionPanel>
-              </AccordionItem>
-            )}
-
-            {hasEdges && (
-              <AccordionItem value={SECTION_LINKS}>
-                <AccordionHeader>
-                  <AccordionTrigger>Links</AccordionTrigger>
-                </AccordionHeader>
-                <AccordionPanel>
-                  <div className="flex flex-col gap-2">
-                    {edges.map((edge, index) => (
-                      <div
+          {hasHighlights && (
+            <AccordionItem value={SECTION_ATTRIBUTES}>
+              <AccordionHeader>
+                <AccordionTrigger>Attributes</AccordionTrigger>
+              </AccordionHeader>
+              <AccordionPanel>
+                <RadioGroup
+                  value={String(highlightIndex)}
+                  onValueChange={(v) => onChangeHighlightIndex(Number(v))}
+                  className="flex flex-col gap-2"
+                >
+                  {highlightLabels.map((label, index) => {
+                    const radioId = `highlight-radio-${index}`;
+                    return (
+                      <RadioItem
                         key={index}
-                        className="flex items-center gap-4 text-base"
-                      >
-                        <EdgeSwatch color={edge.color} />
-                        {edge.label}
-                      </div>
-                    ))}
-                  </div>
-                </AccordionPanel>
-              </AccordionItem>
-            )}
+                        id={radioId}
+                        value={String(index)}
+                        label={label}
+                      />
+                    );
+                  })}
+                </RadioGroup>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
 
-            {hasGroups && (
-              <AccordionItem value={SECTION_GROUPS}>
-                <AccordionHeader>
-                  <AccordionTrigger>Groups</AccordionTrigger>
-                </AccordionHeader>
-                <AccordionPanel>
-                  <div className="flex flex-col gap-2">
-                    {groupLegend.map((entry, index) => (
-                      <div
-                        key={index}
-                        className="flex items-center gap-4 text-base"
-                      >
-                        <span
-                          className="inline-block size-3 rounded-full"
-                          style={{
-                            backgroundColor: `var(--cat-${entry.colorIndex})`,
-                          }}
-                        />
-                        <RenderMarkdown>{entry.label}</RenderMarkdown>
-                      </div>
-                    ))}
-                  </div>
-                </AccordionPanel>
-              </AccordionItem>
-            )}
-          </Accordion>
-        </PopoverContent>
-      </Popover>
-    </LayoutGroup>
+          {hasEdges && (
+            <AccordionItem value={SECTION_LINKS}>
+              <AccordionHeader>
+                <AccordionTrigger>Links</AccordionTrigger>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className="flex flex-col gap-2">
+                  {edges.map((edge, index) => (
+                    <div
+                      key={index}
+                      className="flex items-center gap-4 text-base"
+                    >
+                      <EdgeSwatch color={edge.color} />
+                      {edge.label}
+                    </div>
+                  ))}
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
+
+          {hasGroups && (
+            <AccordionItem value={SECTION_GROUPS}>
+              <AccordionHeader>
+                <AccordionTrigger>Groups</AccordionTrigger>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className="flex flex-col gap-2">
+                  {groupLegend.map((entry, index) => (
+                    <div
+                      key={index}
+                      className="flex items-center gap-4 text-base"
+                    >
+                      <span
+                        className="inline-block size-3 rounded-full"
+                        style={{
+                          backgroundColor: `var(--cat-${entry.colorIndex})`,
+                        }}
+                      />
+                      <RenderMarkdown>{entry.label}</RenderMarkdown>
+                    </div>
+                  ))}
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          )}
+        </Accordion>
+      </PopoverContent>
+    </Popover>
   );
 }
 


### PR DESCRIPTION
## What

Convert the **Narrative** interface's two floating control surfaces to the shared `@codaco/fresco-ui/SegmentedToolbar`:

- **BehavioursPanel** (bottom-left) — was a hand-rolled `MotionSurface` + `IconButton`/`Toggle` panel with `rounded-none` hacks and manual pressed-state classes. Now a config-driven toolbar: pause/resume button → separator → pencil/freeze toggles → reset. Segments are conditional, so a layout-only stage shows just the pause button (no separator) and the separator only appears when both the layout toggle and drawing tools are present.
- **PresetSwitcher** (bottom-right) — the prev / label / next pill is now a draggable `SegmentedToolbar` (its built-in drag handle replaces the manual `GripVertical` + `useDragControls` wiring). The centre label stays a real `Popover` trigger, hosted *inside* the toolbar so it keeps proper `aria-expanded` / focus-return semantics; the legend Popover/accordion is unchanged.

Both toolbars render at `size="lg"`.

## fresco-ui change

To let PresetSwitcher keep its Popover trigger as a toolbar segment, `SegmentedToolbar` gains one small **additive** capability: a button segment can carry an optional `render` element (e.g. a Popover/Menu trigger) that the styled toolbar button composes into — mirroring the existing `Toolbar.Button → Toggle → Button` nesting already used for toggle segments. `dragConstraints` is also widened to accept a nullable ref (matching what motion already accepts). This folds into the existing unreleased `segmented-toolbar` changeset.

## Why

Unifies Narrative's bespoke control panels onto the shared, accessible toolbar component (toolbar roles, roving focus, tooltips, the interview-theme-readable pressed state), removing duplicated drag/toggle/positioning code.

## Notes for reviewers

- **Deliberate visual changes:** BehavioursPanel adopts the unified pill look (Surface + shadow) instead of the old flat `backdrop-blur` panel; the freeze toggle's custom sea-serpent tint is gone — both toggles now use the shared `--selected` pressed style (the snowflake icon still signals "freeze").
- **Changesets:** the fresco-ui `render` escape hatch folds into the existing unreleased `segmented-toolbar` changeset; a `@codaco/interview` patch changeset documents the Narrative control refactor.

## Verification

- **Tests:** SegmentedToolbar 16/16 (added a trigger-hosting / `render` escape-hatch test); PresetSwitcher `buildGroupLegend` 5/5.
- **Typecheck:** all packages pass (via turbo, rebuilding fresco-ui types first). **Lint** + **knip**: clean.
- **Visual (Storybook):** confirmed both toolbars render, the Popover-in-toolbar opens anchored to the label trigger, the toggle pressed state is readable in the dark interview theme, prev/next disable correctly and navigate ("Social View" → "Professional View"), and the a11y tree exposes correct toolbar roles + `aria-expanded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new segmented toolbar style for key interview controls, bringing a more consistent look and improved keyboard/focus behavior.
  * Updated the preset selector to use the new toolbar, including previous/next navigation and drag support.
  * Added support for more flexible toolbar button hosting, enabling richer interactive controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->