### PR TITLE
Restore documentation's broken shadcn animations (tw-animate-css)

### DIFF
--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -72,6 +72,7 @@
     "tailwind-merge": "catalog:",
     "tailwindcss": "catalog:",
     "tsx": "catalog:",
+    "tw-animate-css": "^1.4.0",
     "typescript": "catalog:",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",

--- a/apps/documentation/styles/globals.css
+++ b/apps/documentation/styles/globals.css
@@ -1,5 +1,6 @@
 @config '../tailwind.config.ts';
 @import 'tailwindcss';
+@import 'tw-animate-css';
 
 :root {
   /* UI Colors */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -13827,6 +13830,9 @@ packages:
   turbo@2.9.16:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
     hasBin: true
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -27825,6 +27831,8 @@ snapshots:
       '@turbo/linux-arm64': 2.9.16
       '@turbo/windows-64': 2.9.16
       '@turbo/windows-arm64': 2.9.16
+
+  tw-animate-css@1.4.0: {}
 
   tweetnacl@0.14.5: {}
 


### PR DESCRIPTION
Stacked on #858. Fixes a regression found while doing the Tailwind lint cleanup.

## The regression
Documentation's shadcn components (dialog, sheet, tooltip, select, SharedNav menu) use `tailwindcss-animate` utility classes — `animate-in`, `fade-in-0`, `slide-in-from-*`, `zoom-*`, `data-[state=…]:animate-out`, etc. The `tailwindcss-animate` plugin was **dropped** in commit `bd1d9945f` ("migrate eslint, tsconfig, and tailwind config to tooling"):
```diff
- plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+ plugins: [require('@tailwindcss/typography')],
```
Since then those classes have been undefined, so the overlays pop in/out with no transition.

## The fix
Re-add the utilities the **Tailwind-v4-native** way: `@import 'tw-animate-css'` in `styles/globals.css` (the maintained v4 successor to `tailwindcss-animate`). This restores the animations **and** clears the dead-class lint warnings, because the oxlint Tailwind plugin resolves classes from the CSS entrypoint.

## Result
- `documentation` `no-unknown-classes`: **48 → 10**. The remaining 10 are unrelated: 4 custom `animate-fadeIn/scaleIn/…` in SharedNav/Menu that reference keyframes never defined in the theme, plus a few legacy/ambiguous token classes.
- No changeset (documentation is a private/ignored app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)