### PR TITLE
fix: resolve build and test configuration warnings across the monorepo

### DIFF
--- a/apps/architect-classic/electron.vite.config.js
+++ b/apps/architect-classic/electron.vite.config.js
@@ -110,10 +110,6 @@ export default defineConfig({
         '@utils': resolve(__dirname, 'src/utils'),
       },
     },
-    esbuild: {
-      jsx: 'automatic',
-      jsxImportSource: 'react',
-    },
     optimizeDeps: {
       // Pre-bundle the CommonJS protocol-validation sub-paths used by the
       // renderer so Vite resolves their CJS->ESM interop without a mid-session
@@ -122,8 +118,8 @@ export default defineConfig({
         'protocol-validation/migrations/getMigrationNotes',
         'protocol-validation/validation/validateExternalData',
       ],
-      esbuildOptions: {
-        loader: {
+      rolldownOptions: {
+        moduleTypes: {
           '.js': 'jsx',
         },
       },
@@ -137,7 +133,6 @@ export default defineConfig({
             'global-builtin',
             'legacy-js-api',
             'color-functions',
-            'mixed-decls',
             'slash-div',
             'if-function',
           ],

--- a/apps/architect-classic/src/components/sections/CategoricalBinPrompts/PromptFields.jsx
+++ b/apps/architect-classic/src/components/sections/CategoricalBinPrompts/PromptFields.jsx
@@ -194,6 +194,7 @@ const selectOptionProps = PropTypes.shape({
   label: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.array,
     PropTypes.bool,
   ]),

--- a/apps/architect-classic/src/components/sections/OneToManyDyadCensus/PromptFields.jsx
+++ b/apps/architect-classic/src/components/sections/OneToManyDyadCensus/PromptFields.jsx
@@ -104,6 +104,7 @@ const selectOptionProps = PropTypes.shape({
   label: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.array,
     PropTypes.bool,
   ]),

--- a/apps/architect-classic/src/components/sections/TieStrengthCensusPrompts/PromptFields.jsx
+++ b/apps/architect-classic/src/components/sections/TieStrengthCensusPrompts/PromptFields.jsx
@@ -203,6 +203,7 @@ const selectOptionProps = PropTypes.shape({
   label: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.string,
+    PropTypes.number,
     PropTypes.array,
     PropTypes.bool,
   ]),

--- a/apps/architect/src/utils/fileLaunchQueue.ts
+++ b/apps/architect/src/utils/fileLaunchQueue.ts
@@ -6,6 +6,9 @@
 // Safari and Firefox never define window.launchQueue; everything here is a
 // silent no-op there.
 
+import { generalErrorDialog } from '~/ducks/modules/userActions/dialogs';
+import { store } from '~/ducks/store';
+
 let pendingFiles: File[] = [];
 const listeners = new Set<() => void>();
 let initialized = false;
@@ -14,25 +17,15 @@ const emit = () => {
   for (const listener of listeners) listener();
 };
 
-// Surface a user-facing error when the OS hands us handles we can't read. The
-// store and dialog action are imported lazily so this pre-React capture module
-// stays decoupled from the app graph until a failure actually occurs.
-const reportLaunchReadFailure = async (failedCount: number): Promise<void> => {
-  try {
-    const [{ store }, { generalErrorDialog }] = await Promise.all([
-      import('~/ducks/store'),
-      import('~/ducks/modules/userActions/dialogs'),
-    ]);
-    const noun = failedCount === 1 ? 'file' : 'files';
-    void store.dispatch(
-      generalErrorDialog(
-        'Could not open file',
-        `${failedCount} launched ${noun} could not be read. The ${noun} may have been moved, deleted, or become unavailable since ${failedCount === 1 ? 'it was' : 'they were'} opened.`,
-      ),
-    );
-  } catch (error) {
-    console.error('Failed to report launched-file read failure', error);
-  }
+// Surface a user-facing error when the OS hands us handles we can't read.
+const reportLaunchReadFailure = (failedCount: number): void => {
+  const noun = failedCount === 1 ? 'file' : 'files';
+  void store.dispatch(
+    generalErrorDialog(
+      'Could not open file',
+      `${failedCount} launched ${noun} could not be read. The ${noun} may have been moved, deleted, or become unavailable since ${failedCount === 1 ? 'it was' : 'they were'} opened.`,
+    ),
+  );
 };
 
 export const initFileLaunchCapture = (): void => {
@@ -61,7 +54,7 @@ export const initFileLaunchCapture = (): void => {
         for (const failure of failures) {
           console.error('Failed to read launched file', failure.reason);
         }
-        void reportLaunchReadFailure(failures.length);
+        reportLaunchReadFailure(failures.length);
       }
 
       const netcanvas = files.filter((file) =>

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -176,5 +176,11 @@ export default defineConfig({
     testTimeout: 20_000,
     setupFiles: ['./src/test-setup.ts'],
     exclude: ['**/node_modules/**', '**/dist/**'],
+    // Honour the app's own analytics gate (analytics.ts) so PostHog doesn't
+    // init a real client (in debug mode) against the production host during
+    // unit tests, spamming stderr with config dumps and $pageview payloads.
+    env: {
+      VITE_DISABLE_ANALYTICS: 'true',
+    },
   },
 });

--- a/apps/documentation/next.config.ts
+++ b/apps/documentation/next.config.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import NextBundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 import createNextIntl from 'next-intl/plugin';
@@ -15,6 +17,9 @@ const isProduction =
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
+  // Pin the workspace root: in a git worktree Next otherwise detects the parent
+  // checkout's pnpm-workspace.yaml and infers the wrong root.
+  turbopack: { root: join(import.meta.dirname, '..', '..') },
   // Ships untranspiled TSX + assets referenced via new URL(..., import.meta.url)
   transpilePackages: ['@codaco/interface-images'],
   images: {

--- a/apps/interviewer-classic/vite.renderer.shared.js
+++ b/apps/interviewer-classic/vite.renderer.shared.js
@@ -44,7 +44,6 @@ export const sharedRendererConfig = {
           'global-builtin',
           'legacy-js-api',
           'color-functions',
-          'mixed-decls',
           'slash-div',
           'if-function',
         ],

--- a/apps/networkcanvas.com/next.config.ts
+++ b/apps/networkcanvas.com/next.config.ts
@@ -1,8 +1,13 @@
+import { join } from 'node:path';
+
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
+  // Pin the workspace root: in a git worktree Next otherwise detects the parent
+  // checkout's pnpm-workspace.yaml and infers the wrong root.
+  turbopack: { root: join(import.meta.dirname, '..', '..') },
   images: {
     unoptimized: true,
   },

--- a/packages/fresco-ui/vite.config.ts
+++ b/packages/fresco-ui/vite.config.ts
@@ -71,6 +71,11 @@ export default defineConfig({
           [
             'src/**/*.{ts,tsx}',
             '!src/**/*.{stories,test,spec}.{ts,tsx}',
+            // Story-only helpers (e.g. sliderTestHelpers) import `storybook/test`,
+            // which isn't externalized, so shipping them as entries inlines the
+            // whole test runtime (~874 kB) into dist. They're never imported from
+            // dist — only by *.stories.tsx, which resolve them from src.
+            '!src/**/*TestHelpers.{ts,tsx}',
             '!src/**/__tests__/**',
           ],
           { cwd: here, absolute: true },
@@ -103,6 +108,7 @@ export default defineConfig({
           '**/*.stories.tsx',
           '**/*.test.*',
           '**/*.spec.*',
+          '**/*TestHelpers.*',
           '**/__tests__/**',
         ],
         // Strip the `src/` prefix so dts outputs land alongside the JS in `dist/`.

--- a/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/snapshot.test.ts
+++ b/packages/interview/src/interfaces/NarrativePedigree/export/__tests__/snapshot.test.ts
@@ -22,7 +22,9 @@ describe('exportSnapshot', () => {
     const originalAppend = document.body.appendChild.bind(document.body);
     vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
       if (node instanceof HTMLAnchorElement) {
-        vi.spyOn(node, 'click');
+        // No-op impl: without it the spy calls through and jsdom logs
+        // "Not implemented: navigation to another Document" for the download click.
+        vi.spyOn(node, 'click').mockImplementation(() => {});
         appendedAnchors.push(node);
       }
       return originalAppend(node);

--- a/packages/network-exporters/src/session/generateOutputFiles.ts
+++ b/packages/network-exporters/src/session/generateOutputFiles.ts
@@ -1,3 +1,5 @@
+import type * as NodeOs from 'node:os';
+
 import { Effect, Queue, Ref } from 'effect';
 import { invariant } from 'es-toolkit';
 
@@ -11,14 +13,20 @@ import { getFilePrefix } from '../utils/general';
 import exportFile, { type GenerationResult } from './exportFile';
 import { partitionByType } from './partitionByType';
 
-// Lazy node:os import keeps the module browser-bundleable; the dynamic import
-// is tree-shaken/skipped when navigator.hardwareConcurrency is available.
+// node:os sits behind a runtime-assembled specifier so browser bundlers
+// (interviewer / interviewer-classic re-bundling dist/pipeline.js) don't try to
+// resolve it and emit an "externalized for browser compatibility" warning. This
+// Node-only branch is unreachable in the browser, which always takes the
+// navigator.hardwareConcurrency path above.
+const loadNodeOs = (): Promise<typeof NodeOs> =>
+  import(['node', 'os'].join(':'));
+
 const getDefaultConcurrency = async (): Promise<number> => {
   if (typeof navigator !== 'undefined' && 'hardwareConcurrency' in navigator) {
     return navigator.hardwareConcurrency;
   }
   if (typeof globalThis.process !== 'undefined') {
-    const os = await import('node:os');
+    const os = await loadNodeOs();
     return os.cpus().length;
   }
   return 4;


### PR DESCRIPTION
## What

Clears fixable **configuration** warnings surfaced by `turbo run build` and `turbo run test`. Each was traced to its root cause in the real config/source and fixed minimally. Lint warnings are out of scope (handled separately).

### Build warnings fixed
- **architect-classic** — migrate deprecated `optimizeDeps.esbuildOptions` → `rolldownOptions.moduleTypes`; delete the dead top-level `esbuild.jsx` block (Vite 8/oxc + `@vitejs/plugin-react` babel already do the JSX transform, so it was ignored).
- **architect-classic + interviewer-classic** — drop the obsolete `mixed-decls` entry from Sass `silenceDeprecations` (retired in Sass 1.92; on 1.100 it emits an "obsolete" warning).
- **network-exporters** — hide `node:os` behind a runtime-assembled specifier so `interviewer`/`interviewer-classic` stop emitting *"Module node:os has been externalized for browser compatibility"*. Node/CLI behaviour is byte-for-byte unchanged; the branch is unreachable in browsers (`navigator.hardwareConcurrency` is taken first).
- **documentation + networkcanvas.com** — set `turbopack.root` so Next stops inferring the wrong workspace root inside a git worktree (*"inferred your workspace root, but it may not be correct"*).
- **architect** — convert `fileLaunchQueue`'s dynamic `import()` of `store`/`dialogs` to static imports (both are already statically reachable from `main.tsx`, so there's no cycle and no code-splitting benefit), clearing `INEFFECTIVE_DYNAMIC_IMPORT`.
- **fresco-ui** — exclude `*TestHelpers` from the dist entry glob so the 874 kB (169 kB gzip) storybook-only `sliderTestHelpers` stops shipping in the published tarball (nothing imports it from `dist`).

### Test warnings fixed
- **architect** — set `VITE_DISABLE_ANALYTICS` in the vitest env so PostHog no longer initialises a real client (in debug mode, against the production host) during unit tests, spamming stderr with config dumps and a `$pageview`.
- **interview** — give the NarrativePedigree snapshot test's `click` spy a no-op impl so jsdom stops logging *"Not implemented: navigation to another Document"* on the download anchor.
- **architect-classic** — add `PropTypes.number` to the `PromptFields` option-value shape (the schema allows integer option values; fixes a real *Failed prop type* warning).

## Verification
`turbo run build`, `turbo run test`, `turbo run typecheck` (22/22) and `knip` all pass. A fresh forced build+test confirms every targeted warning above is gone, and the intentionally-left items (chunk-size advisories, `PLUGIN_TIMINGS`, legacy React-16 deprecations in the `*-classic` apps) are unchanged.

## Not included / tracked separately
- **@codaco/interview React `act(...)` log noise** (~100 lines, dominated by `PedigreeView.test.tsx`): Base UI's menu/tooltip transitions schedule rAF-driven state updates that flush during `@testing-library`'s async `userEvent` waits (where it disables the act environment) — a known third-party false-positive (cf. Radix, Headless UI). Investigated thoroughly; there is no clean setup-level fix (`IS_REACT_ACT_ENVIRONMENT` and Base UI's `BASE_UI_ANIMATIONS_DISABLED` are no-ops here; a synchronous rAF breaks the menus). Left for a separate, dedicated change (arguably an upstream Base UI gap — its animations-disabled flag doesn't cover the menu/tooltip rAF path).

## Changeset
None — every change is build-config, test-config, an internal refactor, or a dev-warning cleanup; none is consumer- or participant-visible in a released package or app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)