### PR TITLE
feat(architect): refine Family Pedigree and Narrative Pedigree stage editors

### DIFF
--- a/.changeset/family-pedigree-editor-refinements.md
+++ b/.changeset/family-pedigree-editor-refinements.md
@@ -1,0 +1,22 @@
+---
+'@codaco/protocol-validation': minor
+'@codaco/shared-consts': minor
+'@codaco/protocol-utilities': minor
+'@codaco/interview': minor
+---
+
+Refine the Architect stage editors for the Family Pedigree and Narrative Pedigree interfaces.
+
+**Family Pedigree editor**
+
+- The fixed-framing selector is now a styled select, and the framing section explains what the gamete-based and gendered framings mean in neutral, non-normative terms.
+- Boundary options no longer use "family tree" (always "family pedigree"), explain what off/recommended/required do, and rename "Require Children Contributors" to "Require Co-Parents' Families". Both boundary fields are now required in the editor so a missing value surfaces as a named issue rather than a raw schema error.
+- Fixed a bug where changing the node type cleared the stage-level `framing`, `boundaries`, and `introScreen`, producing a schema error on finish. A seam test now guards the preserve-list against the schema's required fields.
+- The intro screen is now built on the Information content-item model — reorderable text and asset sections instead of a single title/text/video block. The `introScreen` schema field changes from `{ title?, text, videoAssetId? }` to `{ items }`, and the Information item renderer is extracted to a shared `ContentItem` component reused by the pedigree intro step. The intro-screen title field is removed.
+- Node and edge configuration panels split their columns evenly (50% variable column), give variable pills a white background, and edge-type items render on a darker surface to stand out from the panel. Edge configuration explains why the interface needs an edge type, and the gamete-role variable now uses predefined read-only egg/sperm options (shared via `GAMETE_ROLE_OPTIONS` in `@codaco/shared-consts`) in the same way as relationship type.
+- Nomination prompts show an empty-state message when no prompts exist yet.
+
+**Narrative Pedigree editor**
+
+- Corrected the new-stage dialog tags: Narrative Pedigree (read-only) is tagged Display Data only; Family Pedigree gains Capture Edge Attributes.
+- The At-Risk Statuses explanation moves from the section side column into the main column and is formatted with subheadings and lists.

--- a/apps/architect-web/src/components/Screens/NewStageScreen/interfaceOptions.ts
+++ b/apps/architect-web/src/components/Screens/NewStageScreen/interfaceOptions.ts
@@ -96,7 +96,14 @@ export const INTERFACE_TYPES: InterfaceType[] = [
   },
   {
     category: CATEGORIES.GENERATORS,
-    tags: [TAGS.CREATE_NODES, TAGS.CREATE_EDGES, TAGS.NODE_ATTRIBUTES],
+    // Captures node attributes (sex, form fields, nomination flags) and edge
+    // attributes (relationship type, active status, carrier/gamete roles).
+    tags: [
+      TAGS.CREATE_NODES,
+      TAGS.CREATE_EDGES,
+      TAGS.NODE_ATTRIBUTES,
+      TAGS.EDGE_ATTRIBUTES,
+    ],
     keywords:
       'family pedigree tree census namegenerator name generator nodes node edges edge',
     type: 'FamilyPedigree',
@@ -106,7 +113,8 @@ export const INTERFACE_TYPES: InterfaceType[] = [
   },
   {
     category: CATEGORIES.SOCIOGRAMS,
-    tags: [TAGS.PROVIDE_INFORMATION, TAGS.NODE_ATTRIBUTES],
+    // Read-only visualisation: displays data, captures nothing.
+    tags: [TAGS.PROVIDE_INFORMATION],
     keywords:
       'narrative pedigree disease visualize visualise genetics inheritance focal hereditary',
     type: 'NarrativePedigree',

--- a/apps/architect-web/src/components/StageEditor/Interfaces.tsx
+++ b/apps/architect-web/src/components/StageEditor/Interfaces.tsx
@@ -322,7 +322,14 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
         requireChildrenContributors: 'off',
       },
       introScreen: {
-        text: "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
+        items: [
+          {
+            id: 'intro-text',
+            type: 'text',
+            content:
+              "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
+          },
+        ],
       },
     },
   },

--- a/apps/architect-web/src/components/sections/ContentGrid/ContentGrid.tsx
+++ b/apps/architect-web/src/components/sections/ContentGrid/ContentGrid.tsx
@@ -1,48 +1,10 @@
-import { get } from 'es-toolkit/compat';
-import { formValueSelector } from 'redux-form';
-
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
-import type { RootState } from '~/ducks/modules/root';
-import { getAssetManifest } from '~/selectors/protocol';
 
 import Grid from '../../Grid';
 import ItemEditor from './ItemEditor';
 import ItemPreview from './ItemPreview';
+import { denormalizeType, normalizeType } from './itemTypes';
 import { capacity } from './options';
-
-type Item = {
-  type: string;
-  content?: string;
-  [key: string]: unknown;
-};
-
-const normalizeType = (item: Item): Item => ({
-  ...item,
-  type: item.type === 'text' ? 'text' : 'asset',
-});
-
-const denormalizeType = (
-  state: RootState,
-  { form, editField }: { form: string; editField: string },
-): Item | null => {
-  const item = formValueSelector(form)(state, editField) as Item | undefined;
-
-  if (!item) {
-    return null;
-  }
-
-  if (item.type === 'text') {
-    return item;
-  }
-
-  const assetManifest = getAssetManifest(state);
-  const manifestType = get(assetManifest, [item.content ?? '', 'type']);
-
-  return {
-    ...item,
-    type: manifestType as string,
-  };
-};
 
 const ContentGrid = ({ form, ...restProps }: StageEditorSectionProps) => (
   <Grid

--- a/apps/architect-web/src/components/sections/ContentGrid/itemTypes.ts
+++ b/apps/architect-web/src/components/sections/ContentGrid/itemTypes.ts
@@ -36,10 +36,15 @@ export const denormalizeType = (
   }
 
   const assetManifest = getAssetManifest(state);
-  const manifestType = get(assetManifest, [item.content ?? '', 'type']);
+  const manifestType = get(assetManifest, [item.content ?? '', 'type']) as
+    | string
+    | undefined;
 
+  // Fall back to the persisted discriminant when the asset can't be resolved
+  // (no content selected yet, or a stale/deleted reference), so callers never
+  // receive `type: undefined`.
   return {
     ...item,
-    type: manifestType as string,
+    type: manifestType ?? item.type,
   };
 };

