### PR TITLE
Background lights: survive a backgrounded tab, and skip animating during interviews

### DIFF
--- a/.changeset/background-lights-tab-resume.md
+++ b/.changeset/background-lights-tab-resume.md
@@ -1,0 +1,5 @@
+---
+'@codaco/art': patch
+---
+
+Fixed the animated background (`BackgroundLights` and `BackgroundBlobs`) vanishing after a tab was left in the background for a while. The animation clock kept advancing while `requestAnimationFrame` was paused, so the first frame after returning teleported every blob far off-screen in a single step. Frame deltas are now capped so motion stays continuous across background/foreground cycles.

--- a/.changeset/interview-background-battery.md
+++ b/.changeset/interview-background-battery.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Stopped animating the decorative background during an interview. The interview screen already covers it completely, so the animation was running unseen — pausing it while a session is open reduces battery use on long interviews.

--- a/apps/interviewer/src/App.tsx
+++ b/apps/interviewer/src/App.tsx
@@ -32,6 +32,13 @@ function pageKeyFor(location: string): string {
 export default function App() {
   const [location] = useLocation();
 
+  // The interview route paints its own opaque background across the viewport
+  // (see Interview.tsx), so the animated backdrop is never visible during a
+  // session. Unmount it there to stop its requestAnimationFrame loop — an
+  // interview can run uninterrupted for a long time, and animating a backdrop
+  // nobody can see is pure battery drain.
+  const showBackgroundLights = !location.startsWith('/interview/');
+
   return (
     <ThemedRegion theme="interview" className="isolate h-full">
       {/* Bare, dependency-free outer boundary: catches crashes in AppProviders
@@ -41,20 +48,26 @@ export default function App() {
       <ErrorBoundary>
         <AppProviders>
           <PwaUpdateBanner />
-          <motion.div
-            className="fixed inset-0 -z-10"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 0.8 }}
-            transition={{ duration: 2 }}
-          >
-            <BackgroundLights
-              large={0}
-              medium={4}
-              small={0}
-              blendMode="color-dodge"
-              speedFactor={30}
-            />
-          </motion.div>
+          <AnimatePresence>
+            {showBackgroundLights && (
+              <motion.div
+                key="background-lights"
+                className="fixed inset-0 -z-10"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.8 }}
+                exit={{ opacity: 0, transition: { duration: 0.5 } }}
+                transition={{ duration: 2 }}
+              >
+                <BackgroundLights
+                  large={0}
+                  medium={4}
+                  small={0}
+                  blendMode="color-dodge"
+                  speedFactor={30}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
           <AuthGate>
             <AnimatePresence mode="wait">
               <motion.div

--- a/packages/art/src/BackgroundBlobs/NCBlob.ts
+++ b/packages/art/src/BackgroundBlobs/NCBlob.ts
@@ -2,6 +2,8 @@
 
 import * as blobs2Animate from 'blobs/v2/animate';
 
+import { clampFrameDelta } from '../frameDelta';
+
 const random = (a = 1, b = 0) => {
   const lower = Math.min(a, b);
   const upper = Math.max(a, b);
@@ -71,7 +73,7 @@ export class NCBlob {
     if (!this.lastUpdate) {
       this.lastUpdate = timeInSeconds;
     }
-    const timeDelta = timeInSeconds - this.lastUpdate || 1;
+    const timeDelta = clampFrameDelta(timeInSeconds - this.lastUpdate || 1);
 
     this.lastUpdate = timeInSeconds;
 

--- a/packages/art/src/BackgroundBlobs/NCBlob.ts
+++ b/packages/art/src/BackgroundBlobs/NCBlob.ts
@@ -70,10 +70,13 @@ export class NCBlob {
   updatePosition(time: number) {
     const timeInSeconds = time / 1000;
 
-    if (!this.lastUpdate) {
+    // Explicit null check (not `!this.lastUpdate`) so a legitimate 0 timestamp
+    // isn't treated as uninitialised; a first/zero-length frame yields a 0 delta
+    // and no movement, mirroring BackgroundLights' `last === null ? 0 : …`.
+    if (this.lastUpdate === null) {
       this.lastUpdate = timeInSeconds;
     }
-    const timeDelta = clampFrameDelta(timeInSeconds - this.lastUpdate || 1);
+    const timeDelta = clampFrameDelta(timeInSeconds - this.lastUpdate);
 
     this.lastUpdate = timeInSeconds;
 

--- a/packages/art/src/BackgroundLights/BackgroundLights.tsx
+++ b/packages/art/src/BackgroundLights/BackgroundLights.tsx
@@ -3,6 +3,7 @@
 import { type CSSProperties, useEffect, useMemo, useRef } from 'react';
 
 import { defaultGradients } from '../BackgroundBlobs/BackgroundBlobs';
+import { clampFrameDelta } from '../frameDelta';
 
 // Default to the BackgroundBlobs palette. Each entry there is a two-stop linear
 // gradient; here every colour seeds one radial light, so the pairs flatten into
@@ -155,7 +156,7 @@ const BackgroundLights = ({
     const tick = (time: number) => {
       ensurePlaced();
       if (placed) {
-        const dt = last === null ? 0 : (time - last) / 1000;
+        const dt = last === null ? 0 : clampFrameDelta((time - last) / 1000);
         runtime.forEach((entry) => {
           entry.x += entry.light.velocityX * dt;
           entry.y += entry.light.velocityY * dt;

--- a/packages/art/src/__tests__/NCBlob.test.ts
+++ b/packages/art/src/__tests__/NCBlob.test.ts
@@ -83,6 +83,29 @@ describe('NCBlob', () => {
       expect(blob.positionY).toBeGreaterThan(100);
     });
 
+    it('clamps a huge frame gap so a backgrounded tab does not teleport the blob off-screen', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 800;
+      blob.size = 100;
+      blob.velocityX = 45;
+      blob.velocityY = 45;
+      blob.positionX = 500;
+      blob.positionY = 400;
+
+      blob.updatePosition(1000); // establish lastUpdate at t=1s
+      // 10 minutes later: rAF was suspended while the tab was backgrounded, so
+      // this is the first resumed frame. Unclamped, positionX would advance by
+      // 45 * 600 = 27000px and wrap to an off-screen edge (-size); clamped, a
+      // single frame moves at most 45 * (1/30) = 1.5px and the blob stays put.
+      blob.updatePosition(1000 + 600_000);
+
+      expect(blob.positionX).toBeGreaterThanOrEqual(500);
+      expect(blob.positionX).toBeLessThan(510);
+      expect(blob.positionY).toBeGreaterThanOrEqual(400);
+      expect(blob.positionY).toBeLessThan(410);
+    });
+
     it('seeds lastUpdate on first call', () => {
       const blob = new NCBlob(1, 1, palette);
       expect(blob.lastUpdate).toBeNull();

--- a/packages/art/src/__tests__/NCBlob.test.ts
+++ b/packages/art/src/__tests__/NCBlob.test.ts
@@ -113,6 +113,23 @@ describe('NCBlob', () => {
       expect(blob.lastUpdate).toBe(1);
     });
 
+    it('does not advance on a zero time delta (same timestamp twice)', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 800;
+      blob.size = 50;
+      blob.velocityX = 50;
+      blob.velocityY = 50;
+      blob.positionX = 100;
+      blob.positionY = 100;
+
+      blob.updatePosition(1000); // seeds lastUpdate; first frame delta is 0
+      blob.updatePosition(1000); // same timestamp → 0 delta → no movement
+
+      expect(blob.positionX).toBe(100);
+      expect(blob.positionY).toBe(100);
+    });
+
     it('wraps past right edge to left', () => {
       const blob = new NCBlob(1, 1, palette);
       blob.canvasWidth = 1000;

--- a/packages/art/src/__tests__/frameDelta.test.ts
+++ b/packages/art/src/__tests__/frameDelta.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { clampFrameDelta } from '../frameDelta';
+
+describe('clampFrameDelta', () => {
+  it('passes a normal per-frame delta through unchanged', () => {
+    expect(clampFrameDelta(1 / 60)).toBe(1 / 60);
+  });
+
+  it('leaves a slow but plausible frame delta unchanged', () => {
+    expect(clampFrameDelta(1 / 30)).toBe(1 / 30);
+  });
+
+  it('caps a multi-minute gap (a backgrounded tab resuming) to a small step', () => {
+    const capped = clampFrameDelta(600);
+    expect(capped).toBeLessThanOrEqual(1 / 30);
+    // Any long gap clamps to the same ceiling, so a resumed frame can never
+    // teleport by a wall-clock-proportional distance.
+    expect(capped).toBe(clampFrameDelta(10));
+  });
+});

--- a/packages/art/src/frameDelta.ts
+++ b/packages/art/src/frameDelta.ts
@@ -1,0 +1,13 @@
+// requestAnimationFrame pauses while a tab is backgrounded, but the frame clock
+// (performance.now() / the rAF timestamp) keeps advancing in real time. The
+// first frame after the tab is foregrounded therefore carries a delta of however
+// long the tab was hidden — often minutes. Multiplying a per-second velocity by
+// that delta teleports a blob/light thousands of pixels in a single step, and the
+// once-per-frame edge wrap can only pull it back to one off-screen edge, so the
+// background looks empty until everything slowly drifts back on. Capping the
+// delta keeps a resumed frame to one modest step, so motion stays continuous
+// across background/foreground cycles.
+const MAX_FRAME_DELTA_SECONDS = 1 / 30;
+
+export const clampFrameDelta = (deltaSeconds: number): number =>
+  Math.min(deltaSeconds, MAX_FRAME_DELTA_SECONDS);


### PR DESCRIPTION
Two related fixes to the animated background (`@codaco/art`) as used by the interviewer.

---

## 1. Blobs vanish after a backgrounded tab (`fix(art)`)

### Problem
Leaving the interviewer open on a tab and going away for a while left the animated background empty on return — the blobs would only reappear after switching tabs again, which felt strange and non-deterministic.

### Root cause
`requestAnimationFrame` is suspended while a tab is in the background, but the frame clock (`performance.now()` / the rAF timestamp) keeps advancing in real time. The first frame after the tab is foregrounded therefore carries a `dt` of however long the tab was hidden — often minutes.

Both animated backgrounds in `@codaco/art` multiply that delta by a per-second velocity:
- `BackgroundLights` (the DOM variant the interviewer uses) — `entry.x += velocityX * dt`
- `NCBlob.updatePosition` (the canvas `BackgroundBlobs`, used by the documentation site)

So a single resumed frame teleported every blob thousands of pixels, and the once-per-frame edge wrap could only pull each back to a single off-screen edge. Every blob parked off-screen and the background looked empty; because the blobs are large and slow they took a very long time to drift back (which is why a second tab switch seemed to "fix" it).

Reproduction (interviewer config: `medium={4}`, `speedFactor={30}`):

| | after 5s normal | **1st frame after 10-min background** |
|---|---|---|
| current | 4/4 visible | **0/4 visible** |
| with fix | 4/4 visible | **4/4 visible** |

### Fix
A shared `clampFrameDelta` helper caps the per-frame delta (at 1/30s) so a resumed frame advances at most one modest step. This also covers other long-gap causes (laptop sleep/wake, GC pauses, breakpoints), and needs no `visibilitychange` listener (which would complicate the SSR'd documentation usage).

---

## 2. Don't animate the background during an interview (`perf(interviewer)`)

The interview route already paints its own opaque `bg-background` layer across the whole viewport (above the `-z-10` backdrop), so the animated background is **fully occluded during a session** — its `requestAnimationFrame` loop was running purely as invisible battery drain on what can be a long, continuous interview.

`App.tsx` now unmounts the background on the interview route (gated on `location`), tearing down the animation loop, with a short fade so entry/exit stays smooth.

**Verified in-browser:** the `-z-10` backdrop and its light elements are present on `/` and **absent** on `/interview/*`.

---

## Tests & checks
- `frameDelta.test.ts` — the clamp caps long gaps, leaves normal frames untouched.
- `NCBlob.test.ts` — new case: a 10-minute frame gap no longer teleports the blob off-screen.
- Both new guards were mutation-verified to go **red** without the clamp.
- `pnpm typecheck` (incl. interviewer via turbo), `pnpm knip`, oxlint, oxfmt, and all 87 `@codaco/art` tests pass.

Two changesets included (separate lanes): a `@codaco/art` patch and a `@codaco/interviewer` patch.