### PR TITLE
ci: set persist-credentials: false on quality fan-out checkouts

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -202,6 +202,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       # Restore the shared-package builds (cache hit from the `build` job) so
       # oxlint-tsgolint has the workspace types; otherwise it emits false-positive
@@ -214,6 +216,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm exec turbo run //#knip
 
@@ -222,6 +226,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm check:changesets
 
@@ -230,6 +236,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm test:scripts
 
@@ -238,6 +246,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - name: Build shared packages (apps build in their own deploy/release jobs)
         run: pnpm exec turbo run build --filter='./packages/*'
@@ -248,6 +258,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - run: pnpm exec turbo run typecheck
 
@@ -257,6 +269,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
       - name: Write protocol-validation .env (test fixture)
         env:
@@ -1054,6 +1068,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
         with:
           ignore-scripts: 'false'
@@ -1105,6 +1121,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
         with:
           ignore-scripts: 'false'

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1068,8 +1068,6 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-        with:
-          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
         with:
           ignore-scripts: 'false'
@@ -1121,8 +1119,6 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-        with:
-          persist-credentials: false
       - uses: ./.github/actions/turbo-ci-setup
         with:
           ignore-scripts: 'false'


### PR DESCRIPTION
Small follow-up to #835 (merged) — addresses the CodeRabbit / zizmor (`artipacked`) review finding that #835 merged before the fix could be added.

Sets **`persist-credentials: false`** on the `actions/checkout` step of all seven `quality` fan-out jobs (`lint`, `knip`, `check-changesets`, `test-scripts`, `build`, `typecheck`, `test`). Those jobs don't push or use git remotes, so the `GITHUB_TOKEN` shouldn't linger in `.git/config` for the rest of the job — matching the `release` / `apps-release-pr` jobs, which already opt out. (`apps-release-pr` already runs `check:changesets` with this flag, so it's confirmed safe for that job too.)

Not included: Copilot's suggestion to add an actor guard against direct/admin pushes to `main`. Declined — the `main` ruleset requires a PR + merge queue with **no bypass actors**, which blocks all direct pushes, so the only pushes reaching the release/deploy jobs are queue fast-forwards that already passed `quality`. A push-actor guard would be redundant with that rule and fragile (no reliable "came-from-queue" signal; a wrong guard would silently stop releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
