### PR TITLE
fix(pedigree): land follow-up snapshot/dimming/CEGRM changes missed by #713

### DIFF
--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/EdgeRenderer.test.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/EdgeRenderer.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import { edgeKey } from '~/interfaces/NarrativePedigree/highlight';
 
 import { PedigreeEdgeSvg } from '../components/EdgeRenderer';
+import { dimColor } from '../dimColor';
 import type { ConnectorRenderData } from '../pedigreeAdapter';
 import type {
   DuplicateArc,
@@ -213,7 +214,11 @@ describe('PedigreeEdgeSvg — sibling branch off contributing lineage is dimmed'
 // bright; the [100, 180] stretch (toward the non-contributing sibling) is dim.
 // ---------------------------------------------------------------------------
 
-const DIM_BLEND_BLACK = 'color-mix(in oklab, black 30%, var(--background))';
+// Derive the dimmed stroke from dimColor itself, so these assertions verify the
+// renderer dims *via* dimColor rather than duplicating its exact output string
+// (which would go stale whenever the blend target changes, e.g. the snapshot
+// re-theme to --dim-blend).
+const DIM_BLEND_BLACK = dimColor('black');
 
 /** Find the rendered sibling-bar sub-segment <line>s by their shared y. */
 function siblingBarLines(container: HTMLElement, y: number): SVGLineElement[] {
@@ -711,7 +716,7 @@ function makeDuplicateArc(overrides: Partial<DuplicateArc> = {}): DuplicateArc {
 }
 
 describe('PedigreeEdgeSvg — twin and duplicate-arc dimming', () => {
-  const DIM_BLEND = 'color-mix(in oklab, var(--edge-1) 30%, var(--background))';
+  const DIM_BLEND = dimColor('var(--edge-1)');
 
   test('twin bar with neither twin highlighted is dimmed (blended stroke + data-edge-dimmed)', () => {
     const highlightedNodeIds = new Set(['someoneElse']);

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/EdgeRenderer.test.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/EdgeRenderer.test.tsx
@@ -583,6 +583,66 @@ describe('PedigreeEdgeSvg — couple bar transmission (edge-key path, #9)', () =
 });
 
 // ---------------------------------------------------------------------------
+// PedigreeEdgeSvg — consanguineous DOUBLE couple bar tracks the focal highlight
+//
+// A consanguineous couple's bar is drawn as two parallel lines. It must dim /
+// brighten by the same transmission rule as a single couple bar — per half, via
+// highlightedEdgeKeys — on BOTH parallel lines. (Previously the double bar was
+// excluded from the split path and fell back to whole-bar node-membership, so it
+// did not track the focal lineage.)
+// ---------------------------------------------------------------------------
+
+describe('PedigreeEdgeSvg — consanguineous double couple bar', () => {
+  test('both parallel lines split by transmission, like a single couple bar', () => {
+    const bar = makeCoupleBar({
+      partnerIds: ['transmitter', 'coParent'],
+      descentXPositions: [100],
+      double: true,
+      doubleSegment: seg(0, 60, 200, 60),
+    });
+    const highlightedNodeIds = new Set(['transmitter', 'child']);
+    const highlightedEdgeKeys = new Set([edgeKey('transmitter', 'child')]);
+
+    const { container } = render(
+      <PedigreeEdgeSvg
+        connectorData={makeGroupConnectorData([bar])}
+        color="black"
+        width={300}
+        height={300}
+        highlightedNodeIds={highlightedNodeIds}
+        highlightedEdgeKeys={highlightedEdgeKeys}
+      />,
+    );
+
+    // Each of the two parallel lines (y=50, y=60) must split at the descent
+    // x=100: the transmitter's (left) half bright, the co-parent's (right) dim.
+    for (const y of [50, 60]) {
+      const lines = siblingBarLines(container, y);
+      const leftHalf = lines.find(
+        (l) =>
+          Number(l.getAttribute('x1')) === 0 &&
+          Number(l.getAttribute('x2')) === 100,
+      );
+      const rightHalf = lines.find(
+        (l) =>
+          Number(l.getAttribute('x1')) === 100 &&
+          Number(l.getAttribute('x2')) === 200,
+      );
+      expect(
+        leftHalf,
+        `line at y=${String(y)} should split at the descent`,
+      ).toBeDefined();
+      expect(
+        rightHalf,
+        `line at y=${String(y)} should split at the descent`,
+      ).toBeDefined();
+      expect(isLineDimmed(leftHalf!)).toBe(false);
+      expect(isLineDimmed(rightHalf!)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PedigreeEdgeSvg — twin-indicator and duplicate-arc dimming (node-membership)
 //
 // Twin bars and duplicate arcs are decorative-genetic connectors, NOT

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/dimColor.test.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/dimColor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { dimColor } from '../dimColor';
+
+describe('dimColor', () => {
+  it('blends the colour toward an overridable --dim-blend target (default: --background)', () => {
+    // The printable snapshot overrides --dim-blend to white so dimmed nodes and
+    // edges recede into the paper; on screen the variable is unset and falls
+    // back to var(--background). Keeping the target as --dim-blend rather than a
+    // hard-wired var(--background) is what lets the export re-theme dimming — if
+    // this reverts, the export can no longer fade dimming toward white.
+    const result = dimColor('#e53e3e');
+    expect(result.startsWith('color-mix(in oklab,')).toBe(true);
+    expect(result).toContain('#e53e3e');
+    expect(result).toContain('var(--dim-blend, var(--background))');
+  });
+});

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/components/EdgeRenderer.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/components/EdgeRenderer.tsx
@@ -337,9 +337,10 @@ function transmitsToContributor(
  * transmits to a contributing child (via highlightedEdgeKeys) — so a couple bar
  * is NOT lit merely because one partner is the focal person or is otherwise
  * highlighted. Without edge keys (the FamilyPedigree path) it falls back to
- * partner-node membership. Otherwise (no highlight, inactive break bar, or
- * consanguineous double bar) it falls back to whole-bar rendering dimmed by node
- * membership, exactly as before.
+ * partner-node membership. A consanguineous double bar is split the same way,
+ * across both of its parallel lines. Otherwise (no highlight, inactive break
+ * bar, or a childless couple with no descent) it falls back to whole-bar
+ * rendering dimmed by node membership, exactly as before.
  */
 function renderCoupleGroupLine(
   gl: ParentGroupConnector,
@@ -355,7 +356,6 @@ function renderCoupleGroupLine(
   const splittable =
     highlightActive &&
     gl.isActive &&
-    !gl.double &&
     gl.partnerIds !== undefined &&
     descentXs.length > 0;
 
@@ -396,6 +396,17 @@ function renderCoupleGroupLine(
   return (
     <g key={`gl-dim-${idx}`}>
       {renderSplitBar(gl.segment, descentXs, isHalfDimmed, color, `gl-${idx}`)}
+      {/* A consanguineous couple bar is two parallel lines; split the second one
+          the same way so both track the focal lineage. */}
+      {gl.double && gl.doubleSegment
+        ? renderSplitBar(
+            gl.doubleSegment,
+            descentXs,
+            isHalfDimmed,
+            color,
+            `gl-double-${idx}`,
+          )
+        : null}
     </g>
   );
 }

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/dimColor.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/dimColor.ts
@@ -1,17 +1,21 @@
 /**
  * Fraction of a dimmed element's own colour retained when blending toward the
- * interview background. The remainder is filled by `var(--background)`, so a
- * dimmed piece stays fully opaque (no compositing artifacts from overlapping
+ * dim-blend target. The remainder is filled by that target colour, so a dimmed
+ * piece stays fully opaque (no compositing artifacts from overlapping
  * semi-transparent elements) while reading as recessive. Tweak this single
  * constant to make dimming stronger or weaker.
  */
 const DIMMED_BLEND = '30%';
 
 /**
- * Blends a colour toward the interview background by DIMMED_BLEND, producing a
- * fully-opaque "dimmed" variant. `var(--background)` only resolves to the
- * navy-taupe interview colour inside a `data-theme-interview` region.
+ * Blends a colour toward the surface a dimmed element should recede into,
+ * producing a fully-opaque "dimmed" variant. The target is `--dim-blend`, which
+ * defaults to the interview background (`var(--background)` only resolves to the
+ * navy-taupe interview colour inside a `data-theme-interview` region). The
+ * printable snapshot document overrides `--dim-blend` to white so dimmed nodes
+ * and edges recede into the white paper rather than blending toward the dark
+ * on-screen theme.
  */
 export function dimColor(color: string): string {
-  return `color-mix(in oklab, ${color} ${DIMMED_BLEND}, var(--background))`;
+  return `color-mix(in oklab, ${color} ${DIMMED_BLEND}, var(--dim-blend, var(--background)))`;
 }

--- a/packages/interview/src/interfaces/NarrativePedigree/CEGRM.stories.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/CEGRM.stories.tsx
@@ -22,12 +22,12 @@ import StoryInterviewShell from '~/.storybook/StoryInterviewShell';
 //   • FamilyPedigree + NarrativePedigree  → the genetic layer (a hereditary
 //     breast/ovarian cancer family; the pedigree is SEEDED to reduce burden).
 //   • NameGenerator (QuickAdd)            → add fictive/affinal kin to the network.
-//   • Sociogram (member-to-member edges)  → who knows whom.
-//   • Sociogram (attribute nomination)    → the three reciprocal exchanges (two
-//     booleans each) and the disseminator/barrier roles.
+//   • Sociogram (one stage, auto layout)  → who knows whom (edge creation on the
+//     first prompt), then the three reciprocal exchanges (two booleans each) and
+//     the disseminator/barrier roles, each an attribute-nomination prompt.
 // Every network member is one "Person" node type. Only the people placed on the
 // pedigree appear on the pedigree interfaces (via the pedigree's private
-// membership); the sociograms show everyone.
+// membership); the sociogram shows everyone.
 // ---------------------------------------------------------------------------
 
 const EGO_VAR = 'isEgo';
@@ -194,7 +194,82 @@ export function buildCegrmInterview(seed: number) {
     ],
   });
 
-  // --- Stage 2: narrative pedigree (the cancer pathway) -----------------------
+  // --- Stage 2: add non-blood kin --------------------------------------------
+  const ng = si.addStage('NameGeneratorQuickAdd', {
+    label: 'People in your life',
+    subject: { entity: 'node', type: person.id },
+    quickAdd: NAME_VAR,
+  });
+  ng.addPrompt({
+    text: 'Add the friends, colleagues and others who are important to you.',
+  });
+
+  // --- Stage 3: the whole CEGRM sociogram, on one auto-laid-out canvas --------
+  // A single Sociogram stage with force-directed automatic layout, so the
+  // participant reads the network rather than placing every person. The first
+  // prompt draws the member-to-member ties; the rest nominate the three
+  // reciprocal resource exchanges (two booleans each) and the two role booleans.
+  // Edge creation and attribute highlighting cannot share a prompt, so each is a
+  // prompt of its own within this one stage.
+  const sociogram = si.addStage('Sociogram', {
+    label: 'Your support network',
+    subject: { entity: 'node', type: person.id },
+    behaviours: { automaticLayout: true },
+  });
+  // Edge creation first: who knows whom.
+  sociogram.addPrompt({
+    text: 'Connect people who **know one another** by tapping them to create a line',
+    layout: { layoutVariable: LAYOUT_VAR },
+    edges: { create: socialEdge.id, display: [socialEdge.id] },
+  });
+  // Information exchange.
+  sociogram.addPrompt({
+    text: 'Which of these people provides you with genetic or health information?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: INFO_IN_VAR },
+  });
+  sociogram.addPrompt({
+    text: 'Which of these people do you provide with genetic or health information?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: INFO_OUT_VAR },
+  });
+  // Practical support.
+  sociogram.addPrompt({
+    text: 'Which of these people provides you with practical help — like coming to an appointment or minding your children?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: SUPPORT_IN_VAR },
+  });
+  sociogram.addPrompt({
+    text: 'Which of these people do you provide with practical help?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: SUPPORT_OUT_VAR },
+  });
+  // Sharing feelings.
+  sociogram.addPrompt({
+    text: "Which of these people shares their feelings about the family's cancer with you?",
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: FEELINGS_IN_VAR },
+  });
+  sociogram.addPrompt({
+    text: "Which of these people do you share your feelings about the family's cancer with?",
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: FEELINGS_OUT_VAR },
+  });
+  // Disseminator / barrier roles.
+  sociogram.addPrompt({
+    text: 'Which of these people helps the family talk about its cancer risk?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: DISSEMINATOR_VAR },
+  });
+  sociogram.addPrompt({
+    text: 'Which of these people makes it harder for the family to talk about its cancer risk?',
+    layout: { layoutVariable: LAYOUT_VAR },
+    highlight: { variable: BARRIER_VAR },
+  });
+
+  // --- Stage 4: narrative pedigree (the cancer pathway), shown last -----------
+  // Reads the committed FamilyPedigree membership (kin only), so the friends and
+  // colleagues added since do not appear on the family tree.
   si.addStage('NarrativePedigree', {
     label: 'Hereditary cancer risk',
     sourceStageId: fpStage.id,
@@ -210,99 +285,12 @@ export function buildCegrmInterview(seed: number) {
     ],
   });
 
-  // --- Stage 3: add non-blood kin --------------------------------------------
-  const ng = si.addStage('NameGeneratorQuickAdd', {
-    label: 'People in your life',
-    subject: { entity: 'node', type: person.id },
-    quickAdd: NAME_VAR,
-  });
-  ng.addPrompt({
-    text: 'Add the friends, colleagues and others who are important to you.',
-  });
-
-  // --- Stages 4–6: the three resource exchanges, on the sociogram -------------
-  // Each is one Sociogram stage with two attribute-nomination prompts: who
-  // provides the resource to ego, and who ego provides it to. Edge creation and
-  // attribute highlighting cannot share a prompt, so these are separate from the
-  // member-to-member stage below.
-  const infoSociogram = si.addStage('Sociogram', {
-    label: 'Sharing information',
-    subject: { entity: 'node', type: person.id },
-  });
-  infoSociogram.addPrompt({
-    text: 'Which of these people provides you with genetic or health information?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: INFO_IN_VAR },
-  });
-  infoSociogram.addPrompt({
-    text: 'Which of these people do you provide with genetic or health information?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: INFO_OUT_VAR },
-  });
-
-  const supportSociogram = si.addStage('Sociogram', {
-    label: 'Practical support',
-    subject: { entity: 'node', type: person.id },
-  });
-  supportSociogram.addPrompt({
-    text: 'Which of these people provides you with practical help — like coming to an appointment or minding your children?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: SUPPORT_IN_VAR },
-  });
-  supportSociogram.addPrompt({
-    text: 'Which of these people do you provide with practical help?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: SUPPORT_OUT_VAR },
-  });
-
-  const feelingsSociogram = si.addStage('Sociogram', {
-    label: 'Sharing feelings',
-    subject: { entity: 'node', type: person.id },
-  });
-  feelingsSociogram.addPrompt({
-    text: "Which of these people shares their feelings about the family's cancer with you?",
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: FEELINGS_IN_VAR },
-  });
-  feelingsSociogram.addPrompt({
-    text: "Which of these people do you share your feelings about the family's cancer with?",
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: FEELINGS_OUT_VAR },
-  });
-
-  // --- Stage 7: disseminator / barrier roles, on the sociogram ----------------
-  const roleSociogram = si.addStage('Sociogram', {
-    label: 'Talking about risk',
-    subject: { entity: 'node', type: person.id },
-  });
-  roleSociogram.addPrompt({
-    text: 'Which of these people helps the family talk about its cancer risk?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: DISSEMINATOR_VAR },
-  });
-  roleSociogram.addPrompt({
-    text: 'Which of these people makes it harder for the family to talk about its cancer risk?',
-    layout: { layoutVariable: LAYOUT_VAR },
-    highlight: { variable: BARRIER_VAR },
-  });
-
-  // --- Stage 8: member-to-member social network -------------------------------
-  const sociogram = si.addStage('Sociogram', {
-    label: 'How they know each other',
-    subject: { entity: 'node', type: person.id },
-  });
-  sociogram.addPrompt({
-    text: 'Draw a line between any two people who know one another.',
-    layout: { layoutVariable: LAYOUT_VAR },
-    edges: { create: socialEdge.id, display: [socialEdge.id] },
-  });
-
   // --- Seed the network -------------------------------------------------------
   const fpId = fpStage.id;
   const ngId = ng.id;
 
-  // Sociogram positions (normalised 0–1) so the member-to-member network opens
-  // already laid out with its ties drawn, rather than as an empty placement task.
+  // Sociogram positions (normalised 0–1) seed the starting arrangement; the
+  // stage's automatic layout then relaxes the network into a readable shape.
   const POS: Record<string, { x: number; y: number }> = {
     ego: { x: 0.5, y: 0.52 },
     husband: { x: 0.66, y: 0.5 },
@@ -549,30 +537,31 @@ type Story = StoryObj;
 
 /**
  * The whole CEGRM walk-through, starting at the introduction. Use Next to move
- * through the pedigree, the cancer-risk view, adding non-family members, the
- * three resource-exchange sociograms, the disseminator/barrier roles and the
- * member-to-member social network.
+ * through the pedigree, add the non-family members, work through the single
+ * support-network sociogram (drawing ties, then nominating the resource
+ * exchanges and roles) and finish on the hereditary-cancer-risk view.
  */
 export const FullWalkthrough: Story = {
   render: () => <CegrmWrapper seed={11} step={0} />,
 };
 
 /**
- * Jumps straight to the first resource-exchange sociogram (sharing information).
- * Each exchange asks two questions — who provides it to you, and who you provide
- * it to — so reciprocity is inferred. Use Back/Next to move between the
- * information, practical-support, feelings and disseminator/barrier sociograms,
- * each pre-nominated from the seeded data. Shortcut into {@link FullWalkthrough}.
+ * Jumps straight to the one support-network sociogram. Its first prompt draws
+ * the member-to-member ties; the rest nominate the three reciprocal resource
+ * exchanges (each two questions — who provides it to you, and who you provide it
+ * to — so reciprocity is inferred) and the disseminator/barrier roles. The whole
+ * network is auto-laid-out and pre-nominated from the seeded data. Use Back/Next
+ * to move between prompts. Shortcut into {@link FullWalkthrough}.
  */
-export const ResourceExchanges: Story = {
-  render: () => <CegrmWrapper seed={11} step={4} />,
+export const SupportNetwork: Story = {
+  render: () => <CegrmWrapper seed={11} step={3} />,
 };
 
 /**
- * Jumps straight to the member-to-member social network — the family and the
- * non-kin laid out together with their social ties drawn. Shortcut into the end
- * of {@link FullWalkthrough}.
+ * Jumps straight to the hereditary-cancer-risk view shown at the end of the
+ * interview — the seeded family's cancer pathway, with the later-added friends
+ * and colleagues excluded. Shortcut into the end of {@link FullWalkthrough}.
  */
-export const SocialNetwork: Story = {
-  render: () => <CegrmWrapper seed={11} step={8} />,
+export const HereditaryCancerRisk: Story = {
+  render: () => <CegrmWrapper seed={11} step={4} />,
 };

--- a/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
@@ -479,20 +479,21 @@ export default function NarrativePedigreeView({
     // in the cell, so connectors still meet the cell centre.
     return (
       <div className="relative inline-flex size-24 items-center justify-center">
-        {/* The single-condition node is a bare notation symbol (no fresco-ui
-            Node), so it has no built-in selected ring — a selection-coloured glow
-            follows the symbol's silhouette for any shape when it is the focal. */}
-        <span
-          className="relative block size-16"
-          style={
-            selected
-              ? {
-                  filter:
-                    'drop-shadow(0 0 0.5rem var(--selected)) drop-shadow(0 0 0.25rem var(--selected)) drop-shadow(0 0 0.15rem var(--selected))',
-                }
-              : undefined
-          }
-        >
+        {/* The focal person is marked with a downward arrow above the symbol,
+            rather than a glow: the glow washed out the label and, being white,
+            did not print. The arrow reads its colour from --np-label-color, so
+            it is white on the dark interface and dark ink in the printed
+            snapshot (which sets that variable), and it never obscures the label. */}
+        {selected && (
+          <svg
+            aria-hidden
+            viewBox="0 0 24 16"
+            className="absolute top-0 left-1/2 h-4 w-6 -translate-x-1/2"
+          >
+            <path d="M12 15 L3 3 L21 3 Z" fill="var(--np-label-color, #fff)" />
+          </svg>
+        )}
+        <span className="relative block size-16">
           <Sticker
             status={status}
             color={color}

--- a/packages/interview/src/interfaces/NarrativePedigree/export/PedigreeSnapshotDocument.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/export/PedigreeSnapshotDocument.tsx
@@ -59,10 +59,17 @@ export const PedigreeSnapshotDocument = forwardRef<
   },
   ref,
 ) {
-  // The single-condition node labels read their colour from this custom property
-  // (@types/react does not type custom properties, hence the scoped assertion —
-  // the established pattern across fresco-ui/interview).
-  const labelInk = { '--np-label-color': '#111827' } as CSSProperties;
+  // Snapshot-only CSS custom properties (@types/react does not type custom
+  // properties, hence the scoped assertion — the established pattern across
+  // fresco-ui/interview):
+  //  • --np-label-color: dark ink for the single-condition node labels.
+  //  • --dim-blend: the surface dimmed nodes/edges recede into. On screen this
+  //    is the dark interview background; here it is the white paper, so dimmed
+  //    pieces fade toward white instead of muddying toward navy.
+  const snapshotVars = {
+    '--np-label-color': '#111827',
+    '--dim-blend': '#ffffff',
+  } as CSSProperties;
 
   return (
     <div
@@ -82,7 +89,7 @@ export const PedigreeSnapshotDocument = forwardRef<
         flexDirection: 'column',
         gap: '1.5rem',
         padding: '2.5rem',
-        ...labelInk,
+        ...snapshotVars,
       }}
     >
       <h2 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 700 }}>

--- a/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/PedigreeSnapshotDocument.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/PedigreeSnapshotDocument.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { NcEdge, NcNode } from '@codaco/shared-consts';
+import type { VariableConfig } from '~/interfaces/FamilyPedigree/store';
+
+import { PedigreeSnapshotDocument } from '../PedigreeSnapshotDocument';
+
+const variableConfig: VariableConfig = {
+  nodeType: 'person',
+  edgeType: 'family',
+  nodeLabelVariable: 'name',
+  egoVariable: 'isEgo',
+  relationshipVariable: 'relationship',
+  relationshipTypeVariable: 'rel',
+  isActiveVariable: 'active',
+  isGestationalCarrierVariable: 'gc',
+  gameteRoleVariable: 'gameteRole',
+  biologicalSexVariable: 'biologicalSex',
+};
+
+const nodes = new Map<string, NcNode>([
+  ['ego', { _uid: 'ego', type: 'person', attributes: { isEgo: true } }],
+]);
+
+const renderNode = (node: NcNode & { id: string }) => (
+  <div data-testid={`node-${node.id}`}>{node.id}</div>
+);
+
+function renderDocument() {
+  const ref = createRef<HTMLDivElement>();
+  render(
+    <PedigreeSnapshotDocument
+      ref={ref}
+      title="Test snapshot"
+      nodes={nodes}
+      edges={new Map<string, NcEdge>()}
+      variableConfig={variableConfig}
+      nodeWidth={100}
+      nodeHeight={100}
+      renderNode={renderNode}
+      glyphColour="#e53e3e"
+      keyShape="circle"
+      showAtRiskStatuses
+      showKey={false}
+    />,
+  );
+  return ref.current;
+}
+
+describe('PedigreeSnapshotDocument', () => {
+  it('re-themes dimming to white so dimmed nodes and edges recede into the paper', () => {
+    // dimColor() blends toward var(--dim-blend); the printable document must set
+    // that to white. Otherwise dimmed pieces blend toward the dark on-screen
+    // background (which the off-screen document still inherits) and print muddy.
+    const root = renderDocument();
+    expect(root).not.toBeNull();
+    expect(root?.style.getPropertyValue('--dim-blend')).toBe('#ffffff');
+  });
+
+  it('sets dark label ink for the printable document', () => {
+    const root = renderDocument();
+    expect(root?.style.getPropertyValue('--np-label-color')).toBe('#111827');
+  });
+});

--- a/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/snapshot.test.ts
+++ b/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/snapshot.test.ts
@@ -43,6 +43,19 @@ describe('exportSnapshot', () => {
     );
   });
 
+  it('resets the clone to in-flow positioning so the off-screen document is not captured blank', async () => {
+    // The snapshot document is mounted position: fixed; left: -100000px. Without
+    // a position reset html-to-image clones that and renders the whole subtree
+    // outside the capture area, producing an empty PNG.
+    await exportSnapshot(element, 'test.png');
+    expect(htmlToImage.toPng).toHaveBeenCalledWith(
+      element,
+      expect.objectContaining({
+        style: expect.objectContaining({ position: 'static' }),
+      }),
+    );
+  });
+
   it('appends an anchor with the correct href and filename, then clicks and removes it', async () => {
     await exportSnapshot(element, 'pedigree-2026.png');
 

--- a/packages/interview/src/interfaces/NarrativePedigree/export/snapshot.ts
+++ b/packages/interview/src/interfaces/NarrativePedigree/export/snapshot.ts
@@ -9,6 +9,12 @@ export async function exportSnapshot(
     backgroundColor: '#ffffff',
     // Render at 2× for a crisp image regardless of the display's pixel ratio.
     pixelRatio: 2,
+    // The document is mounted off-screen (position: fixed; left: -100000px) so
+    // it never flashes on screen. html-to-image clones the element's computed
+    // style, so without this the clone keeps that positioning and renders the
+    // whole subtree outside the captured area — producing a blank PNG. Reset the
+    // clone (only) to in-flow so it renders at the origin of the capture.
+    style: { position: 'static', left: '0px', top: '0px' },
   });
 
   const anchor = document.createElement('a');


### PR DESCRIPTION
Follow-up to #713. That PR merged the branch at an earlier point (`3741fe885`), so these five pedigree fixes/refinements made afterwards didn't land on `main`. This PR brings them in.

### Changes

- **fix(family-pedigree): dim/highlight consanguinity double lines with the focal lineage** — the couple-bar split that drives edge dimming excluded consanguineous (double) bars, so both parallel lines rendered whole and ignored the focal highlight. Both lines now track the focal lineage.
- **fix(narrative-pedigree): stop exporting blank snapshots** — the off-screen snapshot document is mounted `position: fixed; left: -100000px`; html-to-image cloned that positioning and rendered the subtree outside the capture area, producing a blank PNG. The clone is reset to in-flow positioning.
- **fix(narrative-pedigree): mark the focal individual with an arrow, not a glow** — the selection glow washed out the node label and, being white, didn't print. Replaced with a downward arrow above the symbol that reads its colour from `--np-label-color` (white on screen, dark ink in the printed snapshot).
- **refactor(narrative-pedigree): merge the CEGRM sociograms into one auto-laid-out stage** — collapses the five separate Sociogram stages into a single "Your support network" stage with automatic layout, moves edge creation to the first prompt, and moves the hereditary-cancer-risk view to the end of the interview.
- **fix(narrative-pedigree): blend dimmed nodes and edges to white in snapshots** — `dimColor()` blended dimmed pieces toward the dark interview background, which the off-screen snapshot document still inherited, so they printed muddy. Dimming now blends toward an overridable `var(--dim-blend, var(--background))`; the printable document sets `--dim-blend` to white so dimmed nodes and edges recede into the paper. On-screen appearance is unchanged.

### Testing

- Unit: pedigree-layout + NarrativePedigree suites green (542 tests), including new `dimColor` and `PedigreeSnapshotDocument` seam tests and the consanguinity double-bar / snapshot-position regression tests.
- Typecheck: `turbo run typecheck --filter=@codaco/interview` passes.
- Browser: verified in Storybook that dimmed edges/nodes resolve toward white only under the snapshot's `--dim-blend` override (edge lightness 0.44 → 0.94, node surface 0.50 → 1.0), with on-screen dimming unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pedigree and story views with clearer selection indicators and updated interview/story entry points.
  * Added support for printable snapshot styling, including consistent label colors and dimmed elements.

* **Bug Fixes**
  * Fixed highlighting for double-line family connections so both lines dim and split correctly.
  * Improved image export reliability by preventing blank snapshots from off-screen positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->