--- a/apps/architect-web/src/components/sections/ContentGrid/itemTypes.ts
+++ b/apps/architect-web/src/components/sections/ContentGrid/itemTypes.ts
@@ -1,0 +1,45 @@
+import { get } from 'es-toolkit/compat';
+import { formValueSelector } from 'redux-form';
+
+import type { RootState } from '~/ducks/modules/root';
+import { getAssetManifest } from '~/selectors/protocol';
+
+type Item = {
+  type: string;
+  content?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Content-item type mapping shared by the Information stage editor
+ * (ContentGrid) and the FamilyPedigree intro screen editor. Editing works with
+ * the concrete asset type (image/video/audio) so the right input is shown; the
+ * saved item collapses back to the schema's text/asset discriminant.
+ */
+export const normalizeType = (item: Item): Item => ({
+  ...item,
+  type: item.type === 'text' ? 'text' : 'asset',
+});
+
+export const denormalizeType = (
+  state: RootState,
+  { form, editField }: { form: string; editField: string },
+): Item | null => {
+  const item = formValueSelector(form)(state, editField) as Item | undefined;
+
+  if (!item) {
+    return null;
+  }
+
+  if (item.type === 'text') {
+    return item;
+  }
+
+  const assetManifest = getAssetManifest(state);
+  const manifestType = get(assetManifest, [item.content ?? '', 'type']);
+
+  return {
+    ...item,
+    type: manifestType as string,
+  };
+};

--- a/apps/architect-web/src/components/sections/FamilyPedigree/BoundaryOptions.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/BoundaryOptions.tsx
@@ -17,11 +17,30 @@ const BoundaryOptions = (_props: StageEditorSectionProps) => (
     title="Boundary Options"
     summary={
       <p>
-        Configure whether participants must include grandparents and children
-        who contribute to the family tree.
+        Configure how far the family pedigree must extend beyond the
+        participant&rsquo;s immediate family.
       </p>
     }
   >
+    <p>
+      Each boundary below can be set to one of three enforcement levels, which
+      determine how the interview behaves when the condition is not yet met:
+    </p>
+    <ul className="mb-(--space-md) list-disc pl-(--space-lg) [&_li]:mb-(--space-xs)">
+      <li>
+        <strong>Off</strong> — the condition is never checked, and participants
+        are not asked to provide this information.
+      </li>
+      <li>
+        <strong>Recommended</strong> — participants see a reminder in the
+        completion checklist, but can finish the stage without satisfying the
+        condition.
+      </li>
+      <li>
+        <strong>Required</strong> — participants cannot finish the stage until
+        the condition is satisfied.
+      </li>
+    </ul>
     <FormSection name="boundaries">
       <Row>
         <IssueAnchor
@@ -31,29 +50,40 @@ const BoundaryOptions = (_props: StageEditorSectionProps) => (
         <ValidatedField
           name="requireGrandparents"
           component={NativeSelect}
-          validation={{}}
+          validation={{ required: true }}
           componentProps={{
             label: 'Require Grandparents',
             options: BOUNDARY_REQUIREMENT_OPTIONS,
             placeholder: 'Select an option',
           }}
         />
+        <p className="mt-(--space-xs) text-sm text-current/70">
+          Asks the participant to record two parents for each of their own
+          parents, so that all of the participant&rsquo;s grandparents appear in
+          the family pedigree.
+        </p>
       </Row>
       <Row>
         <IssueAnchor
           fieldName="boundaries.requireChildrenContributors"
-          description="Require Children Contributors"
+          description="Require Co-Parents' Families"
         />
         <ValidatedField
           name="requireChildrenContributors"
           component={NativeSelect}
-          validation={{}}
+          validation={{ required: true }}
           componentProps={{
-            label: 'Require Children Contributors',
+            label: "Require Co-Parents' Families",
             options: BOUNDARY_REQUIREMENT_OPTIONS,
             placeholder: 'Select an option',
           }}
         />
+        <p className="mt-(--space-xs) text-sm text-current/70">
+          For each of the participant&rsquo;s children, asks that the
+          child&rsquo;s other genetic parent has their own parents and
+          grandparents recorded, extending the family pedigree to that side of
+          the family. Participants without children can affirm this instead.
+        </p>
       </Row>
     </FormSection>
   </Section>

--- a/apps/architect-web/src/components/sections/FamilyPedigree/CensusPrompt.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/CensusPrompt.tsx
@@ -19,7 +19,7 @@ const CensusPrompt = (_props: StageEditorSectionProps) => (
       <ValidatedField
         name="censusPrompt"
         component={RichText}
-        componentProps={{ label: 'Prompt for building the family tree' }}
+        componentProps={{ label: 'Prompt for building the family pedigree' }}
         validation={{ required: true }}
       />
     </Row>

--- a/apps/architect-web/src/components/sections/FamilyPedigree/EdgeConfiguration.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/EdgeConfiguration.tsx
@@ -2,7 +2,10 @@ import { useSelector } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 
 import type { VariableOptions } from '@codaco/protocol-validation';
-import { RELATIONSHIP_TYPE_OPTIONS } from '@codaco/shared-consts';
+import {
+  GAMETE_ROLE_OPTIONS,
+  RELATIONSHIP_TYPE_OPTIONS,
+} from '@codaco/shared-consts';
 import { Row, Section } from '~/components/EditorLayout';
 import VariablePicker from '~/components/Form/Fields/VariablePicker/VariablePicker';
 import ValidatedField from '~/components/Form/ValidatedField';
@@ -45,7 +48,7 @@ const VariableRow = ({
   edgeType,
 }: VariableRowProps) => (
   <div className="flex items-start gap-(--space-md)">
-    <div className="flex grow flex-col gap-(--space-xs) pt-(--space-sm)">
+    <div className="flex flex-1 basis-0 flex-col gap-(--space-xs) pt-(--space-sm)">
       <span className="font-semibold">
         {label}
         <span className="text-error ms-(--space-xs)">*</span>
@@ -54,7 +57,7 @@ const VariableRow = ({
         {description}
       </span>
     </div>
-    <div className="relative flex-1">
+    <div className="relative flex-1 basis-0">
       <IssueAnchor fieldName={name} description={`${label} Variable`} />
       <ValidatedField
         name={name}
@@ -95,8 +98,14 @@ const EdgeConfiguration = ({ form }: StageEditorSectionProps) => {
   const booleanEdgeVariables = edgeVariableOptions.filter(
     (v) => v.type === 'boolean',
   );
-  const categoricalEdgeVariables = edgeVariableOptions.filter(
-    (v) => v.type === 'categorical',
+  // Only categorical variables whose options are exactly the canonical
+  // gamete-role set may be bound: the interview writes these exact values
+  // (egg/sperm) onto genetic parent edges, so an existing categorical variable
+  // with a different value set would silently break inheritance tracing.
+  // Mirrors the relationship-type picker above.
+  const gameteRoleCompatible = edgeVariableOptions.filter(
+    (v) =>
+      v.type === 'categorical' && optionsMatch(v.options, GAMETE_ROLE_OPTIONS),
   );
 
   const handleCreatedVariable = (...args: unknown[]) => {
@@ -139,7 +148,13 @@ const EdgeConfiguration = ({ form }: StageEditorSectionProps) => {
 
   const handleNewGameteRoleVariable = (name: string) =>
     openVariableWindow(
-      { initialValues: { name, type: 'categorical' }, lockedOptions: null },
+      {
+        initialValues: { name, type: 'categorical' },
+        // Seed and lock the canonical value set — the interview writes these
+        // exact values, so the researcher may not edit them (mirrors the
+        // relationship-type variable).
+        lockedOptions: GAMETE_ROLE_OPTIONS,
+      },
       { field: 'edgeConfig.gameteRoleVariable' },
     );
 
@@ -148,10 +163,20 @@ const EdgeConfiguration = ({ form }: StageEditorSectionProps) => {
       <Section
         title="Edge Configuration"
         summary={
-          <p>
-            Select the edge type and configure variables for family
-            relationships.
-          </p>
+          <>
+            <p>
+              The family pedigree is stored as a network: each family member is
+              a node, and every parent or partner connection between two people
+              is an edge. This interface needs an edge type so that it can
+              record those connections in your codebook — including the
+              parentage it infers automatically — and so that the structure of
+              the pedigree appears in your exported data.
+            </p>
+            <p>
+              Select the edge type to use, along with the variables that store
+              the details of each relationship.
+            </p>
+          </>
         }
       >
         <Row>
@@ -164,7 +189,8 @@ const EdgeConfiguration = ({ form }: StageEditorSectionProps) => {
           />
         </Row>
         {edgeType && (
-          <div className="bg-surface-2 text-surface-2-foreground mt-(--space-lg) flex flex-col gap-(--space-lg) rounded p-(--space-md)">
+          // `[&_.variable-pill]:bg-white` lifts the pills off the surface-2 panel
+          <div className="bg-surface-2 text-surface-2-foreground mt-(--space-lg) flex flex-col gap-(--space-lg) rounded p-(--space-md) [&_.variable-pill]:bg-white">
             <VariableRow
               name="edgeConfig.relationshipTypeVariable"
               label="Relationship Type"
@@ -191,10 +217,10 @@ const EdgeConfiguration = ({ form }: StageEditorSectionProps) => {
             />
             <VariableRow
               name="edgeConfig.gameteRoleVariable"
-              label="Gamete Role Variable"
-              description="Stores the gamete role for each parent (which gamete each participant contributed)."
+              label="Gamete Role"
+              description="Stores which reproductive cell (gamete) a parent contributed to a child: the egg or the sperm. The interface uses this to trace the biological route of inheritance along each parent relationship. This variable uses a fixed set of values (egg/sperm) that cannot be edited."
               edgeType={edgeType}
-              options={categoricalEdgeVariables}
+              options={gameteRoleCompatible}
               onCreateOption={handleNewGameteRoleVariable}
             />
           </div>

--- a/apps/architect-web/src/components/sections/FamilyPedigree/FramingConfig.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/FramingConfig.tsx
@@ -7,6 +7,7 @@ import {
   type FramingId,
 } from '@codaco/shared-consts';
 import { Section } from '~/components/EditorLayout';
+import NativeSelect from '~/components/Form/Fields/NativeSelect';
 import RadioGroup from '~/components/Form/Fields/RadioGroup';
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
 import { useAppDispatch } from '~/ducks/hooks';
@@ -47,8 +48,10 @@ const FramingConfig = ({ form }: StageEditorSectionProps) => {
     }
   };
 
-  const handleValueChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    dispatch(change(form, 'framing.value', event.target.value));
+  const handleValueChange = (value: string | null) => {
+    if (value) {
+      dispatch(change(form, 'framing.value', value));
+    }
   };
 
   return (
@@ -62,6 +65,29 @@ const FramingConfig = ({ form }: StageEditorSectionProps) => {
         </p>
       }
     >
+      <p>
+        The framing determines the language the interface uses when talking
+        about biological parents:
+      </p>
+      <ul className="mb-(--space-md) list-disc pl-(--space-lg) [&_li]:mb-(--space-xs)">
+        <li>
+          <strong>Gamete-based</strong> — describes each parent by their
+          reproductive contribution, using terms such as &ldquo;egg
+          parent&rdquo; and &ldquo;sperm parent&rdquo; and questions such as
+          &ldquo;Who provided the egg?&rdquo;. This framing works for all family
+          structures, including donor conception, surrogacy, and same-sex
+          parents.
+        </li>
+        <li>
+          <strong>Gendered</strong> — uses gendered kinship terms such as
+          &ldquo;mother&rdquo; and &ldquo;father&rdquo; and questions such as
+          &ldquo;Who is the biological mother?&rdquo;. This framing assumes that
+          each child has a mother and a father.
+        </li>
+      </ul>
+      <p className="mb-(--space-md)">
+        Both framings use the same wording for gestational carriers and donors.
+      </p>
       <RadioGroup
         options={FRAMING_MODE_OPTIONS}
         input={{
@@ -73,17 +99,16 @@ const FramingConfig = ({ form }: StageEditorSectionProps) => {
 
       {mode === 'fixed' && (
         <div className="mt-(--space-md)">
-          <select
-            value={fixedValue}
-            onChange={handleValueChange}
+          <NativeSelect
             aria-label="Select framing"
-          >
-            {FRAMING_VALUE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+            sortOptionsByLabel={false}
+            options={FRAMING_VALUE_OPTIONS}
+            input={{
+              name: 'framing.value',
+              value: fixedValue,
+              onChange: handleValueChange,
+            }}
+          />
         </div>
       )}
     </Section>

--- a/apps/architect-web/src/components/sections/FamilyPedigree/IntroScreen.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/IntroScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 
+import type { FamilyPedigreeIntroItem } from '@codaco/protocol-validation';
 import EditableList from '~/components/EditableList';
 import { Row, Section } from '~/components/EditorLayout';
 import ItemEditor from '~/components/sections/ContentGrid/ItemEditor';
@@ -15,7 +16,7 @@ import { useAppDispatch } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/store';
 
 type IntroScreenValue = {
-  items: { id: string; type: string; content?: string }[];
+  items: FamilyPedigreeIntroItem[];
 } | null;
 
 const IntroScreen = ({ form }: StageEditorSectionProps) => {

--- a/apps/architect-web/src/components/sections/FamilyPedigree/IntroScreen.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/IntroScreen.tsx
@@ -2,20 +2,20 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 
+import EditableList from '~/components/EditableList';
 import { Row, Section } from '~/components/EditorLayout';
-import { Field as RichText } from '~/components/Form/Fields/RichText';
-import TextField from '~/components/Form/Fields/Text';
-import VideoInput from '~/components/Form/Fields/Video';
-import ValidatedField from '~/components/Form/ValidatedField';
-import IssueAnchor from '~/components/IssueAnchor';
+import ItemEditor from '~/components/sections/ContentGrid/ItemEditor';
+import ItemPreview from '~/components/sections/ContentGrid/ItemPreview';
+import {
+  denormalizeType,
+  normalizeType,
+} from '~/components/sections/ContentGrid/itemTypes';
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
 import { useAppDispatch } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/store';
 
 type IntroScreenValue = {
-  title?: string;
-  text: string;
-  videoAssetId?: string;
+  items: { id: string; type: string; content?: string }[];
 } | null;
 
 const IntroScreen = ({ form }: StageEditorSectionProps) => {
@@ -28,11 +28,12 @@ const IntroScreen = ({ form }: StageEditorSectionProps) => {
   );
 
   const isEnabled = introScreen !== null && introScreen !== undefined;
+  const hasItems = !!introScreen?.items?.length;
 
   const handleToggleChange = useCallback(
     async (newState: boolean) => {
       if (newState) {
-        dispatch(change(form, 'introScreen', { text: '' }));
+        dispatch(change(form, 'introScreen', { items: [] }));
         return true;
       }
 
@@ -48,7 +49,8 @@ const IntroScreen = ({ form }: StageEditorSectionProps) => {
       summary={
         <p>
           Optionally show an introductory screen to participants before the
-          family pedigree task begins.
+          family pedigree task begins. Add text and media sections below, and
+          drag them to reorder.
         </p>
       }
       toggleable
@@ -56,33 +58,28 @@ const IntroScreen = ({ form }: StageEditorSectionProps) => {
       handleToggleChange={handleToggleChange}
     >
       <Row>
-        <IssueAnchor fieldName="introScreen.title" description="Title" />
-        <ValidatedField
-          name="introScreen.title"
-          component={TextField}
-          validation={{}}
-          componentProps={{ label: 'Title (optional)' }}
-        />
-      </Row>
-      <Row>
-        <IssueAnchor fieldName="introScreen.text" description="Body text" />
-        <ValidatedField
-          name="introScreen.text"
-          component={RichText}
-          validation={{ required: true }}
-          componentProps={{ label: 'Body text' }}
-        />
-      </Row>
-      <Row>
-        <IssueAnchor
-          fieldName="introScreen.videoAssetId"
-          description="Video (optional)"
-        />
-        <ValidatedField
-          name="introScreen.videoAssetId"
-          component={VideoInput}
-          validation={{}}
-        />
+        <EditableList
+          label="Content sections"
+          previewComponent={ItemPreview}
+          editComponent={ItemEditor}
+          title="Edit Section"
+          fieldName="introScreen.items"
+          form={form}
+          normalize={normalizeType as unknown as (value: unknown) => unknown}
+          itemSelector={
+            denormalizeType as unknown as (
+              state: Record<string, unknown>,
+              params: { form: string; editField: string },
+            ) => unknown
+          }
+        >
+          {!hasItems && (
+            <p className="text-current/70 italic">
+              No content sections have been created yet. Click &ldquo;Create
+              new&rdquo; to add text or media to the intro screen.
+            </p>
+          )}
+        </EditableList>
       </Row>
     </Section>
   );

--- a/apps/architect-web/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
@@ -47,7 +47,12 @@ import NodeFormFieldPreview from './NodeFormFieldPreview';
 
 const nodeEntity: Entity = 'node';
 
-const PRESERVE_ON_NODE_TYPE_CHANGE = [
+// Stage-level configuration that does not reference node variables survives a
+// node-type change; framing/boundaries/introScreen are required (or
+// self-contained) schema fields, so clearing them would make the stage fail
+// schema validation on save. Exported for the seam test that checks it against
+// the schema's required fields.
+export const PRESERVE_ON_NODE_TYPE_CHANGE = [
   'id',
   'type',
   'label',
@@ -55,6 +60,9 @@ const PRESERVE_ON_NODE_TYPE_CHANGE = [
   'skipLogic',
   'edgeConfig',
   'censusPrompt',
+  'framing',
+  'boundaries',
+  'introScreen',
   'nodeConfig.type',
 ];
 
@@ -83,7 +91,7 @@ const VariableRow = ({
   onCreateOption,
 }: VariableRowProps) => (
   <div className="flex items-start gap-(--space-md)">
-    <div className="flex grow flex-col gap-(--space-xs) pt-(--space-sm)">
+    <div className="flex flex-1 basis-0 flex-col gap-(--space-xs) pt-(--space-sm)">
       <span className="font-semibold">
         {label}
         <span className="text-error ms-(--space-xs)">*</span>
@@ -92,7 +100,7 @@ const VariableRow = ({
         {description}
       </span>
     </div>
-    <div className="relative flex-1">
+    <div className="relative flex-1 basis-0">
       <IssueAnchor fieldName={name} description={`${label} Variable`} />
       <ValidatedField
         name={name}
@@ -235,7 +243,8 @@ const NodeConfigurationInner = ({
 
         {nodeType && (
           <>
-            <div className="bg-surface-2 text-surface-2-foreground my-(--space-lg) flex flex-col gap-(--space-lg) rounded p-(--space-md)">
+            {/* `[&_.variable-pill]:bg-white` lifts the pills off the surface-2 panel */}
+            <div className="bg-surface-2 text-surface-2-foreground my-(--space-lg) flex flex-col gap-(--space-lg) rounded p-(--space-md) [&_.variable-pill]:bg-white">
               <VariableRow
                 name="nodeConfig.nodeLabelVariable"
                 label="Node Label"
@@ -247,7 +256,7 @@ const NodeConfigurationInner = ({
               <VariableRow
                 name="nodeConfig.egoVariable"
                 label="Ego Identifier"
-                description="A boolean variable to identify which node represents the participant (ego) in the family tree."
+                description="A boolean variable to identify which node represents the participant (ego) in the family pedigree."
                 entityType={nodeType}
                 options={booleanNodeVariables}
                 onCreateOption={handleNewEgoVariable}
@@ -255,7 +264,7 @@ const NodeConfigurationInner = ({
               <VariableRow
                 name="nodeConfig.relationshipVariable"
                 label="Relationship to Participant"
-                description="Stores each person's relationship to the participant (e.g., mother, uncle, daughter). Automatically calculated by the family tree interface."
+                description="Stores each person's relationship to the participant (e.g., mother, uncle, daughter). Automatically calculated by the family pedigree interface."
                 entityType={nodeType}
                 options={textNodeVariables}
                 onCreateOption={handleNewRelationshipVariable}
@@ -283,7 +292,6 @@ const NodeConfigurationInner = ({
               className="bg-surface-2 text-surface-2-foreground p-(--space-md)"
             >
               <EditableList
-                label="Form Fields"
                 editComponent={FieldFields}
                 editProps={{ type: nodeType, entity: 'node' }}
                 previewComponent={NodeFormFieldPreview}

--- a/apps/architect-web/src/components/sections/FamilyPedigree/NominationPrompts.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/NominationPrompts.tsx
@@ -76,7 +76,14 @@ const NominationPrompts = ({ form }: StageEditorSectionProps) => {
         fieldName="nominationPrompts"
         form={form}
         editProps={{ nodeType }}
-      />
+      >
+        {!hasNominationPrompts?.length && (
+          <p className="text-current/70 italic">
+            No nomination prompts have been created yet. Click &ldquo;Create
+            new&rdquo; to add your first prompt.
+          </p>
+        )}
+      </EditableList>
     </Section>
   );
 };

--- a/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/BoundaryOptions.test.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/BoundaryOptions.test.tsx
@@ -24,10 +24,19 @@ vi.mock('~/components/Form/ValidatedField', () => ({
   default: ({
     name,
     componentProps,
+    validation,
   }: {
     name: string;
     componentProps?: { label?: string };
-  }) => <div data-testid={`field-${name}`}>{componentProps?.label}</div>,
+    validation?: Record<string, unknown>;
+  }) => (
+    <div
+      data-testid={`field-${name}`}
+      data-required={validation?.required ? 'true' : 'false'}
+    >
+      {componentProps?.label}
+    </div>
+  ),
 }));
 
 vi.mock('~/components/Form/Fields/NativeSelect', () => ({
@@ -74,6 +83,16 @@ describe('BoundaryOptions', () => {
     expect(
       screen.getByTestId('field-requireChildrenContributors').textContent,
     ).toContain("Require Co-Parents' Families");
+  });
+
+  it('marks both boundary fields as required', () => {
+    renderSection();
+    expect(
+      screen.getByTestId('field-requireGrandparents').dataset.required,
+    ).toBe('true');
+    expect(
+      screen.getByTestId('field-requireChildrenContributors').dataset.required,
+    ).toBe('true');
   });
 
   it('explains the enforcement levels', () => {

--- a/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/BoundaryOptions.test.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/BoundaryOptions.test.tsx
@@ -73,6 +73,18 @@ describe('BoundaryOptions', () => {
     renderSection();
     expect(
       screen.getByTestId('field-requireChildrenContributors').textContent,
-    ).toContain('Require Children Contributors');
+    ).toContain("Require Co-Parents' Families");
+  });
+
+  it('explains the enforcement levels', () => {
+    renderSection();
+    expect(screen.getByText('Off')).toBeDefined();
+    expect(screen.getByText('Recommended')).toBeDefined();
+    expect(screen.getByText('Required')).toBeDefined();
+  });
+
+  it('does not use the phrase "family tree"', () => {
+    const { container } = renderSection();
+    expect(container.textContent).not.toContain('family tree');
   });
 });

--- a/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/FramingConfig.test.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/FramingConfig.test.tsx
@@ -94,7 +94,29 @@ vi.mock('~/components/Form/Fields/RadioGroup', () => ({
 }));
 
 vi.mock('~/components/Form/Fields/NativeSelect', () => ({
-  default: () => <div data-testid="native-select" />,
+  default: ({
+    options,
+    input,
+  }: {
+    options: { value: string; label: string }[];
+    input: {
+      value: string;
+      name: string;
+      onChange: (v: string | null) => void;
+    };
+  }) => (
+    <select
+      data-testid="native-select"
+      value={input.value}
+      onChange={(e) => input.onChange(e.target.value)}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
 }));
 
 import FramingConfig from '../FramingConfig';
@@ -158,5 +180,23 @@ describe('FramingConfig', () => {
       mode: 'fixed',
       value: 'gamete',
     });
+  });
+
+  it('dispatches change to framing.value when a fixed value is selected', () => {
+    mockFramingValue = { mode: 'fixed', value: 'gamete' };
+    mockDispatch.mockClear();
+    mockChange.mockClear();
+    renderSection();
+
+    fireEvent.change(screen.getByTestId('native-select'), {
+      target: { value: 'gendered' },
+    });
+
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(mockChange).toHaveBeenCalledWith(
+      'edit-stage',
+      'framing.value',
+      'gendered',
+    );
   });
 });

--- a/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/IntroScreen.test.tsx
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/IntroScreen.test.tsx
@@ -83,16 +83,31 @@ vi.mock('~/components/Form/ValidatedField', () => ({
   }) => <div data-testid={`field-${name}`}>{componentProps?.label}</div>,
 }));
 
-vi.mock('~/components/Form/Fields/RichText', () => ({
-  Field: () => <div data-testid="rich-text" />,
-}));
-
 vi.mock('~/components/Form/Fields/Text', () => ({
   default: () => <div data-testid="text-field" />,
 }));
 
-vi.mock('~/components/Form/Fields/Video', () => ({
-  default: () => <div data-testid="video-field" />,
+vi.mock('~/components/EditableList', () => ({
+  default: ({
+    fieldName,
+    children,
+  }: {
+    fieldName: string;
+    children?: React.ReactNode;
+  }) => (
+    <div data-testid={`editable-list-${fieldName}`}>
+      {children}
+      <button>Create new</button>
+    </div>
+  ),
+}));
+
+vi.mock('~/components/sections/ContentGrid/ItemEditor', () => ({
+  default: () => <div data-testid="item-editor" />,
+}));
+
+vi.mock('~/components/sections/ContentGrid/ItemPreview', () => ({
+  default: () => <div data-testid="item-preview" />,
 }));
 
 import IntroScreen from '../IntroScreen';
@@ -124,26 +139,54 @@ describe('IntroScreen', () => {
   });
 
   it('section starts expanded when introScreen has a value', () => {
-    mockIntroScreenValue = { text: 'Hello', title: 'Intro' };
+    mockIntroScreenValue = { items: [] };
     renderSection();
     expect(screen.getByTestId('section-toggle').dataset.expanded).toBe('true');
   });
 
-  it('shows title and text fields when intro screen is enabled', () => {
-    mockIntroScreenValue = { text: 'Hello' };
+  it('shows the content-item list when enabled', () => {
+    mockIntroScreenValue = { items: [] };
     renderSection();
-    expect(screen.getByTestId('field-introScreen.title')).toBeDefined();
-    expect(screen.getByTestId('field-introScreen.text')).toBeDefined();
+    expect(screen.getByTestId('editable-list-introScreen.items')).toBeDefined();
   });
 
-  it('shows video asset field when intro screen is enabled', () => {
-    mockIntroScreenValue = { text: 'Hello' };
+  it('shows an empty-state message when there are no items', () => {
+    mockIntroScreenValue = { items: [] };
     renderSection();
-    expect(screen.getByTestId('field-introScreen.videoAssetId')).toBeDefined();
+    expect(
+      screen.getByText(/No content sections have been created yet/),
+    ).toBeDefined();
+  });
+
+  it('hides the empty-state message when items exist', () => {
+    mockIntroScreenValue = {
+      items: [{ id: 't1', type: 'text', content: 'Hello' }],
+    };
+    renderSection();
+    expect(
+      screen.queryByText(/No content sections have been created yet/),
+    ).toBeNull();
+  });
+
+  it('dispatches change to an empty items list when toggled on', async () => {
+    mockIntroScreenValue = undefined;
+    mockDispatch.mockClear();
+    renderSection();
+
+    expect(capturedToggleChange).toBeTypeOf('function');
+    await capturedToggleChange?.(true);
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'redux-form/CHANGE',
+        field: 'introScreen',
+        value: { items: [] },
+      }),
+    );
   });
 
   it('dispatches change to null when toggled off', async () => {
-    mockIntroScreenValue = { text: 'Hello' };
+    mockIntroScreenValue = { items: [] };
     mockDispatch.mockClear();
     renderSection();
 

--- a/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/preserveOnNodeTypeChange.test.ts
+++ b/apps/architect-web/src/components/sections/FamilyPedigree/__tests__/preserveOnNodeTypeChange.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { familyPedigreeStage } from '@codaco/protocol-validation';
+
+import { PRESERVE_ON_NODE_TYPE_CHANGE } from '../NodeConfiguration';
+
+/**
+ * Changing the node type resets every stage-editor field NOT in
+ * PRESERVE_ON_NODE_TYPE_CHANGE. Any schema-REQUIRED top-level field that gets
+ * cleared and has no editor-level `required` validation surfaces as a raw zod
+ * error when the researcher clicks "Finished Editing" (this shipped once, for
+ * `boundaries`). This seam test fails when a new required field is added to
+ * the FamilyPedigree schema without deciding how the reset should treat it:
+ * either preserve it here, or reset it deliberately and add it to
+ * INTENTIONALLY_RESET below (with editor validation to reprompt for it).
+ */
+describe('PRESERVE_ON_NODE_TYPE_CHANGE covers schema-required fields', () => {
+  // nodeConfig is what the reset is FOR (its variables reference the old node
+  // type); only its `type` subfield is preserved. All its fields have
+  // `required` editor validation, so the researcher is reprompted.
+  const INTENTIONALLY_RESET = ['nodeConfig'];
+
+  it('preserves every required top-level stage field', () => {
+    // A field is required when its schema rejects `undefined` (zod v4
+    // deprecated `.isOptional()`).
+    const requiredKeys = Object.entries(familyPedigreeStage.shape)
+      .filter(([, schema]) => !schema.safeParse(undefined).success)
+      .map(([key]) => key);
+
+    for (const key of requiredKeys) {
+      if (INTENTIONALLY_RESET.includes(key)) {
+        continue;
+      }
+      expect(
+        PRESERVE_ON_NODE_TYPE_CHANGE,
+        `schema-required field "${key}"`,
+      ).toContain(key);
+    }
+  });
+});

--- a/apps/architect-web/src/components/sections/NarrativePedigree/AtRiskStatuses.tsx
+++ b/apps/architect-web/src/components/sections/NarrativePedigree/AtRiskStatuses.tsx
@@ -7,53 +7,11 @@ const AtRiskStatuses = (_props: StageEditorSectionProps) => (
   <Section
     title="At-Risk Statuses"
     summary={
-      <>
-        <p>
-          When enabled, the pedigree also shows <strong>possible</strong>{' '}
-          (at-risk) statuses alongside the certain ones: a person who{' '}
-          <em>may develop</em> a condition, <em>may carry</em> it, or{' '}
-          <em>may be affected</em>. These are drawn as the usual status symbol
-          with a question mark (&ldquo;?&rdquo;) added.
-        </p>
-        <p>
-          <strong>How it is calculated.</strong> At-risk statuses are not
-          observed or diagnosed &mdash; they are inferred from the family
-          structure together with each condition&rsquo;s inheritance pattern.
-          For example, the child of a parent affected by a dominant condition is
-          shown as <em>may develop</em> it; the child of two carriers of a
-          recessive condition is shown as <em>may carry</em> it, or{' '}
-          <em>may be affected</em> when both copies could be inherited (such as
-          a consanguineous union). Only <em>biological</em> and <em>donor</em>{' '}
-          relationships pass conditions on; social, adoptive, surrogate, and
-          partner links do not. Where a person&rsquo;s biological sex is not
-          known, sex-linked inheritance through that person is left uncertain
-          rather than guessed.
-        </p>
-        <p>
-          <strong>&ldquo;May be affected&rdquo; and known carriers.</strong> The{' '}
-          <em>may be affected</em> (possibly two copies) symbol is only shown
-          for a person whose status is still open. It is deliberately{' '}
-          <strong>not</strong> shown for someone the pedigree already
-          establishes is an unaffected carrier of a <em>recessive</em>{' '}
-          condition, because such a person cannot also be affected. The one
-          exception is <strong>X-linked recessive</strong>: a daughter of an
-          affected father and a carrier mother is still shown as{' '}
-          <em>may be affected</em>, because she can inherit an affected copy
-          from each parent, and carrier females of X-linked conditions can
-          themselves show symptoms. X-linked risk is traced along the{' '}
-          <strong>maternal line</strong> only, so relatives connected through an
-          unaffected father are not marked.
-        </p>
-        <p>
-          <strong>Why this is off by default.</strong> At-risk symbols are a
-          strong visual signal that can be read as established fact rather than
-          inferred risk. They are intended for{' '}
-          <strong>clinician-directed use</strong>, where the result is
-          interpreted in context. Standard pedigree nomenclature (Bennett et
-          al., 2022) deliberately does not encode probabilistic risk, so leave
-          this off unless a clinician is guiding interpretation.
-        </p>
-      </>
+      <p>
+        Optionally show <strong>possible</strong> (at-risk) statuses alongside
+        the certain ones, inferred from family structure and inheritance
+        patterns.
+      </p>
     }
   >
     <Row>
@@ -66,6 +24,71 @@ const AtRiskStatuses = (_props: StageEditorSectionProps) => (
         }}
       />
     </Row>
+    <div className="[&_h5]:mt-(--space-md) [&_h5]:mb-(--space-xs) [&_h5]:font-semibold [&_li]:mb-(--space-xs) [&_p]:mb-(--space-sm) [&_ul]:mb-(--space-sm) [&_ul]:list-disc [&_ul]:pl-(--space-lg)">
+      <p>
+        When enabled, the pedigree also shows a person who <em>may develop</em>{' '}
+        a condition, <em>may carry</em> it, or <em>may be affected</em>. These
+        are drawn as the usual status symbol with a question mark
+        (&ldquo;?&rdquo;) added.
+      </p>
+
+      <h5>How it is calculated</h5>
+      <p>
+        At-risk statuses are not observed or diagnosed &mdash; they are inferred
+        from the family structure together with each condition&rsquo;s
+        inheritance pattern. For example:
+      </p>
+      <ul>
+        <li>
+          The child of a parent affected by a dominant condition is shown as{' '}
+          <em>may develop</em> it.
+        </li>
+        <li>
+          The child of two carriers of a recessive condition is shown as{' '}
+          <em>may carry</em> it, or <em>may be affected</em> when both copies
+          could be inherited (such as a consanguineous union).
+        </li>
+      </ul>
+      <p>Two rules constrain how risk travels through the family:</p>
+      <ul>
+        <li>
+          Only <em>biological</em> and <em>donor</em> relationships pass
+          conditions on; social, adoptive, surrogate, and partner links do not.
+        </li>
+        <li>
+          Where a person&rsquo;s biological sex is not known, sex-linked
+          inheritance through that person is left uncertain rather than guessed.
+        </li>
+      </ul>
+
+      <h5>&ldquo;May be affected&rdquo; and known carriers</h5>
+      <p>
+        The <em>may be affected</em> (possibly two copies) symbol is only shown
+        for a person whose status is still open. It is deliberately{' '}
+        <strong>not</strong> shown for someone the pedigree already establishes
+        is an unaffected carrier of a <em>recessive</em> condition, because such
+        a person cannot also be affected.
+      </p>
+      <p>
+        The one exception is <strong>X-linked recessive</strong>: a daughter of
+        an affected father and a carrier mother is still shown as{' '}
+        <em>may be affected</em>, because she can inherit an affected copy from
+        each parent, and carrier females of X-linked conditions can themselves
+        show symptoms. X-linked risk is traced along the{' '}
+        <strong>maternal line</strong> only, so relatives connected through an
+        unaffected father are not marked.
+      </p>
+
+      <h5>Why this is off by default</h5>
+      <p>
+        At-risk symbols are a strong visual signal that can be read as
+        established fact rather than inferred risk. They are intended for{' '}
+        <strong>clinician-directed use</strong>, where the result is interpreted
+        in context. Standard pedigree nomenclature (Bennett et al., 2022)
+        deliberately does not encode probabilistic risk, so leave this off
+        unless a clinician is guiding interpretation.
+      </p>
+    </div>
   </Section>
 );
 

--- a/apps/architect-web/src/components/sections/NarrativePedigree/__tests__/AtRiskStatuses.test.tsx
+++ b/apps/architect-web/src/components/sections/NarrativePedigree/__tests__/AtRiskStatuses.test.tsx
@@ -62,7 +62,9 @@ describe('AtRiskStatuses', () => {
     // WHAT — the "may develop / may carry / may be affected" symbols.
     expect(screen.getAllByText(/may develop/i).length).toBeGreaterThan(0);
     // HOW — derived from inheritance pattern, not observed status.
-    expect(screen.getByText(/inheritance pattern/i)).toBeDefined();
+    expect(screen.getAllByText(/inheritance pattern/i).length).toBeGreaterThan(
+      0,
+    );
     // WHY (caution + Bennett 2022 reference)
     expect(screen.getByText(/clinician-directed use/i)).toBeDefined();
     expect(screen.getByText(/Bennett/)).toBeDefined();

--- a/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect-web/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -106,6 +106,8 @@ const EntitySelectField = ({
             color={color ?? 'edge-color-seq-1'}
             onClick={() => handleClickItem(optionValue)}
             selected={value === optionValue}
+            // surface-2 lifts the pills off the section panel's surface-1 background
+            surface={2}
           />
         ) : (
           <PreviewNode

--- a/apps/architect-web/src/utils/variables.ts
+++ b/apps/architect-web/src/utils/variables.ts
@@ -3,7 +3,7 @@ import type { VariableOptions } from '@codaco/protocol-validation';
 /**
  * Checks if two sets of categorical/ordinal options match exactly.
  * Options must have the same length and identical label/value pairs.
- * Used for family tree census to ensure selected variables have the required locked options.
+ * Used by the family pedigree editor to ensure selected variables have the required locked options.
  */
 export function optionsMatch(
   variableOptions: VariableOptions | undefined,

--- a/packages/interview/src/components/ContentItem.tsx
+++ b/packages/interview/src/components/ContentItem.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  ALLOWED_MARKDOWN_SECTION_TAGS,
+  RenderMarkdown,
+} from '@codaco/fresco-ui/RenderMarkdown';
+import Spinner from '@codaco/fresco-ui/Spinner';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import { cx } from '@codaco/fresco-ui/utils/cva';
+import type { Item } from '@codaco/protocol-validation';
+import { useCaptureException } from '~/analytics/useTrack';
+import { useContractFlags } from '~/contract/context';
+import { useAssetUrl } from '~/hooks/useAssetUrl';
+import { getAssetManifest } from '~/store/modules/protocol';
+
+// UploadThing's CDN serves files uploaded via the `blob` router with an invalid
+// Content-Type (e.g. `video` instead of `video/mp4`). Safari strictly requires
+// a valid MIME type and refuses to play otherwise. We work around this by
+// providing an explicit `type` on the `<source>` element, derived from the
+// original `source` filename extension carried in the asset record (the display
+// `name` may lack an extension on hand-edited protocols).
+const MEDIA_MIME_TYPES: Record<string, string> = {
+  // Video
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  '.webm': 'video/webm',
+  // Many .mov files contain codecs such as H.264 or HEVC, but browser
+  // support varies by codec, browser, and platform. We use video/mp4
+  // instead of video/quicktime because Chrome rejects the latter even
+  // when it can decode the underlying codec.
+  '.mov': 'video/mp4',
+  '.avi': 'video/x-msvideo',
+  '.ogv': 'video/ogg',
+  // Audio (.ogg is audio-only; video ogg files use the .ogv extension above)
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.m4a': 'audio/mp4',
+  '.aac': 'audio/aac',
+};
+
+function getMediaMimeType(
+  filename: string | undefined,
+  fallback: string,
+): string {
+  if (!filename) return fallback;
+  const dotIndex = filename.lastIndexOf('.');
+  if (dotIndex === -1) return fallback;
+  const ext = filename.slice(dotIndex).toLowerCase();
+  return MEDIA_MIME_TYPES[ext] ?? fallback;
+}
+
+// Size applies to image items, which carry a `size` prop. Maps the size
+// magic-strings to max-height bands. Other item types are rendered at their
+// natural size (no max-height treatment).
+function getSizeClass(size: string | undefined): string {
+  return cx(
+    size === 'SMALL' && 'max-h-48',
+    size === 'MEDIUM' && 'max-h-96',
+    size === 'LARGE' && 'max-h-[60vh]',
+  );
+}
+
+function ItemFallback({ message }: { message: string }) {
+  return (
+    <div
+      data-testid="information-item-fallback"
+      className="border-accent flex items-center justify-center rounded border border-dashed p-4"
+    >
+      <Paragraph intent="smallText" className="text-center">
+        {message}
+      </Paragraph>
+    </div>
+  );
+}
+
+type MediaLoadState = 'loading' | 'loaded' | 'error';
+
+function VideoPlayer({
+  src,
+  name,
+  source,
+  isE2E,
+}: {
+  src: string;
+  name: string;
+  source: string | undefined;
+  isE2E: boolean;
+}) {
+  const [state, setState] = useState<MediaLoadState>('loading');
+  const captureException = useCaptureException();
+
+  // Disable autoPlay and preload to prevent browser crashes in headless E2E tests.
+  // MIME type derives from the source filename, falling back to the display name.
+  const mimeType = getMediaMimeType(source ?? name, 'video/mp4');
+
+  return (
+    <div className={cx('relative', state === 'loading' && 'min-h-48')}>
+      {state === 'loading' && !isE2E && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4">
+          <Spinner size="lg" />
+          <Paragraph intent="smallText">Loading video...</Paragraph>
+        </div>
+      )}
+      {state === 'error' && (
+        <Paragraph intent="smallText" className="text-center">
+          Video could not be loaded.
+        </Paragraph>
+      )}
+      <video
+        loop
+        controls
+        aria-label={name}
+        autoPlay={!isE2E}
+        muted={!isE2E}
+        playsInline
+        preload={isE2E ? 'none' : 'auto'}
+        className={cx(
+          (state === 'loading' && !isE2E) || state === 'error'
+            ? 'invisible h-0'
+            : '',
+        )}
+        onLoadedData={() => setState('loaded')}
+        onError={(e) => {
+          setState('error');
+          const code = e.currentTarget.error?.code ?? 'unknown';
+          captureException(new Error(`video load failed: ${code}`), {
+            feature: 'information-media',
+            media_kind: 'video',
+          });
+        }}
+      >
+        <source src={src} type={mimeType} />
+      </video>
+    </div>
+  );
+}
+
+function AssetItem({ item, isE2E }: { item: Item; isE2E: boolean }) {
+  const assetManifest = useSelector(getAssetManifest);
+  const assetMeta = assetManifest[item.content];
+  const { url, isLoading } = useAssetUrl(item.content);
+  // `size` exists only on asset items (text items have no size).
+  const itemSize = item.type === 'asset' ? item.size : undefined;
+
+  if (!assetMeta) {
+    return <ItemFallback message="This item could not be displayed." />;
+  }
+
+  if (isLoading) {
+    const sizeClass =
+      assetMeta.type === 'image'
+        ? cx(
+            itemSize === 'SMALL' && 'min-h-48',
+            itemSize === 'MEDIUM' && 'min-h-96',
+            itemSize === 'LARGE' && 'min-h-[60vh]',
+          )
+        : 'min-h-12';
+
+    return (
+      <div className={cx('flex items-center justify-center', sizeClass)}>
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!url) {
+    return <ItemFallback message="This item could not be displayed." />;
+  }
+
+  switch (assetMeta.type) {
+    case 'image':
+      return (
+        <img
+          src={url}
+          alt={item.description ?? ''}
+          className={cx('size-full object-contain', getSizeClass(itemSize))}
+        />
+      );
+    case 'audio':
+      return (
+        <audio
+          controls
+          autoPlay
+          aria-label={item.description ?? assetMeta.name}
+        >
+          <source
+            src={url}
+            type={getMediaMimeType(
+              assetMeta.source ?? assetMeta.name,
+              'audio/mpeg',
+            )}
+          />
+          <track kind="captions" />
+        </audio>
+      );
+    case 'video':
+      return (
+        <VideoPlayer
+          src={url}
+          name={assetMeta.name}
+          source={assetMeta.source}
+          isE2E={isE2E}
+        />
+      );
+    case 'network':
+    case 'geojson':
+    case 'apikey':
+      return <ItemFallback message="This item could not be displayed." />;
+  }
+}
+
+type ContentItemProps = {
+  item: Item;
+  /**
+   * Elements permitted in a text item's markdown. Defaults to the full
+   * section set used by the Information interface; contexts embedded beneath
+   * their own heading (e.g. the FamilyPedigree intro dialog) pass a
+   * restricted set.
+   */
+  allowedTextElements?: string[];
+};
+
+/**
+ * Renders one content item (text or asset) from the Information content-item
+ * model, shared by the Information interface and the FamilyPedigree intro
+ * screen.
+ */
+export default function ContentItem({
+  item,
+  allowedTextElements = ALLOWED_MARKDOWN_SECTION_TAGS,
+}: ContentItemProps) {
+  const { isE2E } = useContractFlags();
+
+  switch (item.type) {
+    case 'text':
+      return (
+        <RenderMarkdown allowedElements={allowedTextElements}>
+          {item.content}
+        </RenderMarkdown>
+      );
+    case 'asset':
+      return <AssetItem item={item} isE2E={isE2E} />;
+  }
+}

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.framing.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.framing.stories.tsx
@@ -77,8 +77,14 @@ function buildFramingInterview({
     },
     ...(withIntroScreen && {
       introScreen: {
-        title: 'Before we begin',
-        text: 'This pedigree helps us understand your family health history.',
+        items: [
+          {
+            id: 'intro-text',
+            type: 'text' as const,
+            content:
+              'This pedigree helps us understand your family health history.',
+          },
+        ],
       },
     }),
   });

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.stories.tsx
@@ -195,18 +195,23 @@ export const Default: Story = {
         // their parents are referred to (the FramingSelectionStep).
         framing: { mode: 'participantChoice' },
         introScreen: {
-          title: 'About your family pedigree',
-          text: [
-            'A family pedigree is a simple diagram of your biological relatives — the people you are related to by blood — across a few generations. Building one helps us understand patterns of health and inheritance that can run in a family.',
-            '',
-            '### How it works',
-            '',
-            "We'll build the diagram together, one step at a time. You'll start with the parents who conceived you, then add grandparents, any brothers and sisters, and — if you have them — a partner and children. For each person you can share a few details, and you can skip anything you would rather not answer.",
-            '',
-            '### What you will see',
-            '',
-            'Each relative appears as a shape, joined to the others by lines that show how everyone is related. Nothing is final while you work — you can go back and change your answers before you finish.',
-          ].join('\n'),
+          items: [
+            {
+              id: 'intro-text',
+              type: 'text',
+              content: [
+                'A family pedigree is a simple diagram of your biological relatives — the people you are related to by blood — across a few generations. Building one helps us understand patterns of health and inheritance that can run in a family.',
+                '',
+                '### How it works',
+                '',
+                "We'll build the diagram together, one step at a time. You'll start with the parents who conceived you, then add grandparents, any brothers and sisters, and — if you have them — a partner and children. For each person you can share a few details, and you can skip anything you would rather not answer.",
+                '',
+                '### What you will see',
+                '',
+                'Each relative appears as a shape, joined to the others by lines that show how everyone is related. Nothing is final while you work — you can go back and change your answers before you finish.',
+              ].join('\n'),
+            },
+          ],
         },
         boundaries: {
           requireGrandparents: 'off',

--- a/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/IntroStep.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/IntroStep.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { RenderMarkdown } from '@codaco/fresco-ui/RenderMarkdown';
-import Heading from '@codaco/fresco-ui/typography/Heading';
-import { useAssetUrl } from '~/hooks/useAssetUrl';
+import type { Item } from '@codaco/protocol-validation';
+import ContentItem from '~/components/ContentItem';
 import { useStageSelector } from '~/hooks/useStageSelector';
 import { getIntroScreen } from '~/interfaces/FamilyPedigree/utils/stageConfig';
 
@@ -24,28 +23,13 @@ const INTRO_ALLOWED_TAGS = [
 ];
 
 type IntroScreen = {
-  title?: string;
-  text: string;
-  videoAssetId?: string;
+  items: Item[];
 };
 
 export function shouldSkipIntroStep(
   introScreen: IntroScreen | null | undefined,
 ): boolean {
-  return introScreen == null;
-}
-
-function IntroVideo({ assetId }: { assetId: string }) {
-  const { url } = useAssetUrl(assetId);
-
-  if (!url) return null;
-
-  return (
-    <video controls aria-label="Intro video" className="w-full rounded">
-      <source src={url} />
-      <track kind="captions" />
-    </video>
-  );
+  return introScreen == null || introScreen.items.length === 0;
 }
 
 export default function IntroStep() {
@@ -55,13 +39,13 @@ export default function IntroStep() {
 
   return (
     <>
-      {introScreen.title && <Heading level="h3">{introScreen.title}</Heading>}
-      <RenderMarkdown allowedElements={INTRO_ALLOWED_TAGS}>
-        {introScreen.text}
-      </RenderMarkdown>
-      {introScreen.videoAssetId && (
-        <IntroVideo assetId={introScreen.videoAssetId} />
-      )}
+      {introScreen.items.map((item) => (
+        <ContentItem
+          key={item.id}
+          item={item}
+          allowedTextElements={INTRO_ALLOWED_TAGS}
+        />
+      ))}
     </>
   );
 }

--- a/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/IntroStep.test.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/IntroStep.test.tsx
@@ -1,4 +1,7 @@
+import { configureStore } from '@reduxjs/toolkit';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { Provider } from 'react-redux';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('~/hooks/useStageSelector', () => ({
@@ -17,15 +20,39 @@ vi.mock('~/contract/context', () => ({
   useContractFlags: () => ({ isE2E: false }),
 }));
 
+import type { ResolvedAsset } from '~/contract/types';
 import { useAssetUrl } from '~/hooks/useAssetUrl';
 import { useStageSelector } from '~/hooks/useStageSelector';
+import protocol from '~/store/modules/protocol';
 
-import IntroStep from '../IntroStep';
+import IntroStep, { shouldSkipIntroStep } from '../IntroStep';
+
+function renderIntroStep(assets: ResolvedAsset[] = []) {
+  const store = configureStore({
+    reducer: { protocol },
+    preloadedState: {
+      // Partial protocol slice — only `assets` is read by asset items.
+      protocol: { assets } as never,
+    },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  }
+
+  return render(<IntroStep />, { wrapper: Wrapper });
+}
 
 describe('IntroStep', () => {
-  it('renders introScreen text', () => {
+  it('renders text items', () => {
     vi.mocked(useStageSelector).mockReturnValue({
-      text: 'Welcome to the family pedigree builder.',
+      items: [
+        {
+          id: 't1',
+          type: 'text',
+          content: 'Welcome to the family pedigree builder.',
+        },
+      ],
     });
     vi.mocked(useAssetUrl).mockReturnValue({
       url: null,
@@ -33,17 +60,19 @@ describe('IntroStep', () => {
       error: null,
     });
 
-    render(<IntroStep />);
+    renderIntroStep();
 
     expect(
       screen.getByText('Welcome to the family pedigree builder.'),
     ).toBeTruthy();
   });
 
-  it('renders introScreen title when present', () => {
+  it('renders items in order', () => {
     vi.mocked(useStageSelector).mockReturnValue({
-      title: 'Getting Started',
-      text: 'Some introductory text.',
+      items: [
+        { id: 't1', type: 'text', content: 'First section.' },
+        { id: 't2', type: 'text', content: 'Second section.' },
+      ],
     });
     vi.mocked(useAssetUrl).mockReturnValue({
       url: null,
@@ -51,31 +80,18 @@ describe('IntroStep', () => {
       error: null,
     });
 
-    render(<IntroStep />);
+    renderIntroStep();
 
-    expect(screen.getByText('Getting Started')).toBeTruthy();
+    const first = screen.getByText('First section.');
+    const second = screen.getByText('Second section.');
+    expect(
+      first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
-  it('does not render title element when title is absent', () => {
+  it('renders a video element for a video asset item', () => {
     vi.mocked(useStageSelector).mockReturnValue({
-      text: 'Some text without a title.',
-    });
-    vi.mocked(useAssetUrl).mockReturnValue({
-      url: null,
-      isLoading: false,
-      error: null,
-    });
-
-    render(<IntroStep />);
-
-    const heading = screen.queryByRole('heading');
-    expect(heading).toBeNull();
-  });
-
-  it('renders a video element when videoAssetId is present and url resolves', () => {
-    vi.mocked(useStageSelector).mockReturnValue({
-      text: 'Watch this.',
-      videoAssetId: 'asset-123',
+      items: [{ id: 'v1', type: 'asset', content: 'asset-123' }],
     });
     vi.mocked(useAssetUrl).mockReturnValue({
       url: 'https://example.com/video.mp4',
@@ -83,16 +99,23 @@ describe('IntroStep', () => {
       error: null,
     });
 
-    render(<IntroStep />);
+    renderIntroStep([
+      {
+        assetId: 'asset-123',
+        name: 'Intro video',
+        type: 'video',
+        source: 'intro.mp4',
+      },
+    ]);
 
     const video = document.querySelector('video');
     expect(video).toBeTruthy();
     expect(video?.getAttribute('aria-label')).toBe('Intro video');
   });
 
-  it('does not render a video element when videoAssetId is absent', () => {
+  it('does not render a video element when there is no asset item', () => {
     vi.mocked(useStageSelector).mockReturnValue({
-      text: 'No video here.',
+      items: [{ id: 't1', type: 'text', content: 'No video here.' }],
     });
     vi.mocked(useAssetUrl).mockReturnValue({
       url: null,
@@ -100,9 +123,28 @@ describe('IntroStep', () => {
       error: null,
     });
 
-    render(<IntroStep />);
+    renderIntroStep();
 
     const video = document.querySelector('video');
     expect(video).toBeNull();
+  });
+});
+
+describe('shouldSkipIntroStep', () => {
+  it('skips when the intro screen is not configured', () => {
+    expect(shouldSkipIntroStep(null)).toBe(true);
+    expect(shouldSkipIntroStep(undefined)).toBe(true);
+  });
+
+  it('skips when the intro screen has no items', () => {
+    expect(shouldSkipIntroStep({ items: [] })).toBe(true);
+  });
+
+  it('does not skip when the intro screen has items', () => {
+    expect(
+      shouldSkipIntroStep({
+        items: [{ id: 't1', type: 'text', content: 'Hello' }],
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/skipPredicates.test.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/quickStartWizard/__tests__/skipPredicates.test.ts
@@ -12,16 +12,25 @@ describe('shouldSkipIntroStep', () => {
     expect(shouldSkipIntroStep(null)).toBe(true);
   });
 
-  it('returns false when introScreen is present', () => {
-    expect(shouldSkipIntroStep({ text: 'Hello' })).toBe(false);
+  it('returns true when introScreen has no items', () => {
+    expect(shouldSkipIntroStep({ items: [] })).toBe(true);
   });
 
-  it('returns false when introScreen has all fields', () => {
+  it('returns false when introScreen has items', () => {
     expect(
       shouldSkipIntroStep({
-        title: 'Welcome',
-        text: 'This is the intro.',
-        videoAssetId: 'abc123',
+        items: [{ id: 't1', type: 'text', content: 'Hello' }],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when introScreen has multiple items', () => {
+    expect(
+      shouldSkipIntroStep({
+        items: [
+          { id: 't1', type: 'text', content: 'This is the intro.' },
+          { id: 'v1', type: 'asset', content: 'abc123' },
+        ],
       }),
     ).toBe(false);
   });

--- a/packages/interview/src/interfaces/FamilyPedigree/store.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/store.ts
@@ -4,6 +4,7 @@ import { immer } from 'zustand/middleware/immer';
 
 import type {
   FramingId,
+  GAMETE_ROLES,
   NcEdge,
   NcNode,
   RelationshipType,
@@ -48,9 +49,11 @@ export type NodeMetadata = {
 
 /**
  * Which gamete a biological/donor parent contributed. Written to the network
- * as an edge attribute under `variableConfig.gameteRoleVariable`.
+ * as an edge attribute under `variableConfig.gameteRoleVariable`. Derived from
+ * the canonical value set in shared-consts, which Architect locks onto the
+ * categorical edge variable, so the two cannot drift apart.
  */
-export type GameteRole = 'egg' | 'sperm';
+export type GameteRole = (typeof GAMETE_ROLES)[number];
 
 /** A pedigree edge. gameteRole is stored in `attributes[gameteRoleVariable]`. */
 export type FamilyEdge = NcEdge;

--- a/packages/interview/src/interfaces/Information/Information.tsx
+++ b/packages/interview/src/interfaces/Information/Information.tsx
@@ -1,257 +1,27 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-
 import Surface from '@codaco/fresco-ui/layout/Surface';
-import {
-  ALLOWED_MARKDOWN_SECTION_TAGS,
-  RenderMarkdown,
-} from '@codaco/fresco-ui/RenderMarkdown';
 import { ScrollArea } from '@codaco/fresco-ui/ScrollArea';
-import Spinner from '@codaco/fresco-ui/Spinner';
 import Heading from '@codaco/fresco-ui/typography/Heading';
-import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
-import { cx } from '@codaco/fresco-ui/utils/cva';
-import type { Item } from '@codaco/protocol-validation';
-import { useCaptureException } from '~/analytics/useTrack';
-import { useContractFlags } from '~/contract/context';
-import { useAssetUrl } from '~/hooks/useAssetUrl';
-import { getAssetManifest } from '~/store/modules/protocol';
+import ContentItem from '~/components/ContentItem';
 import type { StageProps } from '~/types';
-
-// UploadThing's CDN serves files uploaded via the `blob` router with an invalid
-// Content-Type (e.g. `video` instead of `video/mp4`). Safari strictly requires
-// a valid MIME type and refuses to play otherwise. We work around this by
-// providing an explicit `type` on the `<source>` element, derived from the
-// original `source` filename extension carried in the asset record (the display
-// `name` may lack an extension on hand-edited protocols).
-const MEDIA_MIME_TYPES: Record<string, string> = {
-  // Video
-  '.mp4': 'video/mp4',
-  '.m4v': 'video/mp4',
-  '.webm': 'video/webm',
-  // Many .mov files contain codecs such as H.264 or HEVC, but browser
-  // support varies by codec, browser, and platform. We use video/mp4
-  // instead of video/quicktime because Chrome rejects the latter even
-  // when it can decode the underlying codec.
-  '.mov': 'video/mp4',
-  '.avi': 'video/x-msvideo',
-  '.ogv': 'video/ogg',
-  // Audio (.ogg is audio-only; video ogg files use the .ogv extension above)
-  '.mp3': 'audio/mpeg',
-  '.wav': 'audio/wav',
-  '.ogg': 'audio/ogg',
-  '.m4a': 'audio/mp4',
-  '.aac': 'audio/aac',
-};
-
-function getMediaMimeType(
-  filename: string | undefined,
-  fallback: string,
-): string {
-  if (!filename) return fallback;
-  const dotIndex = filename.lastIndexOf('.');
-  if (dotIndex === -1) return fallback;
-  const ext = filename.slice(dotIndex).toLowerCase();
-  return MEDIA_MIME_TYPES[ext] ?? fallback;
-}
-
-// Size applies to image items, which carry a `size` prop. Maps the size
-// magic-strings to max-height bands. Other item types are rendered at their
-// natural size (no max-height treatment).
-function getSizeClass(size: string | undefined): string {
-  return cx(
-    size === 'SMALL' && 'max-h-48',
-    size === 'MEDIUM' && 'max-h-96',
-    size === 'LARGE' && 'max-h-[60vh]',
-  );
-}
-
-function ItemFallback({ message }: { message: string }) {
-  return (
-    <div
-      data-testid="information-item-fallback"
-      className="border-accent flex items-center justify-center rounded border border-dashed p-4"
-    >
-      <Paragraph intent="smallText" className="text-center">
-        {message}
-      </Paragraph>
-    </div>
-  );
-}
-
-type MediaLoadState = 'loading' | 'loaded' | 'error';
-
-function VideoPlayer({
-  src,
-  name,
-  source,
-  isE2E,
-}: {
-  src: string;
-  name: string;
-  source: string | undefined;
-  isE2E: boolean;
-}) {
-  const [state, setState] = useState<MediaLoadState>('loading');
-  const captureException = useCaptureException();
-
-  // Disable autoPlay and preload to prevent browser crashes in headless E2E tests.
-  // MIME type derives from the source filename, falling back to the display name.
-  const mimeType = getMediaMimeType(source ?? name, 'video/mp4');
-
-  return (
-    <div className={cx('relative', state === 'loading' && 'min-h-48')}>
-      {state === 'loading' && !isE2E && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4">
-          <Spinner size="lg" />
-          <Paragraph intent="smallText">Loading video...</Paragraph>
-        </div>
-      )}
-      {state === 'error' && (
-        <Paragraph intent="smallText" className="text-center">
-          Video could not be loaded.
-        </Paragraph>
-      )}
-      <video
-        loop
-        controls
-        aria-label={name}
-        autoPlay={!isE2E}
-        muted={!isE2E}
-        playsInline
-        preload={isE2E ? 'none' : 'auto'}
-        className={cx(
-          (state === 'loading' && !isE2E) || state === 'error'
-            ? 'invisible h-0'
-            : '',
-        )}
-        onLoadedData={() => setState('loaded')}
-        onError={(e) => {
-          setState('error');
-          const code = e.currentTarget.error?.code ?? 'unknown';
-          captureException(new Error(`video load failed: ${code}`), {
-            feature: 'information-media',
-            media_kind: 'video',
-          });
-        }}
-      >
-        <source src={src} type={mimeType} />
-      </video>
-    </div>
-  );
-}
-
-function AssetItem({ item, isE2E }: { item: Item; isE2E: boolean }) {
-  const assetManifest = useSelector(getAssetManifest);
-  const assetMeta = assetManifest[item.content];
-  const { url, isLoading } = useAssetUrl(item.content);
-  // `size` exists only on asset items (text items have no size).
-  const itemSize = item.type === 'asset' ? item.size : undefined;
-
-  if (!assetMeta) {
-    return <ItemFallback message="This item could not be displayed." />;
-  }
-
-  if (isLoading) {
-    const sizeClass =
-      assetMeta.type === 'image'
-        ? cx(
-            itemSize === 'SMALL' && 'min-h-48',
-            itemSize === 'MEDIUM' && 'min-h-96',
-            itemSize === 'LARGE' && 'min-h-[60vh]',
-          )
-        : 'min-h-12';
-
-    return (
-      <div className={cx('flex items-center justify-center', sizeClass)}>
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (!url) {
-    return <ItemFallback message="This item could not be displayed." />;
-  }
-
-  switch (assetMeta.type) {
-    case 'image':
-      return (
-        <img
-          src={url}
-          alt={item.description ?? ''}
-          className={cx('size-full object-contain', getSizeClass(itemSize))}
-        />
-      );
-    case 'audio':
-      return (
-        <audio
-          controls
-          autoPlay
-          aria-label={item.description ?? assetMeta.name}
-        >
-          <source
-            src={url}
-            type={getMediaMimeType(
-              assetMeta.source ?? assetMeta.name,
-              'audio/mpeg',
-            )}
-          />
-          <track kind="captions" />
-        </audio>
-      );
-    case 'video':
-      return (
-        <VideoPlayer
-          src={url}
-          name={assetMeta.name}
-          source={assetMeta.source}
-          isE2E={isE2E}
-        />
-      );
-    case 'network':
-    case 'geojson':
-    case 'apikey':
-      return <ItemFallback message="This item could not be displayed." />;
-  }
-}
-
-const getItemComponent = (item: Item, isE2E: boolean) => {
-  switch (item.type) {
-    case 'text':
-      return (
-        <RenderMarkdown allowedElements={ALLOWED_MARKDOWN_SECTION_TAGS}>
-          {item.content}
-        </RenderMarkdown>
-      );
-    case 'asset':
-      return <AssetItem item={item} isE2E={isE2E} />;
-  }
-};
 
 type InformationProps = StageProps<'Information'>;
 
 /**
  * Information Interface
  */
-const Information = ({ stage: { title, items } }: InformationProps) => {
-  const { isE2E } = useContractFlags();
-
-  return (
-    <ScrollArea className="m-0 size-full">
-      <div className="interface allow-text-selection mx-auto flex min-h-full max-w-[80ch] flex-col justify-center">
-        <Surface className="grow-0" noContainer spacing="lg" shadow="lg">
-          <Heading level="h1" className="text-center">
-            {title}
-          </Heading>
-          {items.map((item) => (
-            <React.Fragment key={item.id}>
-              {getItemComponent(item, isE2E)}
-            </React.Fragment>
-          ))}
-        </Surface>
-      </div>
-    </ScrollArea>
-  );
-};
+const Information = ({ stage: { title, items } }: InformationProps) => (
+  <ScrollArea className="m-0 size-full">
+    <div className="interface allow-text-selection mx-auto flex min-h-full max-w-[80ch] flex-col justify-center">
+      <Surface className="grow-0" noContainer spacing="lg" shadow="lg">
+        <Heading level="h1" className="text-center">
+          {title}
+        </Heading>
+        {items.map((item) => (
+          <ContentItem key={item.id} item={item} />
+        ))}
+      </Surface>
+    </div>
+  </ScrollArea>
+);
 
 export default Information;

--- a/packages/protocol-utilities/src/types.ts
+++ b/packages/protocol-utilities/src/types.ts
@@ -195,11 +195,22 @@ type PanelEntry = {
   dataSource: string;
 };
 
-type InformationItem = {
-  id: string;
-  type: 'text';
-  content: string;
-};
+// Mirrors protocol-validation's `ItemSchema` (Information stage content items,
+// reused by the FamilyPedigree intro screen): a text section or a media asset.
+type InformationItem =
+  | {
+      id: string;
+      type: 'text';
+      content: string;
+      description?: string;
+    }
+  | {
+      id: string;
+      type: 'asset';
+      content: string;
+      description?: string;
+      size?: 'SMALL' | 'MEDIUM' | 'LARGE';
+    };
 
 export type StageEntry = {
   id: string;

--- a/packages/protocol-utilities/src/types.ts
+++ b/packages/protocol-utilities/src/types.ts
@@ -1,10 +1,16 @@
 import type {
   ComponentType,
+  FamilyPedigreeBoundaries,
+  FamilyPedigreeEdgeConfigInput,
+  FamilyPedigreeFraming,
+  FamilyPedigreeIntroItem,
+  FamilyPedigreeNodeConfigInput,
+  FamilyPedigreeNominationPromptInput,
+  Item,
   StageType,
   VariableOption,
   VariableType,
 } from '@codaco/protocol-validation';
-import type { FramingId } from '@codaco/shared-consts';
 
 export type VariableEntry = {
   id: string;
@@ -195,23 +201,6 @@ type PanelEntry = {
   dataSource: string;
 };
 
-// Mirrors protocol-validation's `ItemSchema` (Information stage content items,
-// reused by the FamilyPedigree intro screen): a text section or a media asset.
-type InformationItem =
-  | {
-      id: string;
-      type: 'text';
-      content: string;
-      description?: string;
-    }
-  | {
-      id: string;
-      type: 'asset';
-      content: string;
-      description?: string;
-      size?: 'SMALL' | 'MEDIUM' | 'LARGE';
-    };
-
 export type StageEntry = {
   id: string;
   type: StageType;
@@ -239,7 +228,7 @@ export type StageEntry = {
     text: string;
   };
   title?: string;
-  items?: InformationItem[];
+  items?: Item[];
   initialEdges: [number, number][];
   // NameGeneratorQuickAdd
   quickAdd?: string;
@@ -263,37 +252,21 @@ export type StageEntry = {
   };
   // TieStrengthCensus (edge type reference on stage)
   edgeType?: { entity: 'edge'; type: string };
-  // FamilyPedigree-specific fields
-  nodeConfig?: {
-    type: string;
-    nodeLabelVariable: string;
-    egoVariable: string;
-    relationshipVariable: string;
-    biologicalSexVariable: string;
-    form: { variable: string; prompt: string }[];
-  };
-  edgeConfig?: {
-    type: string;
-    relationshipTypeVariable: string;
-    isActiveVariable: string;
-    isGestationalCarrierVariable: string;
-    // Required by EdgeConfigSchema (strictObject); the builder always sets it.
-    gameteRoleVariable: string;
-  };
-  framing?: { mode: 'fixed'; value: FramingId } | { mode: 'participantChoice' };
+  // FamilyPedigree-specific fields, derived from the protocol-validation schema
+  // so they cannot drift from it.
+  nodeConfig?: FamilyPedigreeNodeConfigInput;
+  edgeConfig?: FamilyPedigreeEdgeConfigInput;
+  framing?: FamilyPedigreeFraming;
   // NarrativePedigree-specific fields
   narrativePedigreeSourceStageId?: string;
   narrativePedigreeDiseases?: NarrativeDiseaseEntry[];
   narrativePedigreeShowAtRiskStatuses?: boolean;
-  boundaries?: {
-    requireGrandparents: 'required' | 'recommended' | 'off';
-    requireChildrenContributors: 'required' | 'recommended' | 'off';
-  };
+  boundaries?: FamilyPedigreeBoundaries;
   introScreen?: {
-    items: InformationItem[];
+    items: FamilyPedigreeIntroItem[];
   };
   censusPrompt?: string;
-  nominationPrompts?: { id: string; text: string; variable: string }[];
+  nominationPrompts?: FamilyPedigreeNominationPromptInput[];
   // Geospatial
   mapOptions?: MapOptionsEntry;
   // NetworkComposer
@@ -422,31 +395,23 @@ export type AddStageInput = {
     body?: string;
   };
   // FamilyPedigree
-  nodeConfig?: {
-    type: string;
-    nodeLabelVariable: string;
-    egoVariable: string;
-    relationshipVariable: string;
-    biologicalSexVariable: string;
-    form?: { variable: string; prompt: string }[];
-  };
-  edgeConfig?: {
-    type: string;
-    relationshipTypeVariable: string;
-    isActiveVariable?: string;
-    isGestationalCarrierVariable?: string;
-    gameteRoleVariable?: string;
-  };
-  framing?: { mode: 'fixed'; value: FramingId } | { mode: 'participantChoice' };
-  boundaries?: {
-    requireGrandparents: 'required' | 'recommended' | 'off';
-    requireChildrenContributors: 'required' | 'recommended' | 'off';
-  };
+  nodeConfig?: FamilyPedigreeNodeConfigInput;
+  // Derived from the schema's edge config, but the builder fills the non-core
+  // variables when omitted, so they are optional here.
+  edgeConfig?: Pick<
+    FamilyPedigreeEdgeConfigInput,
+    'type' | 'relationshipTypeVariable'
+  > &
+    Partial<
+      Omit<FamilyPedigreeEdgeConfigInput, 'type' | 'relationshipTypeVariable'>
+    >;
+  framing?: FamilyPedigreeFraming;
+  boundaries?: FamilyPedigreeBoundaries;
   introScreen?: {
-    items: InformationItem[];
+    items: FamilyPedigreeIntroItem[];
   };
   censusPrompt?: string;
-  nominationPrompts?: { id: string; text: string; variable: string }[];
+  nominationPrompts?: FamilyPedigreeNominationPromptInput[];
   // Geospatial
   mapOptions?: MapOptionsEntry;
   // NarrativePedigree

--- a/packages/protocol-utilities/src/types.ts
+++ b/packages/protocol-utilities/src/types.ts
@@ -279,9 +279,7 @@ export type StageEntry = {
     requireChildrenContributors: 'required' | 'recommended' | 'off';
   };
   introScreen?: {
-    title?: string;
-    text: string;
-    videoAssetId?: string;
+    items: InformationItem[];
   };
   censusPrompt?: string;
   nominationPrompts?: { id: string; text: string; variable: string }[];
@@ -434,9 +432,7 @@ export type AddStageInput = {
     requireChildrenContributors: 'required' | 'recommended' | 'off';
   };
   introScreen?: {
-    title?: string;
-    text: string;
-    videoAssetId?: string;
+    items: InformationItem[];
   };
   censusPrompt?: string;
   nominationPrompts?: { id: string; text: string; variable: string }[];

--- a/packages/protocol-validation/src/schemas/8/__tests__/schema8-superrefine-validation.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/schema8-superrefine-validation.test.ts
@@ -2394,4 +2394,107 @@ describe('Protocol Schema V8 - Superrefine Validation', () => {
       }
     });
   });
+
+  describe('FamilyPedigree introScreen asset validation', () => {
+    // A shape-valid FamilyPedigree stage. Its config variables need not exist in
+    // the codebook for this suite: superRefine accumulates all issues, so the
+    // introScreen asset check runs regardless, and we assert its issue via
+    // find().
+    const familyPedigreeStage = {
+      id: 'fp1',
+      type: 'FamilyPedigree' as const,
+      label: 'Family Pedigree',
+      nodeConfig: {
+        type: 'person',
+        nodeLabelVariable: 'label',
+        egoVariable: 'isEgo',
+        relationshipVariable: 'rel',
+        biologicalSexVariable: 'bioSex',
+      },
+      edgeConfig: {
+        type: 'family',
+        relationshipTypeVariable: 'relType',
+        isActiveVariable: 'isActive',
+        isGestationalCarrierVariable: 'isGc',
+        gameteRoleVariable: 'gameteRole',
+      },
+      framing: { mode: 'fixed' as const, value: 'gamete' as const },
+      boundaries: {
+        requireGrandparents: 'off' as const,
+        requireChildrenContributors: 'off' as const,
+      },
+      censusPrompt: 'Build your family',
+    };
+
+    const protocolWithIntroItem = (
+      item: Record<string, unknown>,
+      assetManifest?: Record<string, unknown>,
+    ) => ({
+      ...baseValidProtocol,
+      ...(assetManifest ? { assetManifest } : {}),
+      stages: [{ ...familyPedigreeStage, introScreen: { items: [item] } }],
+    });
+
+    it('rejects an intro asset item absent from the manifest', () => {
+      const result = ProtocolSchemaV8.safeParse(
+        protocolWithIntroItem({
+          id: 'i1',
+          type: 'asset',
+          content: 'missing-asset',
+        }),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.message.includes(
+            'introScreen item "missing-asset" does not reference an asset in the manifest',
+          ),
+        );
+        expect(issue).toBeDefined();
+        expect(issue?.path).toEqual([
+          'stages',
+          0,
+          'introScreen',
+          'items',
+          0,
+          'content',
+        ]);
+      }
+    });
+
+    it('rejects an intro asset item of a non-displayable type', () => {
+      const result = ProtocolSchemaV8.safeParse(
+        protocolWithIntroItem(
+          { id: 'i1', type: 'asset', content: 'net-1' },
+          {
+            'net-1': {
+              id: 'net-1',
+              type: 'network',
+              name: 'Roster',
+              source: 'roster.csv',
+            },
+          },
+        ),
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) =>
+            i.message.includes('introScreen item "net-1"') &&
+            i.message.includes('must reference an asset of type'),
+        );
+        expect(issue).toBeDefined();
+      }
+    });
+
+    it('does not raise an introScreen asset issue for a text item', () => {
+      const result = ProtocolSchemaV8.safeParse(
+        protocolWithIntroItem({ id: 'i1', type: 'text', content: 'Welcome' }),
+      );
+      const introAssetIssue =
+        !result.success &&
+        result.error.issues.find((i) => i.message.includes('introScreen item'));
+      expect(introAssetIssue).toBeFalsy();
+    });
+  });
 });

--- a/packages/protocol-validation/src/schemas/8/schema.ts
+++ b/packages/protocol-validation/src/schemas/8/schema.ts
@@ -473,28 +473,47 @@ const ProtocolSchema = z
         }
       }
 
-      // 3e.iii.b. FamilyPedigree: introScreen.videoAssetId must resolve to a
-      // manifest entry of type 'video'.
+      // 3e.iii.b. FamilyPedigree: each introScreen asset item must resolve to
+      // a manifest entry of a displayable type (image/video/audio).
       if (
         stage.type === 'FamilyPedigree' &&
         'introScreen' in stage &&
-        stage.introScreen?.videoAssetId
+        stage.introScreen
       ) {
-        const videoAssetId = stage.introScreen.videoAssetId;
-        const asset = protocol.assetManifest?.[videoAssetId];
-        if (!asset) {
-          ctx.addIssue({
-            code: 'custom' as const,
-            message: `FamilyPedigree introScreen videoAssetId "${videoAssetId}" does not reference an asset in the manifest.`,
-            path: ['stages', stageIndex, 'introScreen', 'videoAssetId'],
-          });
-        } else if (asset.type !== 'video') {
-          ctx.addIssue({
-            code: 'custom' as const,
-            message: `FamilyPedigree introScreen videoAssetId "${videoAssetId}" must reference a 'video' asset, but is of type "${asset.type}".`,
-            path: ['stages', stageIndex, 'introScreen', 'videoAssetId'],
-          });
-        }
+        const displayableAssetTypes = ['image', 'video', 'audio'];
+        stage.introScreen.items.forEach((item, itemIndex) => {
+          if (item.type !== 'asset') {
+            return;
+          }
+          const asset = protocol.assetManifest?.[item.content];
+          if (!asset) {
+            ctx.addIssue({
+              code: 'custom' as const,
+              message: `FamilyPedigree introScreen item "${item.content}" does not reference an asset in the manifest.`,
+              path: [
+                'stages',
+                stageIndex,
+                'introScreen',
+                'items',
+                itemIndex,
+                'content',
+              ],
+            });
+          } else if (!displayableAssetTypes.includes(asset.type)) {
+            ctx.addIssue({
+              code: 'custom' as const,
+              message: `FamilyPedigree introScreen item "${item.content}" must reference an asset of type ${displayableAssetTypes.map((t) => `'${t}'`).join(' or ')}, but is of type "${asset.type}".`,
+              path: [
+                'stages',
+                stageIndex,
+                'introScreen',
+                'items',
+                itemIndex,
+                'content',
+              ],
+            });
+          }
+        });
       }
 
       // 3e.iii.b-2. FamilyPedigree: each nomination prompt variable must exist

--- a/packages/protocol-validation/src/schemas/8/stages/__tests__/family-pedigree.test.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/__tests__/family-pedigree.test.ts
@@ -82,7 +82,7 @@ describe('familyPedigreeStage framing/boundaries/introScreen', () => {
     ).toBe(false);
   });
 
-  it('accepts an optional intro screen', () => {
+  it('accepts an optional intro screen with content items', () => {
     expect(
       familyPedigreeStage.safeParse({
         ...base,
@@ -91,8 +91,36 @@ describe('familyPedigreeStage framing/boundaries/introScreen', () => {
           requireGrandparents: 'off',
           requireChildrenContributors: 'off',
         },
-        introScreen: { text: 'Welcome' },
+        introScreen: {
+          items: [
+            { id: 'text1', type: 'text', content: 'Welcome' },
+            { id: 'video1', type: 'asset', content: 'assetId1' },
+          ],
+        },
       }).success,
     ).toBe(true);
+  });
+
+  it('rejects the legacy intro screen text shape', () => {
+    expect(
+      familyPedigreeStage.safeParse({
+        ...base,
+        introScreen: { text: 'Welcome' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects intro screen items with duplicate ids', () => {
+    expect(
+      familyPedigreeStage.safeParse({
+        ...base,
+        introScreen: {
+          items: [
+            { id: 'dup', type: 'text', content: 'One' },
+            { id: 'dup', type: 'text', content: 'Two' },
+          ],
+        },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/protocol-validation/src/schemas/8/stages/family-pedigree.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/family-pedigree.ts
@@ -10,6 +10,7 @@ import {
 import { entityAttributeReference } from '../entity-attribute-reference';
 import { entityTypeReference } from '../entity-type-reference';
 import { baseStageSchema } from './base';
+import { ItemSchema } from './information';
 
 // Reserved id used by the interview for the synthetic census/scaffolding prompt;
 // an author-supplied nomination prompt may not reuse it (collides at runtime).
@@ -77,11 +78,20 @@ export const familyPedigreeStage = baseStageSchema.extend({
     requireChildrenContributors: z.enum(['required', 'recommended', 'off']),
   }),
   // Optional introductory screen shown before the main pedigree-building step.
+  // Reuses the Information stage's content-item model: an ordered list of text
+  // and asset sections.
   introScreen: z
     .object({
-      title: z.string().optional(),
-      text: z.string(),
-      videoAssetId: z.string().optional(),
+      items: z.array(ItemSchema).superRefine((items, ctx) => {
+        const duplicateItemId = findDuplicateId(items);
+        if (duplicateItemId) {
+          ctx.addIssue({
+            code: 'custom' as const,
+            message: `Intro screen items contain duplicate ID "${duplicateItemId}"`,
+            path: [],
+          });
+        }
+      }),
     })
     .optional(),
   // Prompt shown during the family building phase

--- a/packages/protocol-validation/src/schemas/8/stages/family-pedigree.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/family-pedigree.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
 import { FRAMING_IDS } from '@codaco/shared-consts';
-import { findDuplicateId } from '~/utils/validation-helpers';
+import {
+  duplicateIdRefinement,
+  findDuplicateId,
+} from '~/utils/validation-helpers';
 
 import {
   FormFieldSchema,
@@ -10,11 +13,26 @@ import {
 import { entityAttributeReference } from '../entity-attribute-reference';
 import { entityTypeReference } from '../entity-type-reference';
 import { baseStageSchema } from './base';
-import { ItemSchema } from './information';
 
 // Reserved id used by the interview for the synthetic census/scaffolding prompt;
 // an author-supplied nomination prompt may not reuse it (collides at runtime).
 const RESERVED_NOMINATION_PROMPT_ID = 'scaffolding';
+
+// The intro screen reuses the Information stage's text/asset content model, but
+// its own schema: the pedigree intro editor has no item-resizing UI, so — unlike
+// the Information stage — intro asset items carry no `size`.
+const introScreenBaseItem = z.strictObject({
+  id: z.string(),
+  content: z.string(),
+  description: z.string().optional(),
+});
+
+const IntroScreenItemSchema = z.discriminatedUnion('type', [
+  introScreenBaseItem.extend({ type: z.literal('text') }),
+  introScreenBaseItem.extend({ type: z.literal('asset') }),
+]);
+
+export type FamilyPedigreeIntroItem = z.infer<typeof IntroScreenItemSchema>;
 
 export const NodeConfigSchema = z.strictObject({
   // Node type for alter nodes in the codebook
@@ -82,16 +100,9 @@ export const familyPedigreeStage = baseStageSchema.extend({
   // and asset sections.
   introScreen: z
     .object({
-      items: z.array(ItemSchema).superRefine((items, ctx) => {
-        const duplicateItemId = findDuplicateId(items);
-        if (duplicateItemId) {
-          ctx.addIssue({
-            code: 'custom' as const,
-            message: `Intro screen items contain duplicate ID "${duplicateItemId}"`,
-            path: [],
-          });
-        }
-      }),
+      items: z
+        .array(IntroScreenItemSchema)
+        .superRefine(duplicateIdRefinement('Intro screen items')),
     })
     .optional(),
   // Prompt shown during the family building phase
@@ -125,3 +136,23 @@ export const familyPedigreeStage = baseStageSchema.extend({
       }
     }),
 });
+
+// Config types, the single source of truth for the FamilyPedigree stage shape.
+// Consumers (e.g. @codaco/protocol-utilities) derive from these rather than
+// hand-mirroring, so they cannot drift from the schema.
+export type FamilyPedigreeStageDefinition = z.infer<typeof familyPedigreeStage>;
+// Node/edge config and nomination prompts contain entityAttributeReference
+// fields, which the schema brands on parse (`string & $brand<…>`). Builders that
+// assemble a stage from plain ids *before* validation (e.g. the synthetic
+// interview builder) need the pre-parse `z.input` shape, where those references
+// are still plain strings.
+export type FamilyPedigreeNodeConfigInput = z.input<typeof NodeConfigSchema>;
+export type FamilyPedigreeEdgeConfigInput = z.input<typeof EdgeConfigSchema>;
+export type FamilyPedigreeNominationPromptInput = z.input<
+  typeof familyPedigreeNominationPromptSchema
+>;
+// Framing, boundaries, and intro-screen items contain no branded references, so
+// input and output shapes are identical.
+export type FamilyPedigreeFraming = FamilyPedigreeStageDefinition['framing'];
+export type FamilyPedigreeBoundaries =
+  FamilyPedigreeStageDefinition['boundaries'];

--- a/packages/protocol-validation/src/schemas/8/stages/information.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/information.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { findDuplicateId } from '~/utils/validation-helpers';
+import { duplicateIdRefinement } from '~/utils/validation-helpers';
 
 import { baseStageSchema } from './base';
 
@@ -23,9 +23,7 @@ const assetItemSchema = baseItemSchema.extend({
   size: ItemSizeSchema.optional(),
 });
 
-// Also consumed by the FamilyPedigree stage, whose intro screen reuses the
-// Information content-item model.
-export const ItemSchema = z.discriminatedUnion('type', [
+const ItemSchema = z.discriminatedUnion('type', [
   textItemSchema,
   assetItemSchema,
 ]);
@@ -35,15 +33,5 @@ export type Item = z.infer<typeof ItemSchema>;
 export const informationStage = baseStageSchema.extend({
   type: z.literal('Information'),
   title: z.string().optional(),
-  items: z.array(ItemSchema).superRefine((items, ctx) => {
-    // Check for duplicate item IDs
-    const duplicateItemId = findDuplicateId(items);
-    if (duplicateItemId) {
-      ctx.addIssue({
-        code: 'custom' as const,
-        message: `Items contain duplicate ID "${duplicateItemId}"`,
-        path: [],
-      });
-    }
-  }),
+  items: z.array(ItemSchema).superRefine(duplicateIdRefinement('Items')),
 });

--- a/packages/protocol-validation/src/schemas/8/stages/information.ts
+++ b/packages/protocol-validation/src/schemas/8/stages/information.ts
@@ -23,7 +23,9 @@ const assetItemSchema = baseItemSchema.extend({
   size: ItemSizeSchema.optional(),
 });
 
-const ItemSchema = z.discriminatedUnion('type', [
+// Also consumed by the FamilyPedigree stage, whose intro screen reuses the
+// Information content-item model.
+export const ItemSchema = z.discriminatedUnion('type', [
   textItemSchema,
   assetItemSchema,
 ]);

--- a/packages/protocol-validation/src/utils/validation-helpers.ts
+++ b/packages/protocol-validation/src/utils/validation-helpers.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+
 import type {
   Codebook,
   EntityDefinition,
@@ -91,6 +93,25 @@ export const findDuplicateId = <T extends { id: string }>(
   }
   return null;
 };
+
+/**
+ * A `superRefine` callback that flags duplicate `id`s in an array of content
+ * items. Shared by the Information stage and the FamilyPedigree intro screen,
+ * which validate their own (separate) item schemas with the same rule.
+ * `label` names the collection in the error message.
+ */
+export const duplicateIdRefinement =
+  (label: string) =>
+  (items: { id: string }[], ctx: z.RefinementCtx): void => {
+    const duplicateItemId = findDuplicateId(items);
+    if (duplicateItemId) {
+      ctx.addIssue({
+        code: 'custom' as const,
+        message: `${label} contain duplicate ID "${duplicateItemId}"`,
+        path: [],
+      });
+    }
+  };
 
 /**
  * Check for duplicate names in array

--- a/packages/shared-consts/src/family-pedigree-framing.ts
+++ b/packages/shared-consts/src/family-pedigree-framing.ts
@@ -2,7 +2,7 @@
  * Framing identifiers and terminology for the FamilyPedigree interface.
  *
  * Two framings are supported: 'gamete' (biology-first language) and 'gendered'
- * (conventional mother/father language). Gestational carrier and donor terms
+ * (mother/father kinship terms). Gestational carrier and donor terms
  * are intentionally identical across both framings.
  */
 export const FRAMING_IDS = ['gamete', 'gendered'] as const;

--- a/packages/shared-consts/src/family-pedigree.ts
+++ b/packages/shared-consts/src/family-pedigree.ts
@@ -39,6 +39,36 @@ export const RELATIONSHIP_TYPE_OPTIONS: {
 }));
 
 /**
+ * Canonical gamete-role values for the FamilyPedigree interface — which
+ * reproductive cell (gamete) a parent contributed to a child.
+ *
+ * Stored on the `gameteRole` categorical edge variable of genetic parent
+ * edges. Shared so that Architect (which locks them onto the variable) and
+ * the interview interface (which writes and branches on them) cannot drift
+ * apart.
+ */
+export const GAMETE_ROLES = ['egg', 'sperm'] as const;
+
+export type GameteRole = (typeof GAMETE_ROLES)[number];
+
+const GAMETE_ROLE_LABELS: Record<GameteRole, string> = {
+  egg: 'Egg',
+  sperm: 'Sperm',
+};
+
+/**
+ * The gamete-role options as `{ value, label }` pairs, in canonical order.
+ * Architect locks the categorical edge variable to exactly this set.
+ */
+export const GAMETE_ROLE_OPTIONS: {
+  value: GameteRole;
+  label: string;
+}[] = GAMETE_ROLES.map((value) => ({
+  value,
+  label: GAMETE_ROLE_LABELS[value],
+}));
+
+/**
  * Canonical biological-sex values for pedigree participants — the sex recorded
  * at birth, needed for sex-linked genetic transmission (X-linked, Y-linked,
  * mitochondrial). This is distinct from gender identity.


### PR DESCRIPTION
Refinements to the Architect stage editors for the two pedigree interfaces, from a round of hands-on review. Behavioural changes are almost entirely in `architect-web` (private); the published-package changes are a schema shape change, a new shared constant, and a small refactor.

## Family Pedigree editor
- **Framing** — the fixed-framing selector is now a styled select, and the section explains the gamete-based vs gendered framings in neutral, non-normative language.
- **Boundary options** — no longer says "family tree"; explains what off/recommended/required actually do; "Require Children Contributors" renamed to "Require Co-Parents' Families". Both fields are now required in the editor.
- **Node-type-change bug (was producing a raw schema error on finish)** — changing the node type was clearing the stage-level `framing`, `boundaries`, and `introScreen`. `boundaries` is schema-required with no editor validation, so nothing flagged it until "Finished Editing" surfaced a raw zod error. Those fields are now preserved, and a seam test guards the preserve-list against the schema's required fields so a new required field can't silently regress this.
- **Intro screen** — rebuilt on the Information content-item model: reorderable text/asset sections instead of a single title/text/video block. `introScreen` schema changes from `{ title?, text, videoAssetId? }` to `{ items }`; the Information item renderer is extracted to a shared `ContentItem`. The intro title field is removed.
- **Node/edge config** — columns split 50/50, variable pills get a white background, edge-type items render on a darker surface, edge config explains why an edge type is needed, and the gamete-role variable uses predefined read-only egg/sperm options (shared `GAMETE_ROLE_OPTIONS`) like relationship type.
- **Nomination prompts** — empty-state message when none exist.

## Narrative Pedigree editor
- Corrected new-stage dialog tags: Narrative Pedigree (read-only) is Display Data only; Family Pedigree gains Capture Edge Attributes.
- At-Risk Statuses explanation moved from the side column into the main column, formatted with subheadings and lists.

## Verification
- `pnpm typecheck` clean; `pnpm knip` clean; lint clean (pre-commit hook).
- Tests: architect-web 532, interview units 1116, protocol-validation 605, protocol-utilities 70, shared-consts — all passing.
- Visually verified each change in the running Architect dev server (framing/boundary copy, 50/50 columns + white/dark-surface pills, intro-screen item editor with empty state, corrected tags in the new-stage dialog, and the two-column At-Risk layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Family Pedigree intro screens now support multiple content sections, including text and media items.
  * Added clearer gamete-role options and updated pedigree framing terminology.
  * Information-style pages now render mixed content consistently.

* **Bug Fixes**
  * Preserved key stage settings when changing node types.
  * Fixed new-stage dialog behavior and improved validation for duplicate intro content items.

* **UI Improvements**
  * Updated boundary, edge, and at-risk explanation copy.
  * Added empty states for intro content and nomination prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->