### PR TITLE
test(interview-e2e): retry known flakes on CI and surface them

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -739,6 +739,9 @@ jobs:
           sudo chown -R "$(id -u):$(id -g)" \
             packages/interview/e2e/playwright-report \
             packages/interview/e2e/test-results 2>/dev/null || true
+      - name: Flag flaky tests
+        if: always()
+        run: node packages/interview/e2e/scripts/flaky-summary.mjs
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -740,7 +740,10 @@ jobs:
             packages/interview/e2e/playwright-report \
             packages/interview/e2e/test-results 2>/dev/null || true
       - name: Flag flaky tests
+        # Reporting only — never gate the job on it (belt-and-suspenders with the
+        # script's own guards).
         if: always()
+        continue-on-error: true
         run: node packages/interview/e2e/scripts/flaky-summary.mjs
       - name: Upload report
         if: always()

--- a/packages/interview/e2e/playwright.config.ts
+++ b/packages/interview/e2e/playwright.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
 
   fullyParallel: false,
   workers: 1,
-  retries: 0,
+  // Retry on CI only. The suite is serial (mode: 'serial'), so a retry re-runs
+  // the whole group from beforeAll and rebuilds state — recovering known
+  // transient visual flakes (e.g. SILOS stage-29, issue #844) so the gate stays
+  // green while Playwright still reports them as flaky. Local stays 0 so flakes
+  // surface deterministically while developing.
+  retries: process.env.CI ? 2 : 0,
   timeout: 30_000,
 
   reporter: [

--- a/packages/interview/e2e/scripts/flaky-summary.mjs
+++ b/packages/interview/e2e/scripts/flaky-summary.mjs
@@ -42,5 +42,10 @@ const md = [
 
 console.log(md);
 if (process.env.GITHUB_STEP_SUMMARY) {
-  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${md}\n`);
+  try {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${md}\n`);
+  } catch {
+    // Best-effort write; a failed summary append must never gate CI. The
+    // console.log above already carries the same content into the step log.
+  }
 }

