### PR TITLE
ci: keep release-PR quality runs from getting stuck as 'skipped'

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -30,7 +30,15 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Cancel superseded PR runs — EXCEPT the changesets bot's release PRs
+  # (`changeset-release/*`), which get force-updated on every merge to main.
+  # Cancelling those leaves the `quality` aggregate `skipped` (it is
+  # `if: !cancelled()`), and a skipped required check blocks the PR, so the
+  # release PRs could never satisfy the merge queue. Not cancelling lets their
+  # `quality` run complete (success/failure) so they stay mergeable.
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request'
+    && !startsWith(github.head_ref, 'changeset-release/') }}
 
 jobs:
   detect:


### PR DESCRIPTION
Fixes the release-PR churn surfaced on the "Release apps (beta)" / "Version Packages" PRs, where they show *"waiting for quality (required)"* and can't merge.

## Root cause
The changesets bot force-updates `changeset-release/*` on every merge to `main`. The workflow's `concurrency: cancel-in-progress` then **cancels** the in-flight run, and the `quality` aggregator (`if: ${{ !cancelled() && … }}`) is therefore **skipped**. GitHub treats a *skipped* required check as "not reported" → the release PR is blocked.

## Fix
Keep cancel-on-superseding-push for normal PRs, but **not** for the auto-updating release PRs, so their `quality` run always *completes* (success/failure) rather than landing on `skipped`:

```yaml
cancel-in-progress: >-
  ${{ github.event_name == 'pull_request'
  && !startsWith(github.head_ref, 'changeset-release/') }}
```

Non-PR events (`push`, `merge_group`) were already `false` here, so their behaviour is unchanged. Cost is a few extra concurrent runs on the two release PRs during release churn; no change to the safety model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
