### PR TITLE
ci: drop redundant push-time quality run (release/deploy trust the merge queue)

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -198,6 +198,7 @@ jobs:
   # type-aware rules resolve workspace imports through built `.d.ts` files.
   lint:
     needs: build
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -209,6 +210,7 @@ jobs:
       - run: pnpm exec turbo run //#lint
 
   knip:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -216,6 +218,7 @@ jobs:
       - run: pnpm exec turbo run //#knip
 
   check-changesets:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -223,6 +226,7 @@ jobs:
       - run: pnpm check:changesets
 
   test-scripts:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -230,6 +234,7 @@ jobs:
       - run: pnpm test:scripts
 
   build:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -239,6 +244,7 @@ jobs:
 
   typecheck:
     needs: build
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -247,6 +253,7 @@ jobs:
 
   test:
     needs: build
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -266,7 +273,7 @@ jobs:
 
   quality:
     needs: [lint, knip, check-changesets, test-scripts, build, typecheck, test]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name != 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify all quality checks passed
@@ -336,13 +343,12 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
   deploy-docs-prod:
-    needs: [detect, quality]
+    needs: [detect]
     if: |
       always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      needs.detect.outputs.docs == 'true' &&
-      needs.quality.result == 'success'
+      needs.detect.outputs.docs == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -545,13 +551,12 @@ jobs:
             }
 
   deploy-website-prod:
-    needs: [detect, quality]
+    needs: [detect]
     if: |
       always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      needs.detect.outputs.website == 'true' &&
-      needs.quality.result == 'success'
+      needs.detect.outputs.website == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -788,7 +793,6 @@ jobs:
             });
 
   release:
-    needs: quality
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -825,7 +829,6 @@ jobs:
   # are ignored by the library release, so
   # they persist in .changeset/ until this job consumes them.
   apps-release-pr:
-    needs: quality
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -860,7 +863,6 @@ jobs:
   # merged), detect which app(s) moved — mirrors detect-legacy-release.sh, but
   # idempotency is a local git-tag check (no external repo).
   apps-release-detect:
-    needs: quality
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -999,7 +1001,6 @@ jobs:
   #     even if the release somehow predates this check).
   # version is always the current apps/<app>/package.json version.
   legacy-release-detect:
-    needs: quality
     # Only ever runs on main — a manual workflow_dispatch from a feature branch
     # must not mirror/publish branch-only code to the external app repos.
     if: >-


### PR DESCRIPTION
Final PR of the **CI: authoritative merge-queue check + parallelised `quality`** effort — this removes the redundant run the whole effort was about.

## What's here
Now that the merge queue is live and authoritative on `main`:
- **`quality` (all 8 fan-out jobs) skips on push** (`if: github.event_name != 'push'`; the aggregator keeps `!cancelled()`). It still runs on `pull_request` (feedback) and `merge_group` (authoritative).
- **Six push-to-main jobs stop gating on `quality`** and trust the queue: `release`, `apps-release-pr`, `apps-release-detect`, `legacy-release-detect`, `deploy-docs-prod`, `deploy-website-prod`. Every one keeps its existing `push`+`main` (and `detect`) guards — only the `quality` dependency is removed.

## Why it's safe
Every push to `main` now arrives through the merge queue, which fast-forwards only after `quality` passes on the exact commit (main + the PR) in a `merge_group` run. So re-running `quality` on the resulting push was pure redundancy. Remaining `needs: quality` references are all on `pull_request`-scoped jobs (preview deploys / chromatic / e2e), where `quality` still runs.

## This PR is the first merge-queue merge
It rides the queue itself — end-to-end validation that a `merge_group` run executes only the `quality` sub-graph and fast-forwards on green.

Reviewed (spec + quality): publish/deploy guards preserved byte-identical; aggregator `!cancelled()` retained; scope limited to the 14 jobs; `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI and release gating so production documentation and website deployments only run when the required checks and branch conditions are met.
  * Reduced unnecessary pipeline blocking by letting several non-essential jobs skip direct push events.
  * Streamlined release job flow so release-related tasks no longer wait on the main quality check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->