### PR TITLE
ci: adopt GitHub-Actions-Cache-backed Turborepo remote cache

### DIFF
--- a/.github/actions/turbo-ci-setup/action.yml
+++ b/.github/actions/turbo-ci-setup/action.yml
@@ -1,5 +1,9 @@
 name: Turbo CI setup
 description: pnpm + Node + install + Turborepo remote cache (GitHub Actions Cache backend).
+inputs:
+  ignore-scripts:
+    description: Pass --ignore-scripts to pnpm install. Set 'false' for jobs that need native-module postinstall (Electron builds).
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -8,7 +12,7 @@ runs:
       with:
         node-version-file: .nvmrc
         cache: pnpm
-    - run: pnpm install --frozen-lockfile --ignore-scripts
+    - run: pnpm install --frozen-lockfile ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
       shell: bash
     # Runner-local server implementing turbo's remote-cache protocol, backed by
     # the GitHub Actions Cache. Per-task, hash-addressed entries so fan-out jobs

--- a/.github/actions/turbo-ci-setup/action.yml
+++ b/.github/actions/turbo-ci-setup/action.yml
@@ -1,0 +1,16 @@
+name: Turbo CI setup
+description: pnpm + Node + install + Turborepo remote cache (GitHub Actions Cache backend).
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version-file: .nvmrc
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile --ignore-scripts
+      shell: bash
+    # Runner-local server implementing turbo's remote-cache protocol, backed by
+    # the GitHub Actions Cache. Per-task, hash-addressed entries so fan-out jobs
+    # share build outputs without the whole-.turbo-tarball race.
+    - uses: rharkor/caching-for-turbo@75f8ebf4a43d2c60b23bc2a27082cfea94ffdad9 # v2.5.0

--- a/.github/actions/turbo-ci-setup/action.yml
+++ b/.github/actions/turbo-ci-setup/action.yml
@@ -12,7 +12,9 @@ runs:
       with:
         node-version-file: .nvmrc
         cache: pnpm
-    - run: pnpm install --frozen-lockfile ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
+    # Bracket notation: a hyphenated input name is not a valid dot-notation
+    # identifier in Actions expressions.
+    - run: pnpm install --frozen-lockfile ${{ inputs['ignore-scripts'] == 'true' && '--ignore-scripts' || '' }}
       shell: bash
     # Runner-local server implementing turbo's remote-cache protocol, backed by
     # the GitHub Actions Cache. Per-task, hash-addressed entries so fan-out jobs

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -989,6 +989,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: ./.github/actions/turbo-ci-setup
+        with:
+          ignore-scripts: 'false'
       - name: Build app + workspace deps
         run: pnpm exec turbo run build --filter=@codaco/interviewer-classic
       - name: Decode App Store Connect API key
@@ -1038,6 +1040,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: ./.github/actions/turbo-ci-setup
+        with:
+          ignore-scripts: 'false'
       - name: Build app + workspace deps
         run: pnpm exec turbo run build --filter=@codaco/architect-classic
       - name: Decode App Store Connect API key

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -197,17 +197,7 @@ jobs:
     # jobs and the cache that quality writes is reusable by the app deploy jobs.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - name: Write protocol-validation .env (test fixture)
         env:
           PROTOCOL_ENCRYPTION_KEY: ${{ secrets.PROTOCOL_ENCRYPTION_KEY }}

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -255,17 +255,7 @@ jobs:
       NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy docs preview
         run: |
@@ -302,17 +292,7 @@ jobs:
       NEXT_PUBLIC_GA_ID: ${{ secrets.NEXT_PUBLIC_GA_ID }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy docs production
         run: |
@@ -349,17 +329,7 @@ jobs:
       VITE_DISABLE_ANALYTICS: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy architect preview
         run: |
@@ -402,17 +372,7 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy interviewer preview
         run: |
@@ -446,17 +406,7 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy networkcanvas.com preview
         run: |
@@ -546,17 +496,7 @@ jobs:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: deploy
         name: Build and deploy networkcanvas.com production
         run: |
@@ -630,17 +570,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm exec turbo run build-storybook --filter=@codaco/fresco-ui
       - working-directory: packages/fresco-ui
         env:
@@ -667,17 +597,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm exec turbo run build-storybook --filter=@codaco/interview
       - working-directory: packages/interview
         env:
@@ -703,17 +623,7 @@ jobs:
       slug: ${{ steps.meta.outputs.slug }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - id: meta
         env:
           REF: ${{ github.head_ref || github.ref_name }}
@@ -828,17 +738,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 2
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - name: Build all publishable packages
         # Only build the workspaces under packages/ — those are what changesets
         # publishes to npm. Apps (./apps/*) are private:true and don't need to
@@ -1088,18 +988,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - name: Build app + workspace deps
         run: pnpm exec turbo run build --filter=@codaco/interviewer-classic
       - name: Decode App Store Connect API key
@@ -1148,18 +1037,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-turbo-
+      - uses: ./.github/actions/turbo-ci-setup
       - name: Build app + workspace deps
         run: pnpm exec turbo run build --filter=@codaco/architect-classic
       - name: Decode App Store Connect API key


### PR DESCRIPTION
Second PR of the **CI: authoritative merge-queue check + parallelised, better-cached `quality`** effort (follows #829).

## What's here
Introduces a **GitHub-Actions-Cache-backed Turborepo remote cache** and routes every turbo job through it:
- New composite action `.github/actions/turbo-ci-setup` — pnpm + Node (`.nvmrc`) + `pnpm install` + `rharkor/caching-for-turbo` (pinned `@75f8ebf4… # v2.5.0`). Single source of truth for turbo-job setup.
- All **13** jobs that cached `.turbo` via `actions/cache` now use the composite instead (per-task, hash-addressed remote cache; no whole-`.turbo`-tarball). `grep -c "path: .turbo"` → 0.
- **No structural change to `quality`** yet (fan-out is the next PR). No `needs:`/`if:` changes.

## Electron builds
`interviewer-release-build` and `architect-release-build` keep pnpm postinstall scripts (native modules) via `ignore-scripts: 'false'` on the composite — reproducing `main`'s `pnpm install --frozen-lockfile` (no `--ignore-scripts`). All other jobs keep `--ignore-scripts`.

## What to watch on this run (CI-only, can't be checked from the diff)
- `rharkor/caching-for-turbo` server startup + turbo `cache hit` / remote-caching lines in the `quality`/build jobs.
- The **macOS** legs of the two Electron matrix jobs — the cache action now runs there too (was Linux-only). Low risk (JS action; Windows upstream-tested), but worth confirming green.

Reviewed (spec + quality): all 13 conversions verified byte-identical apart from the setup/cache swap; no dropped steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