--- a/packages/interview/e2e/scripts/flaky-summary.mjs
+++ b/packages/interview/e2e/scripts/flaky-summary.mjs
@@ -1,0 +1,46 @@
+// Surface tests that only passed on retry ("flaky") so CI retries don't quietly
+// hide accumulating flakiness. Reads Playwright's JSON report and, if any test
+// is flaky, writes a note to the GitHub job summary (and stdout). Exits 0 always
+// — this is reporting, never a gate.
+
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const REPORT = 'packages/interview/e2e/test-results/results.json';
+
+let report;
+try {
+  report = JSON.parse(readFileSync(REPORT, 'utf8'));
+} catch {
+  // No report (e.g. the suite crashed before writing one) — nothing to surface.
+  process.exit(0);
+}
+
+const flaky = [];
+const walk = (suite) => {
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      if (test.status === 'flaky') {
+        flaky.push(`${spec.title} [${test.projectName ?? 'unknown'}]`);
+      }
+    }
+  }
+  for (const child of suite.suites ?? []) walk(child);
+};
+for (const suite of report.suites ?? []) walk(suite);
+
+if (flaky.length === 0) process.exit(0);
+
+const md = [
+  '### ⚠️ Flaky tests (passed only on retry)',
+  '',
+  'The job is green, but these failed then passed on retry. The flake is real —',
+  'keep it on the radar (see tagged tests / tracking issues).',
+  '',
+  ...flaky.map((f) => `- \`${f}\``),
+  '',
+].join('\n');
+
+console.log(md);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${md}\n`);
+}

--- a/packages/interview/e2e/specs/silos-protocol.spec.ts
+++ b/packages/interview/e2e/specs/silos-protocol.spec.ts
@@ -1200,34 +1200,38 @@ test.describe('SILOS Protocol', () => {
       await interview.captureFinal();
     });
 
-    test('Stage 29: Alter ART (CategoricalBin)', async ({
-      interview,
-      stage,
-    }) => {
-      await interview.captureInitial();
-      await expect(interview.page).toHaveURL(/step=29/);
-      // Only shows partners whose HIV status IS HIV Positive
-      await expect(stage.getPrompt()).toBeVisible();
+    // @flaky: on firefox, captureInitial races the CategoricalBin's initial
+    // render and intermittently snapshots a pre-placed node (issue #844). CI
+    // retries (playwright.config.ts) recover it; the tag keeps it on the radar.
+    test(
+      'Stage 29: Alter ART (CategoricalBin)',
+      { tag: '@flaky' },
+      async ({ interview, stage }) => {
+        await interview.captureInitial();
+        await expect(interview.page).toHaveURL(/step=29/);
+        // Only shows partners whose HIV status IS HIV Positive
+        await expect(stage.getPrompt()).toBeVisible();
 
-      await expect(stage.categoricalBin.getBin('Yes')).toBeVisible();
-      await expect(stage.categoricalBin.getBin('No')).toBeVisible();
+        await expect(stage.categoricalBin.getBin('Yes')).toBeVisible();
+        await expect(stage.categoricalBin.getBin('No')).toBeVisible();
 
-      const unplaced = await stage.categoricalBin.getUnplacedCount();
-      expect(unplaced).toBeGreaterThanOrEqual(1);
+        const unplaced = await stage.categoricalBin.getUnplacedCount();
+        expect(unplaced).toBeGreaterThanOrEqual(1);
 
-      // Drag the HIV Positive partner to "Yes"
-      const firstNode = stage.page
-        .getByRole('button', { name: /Bob|Evan/ })
-        .first();
-      const nodeName = await firstNode.textContent();
-      if (nodeName) {
-        await stage.categoricalBin.dragNodeToBin(nodeName.trim(), 'Yes');
-      }
+        // Drag the HIV Positive partner to "Yes"
+        const firstNode = stage.page
+          .getByRole('button', { name: /Bob|Evan/ })
+          .first();
+        const nodeName = await firstNode.textContent();
+        if (nodeName) {
+          await stage.categoricalBin.dragNodeToBin(nodeName.trim(), 'Yes');
+        }
 
-      await expect(interview.nextButton).toBeEnabled();
+        await expect(interview.nextButton).toBeEnabled();
 
-      await interview.captureFinal();
-    });
+        await interview.captureFinal();
+      },
+    );
 
     test('Stage 30: Alter Substances (AlterForm)', async ({
       interview,


### PR DESCRIPTION
## What & why

Follow-up to #841. The `interview-e2e` gate ran with **`retries: 0`**, so a single known-transient visual flake — SILOS **stage-29 "Alter ART"** on firefox (#844) — reddened the whole 171-test gate and forced a manual re-run. This makes that recovery automatic while keeping the flake visible.

### Changes
- **`retries: process.env.CI ? 2 : 0`** — the suite is serial (`test.describe.configure({ mode: 'serial' })`), so on failure Playwright re-runs the whole group from `beforeAll`, rebuilding stage 0→N state. That correctly recovers a transient flake (rather than re-running stage-29 against broken state), and the job goes **green** while Playwright still marks the test **flaky**. Local stays `0` so flakes surface deterministically while developing.
- **Tag stage-29 `@flaky`** and link the tracking issue (#844), so known flakes are filterable (`--grep @flaky`) and on the record.
- **New "Flag flaky tests" CI step** — reads Playwright's already-configured JSON report and writes any *passed-on-retry* test to the GitHub **job summary**, so retries don't silently hide accumulating flakiness.

### Trade-off
Retries also mask *genuine* intermittent regressions. Mitigated three ways: Playwright still reports flakes (line reporter + the HTML report published to Pages), the new job-summary step makes them loud, and local retries stay `0`. The real fix for stage-29 is tracked in #844.

## Verification
- `flaky-summary.mjs` verified against fixtures: flaky present → writes the summary (exit 0); none → silent (exit 0). `test-results/` is gitignored.
- Workflow YAML parses; the step is placed after ownership-reclaim (so `results.json` is readable) and before upload.
- The `@flaky` tag uses the standard Playwright 3-arg `test(title, { tag }, fn)` overload; the e2e specs aren't wired to a CI typecheck task, and the change adds no imports.

## Changeset
None — CI/test-tooling only; no consumer-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by retrying tests in CI and handling a known intermittent browser timing issue.
  * Added flaky-test reporting in the CI release workflow so unstable tests are surfaced more clearly.
* **Chores**
  * Updated the test suite to mark a known flaky scenario accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->