### PR TITLE
perf(architect-web): render background lights as gradients

### DIFF
--- a/apps/architect-web/src/components/BackgroundLights.tsx
+++ b/apps/architect-web/src/components/BackgroundLights.tsx
@@ -37,9 +37,9 @@ const BackgroundLights = ({ intensity }: { intensity: Intensity }) => (
     animate={{ opacity: LAYER_OPACITY[intensity] }}
     transition={{ duration: 1 }}
   >
-    {LIGHTS.map(({ position, color }) => (
+    {LIGHTS.map(({ position, color }, index) => (
       <div
-        key={position}
+        key={index}
         className={`absolute ${position}`}
         style={{
           background: `radial-gradient(circle, ${color}, transparent 75%)`,

--- a/apps/architect-web/src/components/BackgroundLights.tsx
+++ b/apps/architect-web/src/components/BackgroundLights.tsx
@@ -10,22 +10,25 @@ const LAYER_OPACITY: Record<Intensity, number> = {
   dim: 0.1,
 };
 
+// Tints expressed uniformly as color-mix(in oklab, …) — matching the oklab
+// color-mix used elsewhere in architect-web (e.g. the shadow scale). Mixing a
+// colour with `transparent N%` is equivalent to alpha (100 − N)%.
 const LIGHTS = [
   {
     position: '-top-[20vmax] -left-[15vmax] h-[55vmax] w-[55vmax]',
-    color: 'hsl(var(--sea-green) / 0.45)',
+    color: 'color-mix(in oklab, var(--color-sea-green), transparent 55%)',
   },
   {
     position: '-bottom-[25vmax] -right-[10vmax] h-[60vmax] w-[60vmax]',
-    color: 'color-mix(in oklch, var(--color-fresco-purple), transparent 78%)',
+    color: 'color-mix(in oklab, var(--color-fresco-purple), transparent 78%)',
   },
   {
     position: '-top-[10vmax] right-[5vmax] h-[40vmax] w-[40vmax]',
-    color: 'hsl(var(--slate-blue) / 0.4)',
+    color: 'color-mix(in oklab, var(--color-slate-blue), transparent 60%)',
   },
   {
     position: 'bottom-[5vmax] -left-[10vmax] h-[35vmax] w-[35vmax]',
-    color: 'hsl(var(--sea-green) / 0.3)',
+    color: 'color-mix(in oklab, var(--color-sea-green), transparent 70%)',
   },
 ];
 

--- a/apps/architect-web/src/components/BackgroundLights.tsx
+++ b/apps/architect-web/src/components/BackgroundLights.tsx
@@ -10,23 +10,23 @@ const LAYER_OPACITY: Record<Intensity, number> = {
   dim: 0.1,
 };
 
-// A static set of softly blurred "lights" tinted with the app's brand colors:
-// the sea green brand colour, the deep nav-bar purple, and the lighter slate
-// blue. They sit far enough off-screen that only their blurred edges bleed in,
-// giving a subtle tinted glow over the platinum page background. Each light is
-// a plain blurred div, so unlike the previous canvas-based BackgroundBlobs this
-// renders once and costs nothing to keep on screen.
 const LIGHTS = [
-  // Sea green brand glow, top-left.
-  'bg-sea-green/20 -top-[20vmax] -left-[15vmax] h-[55vmax] w-[55vmax]',
-  // Deep nav-bar purple, lower-right, gently anchoring the composition. Kept at
-  // a low opacity since this colour is very dark and would otherwise read as a
-  // hard shadow rather than a soft light.
-  'bg-fresco-purple/10 -bottom-[25vmax] -right-[10vmax] h-[60vmax] w-[60vmax]',
-  // Lighter slate blue accent, upper-right.
-  'bg-slate-blue/15 -top-[10vmax] right-[5vmax] h-[40vmax] w-[40vmax]',
-  // A faint second sea green pool, lower-left, for balance.
-  'bg-sea-green/12 bottom-[5vmax] -left-[10vmax] h-[35vmax] w-[35vmax]',
+  {
+    position: '-top-[20vmax] -left-[15vmax] h-[55vmax] w-[55vmax]',
+    color: 'hsl(var(--sea-green) / 0.45)',
+  },
+  {
+    position: '-bottom-[25vmax] -right-[10vmax] h-[60vmax] w-[60vmax]',
+    color: 'color-mix(in oklch, var(--color-fresco-purple), transparent 78%)',
+  },
+  {
+    position: '-top-[10vmax] right-[5vmax] h-[40vmax] w-[40vmax]',
+    color: 'hsl(var(--slate-blue) / 0.4)',
+  },
+  {
+    position: 'bottom-[5vmax] -left-[10vmax] h-[35vmax] w-[35vmax]',
+    color: 'hsl(var(--sea-green) / 0.3)',
+  },
 ];
 
 const BackgroundLights = ({ intensity }: { intensity: Intensity }) => (
@@ -37,10 +37,13 @@ const BackgroundLights = ({ intensity }: { intensity: Intensity }) => (
     animate={{ opacity: LAYER_OPACITY[intensity] }}
     transition={{ duration: 1 }}
   >
-    {LIGHTS.map((light) => (
+    {LIGHTS.map(({ position, color }) => (
       <div
-        key={light}
-        className={`absolute rounded-full blur-[8rem] ${light}`}
+        key={position}
+        className={`absolute ${position}`}
+        style={{
+          background: `radial-gradient(circle, ${color}, transparent 75%)`,
+        }}
       />
     ))}
   </motion.div>

--- a/apps/interviewer-v8/src/App.tsx
+++ b/apps/interviewer-v8/src/App.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { Route, Switch, useLocation } from 'wouter';
 
-import { BackgroundBlobs } from '@codaco/art';
+import { BackgroundLights } from '@codaco/art';
 import { ThemedRegion } from '@codaco/fresco-ui/ThemedRegion';
 
 import { AppErrorBoundary } from './components/AppErrorBoundary';
@@ -43,16 +43,17 @@ export default function App() {
             />
           )}
           <motion.div
-            className="fixed inset-0 -z-10 blur-[10rem]"
+            className="fixed inset-0 -z-10"
             initial={{ opacity: 0 }}
             animate={{ opacity: 0.8 }}
             transition={{ duration: 2 }}
           >
-            <BackgroundBlobs
+            <BackgroundLights
               large={0}
               medium={4}
               small={0}
-              compositeOperation="color-dodge"
+              blendMode="color-dodge"
+              speedFactor={30}
             />
           </motion.div>
           <AuthGate>

--- a/apps/interviewer-v8/src/components/AppErrorBoundary.tsx
+++ b/apps/interviewer-v8/src/components/AppErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 
-import { BackgroundBlobs } from '@codaco/art';
+import { BackgroundLights } from '@codaco/art';
 import Button from '@codaco/fresco-ui/Button';
 import Dialog from '@codaco/fresco-ui/dialogs/Dialog';
 import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
@@ -35,16 +35,17 @@ class ErrorBoundary extends Component<Props, State> {
     return (
       <>
         <motion.div
-          className="fixed inset-0 -z-10 blur-[10rem]"
+          className="fixed inset-0 -z-10"
           initial={{ opacity: 0 }}
           animate={{ opacity: 0.8 }}
           transition={{ duration: 2 }}
         >
-          <BackgroundBlobs
+          <BackgroundLights
             large={0}
             medium={4}
             small={0}
-            compositeOperation="color-dodge"
+            blendMode="color-dodge"
+            speedFactor={30}
           />
         </motion.div>
         <Dialog

--- a/apps/interviewer-v8/src/components/__tests__/AppErrorBoundary.test.tsx
+++ b/apps/interviewer-v8/src/components/__tests__/AppErrorBoundary.test.tsx
@@ -11,8 +11,8 @@ vi.mock('~/lib/analytics/AnalyticsProvider', () => ({
   useAnalytics: () => ({ captureException }),
 }));
 
-// The real Dialog (motion animations) and BackgroundBlobs (canvas loop) hang
-// under jsdom — fresco-ui tests them in its own suite. Stub them here and
+// The real Dialog (motion animations) and BackgroundLights (animation loop)
+// hang under jsdom — fresco-ui tests them in its own suite. Stub them here and
 // assert the props the boundary passes; the full dialog render is covered by
 // AppErrorBoundary.stories.tsx in the browser-based storybook test project.
 vi.mock('@codaco/fresco-ui/dialogs/Dialog', () => ({
@@ -28,7 +28,7 @@ vi.mock('@codaco/fresco-ui/dialogs/Dialog', () => ({
 }));
 
 vi.mock('@codaco/art', () => ({
-  BackgroundBlobs: () => null,
+  BackgroundLights: () => null,
 }));
 
 function Thrower(): never {

--- a/packages/art/src/BackgroundBlobs/BackgroundBlobs.tsx
+++ b/packages/art/src/BackgroundBlobs/BackgroundBlobs.tsx
@@ -5,7 +5,7 @@ import { memo, useMemo } from 'react';
 import Canvas from './Canvas';
 import { NCBlob } from './NCBlob';
 
-const defaultGradients: ReadonlyArray<readonly [string, string]> = [
+export const defaultGradients: ReadonlyArray<readonly [string, string]> = [
   ['rgb(237,0,140)', 'rgb(226,33,91)'],
   ['#00c9ff', '#92fe9d'],
   ['#fc466b', '#3f5efb'],

--- a/packages/art/src/BackgroundLights/BackgroundLights.tsx
+++ b/packages/art/src/BackgroundLights/BackgroundLights.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { type CSSProperties, useEffect, useMemo, useRef } from 'react';
+
+import { defaultGradients } from '../BackgroundBlobs/BackgroundBlobs';
+
+// Default to the BackgroundBlobs palette. Each entry there is a two-stop linear
+// gradient; here every colour seeds one radial light, so the pairs flatten into
+// a flat list of single colours.
+const defaultColors = defaultGradients.flatMap((pair) => pair);
+
+type Layer = 1 | 2 | 3;
+
+const random = (min: number, max: number) => min + Math.random() * (max - min);
+
+// Per-layer drift speed (px/second) and radius (fraction of the smaller
+// viewport edge), mirroring @codaco/art's canvas NCBlob so a DOM light drifts
+// and wraps like a blob of the same layer.
+const layerSpeed: Record<Layer, () => number> = {
+  1: () => random(3, 6),
+  2: () => random(0.5, 1.5),
+  3: () => 0.5,
+};
+// Radii as a fraction of the smaller viewport edge. These run large so each
+// light carries its own soft, wide falloff.
+const layerSize: Record<Layer, () => number> = {
+  1: () => random(0.4, 0.6),
+  2: () => random(1, 1.5),
+  3: () => random(2, 2.6),
+};
+
+type Light = {
+  color: string;
+  sizeFraction: number;
+  velocityX: number;
+  velocityY: number;
+};
+
+const makeLayer = (
+  layer: Layer,
+  count: number,
+  speedFactor: number,
+  colors: readonly string[],
+): Light[] =>
+  Array.from({ length: count }, () => {
+    const angle = random(0, Math.PI * 2);
+    const speed = layerSpeed[layer]() * speedFactor;
+    return {
+      color:
+        colors[Math.floor(random(0, colors.length))] ?? colors[0] ?? '#fff',
+      sizeFraction: layerSize[layer](),
+      velocityX: Math.sin(angle) * speed,
+      velocityY: Math.cos(angle) * speed,
+    };
+  });
+
+type BackgroundLightsProps = {
+  large?: number;
+  medium?: number;
+  small?: number;
+  speedFactor?: number;
+  colors?: readonly string[];
+  // Blends the lights against one another on the container's isolated,
+  // transparent backdrop. 'color-dodge' reproduces the additive glow of
+  // BackgroundBlobs' canvas compositing; the effect shows where lights overlap.
+  blendMode?: CSSProperties['mixBlendMode'];
+};
+
+const BackgroundLights = ({
+  large = 2,
+  medium = 4,
+  small = 4,
+  speedFactor = 1,
+  colors = defaultColors,
+  blendMode,
+}: BackgroundLightsProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const elementsRef = useRef<(HTMLDivElement | null)[]>([]);
+
+  // large → big/slow, small → small/fast, matching BackgroundBlobs' layers.
+  const lights = useMemo(
+    () => [
+      ...makeLayer(3, large, speedFactor, colors),
+      ...makeLayer(2, medium, speedFactor, colors),
+      ...makeLayer(1, small, speedFactor, colors),
+    ],
+    [large, medium, small, speedFactor, colors],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    // Runtime position/size lives outside React state so the animation loop can
+    // mutate transforms every frame without triggering a re-render.
+    const runtime = lights.map((light) => ({ light, x: 0, y: 0, size: 0 }));
+    let width = 0;
+    let height = 0;
+    let placed = false;
+
+    const measure = () => {
+      width = container.clientWidth;
+      height = container.clientHeight;
+      const vmin = Math.min(width, height);
+      runtime.forEach((entry, index) => {
+        entry.size = entry.light.sizeFraction * vmin;
+        const element = elementsRef.current[index];
+        if (element) {
+          element.style.width = `${entry.size}px`;
+          element.style.height = `${entry.size}px`;
+        }
+      });
+    };
+
+    const applyTransforms = () => {
+      runtime.forEach((entry, index) => {
+        const element = elementsRef.current[index];
+        if (element) {
+          element.style.transform = `translate3d(${entry.x}px, ${entry.y}px, 0)`;
+        }
+      });
+    };
+
+    // Seed each light at a random position across the viewport once real
+    // dimensions are known (layout may not have happened when the effect runs).
+    const ensurePlaced = () => {
+      if (placed || width <= 0 || height <= 0) return;
+      runtime.forEach((entry) => {
+        entry.x = random(-entry.size / 2, width - entry.size / 2);
+        entry.y = random(-entry.size / 2, height - entry.size / 2);
+      });
+      placed = true;
+      applyTransforms();
+    };
+
+    measure();
+    ensurePlaced();
+
+    const resizeObserver = new ResizeObserver(() => {
+      measure();
+      ensurePlaced();
+    });
+    resizeObserver.observe(container);
+
+    const prefersReducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
+      return () => resizeObserver.disconnect();
+    }
+
+    let raf = 0;
+    let last: number | null = null;
+    const tick = (time: number) => {
+      ensurePlaced();
+      if (placed) {
+        const dt = last === null ? 0 : (time - last) / 1000;
+        runtime.forEach((entry) => {
+          entry.x += entry.light.velocityX * dt;
+          entry.y += entry.light.velocityY * dt;
+          // Wrap offscreen → reappear on the opposite edge (mirrors NCBlob;
+          // branches stay mutually exclusive so a reset can't re-trigger).
+          if (entry.x < -entry.size) entry.x = width + entry.size;
+          else if (entry.x > width) entry.x = -entry.size;
+          if (entry.y < -entry.size) entry.y = height + entry.size;
+          else if (entry.y > height) entry.y = -entry.size;
+        });
+        applyTransforms();
+      }
+      last = time;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      resizeObserver.disconnect();
+    };
+  }, [lights]);
+
+  return (
+    <div
+      ref={containerRef}
+      aria-hidden
+      className="absolute inset-0 isolate overflow-hidden"
+    >
+      {lights.map((light, index) => (
+        <div
+          key={index}
+          ref={(element) => {
+            elementsRef.current[index] = element;
+          }}
+          className="absolute top-0 left-0 will-change-transform"
+          style={{
+            // `closest-side` fades the glow to transparent by the div's nearest
+            // edge, so the square box never shows as a hard clip.
+            background: `radial-gradient(circle closest-side, ${light.color}, transparent)`,
+            mixBlendMode: blendMode,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default BackgroundLights;

--- a/packages/art/src/index.ts
+++ b/packages/art/src/index.ts
@@ -1,5 +1,6 @@
 import BackgroundBlobs from './BackgroundBlobs/BackgroundBlobs';
 import useCanvas from './BackgroundBlobs/useCanvas';
+import BackgroundLights from './BackgroundLights/BackgroundLights';
 import { seedToPatternPalette } from './Pattern/palette';
 import type { PatternPalette } from './Pattern/palette';
 import { Pattern } from './Pattern/Pattern';
@@ -15,6 +16,7 @@ import { TruchetPattern } from './Pattern/variants/Truchet';
 export type { PatternPalette, PatternProps, PatternVariant };
 export {
   BackgroundBlobs,
+  BackgroundLights,
   CrossesPattern,
   DotsPattern,
   FlowPattern,


### PR DESCRIPTION
Blur was causing performance issues in safari: (https://github.com/complexdatacollective/network-canvas-monorepo/issues/684)

This PR refactors to use gradients instead which do not cause performance issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new animated “Background Lights” component with configurable sizes, animation speed, and blend behavior.

* **Bug Fixes**
  * Improved backdrop rendering consistency by switching affected screens from blob-based visuals to gradient-based lights.
  * Respects reduced-motion preferences by disabling continuous animation when enabled.

* **Style**
  * Refined the full-screen animated backdrop appearance for a smoother, more cohesive glow effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->