### PR TITLE
fix(family-pedigree): keep sibships together, tighten couples, stop spurious connector dimming

### DIFF
--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/fixtures.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/fixtures.ts
@@ -220,3 +220,19 @@ export const crossFamily: PedigreeInput = {
     { partnerIndex1: 4, partnerIndex2: 5, isActive: true },
   ],
 };
+
+/**
+ * A remarried parent who ALSO has a sibling shown. Grandparents (0,1) have two
+ * children Mom(2) and Aunt(3); Mom is partnered to Dad(5, ex) and StepDad(6),
+ * and Ego(4) descends from Mom+Dad. Mom is a multi-marriage anchor AND a member
+ * of a sibship, so she must sit BETWEEN her two spouses — both marriage lines
+ * must stay contiguous.
+ */
+export const remarriedParentWithSibling: PedigreeInput = {
+  id: ['gp1', 'gp2', 'mom', 'aunt', 'ego', 'dad', 'stepDad'],
+  parents: [[], [], [sp(0), sp(1)], [sp(0), sp(1)], [sp(2), sp(5)], [], []],
+  partners: [
+    { partnerIndex1: 2, partnerIndex2: 5, isActive: false },
+    { partnerIndex1: 2, partnerIndex2: 6, isActive: true },
+  ],
+};

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/sugiyamaLayout.test.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/__tests__/sugiyamaLayout.test.ts
@@ -10,6 +10,7 @@ import {
   consanguineousUnion,
   multipleMarriages,
   nuclearFamily,
+  remarriedParentWithSibling,
   singleParent,
   surrogacyFamily,
   threeGeneration,
@@ -145,6 +146,25 @@ describe('minimizeCrossings', () => {
       positions.sort((a, b) => a - b);
 
       // All members must be at consecutive positions
+      for (let i = 1; i < positions.length; i++) {
+        expect(positions[i]! - positions[i - 1]!).toBe(1);
+      }
+    }
+  });
+
+  it('keeps both marriages of a remarried sibling contiguous', () => {
+    // A sibling who anchors two marriages must sit between her spouses; a
+    // grouping that pushes both spouses to one side leaves the far spouse
+    // non-adjacent and silently drops that marriage line.
+    const graph = buildPedigreeGraph(remarriedParentWithSibling);
+    const ordering = minimizeCrossings(graph);
+
+    for (const pg of graph.partnerGroups) {
+      const layer = graph.layers[pg.members[0]!]!;
+      const layerOrdering = ordering[layer]!;
+      const positions = pg.members
+        .map((m) => layerOrdering.indexOf(m))
+        .toSorted((a, b) => a - b);
       for (let i = 1; i < positions.length; i++) {
         expect(positions[i]! - positions[i - 1]!).toBe(1);
       }

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/sugiyamaLayout.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/sugiyamaLayout.ts
@@ -287,34 +287,91 @@ function getParentsOf(node: number, graph: PedigreeGraph): number[] {
 function buildConstraintBlocks(
   nodesOnLayer: number[],
   graph: PedigreeGraph,
-  layer: number,
 ): ConstraintBlock[] {
   const nodeSet = new Set(nodesOnLayer);
   const assigned = new Set<number>();
   const blocks: ConstraintBlock[] = [];
 
-  // Multi-partner merging: find anchor nodes shared across partner groups
-  const nodeToPartnerGroups = new Map<number, number[]>();
-  for (let gi = 0; gi < graph.partnerGroups.length; gi++) {
-    const pg = graph.partnerGroups[gi]!;
+  // Sibships with ≥2 members present on this layer. Their members are kept
+  // together as one block EVEN WHEN they are partnered — otherwise each married
+  // sibling drifts toward its own spouse's barycenter and the sibship is torn
+  // apart (e.g. two married siblings ending up at opposite ends of the row).
+  const realSibships = graph.siblingGroups
+    .map((sg) => sg.members.filter((m) => nodeSet.has(m)))
+    .filter((members) => members.length > 1);
+  const inRealSibship = new Set<number>();
+  for (const members of realSibships) {
+    for (const m of members) inRealSibship.add(m);
+  }
+
+  // Spouses present on this layer, per node (from partner groups fully on-layer).
+  const spousesOf = new Map<number, number[]>();
+  for (const pg of graph.partnerGroups) {
     if (!pg.members.every((m) => nodeSet.has(m))) continue;
     for (const m of pg.members) {
+      const existing = spousesOf.get(m) ?? [];
+      existing.push(...pg.members.filter((x) => x !== m));
+      spousesOf.set(m, existing);
+    }
+  }
+
+  // A spouse can be attached to a sibling's sibship block only when the spouse
+  // is not itself holding another sibship together (i.e. is not in a real
+  // sibship on this layer). When both spouses have siblings shown (two sibships
+  // intermarry) the couple becomes an inter-block link — the only arrangement
+  // that keeps BOTH sibships contiguous.
+  const attachableSpouses = (sibling: number): number[] =>
+    (spousesOf.get(sibling) ?? []).filter(
+      (sp) => !inRealSibship.has(sp) && !assigned.has(sp),
+    );
+
+  // 1. One block per real sibship: siblings in index order, with each married
+  //    sibling's attachable spouse beside it — the leftmost sibling's spouse to
+  //    its left, later siblings' spouses to their right — so couples stay
+  //    adjacent while the sibship stays contiguous.
+  for (const members of realSibships) {
+    const siblings = members.toSorted((a, b) => a - b);
+    const ordered: number[] = [];
+    siblings.forEach((sib, idx) => {
+      const spouses = attachableSpouses(sib).toSorted((a, b) => a - b);
+      if (idx === 0) {
+        ordered.push(...spouses, sib);
+      } else {
+        ordered.push(sib, ...spouses);
+      }
+      assigned.add(sib);
+      for (const sp of spouses) assigned.add(sp);
+    });
+    blocks.push({ nodes: ordered, barycenter: 0 });
+  }
+
+  // 2. Partner blocks for the remaining couples — those where neither partner is
+  //    in a real sibship (e.g. a consanguineous cousin union, both only-children)
+  //    — reusing the anchor-merge so a person with multiple partners sits between
+  //    them. Only partner groups whose members are all still unassigned qualify.
+  const eligible = new Set<number>();
+  for (let gi = 0; gi < graph.partnerGroups.length; gi++) {
+    const pg = graph.partnerGroups[gi]!;
+    if (!pg.members.every((m) => nodeSet.has(m) && !assigned.has(m))) continue;
+    eligible.add(gi);
+  }
+
+  const nodeToPartnerGroups = new Map<number, number[]>();
+  for (const gi of eligible) {
+    for (const m of graph.partnerGroups[gi]!.members) {
       const existing = nodeToPartnerGroups.get(m) ?? [];
       existing.push(gi);
       nodeToPartnerGroups.set(m, existing);
     }
   }
 
-  // Find partner groups that share an anchor and merge them
   const groupUnion = new Map<number, Set<number>>(); // groupIdx -> merged members
   const mergedInto = new Map<number, number>(); // groupIdx -> canonical groupIdx
 
-  for (let gi = 0; gi < graph.partnerGroups.length; gi++) {
-    const pg = graph.partnerGroups[gi]!;
-    if (!pg.members.every((m) => nodeSet.has(m))) continue;
+  for (const gi of eligible) {
     if (mergedInto.has(gi)) continue;
 
-    const merged = new Set(pg.members);
+    const merged = new Set(graph.partnerGroups[gi]!.members);
     const toProcess = [gi];
     const visited = new Set<number>([gi]);
 
@@ -327,7 +384,6 @@ function buildConstraintBlocks(
           if (visited.has(otherGi)) continue;
           visited.add(otherGi);
           const otherPg = graph.partnerGroups[otherGi]!;
-          if (!otherPg.members.every((om) => nodeSet.has(om))) continue;
           for (const om of otherPg.members) merged.add(om);
           mergedInto.set(otherGi, gi);
           toProcess.push(otherGi);
@@ -338,7 +394,6 @@ function buildConstraintBlocks(
     groupUnion.set(gi, merged);
   }
 
-  // Build partner blocks from merged groups
   for (const [, members] of groupUnion) {
     const blockNodes = [...members].toSorted((a, b) => a - b);
     // Order anchor (shared node) between its partners
@@ -348,7 +403,6 @@ function buildConstraintBlocks(
     if (anchors.length === 1) {
       const anchor = anchors[0]!;
       const others = blockNodes.filter((n) => n !== anchor);
-      // Place anchor in the middle
       const half = Math.floor(others.length / 2);
       const ordered = [...others.slice(0, half), anchor, ...others.slice(half)];
       for (const n of ordered) assigned.add(n);
@@ -359,19 +413,7 @@ function buildConstraintBlocks(
     }
   }
 
-  // Sibling group blocks (only for nodes not already in a partner block on this layer)
-  for (const sg of graph.siblingGroups) {
-    const membersOnLayer = sg.members.filter(
-      (m) => graph.layers[m] === layer && !assigned.has(m),
-    );
-    if (membersOnLayer.length > 1) {
-      const sorted = membersOnLayer.toSorted((a, b) => a - b);
-      for (const n of sorted) assigned.add(n);
-      blocks.push({ nodes: sorted, barycenter: 0 });
-    }
-  }
-
-  // Singleton blocks for remaining nodes
+  // 3. Singleton blocks for remaining nodes.
   for (const node of nodesOnLayer) {
     if (!assigned.has(node)) {
       blocks.push({ nodes: [node], barycenter: 0 });
@@ -496,9 +538,7 @@ function barycentricSweep(
       }
 
       const currentLayer = result[k]!;
-      const layerIdx =
-        currentLayer.length > 0 ? graph.layers[currentLayer[0]!]! : k;
-      const blocks = buildConstraintBlocks(currentLayer, graph, layerIdx);
+      const blocks = buildConstraintBlocks(currentLayer, graph);
 
       // Compute barycenters
       for (const block of blocks) {
@@ -539,9 +579,7 @@ function barycentricSweep(
       }
 
       const currentLayer = result[k]!;
-      const layerIdx =
-        currentLayer.length > 0 ? graph.layers[currentLayer[0]!]! : k;
-      const blocks = buildConstraintBlocks(currentLayer, graph, layerIdx);
+      const blocks = buildConstraintBlocks(currentLayer, graph);
 
       for (const block of blocks) {
         let totalBarycenter = 0;
@@ -582,7 +620,7 @@ function minimizeCrossings(graph: PedigreeGraph): number[][] {
   const ordering: number[][] = [];
   for (let layer = 0; layer <= maxLayer; layer++) {
     const nodesOnLayer = getNodesAtLayer(graph, layer);
-    const blocks = buildConstraintBlocks(nodesOnLayer, graph, layer);
+    const blocks = buildConstraintBlocks(nodesOnLayer, graph);
     ordering.push(blocks.flatMap((b) => b.nodes));
   }
 
@@ -752,6 +790,27 @@ function encodePedigreeLayout(
         }
         break;
       }
+    }
+
+    // Pull each two-person couple whose members already sit at consecutive
+    // columns to be adjacent around their shared midpoint. Centering each
+    // partner under its own parents (above) otherwise leaves a couple where BOTH
+    // partners have parents — e.g. a consanguineous cousin union — spread apart
+    // when those parents are far from each other. The midpoint is preserved so
+    // the couple still sits over the descent to their children.
+    for (const pg of graph.partnerGroups) {
+      if (pg.members.length !== 2) continue;
+      const cols = pg.members
+        .map((m) => {
+          const loc = nodeLocation.get(m);
+          return loc?.layer === layer ? loc.col : -1;
+        })
+        .filter((c) => c >= 0)
+        .toSorted((a, b) => a - b);
+      if (cols.length !== 2 || cols[1]! - cols[0]! !== 1) continue;
+      const mid = (ideal[cols[0]!]! + ideal[cols[1]!]!) / 2;
+      ideal[cols[0]!] = mid - 0.5;
+      ideal[cols[1]!] = mid + 0.5;
     }
 
     // Resolve overlaps: left-to-right sweep enforcing min gap of 1

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/sugiyamaLayout.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/sugiyamaLayout.ts
@@ -326,21 +326,27 @@ function buildConstraintBlocks(
     );
 
   // 1. One block per real sibship: siblings in index order, with each married
-  //    sibling's attachable spouse beside it — the leftmost sibling's spouse to
-  //    its left, later siblings' spouses to their right — so couples stay
-  //    adjacent while the sibship stays contiguous.
+  //    sibling's attachable spouse(s) beside it so couples stay adjacent while
+  //    the sibship stays contiguous. A sibling that anchors TWO OR MORE marriages
+  //    must sit BETWEEN its spouses — pushing them all to one side would leave a
+  //    spouse non-adjacent and silently drop that marriage line. A single spouse
+  //    goes on the outer side (the leftmost sibling's to its left, later siblings'
+  //    to their right) to keep the block compact.
   for (const members of realSibships) {
     const siblings = members.toSorted((a, b) => a - b);
     const ordered: number[] = [];
     siblings.forEach((sib, idx) => {
       const spouses = attachableSpouses(sib).toSorted((a, b) => a - b);
-      if (idx === 0) {
+      assigned.add(sib);
+      for (const sp of spouses) assigned.add(sp);
+      if (spouses.length >= 2) {
+        const half = Math.floor(spouses.length / 2);
+        ordered.push(...spouses.slice(0, half), sib, ...spouses.slice(half));
+      } else if (idx === 0) {
         ordered.push(...spouses, sib);
       } else {
         ordered.push(sib, ...spouses);
       }
-      assigned.add(sib);
-      for (const sp of spouses) assigned.add(sp);
     });
     blocks.push({ nodes: ordered, barycenter: 0 });
   }

--- a/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/__tests__/NarrativePedigreeView.test.tsx
@@ -889,3 +889,88 @@ describe('NarrativePedigreeView — affected nodes omit the contradictory homozy
     expect(kid).not.toHaveAccessibleDescription(/homozygous/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// No-focal dimming. When no focal node is selected, NOTHING should be dimmed —
+// including a couple connector where one partner is a SOCIAL/gestational parent
+// (no genetic edge). Before the fix, the couple-bar splitter ran in the
+// "everything highlighted" state and dimmed that partner's half of the bar.
+// The view now passes no highlight sets when there is no focal node.
+// ---------------------------------------------------------------------------
+describe('NarrativePedigreeView — no dimming without a focal node', () => {
+  const SRC_SOCIAL = 'source-fp-social';
+
+  it('does not dim a social parent’s couple connector when nothing is focused', async () => {
+    const socialSource = { ...sourceStage, id: SRC_SOCIAL };
+    // Social mother + biological father → child. The mother's link to the child
+    // is a non-genetic `social` edge, so she has no genetic parent→child edge.
+    const socialNodes: NcNode[] = [
+      makeNode('socialMum', { [NAME_VAR]: 'Mum', [BIO_SEX_VAR]: 'female' }),
+      makeNode('bioDad', { [NAME_VAR]: 'Dad', [BIO_SEX_VAR]: 'male' }),
+      makeNode('kid', {
+        [NAME_VAR]: 'Kid',
+        [EGO_VAR]: true,
+        [BIO_SEX_VAR]: 'male',
+      }),
+    ];
+    const socialEdges: NcEdge[] = [
+      makeCEdge('socialMum', 'kid', ['social']),
+      makeCEdge('bioDad', 'kid', ['biological']),
+      makeCEdge('socialMum', 'bioDad', ['partner']),
+    ];
+    const stage: NarrativeStage = {
+      id: 'np-social',
+      type: 'NarrativePedigree',
+      label: 'Social Parent Pedigree',
+      sourceStageId: SRC_SOCIAL,
+      showAtRiskStatuses: false,
+      diseases: [
+        {
+          id: 'da',
+          label: 'Disease A',
+          color: '#ff0000',
+          variable: asEntityAttributeReference(DISEASE_A_VAR),
+          inheritancePattern: 'autosomalDominant',
+        },
+      ],
+    };
+    const store = configureStore({
+      reducer: { protocol, session },
+      preloadedState: {
+        protocol: {
+          codebook,
+          stages: [socialSource, stage],
+          assets: [],
+        } as never,
+        session: {
+          id: 'social-session',
+          network: {
+            nodes: socialNodes,
+            edges: socialEdges,
+            ego: { [entityAttributesProperty]: {} },
+          },
+          stageMetadata: {},
+        } as never,
+      },
+      middleware: (g) => g({ serializableCheck: false }),
+    });
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <Provider store={store}>
+          <CurrentStepProvider currentStep={1} onStepChange={() => undefined}>
+            {children}
+          </CurrentStepProvider>
+        </Provider>
+      );
+    }
+    render(<NarrativePedigreeView stage={stage} />, { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-pedigree-member]')).toBeTruthy(),
+    );
+
+    // No focal node is selected → no edge anywhere may be dimmed.
+    const view = document.querySelector('[data-narrative-pedigree-view]');
+    expect(view?.querySelectorAll('[data-edge-dimmed]').length).toBe(0);
+  });
+});

--- a/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
+++ b/packages/interview/src/interfaces/NarrativePedigree/components/NarrativePedigreeView.tsx
@@ -605,8 +605,8 @@ export default function NarrativePedigreeView({
           nodeWidth={nodeWidth}
           nodeHeight={nodeHeight}
           renderNode={renderNode}
-          highlightedNodeIds={highlight.nodes}
-          highlightedEdgeKeys={highlight.edges}
+          highlightedNodeIds={focalId !== null ? highlight.nodes : undefined}
+          highlightedEdgeKeys={focalId !== null ? highlight.edges : undefined}
           glyphColour={snapshotGlyphColour}
           keyShape="circle"
           showAtRiskStatuses={showAtRiskStatuses}
@@ -683,8 +683,12 @@ export default function NarrativePedigreeView({
               nodeWidth={nodeWidth}
               nodeHeight={nodeHeight}
               renderNode={renderNode}
-              highlightedNodeIds={highlight.nodes}
-              highlightedEdgeKeys={highlight.edges}
+              highlightedNodeIds={
+                focalId !== null ? highlight.nodes : undefined
+              }
+              highlightedEdgeKeys={
+                focalId !== null ? highlight.edges : undefined
+              }
             />
           </div>
           {focalId !== null && (


### PR DESCRIPTION
Three self-contained layout-engine fixes surfaced while reviewing the NarrativePedigree storybook (#849). The WIP recursive-layout port these build toward is tracked separately in #862.

## Fixes

1. **Sibships stay together** — `buildConstraintBlocks` now groups a sibship into one block *even when its members are married*, attaching each married sibling's spouse beside them. Previously partner blocks were built first and partnered siblings were excluded from their sibling block, so two married siblings drifted to opposite ends of the row following their spouses' barycenters (ego ended up far from her sibling).
2. **Tight couples** — the encoder pulls a column-adjacent couple to its shared midpoint, so a couple where *both* partners have parents (a consanguineous cousin union) is no longer centred apart under its separated parents.
3. **No spurious dimming** — `NarrativePedigreeView` passes *no* highlight sets when there's no focal node selected, fixing a `social`/gestational parent's couple connector rendering dimmed with nothing focused (the couple-bar splitter keys off a genetic edge a social parent lacks).

## Testing / impact

- 211 structural layout unit tests pass.
- **No e2e visual baseline change**: the interview e2e protocol contains no FamilyPedigree stage, so these ordering/rendering changes touch nothing the visual snapshots cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)