### PR TITLE
Fix blob URL leak on fast unmount in ProtocolSummary useAssetData

### DIFF
--- a/.changeset/fix-protocol-summary-asset-blob-url-leak.md
+++ b/.changeset/fix-protocol-summary-asset-blob-url-leak.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Fixed a memory leak in the protocol summary where an asset preview's object URL was never released if the asset finished loading after the preview had already closed or switched to a different asset.

--- a/apps/architect/src/lib/ProtocolSummary/components/useAssetData.tsx
+++ b/apps/architect/src/lib/ProtocolSummary/components/useAssetData.tsx
@@ -54,12 +54,17 @@ const useAssetData = (id: string) => {
       try {
         const blobUrl = await getAssetBlobUrl(id);
 
-        if (!isMounted) return;
+        if (!blobUrl) return;
 
-        if (blobUrl) {
-          currentUrl = blobUrl;
-          setUrl(blobUrl);
+        // The effect was cleaned up (unmount or id change) while the read was
+        // in flight, so no one will render or revoke this URL — revoke it now.
+        if (!isMounted) {
+          revokeBlobUrl(blobUrl);
+          return;
         }
+
+        currentUrl = blobUrl;
+        setUrl(blobUrl);
       } catch (error) {
         // The asset can't be shown; report it rather than leaving a blank
         // image with no trace of why.


### PR DESCRIPTION
## Summary

Fixes an object-URL leak in `apps/architect/src/lib/ProtocolSummary/components/useAssetData.tsx` — the same class of bug that issue #805 fixed in the sibling file `apps/architect/src/components/Assets/withAssetUrl.tsx`.

The asset-loading effect awaited `getAssetBlobUrl(id)` and then returned on `!isMounted` **without revoking** the blob URL it had just created. Because `getAssetBlobUrl` calls `URL.createObjectURL` only *after* its async IndexedDB read resolves, a fast unmount or `id` change leads to:

1. cleanup runs first with `currentUrl` still `null` → nothing to revoke;
2. the awaited continuation then resumes and bails out on `!isMounted`, leaving the freshly-created object URL permanently leaked.

## Changes

- After the `await`, bail early if there's no URL (`if (!blobUrl) return;`).
- If the effect was cleaned up while the read was in flight (`!isMounted`), revoke the URL before returning.
- Otherwise record it in `currentUrl` and set state — matching the exact pattern (and explanatory comment) in `withAssetUrl.tsx`.
- Added an `@codaco/architect` patch changeset.

`revokeBlobUrl` was already imported, so no import changes were needed.

## Testing

- `pnpm --filter @codaco/architect` typecheck (`tsc --build --noEmit`) — passes
- `oxlint` / `oxfmt --check` on the changed file — clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGydKGCW1kRbvVfhPQ6Apa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGydKGCW1kRbvVfhPQ6Apa)_