### PR TITLE
Lint cleanup: typed createAppAsyncThunk seam (remove getState() as RootState casts)

### DIFF
--- a/apps/architect/src/ducks/createAppAsyncThunk.ts
+++ b/apps/architect/src/ducks/createAppAsyncThunk.ts
@@ -1,0 +1,13 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import type { RootState } from './store';
+
+/**
+ * `createAsyncThunk` pre-typed with the app's `RootState`, so thunk `getState()`
+ * returns `RootState` without a per-call `as RootState` cast. Only `state` is
+ * pinned; typing `dispatch` too makes the produced action undispatchable by the
+ * store's own dispatch (extra-arg `unknown`/`undefined` mismatch).
+ */
+export const createAppAsyncThunk = createAsyncThunk.withTypes<{
+  state: RootState;
+}>();

--- a/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 
 import type { Stage } from '@codaco/protocol-validation';
+import type { AppDispatch } from '~/ducks/store';
 
 import reducer, { actionCreators, test } from '../stages';
 
@@ -141,7 +142,14 @@ describe('protocol.stages', () => {
           ),
       });
 
-      return { store, dispatched };
+      // This mock store models only a few of the app's slices, so its inferred
+      // dispatch type doesn't match the app thunks (pinned to the real
+      // RootState). Bridge its dispatch to the real AppDispatch so the tests can
+      // dispatch them.
+      return {
+        store: store as unknown as typeof store & { dispatch: AppDispatch },
+        dispatched,
+      };
     };
 
     describe('deleteStageAsync', () => {

--- a/apps/architect/src/ducks/modules/protocol/codebook.ts
+++ b/apps/architect/src/ducks/modules/protocol/codebook.ts
@@ -1,9 +1,4 @@
-import {
-  createAsyncThunk,
-  createSlice,
-  current,
-  type PayloadAction,
-} from '@reduxjs/toolkit';
+import { createSlice, current, type PayloadAction } from '@reduxjs/toolkit';
 import { find, get, has, isEmpty, omit } from 'es-toolkit/compat';
 import { v4 as uuid } from 'uuid';
 
@@ -15,7 +10,7 @@ import type {
   EntityDefinition,
   Variable,
 } from '@codaco/protocol-validation';
-import type { RootState } from '~/ducks/modules/root';
+import { createAppAsyncThunk } from '~/ducks/createAppAsyncThunk';
 import {
   getAllVariableUUIDsByEntity,
   getVariablesForSubject,
@@ -77,7 +72,7 @@ const defaultTypeTemplate: Partial<EntityDefinition> = {
 };
 
 // Async thunks
-export const createTypeAsync = createAsyncThunk(
+export const createTypeAsync = createAppAsyncThunk(
   'codebook/createTypeAsync',
   async (
     {
@@ -101,7 +96,7 @@ export const createTypeAsync = createAsyncThunk(
   },
 );
 
-export const updateTypeAsync = createAsyncThunk(
+export const updateTypeAsync = createAppAsyncThunk(
   'codebook/updateTypeAsync',
   async (
     {
@@ -121,11 +116,11 @@ export const updateTypeAsync = createAsyncThunk(
   },
 );
 
-export const createEdgeAsync = createAsyncThunk(
+export const createEdgeAsync = createAppAsyncThunk(
   'codebook/createEdgeAsync',
   async (configuration: Partial<EdgeDefinition>, { dispatch, getState }) => {
     const entity: Entity = 'edge';
-    const state = getState() as RootState;
+    const state = getState();
     const protocol = (state.activeProtocol?.present ||
       state.activeProtocol) as CurrentProtocol;
     const colorFromHelper = getNextCategoryColor(protocol, entity);
@@ -147,7 +142,7 @@ export const createEdgeAsync = createAsyncThunk(
   },
 );
 
-export const createVariableAsync = createAsyncThunk(
+export const createVariableAsync = createAppAsyncThunk(
   'codebook/createVariableAsync',
   async (
     {
@@ -174,7 +169,7 @@ export const createVariableAsync = createAsyncThunk(
       throw new Error('Variable name contains no valid characters');
     }
 
-    const state = getState() as RootState;
+    const state = getState();
     const variables = getVariablesForSubject(state, { entity, type });
     const variableNameExists = Object.values(variables).some(
       ({ name }) => name === safeConfiguration.name,
@@ -200,7 +195,7 @@ export const createVariableAsync = createAsyncThunk(
   },
 );
 
-export const updateVariableAsync = createAsyncThunk(
+export const updateVariableAsync = createAppAsyncThunk(
   'codebook/updateVariableAsync',
   async (
     {
@@ -224,7 +219,7 @@ export const updateVariableAsync = createAsyncThunk(
 
     // If entity and type are provided, validate the variable exists
     if (entity && type) {
-      const state = getState() as RootState;
+      const state = getState();
       const variableExists = has(
         getVariablesForSubject(state, { entity, type }),
         variable,
@@ -246,7 +241,7 @@ export const updateVariableAsync = createAsyncThunk(
   },
 );
 
-export const deleteVariableAsync = createAsyncThunk(
+export const deleteVariableAsync = createAppAsyncThunk(
   'codebook/deleteVariableAsync',
   async (
     {
@@ -256,7 +251,7 @@ export const deleteVariableAsync = createAsyncThunk(
     }: { entity: Entity; type?: string; variable: string },
     { dispatch, getState },
   ) => {
-    const state = getState() as RootState;
+    const state = getState();
     const isUsed = getIsUsed(state);
 
     if (get(isUsed, variable, false)) {
@@ -303,7 +298,7 @@ const getDeleteAction = ({
   }
 };
 
-export const deleteTypeAsync = createAsyncThunk(
+export const deleteTypeAsync = createAppAsyncThunk(
   'codebook/deleteTypeAsync',
   async (
     {
@@ -326,7 +321,7 @@ export const deleteTypeAsync = createAsyncThunk(
 
     // Scan usage BEFORE removing the type, so the cascade sees the stages and
     // prompts that reference it.
-    const state = getState() as RootState;
+    const state = getState();
     const getUsageForType = makeGetUsageForType(state);
     const usageForType = getUsageForType(entity, type);
 

--- a/apps/architect/src/ducks/modules/protocol/stages.ts
+++ b/apps/architect/src/ducks/modules/protocol/stages.ts
@@ -1,15 +1,11 @@
-import {
-  createAsyncThunk,
-  createSlice,
-  type PayloadAction,
-} from '@reduxjs/toolkit';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { invariant } from 'es-toolkit';
 import { compact, omit } from 'es-toolkit/compat';
 import { v1 as uuid } from 'uuid';
 
 import type { Stage } from '@codaco/protocol-validation';
+import { createAppAsyncThunk } from '~/ducks/createAppAsyncThunk';
 import { openDialog } from '~/ducks/modules/dialogs';
-import type { RootState } from '~/ducks/modules/root';
 import { getNodeTypes } from '~/selectors/codebook';
 import { getProtocol, getStage } from '~/selectors/protocol';
 import prune from '~/utils/prune';
@@ -48,7 +44,7 @@ const initialStage = {
 };
 
 // Async thunks
-const createStageAsync = createAsyncThunk(
+const createStageAsync = createAppAsyncThunk(
   'stages/createStageAsync',
   async (
     { options, index }: { options: Partial<Stage>; index?: number },
@@ -62,10 +58,10 @@ const createStageAsync = createAsyncThunk(
   },
 );
 
-const deleteStageAsync = createAsyncThunk(
+const deleteStageAsync = createAppAsyncThunk(
   'stages/deleteStageAsync',
   async (stageId: string, { dispatch, getState }) => {
-    const state = getState() as RootState;
+    const state = getState();
     const stage = getStage(state, stageId);
 
     // A NarrativePedigree renders a FamilyPedigree's finalised network via

--- a/apps/architect/src/ducks/modules/userActions/userActions.ts
+++ b/apps/architect/src/ducks/modules/userActions/userActions.ts
@@ -1,4 +1,4 @@
-import { createAsyncThunk, type Dispatch } from '@reduxjs/toolkit';
+import { type Dispatch } from '@reduxjs/toolkit';
 import { navigate } from 'wouter/use-browser-location';
 import { z } from 'zod';
 
@@ -12,13 +12,13 @@ import {
 } from '@codaco/protocol-validation';
 import { posthog } from '~/analytics';
 import { APP_SCHEMA_VERSION } from '~/config';
+import { createAppAsyncThunk } from '~/ducks/createAppAsyncThunk';
 import {
   appUpgradeRequiredDialog,
   generalErrorDialog,
   mayUpgradeProtocolDialog,
   validationErrorDialog,
 } from '~/ducks/modules/userActions/dialogs';
-import type { RootState } from '~/ducks/store';
 import {
   saveProtocolAssets,
   saveProtocolAssetsToMemory,
@@ -149,7 +149,7 @@ const instantiateProtocol = async (
   navigate('/protocol');
 };
 
-export const openLocalNetcanvas = createAsyncThunk(
+export const openLocalNetcanvas = createAppAsyncThunk(
   'protocol/openLocalNetcanvas',
   async (file: File, { dispatch }) => {
     // Signal an import is in flight so a fresh-load service-worker update won't
@@ -275,7 +275,7 @@ const checkSchemaVersion = (protocol: CurrentProtocol): schemaVersionStates => {
 };
 
 // helper function so we can use loadingLock
-const handleProtocolMigration = createAsyncThunk(
+const handleProtocolMigration = createAppAsyncThunk(
   'protocol/openOrUpgrade',
   async (
     { protocol, name }: { protocol: CurrentProtocol; name: string },
@@ -322,7 +322,7 @@ type CreateNetcanvasParams = {
 };
 
 // Create a new protocol
-export const createNetcanvas = createAsyncThunk(
+export const createNetcanvas = createAppAsyncThunk(
   'webUserActions/createNetcanvas',
   async ({ name, description }: CreateNetcanvasParams, { dispatch }) => {
     // Create a new empty protocol
@@ -351,7 +351,7 @@ export const createNetcanvas = createAsyncThunk(
 // migration steps and validate it directly. Like the remote-template flow, a
 // fresh library entry (new id) is created so a template can be opened
 // repeatedly without overwriting earlier copies.
-export const openBundledTemplate = createAsyncThunk(
+export const openBundledTemplate = createAppAsyncThunk(
   'webUserActions/openBundledTemplate',
   async (
     {
@@ -392,10 +392,10 @@ export const openBundledTemplate = createAsyncThunk(
 );
 
 // Export protocol as .netcanvas file
-export const exportNetcanvas = createAsyncThunk(
+export const exportNetcanvas = createAppAsyncThunk(
   'webUserActions/exportNetcanvas',
   async (_, { dispatch, getState }) => {
-    const state = getState() as RootState;
+    const state = getState();
     const protocol = state.activeProtocol?.present;
 
     if (!protocol) {
@@ -435,7 +435,7 @@ export const exportNetcanvas = createAsyncThunk(
 
 // Load a protocol already saved in the library into the editing buffer. Its
 // assets are already namespaced under this id in IndexedDB.
-export const openLibraryProtocol = createAsyncThunk(
+export const openLibraryProtocol = createAppAsyncThunk(
   'webUserActions/openLibraryProtocol',
   async (id: string, { dispatch }) => {
     const row = await getStoredProtocol(id);
@@ -460,12 +460,12 @@ export const openLibraryProtocol = createAsyncThunk(
 
 // Remove a protocol (and its assets) from the library. If it is the one
 // currently being edited, also close the editing buffer.
-export const deleteLibraryProtocol = createAsyncThunk(
+export const deleteLibraryProtocol = createAppAsyncThunk(
   'webUserActions/deleteLibraryProtocol',
   async (id: string, { dispatch, getState }) => {
     await deleteStoredProtocol(id);
 
-    const state = getState() as RootState;
+    const state = getState();
     if (getActiveProtocolId(state) === id) {
       disarmInMemoryUnloadGuard();
       dispatch(setActiveProtocolId(null));

--- a/packages/interview/src/store/createAppAsyncThunk.ts
+++ b/packages/interview/src/store/createAppAsyncThunk.ts
@@ -1,0 +1,13 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import type { RootState } from './store';
+
+/**
+ * `createAsyncThunk` pre-typed with the store's `RootState`, so thunk `getState()`
+ * returns `RootState` without a per-call `as RootState` cast. Only `state` is
+ * pinned; typing `dispatch` too makes the produced action undispatchable by the
+ * store's own dispatch (extra-arg `unknown`/`undefined` mismatch).
+ */
+export const createAppAsyncThunk = createAsyncThunk.withTypes<{
+  state: RootState;
+}>();

--- a/packages/interview/src/store/modules/__tests__/session.test.ts
+++ b/packages/interview/src/store/modules/__tests__/session.test.ts
@@ -9,6 +9,7 @@ import type {
 } from '@codaco/shared-consts';
 
 import { createInitialNetwork } from '../../../contract/network';
+import type { AppDispatch } from '../../store';
 import sessionReducer, {
   addEdge,
   addNode,
@@ -42,7 +43,7 @@ function createTestStore(options: {
   type ProtocolState = ReturnType<typeof createTestProtocolState>;
   type UIState = typeof uiState;
 
-  return configureStore({
+  const store = configureStore({
     reducer: {
       session: (state: SessionState = sessionState): SessionState => state,
       protocol: (state: ProtocolState = protocolState): ProtocolState => state,
@@ -54,6 +55,11 @@ function createTestStore(options: {
       ui: uiState,
     },
   });
+
+  // This mock store models only the slices these thunks read, so its inferred
+  // dispatch type doesn't match the app thunks (pinned to the real RootState).
+  // Bridge its dispatch to the real AppDispatch so the tests can dispatch them.
+  return store as unknown as typeof store & { dispatch: AppDispatch };
 
   function createTestSessionState() {
     return {
@@ -317,7 +323,7 @@ function createTestStoreWithEgo(options: {
   type ProtocolState = ReturnType<typeof createTestProtocolState>;
   type UIState = typeof uiState;
 
-  return configureStore({
+  const store = configureStore({
     reducer: {
       session: (state: SessionState = sessionState): SessionState => state,
       protocol: (state: ProtocolState = protocolState): ProtocolState => state,
@@ -329,6 +335,8 @@ function createTestStoreWithEgo(options: {
       ui: uiState,
     },
   });
+
+  return store as unknown as typeof store & { dispatch: AppDispatch };
 
   function createTestSessionState() {
     return {
@@ -384,7 +392,7 @@ function createTestStoreWithEdge(options: {
   type ProtocolState = ReturnType<typeof createTestProtocolState>;
   type UIState = typeof uiState;
 
-  return configureStore({
+  const store = configureStore({
     reducer: {
       session: (state: SessionState = sessionState): SessionState => state,
       protocol: (state: ProtocolState = protocolState): ProtocolState => state,
@@ -396,6 +404,8 @@ function createTestStoreWithEdge(options: {
       ui: uiState,
     },
   });
+
+  return store as unknown as typeof store & { dispatch: AppDispatch };
 
   function createTestSessionState() {
     return {
@@ -594,7 +604,7 @@ function createTestStoreWithPrompts(options: {
 
   type ProtocolState = typeof protocolState;
 
-  return configureStore({
+  const store = configureStore({
     reducer: {
       // Use the real session reducer so .fulfilled handlers run and we can
       // assert the resulting node state.
@@ -606,6 +616,8 @@ function createTestStoreWithPrompts(options: {
       protocol: protocolState,
     },
   });
+
+  return store as unknown as typeof store & { dispatch: AppDispatch };
 }
 
 describe('addNodeToPrompt', () => {
@@ -803,10 +815,12 @@ function createTestStoreWithMetadata(stageMetadata: StageMetadata) {
     stageMetadata,
   };
 
-  return configureStore({
+  const store = configureStore({
     reducer: { session: sessionReducer },
     preloadedState: { session: sessionState },
   });
+
+  return store as unknown as typeof store & { dispatch: AppDispatch };
 }
 
 describe('deleteNode', () => {

--- a/packages/interview/src/store/modules/session.ts
+++ b/packages/interview/src/store/modules/session.ts
@@ -1,9 +1,4 @@
-import {
-  createAction,
-  createAsyncThunk,
-  createReducer,
-  createSelector,
-} from '@reduxjs/toolkit';
+import { createAction, createReducer, createSelector } from '@reduxjs/toolkit';
 import { invariant } from 'es-toolkit';
 import { find, get } from 'es-toolkit/compat';
 import { v4 as uuid } from 'uuid';
@@ -36,7 +31,7 @@ import {
 } from '~/selectors/session';
 import { getDefaultAttributesForEntityType } from '~/utils/getDefaultAttributesForEntityType';
 
-import type { RootState } from '../store';
+import { createAppAsyncThunk } from '../createAppAsyncThunk';
 import { getShouldEncryptNames } from './protocol';
 
 // reducer helpers:
@@ -160,7 +155,7 @@ type AddNodeArgs = {
   allowUnknownAttributes?: boolean;
 };
 
-export const addNode = createAsyncThunk(
+export const addNode = createAppAsyncThunk(
   actionTypes.addNode,
   async (args: AddNodeArgs, thunkApi) => {
     const {
@@ -171,7 +166,7 @@ export const addNode = createAsyncThunk(
       allowUnknownAttributes,
       currentStep,
     } = args;
-    const state = thunkApi.getState() as RootState;
+    const state = thunkApi.getState();
 
     const getCodebookVariablesForNodeType =
       makeGetCodebookVariablesForNodeType(state);
@@ -230,7 +225,7 @@ export const addNode = createAsyncThunk(
   },
 );
 
-export const addEdge = createAsyncThunk(
+export const addEdge = createAppAsyncThunk(
   actionTypes.addEdge,
   (
     props: {
@@ -243,7 +238,7 @@ export const addEdge = createAsyncThunk(
     { getState },
   ) => {
     const { from, to, type, attributeData, currentStep } = props;
-    const state = getState() as RootState;
+    const state = getState();
     const sessionMeta = getSessionMeta(state, currentStep);
 
     const getCodebookVariablesForEdgeType =
@@ -281,7 +276,7 @@ export const addEdge = createAsyncThunk(
   },
 );
 
-export const updateNode = createAsyncThunk(
+export const updateNode = createAppAsyncThunk(
   actionTypes.updateNode,
   async (
     args: {
@@ -293,7 +288,7 @@ export const updateNode = createAsyncThunk(
     thunkApi,
   ) => {
     const { newAttributeData, newModelData, nodeId, currentStep } = args;
-    const state = thunkApi.getState() as RootState;
+    const state = thunkApi.getState();
     const getNodeById = makeGetNodeById(state, currentStep);
     const node = getNodeById(nodeId);
 
@@ -366,10 +361,10 @@ export const updatePrompt = createAction<number>(actionTypes.updatePrompt);
  */
 export const transitionStage = createAction(actionTypes.transitionStage);
 
-export const updateEgo = createAsyncThunk(
+export const updateEgo = createAppAsyncThunk(
   actionTypes.updateEgo,
   (egoAttributes: NcEgo[EntityAttributesProperty], { getState }) => {
-    const state = getState() as RootState;
+    const state = getState();
     const codebook = state.protocol.codebook as Codebook; // Needed because schema 7 doesn't have strongly typed codebook
     const egoVariables = codebook.ego?.variables;
 
@@ -393,7 +388,7 @@ export const updateEgo = createAsyncThunk(
   },
 );
 
-export const toggleEdge = createAsyncThunk(
+export const toggleEdge = createAppAsyncThunk(
   actionTypes.toggleEdge,
   async (
     props: {
@@ -406,7 +401,7 @@ export const toggleEdge = createAsyncThunk(
     { getState, dispatch },
   ) => {
     const { from, to, type, attributeData, currentStep } = props;
-    const state = getState() as RootState;
+    const state = getState();
 
     const existingEdge = edgeExists(
       state.session.network.edges,
@@ -429,7 +424,7 @@ const getSessionMeta = createSelector(
   (promptId, stageId) => ({ promptId, stageId }),
 );
 
-export const addNodeToPrompt = createAsyncThunk(
+export const addNodeToPrompt = createAppAsyncThunk(
   actionTypes.addNodeToPrompt,
   (
     props: {
@@ -440,7 +435,7 @@ export const addNodeToPrompt = createAsyncThunk(
     { getState },
   ) => {
     const { nodeId, promptAttributes, currentStep } = props;
-    const state = getState() as RootState;
+    const state = getState();
     const promptId = getPromptId(state, currentStep);
 
     return {
@@ -474,14 +469,14 @@ function getPromptAdditionalAttributesMap(
   );
 }
 
-export const removeNodeFromPrompt = createAsyncThunk(
+export const removeNodeFromPrompt = createAppAsyncThunk(
   actionTypes.removeNodeFromPrompt,
   (
     args: { nodeId: NcNode[EntityPrimaryKey]; currentStep: number },
     { getState },
   ) => {
     const { nodeId, currentStep } = args;
-    const state = getState() as RootState;
+    const state = getState();
     const promptId = getPromptId(state, currentStep);
     invariant(promptId, 'Prompt ID is required to remove a node from a prompt');
 
@@ -535,7 +530,7 @@ export const removeNodeFromPrompt = createAsyncThunk(
   },
 );
 
-export const updateEdge = createAsyncThunk(
+export const updateEdge = createAppAsyncThunk(
   actionTypes.updateEdge,
   (
     args: {
@@ -546,7 +541,7 @@ export const updateEdge = createAsyncThunk(
     { getState },
   ) => {
     const { edgeId, newModelData, newAttributeData } = args;
-    const state = getState() as RootState;
+    const state = getState();
     const edge = state.session.network.edges.find(
       (e) => e[entityPrimaryKeyProperty] === edgeId,
     );


### PR DESCRIPTION
Stacked on #858. Removes 16 `getState() as RootState` casts by introducing a typed thunk seam — the RTK piece of the lint-warning reduction ([spec](docs/superpowers/specs/2026-07-07-lint-warning-reduction-design.md)). `no-unsafe-type-assertion` 993 → 977 (part of the broader src reduction).

## What
- New `createAppAsyncThunk = createAsyncThunk.withTypes<{ state: RootState }>()` in `apps/architect/src/ducks/` and `packages/interview/src/store/`.
- Migrated the `codebook`, `stages`, `userActions` (architect) and `session` (interview) thunks to it, so `getState()` is typed `RootState` and the per-call casts are gone.

## Two things worth a reviewer's eye
- **The seam pins only `state`, deliberately.** Pinning `dispatch: AppDispatch` as well makes the produced `AsyncThunkAction` undispatchable by the store's own dispatch (the thunk then requires thunk-extra `unknown`, but `AppDispatch` has `undefined`). Verified.
- **Two store-test mock factories** (`createTestStore*` in `session.test.ts`, `createThunkStore` in `stages.test.ts`) build partial/simplified-state stores, so their inferred dispatch no longer matches the now-`RootState`-typed thunks. Their returned store's `dispatch` is bridged to the real `AppDispatch` via a documented test-only cast — legitimate here because `no-unsafe-type-assertion` is scoped off in test files.

## Verification
- `pnpm --filter @codaco/interview typecheck` and `pnpm --filter @codaco/architect typecheck` — both pass.
- `oxlint`: 0 errors; `no-unsafe-type-assertion` −16.
- Internal refactor, no consumer-visible change → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)