### PR TITLE
docs: add validating-a-protocol Claude Code skill

### DIFF
--- a/.claude/skills/validating-a-protocol/SKILL.md
+++ b/.claude/skills/validating-a-protocol/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: validating-a-protocol
+description: Use when a protocol.json or .netcanvas file needs to be checked for validity against the Network Canvas protocol schema, when interpreting protocol validation errors, or when the validation CLI exits 1 with no output.
+---
+
+# Validating a Protocol
+
+## Overview
+
+`@codaco/protocol-validation` ships a CLI at `packages/protocol-validation/scripts/cli.js` that validates a `protocol.json` or `.netcanvas` file against the versioned Zod schema, including cross-reference (codebook) validation. Use it — do not write ad-hoc runner scripts against `src/`.
+
+## Recipe (from the repo root)
+
+```bash
+# 1. Build the package once per checkout — the CLI imports from dist/
+pnpm --filter @codaco/protocol-validation build
+
+# 2. Validate (accepts .json or .netcanvas)
+node packages/protocol-validation/scripts/cli.js path/to/protocol.json; echo "exit: $?"
+```
+
+## Interpreting the result
+
+Always capture the exit code — a valid protocol prints **nothing**.
+
+| Exit | Output                        | Meaning                                                                                                                                                           |
+| ---- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | none                          | Valid. Silence is success (the CLI's success message is stubbed out).                                                                                             |
+| 1    | ZodError issue list on stderr | Validation failed. Each issue has a `path` (JSON path into the protocol) and `message`. A stack trace follows the issue list — that's normal output, not a crash. |
+| 1    | none                          | Infrastructure error, silently swallowed by the CLI — see below.                                                                                                  |
+
+### Silent exit 1 — diagnosis checklist
+
+The CLI's catch block discards errors, so these all exit 1 with no output:
+
+1. No argument, or the file doesn't exist.
+2. Extension is not `.json` or `.netcanvas`.
+3. Malformed JSON — check with `jq empty <file>`.
+4. `dist/` missing or stale — rebuild (step 1 above).
+5. `.netcanvas` extraction failed: the zip must contain `protocol.json` at its root, and every file referenced by the `assetManifest` must exist under `assets/`.
+
+To surface the real extraction error, call the library directly (the path arrives as `process.argv[1]` after `--`):
+
+```bash
+node -e "import('./packages/protocol-validation/dist/index.js').then(async (m) => {
+  const fs = await import('node:fs');
+  await m.extractProtocol(fs.readFileSync(process.argv[1]));
+}).catch((e) => { console.error(e.message); process.exit(1); })" -- path/to/file.netcanvas
+```
+
+Extraction **fails fast** — it reports only the first missing asset. To enumerate everything wrong with a broken `.netcanvas`:
+
+```bash
+# All filenames the manifest expects (stored in the zip under assets/) vs. what's actually there
+unzip -p file.netcanvas protocol.json | jq -r '.assetManifest[].source'
+zipinfo -1 file.netcanvas
+
+# Validate the embedded protocol independently — tells you whether re-zipping alone will fix it
+unzip -p file.netcanvas protocol.json > /tmp/embedded.json
+node packages/protocol-validation/scripts/cli.js /tmp/embedded.json; echo "exit: $?"
+```
+
+## Gotchas
+
+- Only `schemaVersion` 7 and 8 are validatable (`VersionedProtocolSchema`). Older protocols fail the `schemaVersion` discriminator and must be migrated first (migration lives in the same package).
+- An invalid stage `type` is a discriminated-union failure, so that stage's _contents_ were never checked — fix the `type` and re-run; more errors may surface inside the stage.
+- Protocol files are often minified to one line. Locate errors with the issue's `path` array and `jq`, not line numbers.
+- A `.netcanvas` is a zip with `protocol.json` and `assets/` at the root. To build one for testing: `cd <dir> && zip -r out.netcanvas protocol.json assets`.
+- Programmatic use: import `validateProtocol` from `packages/protocol-validation/dist/index.js`; it returns a Zod `safeParseAsync` result (`{ success, error }`).


### PR DESCRIPTION
## What

Adds a project skill at `.claude/skills/validating-a-protocol/SKILL.md` that documents how to validate a `protocol.json` or `.netcanvas` file using the `@codaco/protocol-validation` CLI (`packages/protocol-validation/scripts/cli.js`).

## Why

The CLI's `success()`/`error()` printers are no-op stubs and its catch block discards errors, so its behavior is easy to misread without documentation:

- exit 0 prints **nothing** — silence is success
- exit 1 with a ZodError issue list on stderr = schema/cross-reference failure
- exit 1 with **no output** = infrastructure error (missing file, malformed JSON, unbuilt `dist/`, or failed `.netcanvas` extraction), silently swallowed

Without guidance, an agent asked to validate a protocol found the CLI, hit the unbuilt `dist/`, and hand-rolled a tsx runner script instead. With the skill, a fresh agent followed the documented recipe and correctly diagnosed both a schema-invalid protocol and a `.netcanvas` failing silently on missing assets.

## Notes for reviewers

- The skill covers the silent-exit-1 diagnosis checklist, a direct `extractProtocol` call to surface the real extraction error (which fails fast on the first missing asset), enumerating all missing assets via `.assetManifest[].source` vs `zipinfo -1`, and validating the embedded protocol independently.
- All commands in the skill were executed and verified against the development protocol (valid case), a deliberately broken protocol (schema-failure case), and a zip missing its `assets/` directory (silent-failure case).
- Docs-only change; no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for validating protocol files and diagnosing common validation issues.
  * Included steps for running the validation CLI from the repo root and interpreting exit codes.
  * Added troubleshooting tips for malformed JSON, missing build output, extraction failures, schema compatibility, and locating validation errors.
  * Mentioned programmatic validation options for integrating checks into scripts or tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->