### PR TITLE
ci: parallelise quality into a fan-out + aggregator; add inert merge_group trigger

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -193,12 +193,19 @@ jobs:
   # fan-out of independent sub-jobs behind the `quality` aggregator below, so
   # they run in parallel runners instead of one after another. Sub-jobs
   # deliberately do NOT `needs: detect` so they still run under `merge_group`
-  # (where `detect` is skipped) — only `typecheck`/`test` need `build`'s output.
+  # (where `detect` is skipped). `typecheck`/`test` restore `build`'s output via
+  # their own `^build` dependency; `lint` needs it too (below) because oxlint's
+  # type-aware rules resolve workspace imports through built `.d.ts` files.
   lint:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: ./.github/actions/turbo-ci-setup
+      # Restore the shared-package builds (cache hit from the `build` job) so
+      # oxlint-tsgolint has the workspace types; otherwise it emits false-positive
+      # type errors (`//#lint` has no `^build` dependency of its own).
+      - run: pnpm exec turbo run build --filter='./packages/*'
       - run: pnpm exec turbo run //#lint
 
   knip:

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -186,15 +186,59 @@ jobs:
   # writes the SHA-specific slot; subsequent jobs read it via `restore-keys`
   # fallback. Per-package env values (NEXT_PUBLIC_*, VITE_*) are part of each
   # build task's `env:` list in turbo.json so they participate in the cache key.
-  quality:
-    needs: detect
+  #
+  # `quality` used to be a single job running everything serially; it is now a
+  # fan-out of independent sub-jobs behind the `quality` aggregator below, so
+  # they run in parallel runners instead of one after another. Sub-jobs
+  # deliberately do NOT `needs: detect` so they still run under `merge_group`
+  # (where `detect` is skipped) — only `typecheck`/`test` need `build`'s output.
+  lint:
     runs-on: ubuntu-latest
-    # No NEXT_PUBLIC_* / VITE_* env vars here. Quality builds only the shared
-    # packages (apps build in their own deploy/release jobs) and verifies the
-    # whole workspace — types, unit tests, lint, dead-code. Keeping these vars
-    # unset matches chromatic/e2e, so the shared package builds (fresco-ui,
-    # shared-consts, interview, …) compute the same task hash across all those
-    # jobs and the cache that quality writes is reusable by the app deploy jobs.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - run: pnpm exec turbo run //#lint
+
+  knip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - run: pnpm exec turbo run //#knip
+
+  check-changesets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - run: pnpm check:changesets
+
+  test-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - run: pnpm test:scripts
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - name: Build shared packages (apps build in their own deploy/release jobs)
+        run: pnpm exec turbo run build --filter='./packages/*'
+
+  typecheck:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: ./.github/actions/turbo-ci-setup
+      - run: pnpm exec turbo run typecheck
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: ./.github/actions/turbo-ci-setup
@@ -209,14 +253,26 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      - name: Build shared packages (apps build in their own deploy/release jobs)
-        run: pnpm exec turbo run build --filter='./packages/*'
-      - name: Quality gates — lint, dead-code, types, unit tests (whole workspace)
-        run: pnpm exec turbo run //#lint //#knip typecheck test
-      - name: Changeset app-isolation guard
-        run: pnpm check:changesets
-      - name: Release-script unit tests
-        run: pnpm test:scripts
+      - run: pnpm exec turbo run test
+
+  quality:
+    needs: [lint, knip, check-changesets, test-scripts, build, typecheck, test]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all quality checks passed
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "sub-job results: $RESULTS"
+          IFS=',' read -ra arr <<< "$RESULTS"
+          for r in "${arr[@]}"; do
+            if [ "$r" != "success" ]; then
+              echo "::error::quality gate failed — a sub-job concluded '$r'"
+              exit 1
+            fi
+          done
+          echo "quality gate passed"
 
   # Deploy jobs are split per-app and per-environment so:
   #   * one app's build failure never blocks the other app's deploy

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -33,6 +34,7 @@ concurrency:
 
 jobs:
   detect:
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     outputs:
       any_app: ${{ steps.flags.outputs.any_app }}


### PR DESCRIPTION
Third PR of the **CI: authoritative merge-queue check + parallelised `quality`** effort.

> **Stacked on #831** (the remote-cache composite action). Base is `ci/turbo-remote-cache`; I'll retarget to `main` once #831 merges. Review the [compare against #831](https://github.com/complexdatacollective/network-canvas-monorepo/compare/ci/turbo-remote-cache...ci/quality-fanout) for just this PR's changes.

## What's here
- Fans the single `quality` job into **seven parallel sub-jobs** — `lint`, `knip`, `check-changesets`, `test-scripts`, `build`, and (`needs: build`) `typecheck` + `test` — behind an **aggregator job that stays named `quality`**. The aggregator `needs` all seven and fails if any concludes non-success (`if: !cancelled()` + explicit per-result check), so it remains the single check every downstream job gates on.
- Adds an **inert `merge_group:` trigger** and guards `detect` with `if: github.event_name != 'merge_group'`, so only the `quality` sub-graph runs on a queue entry. Audited: no other job becomes runnable on `merge_group`.

## What this PR deliberately does NOT do
- **No change to push-time behaviour.** `quality` still runs on push and every `needs: quality` gate is untouched — this is a pure refactor + an inert trigger. The `merge_group` trigger does nothing until a merge-queue ruleset references the `quality` check.

## Ordering (important)
Merge **#831 → this → then enable the merge-queue ruleset** (that ruleset must go live only after this PR's `merge_group` trigger is on `main`, or the queue would hang waiting for a check that never runs). Dropping the redundant push-time `quality` run is the follow-up PR, after the queue is live.

Reviewed (spec + quality): aggregator fail-logic verified correct; no premature push-skip; all 10 downstream `needs: quality` jobs intact; `merge_group` scope audit clean; `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
