### PR TITLE
fix(architect-web): unify stage editor section heading styles

### DIFF
--- a/apps/architect-web/src/components/sections/Background/Background.tsx
+++ b/apps/architect-web/src/components/sections/Background/Background.tsx
@@ -50,9 +50,7 @@ class Background extends PureComponent<BackgroundProps> {
       >
         {imageAllowed && (
           <Row>
-            <h4 className="small-heading text-muted-foreground m-0">
-              Choose a background type
-            </h4>
+            <h4>Choose a background type</h4>
             <DetachedField
               component={
                 BooleanField as React.ComponentType<Record<string, unknown>>

--- a/apps/architect-web/src/components/sections/CategoricalBinPrompts/PromptFields.tsx
+++ b/apps/architect-web/src/components/sections/CategoricalBinPrompts/PromptFields.tsx
@@ -123,7 +123,7 @@ const PromptFields = ({
         </Row>
         {variable && (
           <Row>
-            <h3 id={getFieldId('options')}>Variable Options</h3>
+            <h4 id={getFieldId('options')}>Variable Options</h4>
             <p>
               Create <strong>up to 8</strong> options for this variable.
             </p>

--- a/apps/architect-web/src/components/sections/Form/FieldFields.tsx
+++ b/apps/architect-web/src/components/sections/Form/FieldFields.tsx
@@ -133,7 +133,7 @@ const PromptFields = ({
         </div>
         <div className="flex items-center justify-between gap-(--space-md)">
           <div>
-            <h4 className="text-base font-semibold">Show validation hints?</h4>
+            <h4>Show validation hints?</h4>
             <p className="text-sm text-current/70">
               Automatically display hints derived from this field&apos;s
               validation rules, helping participants understand input

--- a/apps/architect-web/src/components/sections/TieStrengthCensusPrompts/PromptFields.tsx
+++ b/apps/architect-web/src/components/sections/TieStrengthCensusPrompts/PromptFields.tsx
@@ -187,7 +187,7 @@ const PromptFields = ({
             </Row>
             {edgeVariable && (
               <Row>
-                <h3 id={getFieldId('variableOptions')}>Variable Options</h3>
+                <h4 id={getFieldId('variableOptions')}>Variable Options</h4>
                 <p>
                   The following choices or &apos;options&apos; are configured
                   for this variable. We suggest no more than four options should


### PR DESCRIPTION
## Summary

Fixes inconsistent heading styles across architect-web stage editor sections. Every in-section sub-heading now uses the standard bare `<h4>` (18px, semibold, sentence-case) that the rest of the editors already use.

Four outliers normalised:

- **Background** — `Choose a background type` was a small/uppercase/muted eyebrow (`small-heading text-muted-foreground m-0`); now a plain `<h4>`, matching `Number of concentric circles to use:` directly beneath it. _(original report)_
- **Form field editor** (`FieldFields`) — `Show validation hints?` was `text-base font-semibold`; now matches its siblings `Prompt Text` / `Hint Text` / `Preview`.
- **Categorical Bin** & **Tie-Strength Census** prompt editors — `Variable Options` was an `<h3>` (larger `text-xl`); now `<h4>`, with the `id` attributes preserved for issue-anchor scroll targeting.

The `Section` title is a styled `<span>`, not a heading element, so there was no real heading outline to preserve — the `<h3>`→`<h4>` change also improves the hierarchy inside the prompt-edit modals (the sub-heading no longer competes in size with the section title above it).

## Verification

Ran architect-web with the **Development Protocol** and drove each editor with Playwright:

- **Sociogram → Background**: `Choose a background type` and `Number of concentric circles to use:` now report identical computed style (H4 / 18px / 600 / sentence-case).
- **Alter Form → Edit Field**: `Show validation hints?` now 18px, matching `Prompt Text` / `Hint Text` / `Preview`.
- **Categorical Bin** & **Tie-Strength Census → Edit Prompt**: `Variable Options` now `H4` / 18px.

`oxfmt --check` and `oxlint` are clean on the changed files. `@codaco/architect-web` is in the changeset ignore list, so no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated several section headings across the form and background setup screens for more consistent heading hierarchy and presentation.
  * Adjusted a few labels and section headers to improve visual consistency without changing any functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->