### PR TITLE
feat(fresco-ui, interviewer): glass controls, Tabs component, tablet-portrait UI

### DIFF
--- a/.changeset/glass-controls-and-tabs.md
+++ b/.changeset/glass-controls-and-tabs.md
@@ -1,0 +1,12 @@
+---
+'@codaco/fresco-ui': minor
+'@codaco/tailwind-config': minor
+---
+
+Add a compound `Tabs` component (Base UI-backed vertical tabs: import `Tabs` and `TabsPanel`; the rail is driven by a `tabs` array and renders its own active indicator).
+
+Add a reusable "glass" control treatment — a new `control-glass` utility and `--control-border-width` token in the Tailwind config — exposed as a Button `glass` variant and a `SegmentedSwitcher` `variant` prop (`'outline'` default, `'glass'` opt-in). `SegmentedSwitcher` now defaults to an outline-button treatment, gains an `xl` size, and has its outer height and active-pill radius harmonised with Button.
+
+`BaseField`'s inline layout is now driven by a container query rather than a viewport breakpoint, and `Table`'s `bodyScroll` region suppresses overscroll chaining (no rubber-band).
+
+`InputField` now applies the caller's `className` to the field wrapper only, not to the inner `<input>` — so a background/backdrop passed to the field no longer double-applies onto the input.

--- a/.changeset/interviewer-tablet-portrait-ui.md
+++ b/.changeset/interviewer-tablet-portrait-ui.md
@@ -1,0 +1,12 @@
+---
+'@codaco/interviewer': minor
+---
+
+Refine the start and data screens on tablet, especially in portrait:
+
+- Harmonise the top-bar view switcher, settings and lock buttons, and the protocol deck's navigation into one consistent translucent "glass" style.
+- Fix the "resume last interview" pill overlapping the view switcher and the protocol cards in portrait.
+- Reduce the page margins on smaller tablets in portrait so content has more room.
+- Widen the settings dialog and let its sections reflow responsively; the settings navigation now uses a tabbed layout.
+- Stop the data table's rubber-band overscroll, and give the data search field and status filter the same glass treatment.
+- Fix a Chrome-only issue where the import-protocol card's background blur did not render.

--- a/.claude/skills/developing-in-network-canvas/SKILL.md
+++ b/.claude/skills/developing-in-network-canvas/SKILL.md
@@ -69,6 +69,21 @@ Apply the Step 1 ladder to components: new UI is **assembled from `@codaco/fresc
 
 If you must build a new component, it is **founded on a Base-UI primitive** and mirrors the closest fresco-ui component's patterns (prop shape, variants, token usage) — never raw `div`s + click handlers.
 
+### Building a new shared component
+
+When the reuse ladder bottoms out and you add a new `@codaco/fresco-ui` component:
+
+- **Mirror the existing export style.** Compound components are **named exports from one file** (see `DropdownMenu`), named after the underlying Base-UI parts (`Tabs`, `TabsList`, `TabsTab`, `TabsPanel`, `TabsIndicator`) — not a barrel, not a `.`-namespace. Add the subpath to `packages/fresco-ui/package.json` `exports`, and rebuild the package (`pnpm --filter @codaco/fresco-ui build`) before a consuming app's typecheck will see it — apps resolve fresco-ui from `dist`, not `src`.
+- **Size with container queries, never viewport breakpoints.** A shared component doesn't know the viewport, only its container — key responsive layout off `@container` + `@min-[…]`, and make the component (or the relevant part) an `@container` so its own descendants can query it. Give size-flexible parts a floor **and** a cap that _both_ step up across breakpoints, so the part gains presence as its container grows and only wraps/clips once content exceeds the cap (e.g. a rail that is `w-fit` between a per-breakpoint `min-w`/`max-w`).
+- **Never fix a height/size that clips content.** Let content flow; a fixed `h-*`/`max-w` that cuts off items or wraps a label unexpectedly is a bug, not a constraint.
+
+**Write a Storybook story that documents, not just renders** (co-located `*.stories.tsx`, `tags: ['autodocs']`):
+
+- **Render the component bare.** No decorative wrapper (card, padding, background, fixed frame) that isn't part of the component — it misrepresents the API and hides real behaviour. Drive size/context through the component's own props (`style`, `className`), not an outer `<div>`.
+- **Document composition and props, not just appearance.** Put a real composition example (imports + the full nesting) and a per-part props list in `parameters.docs.description.component`; expose the meaningful variations as **controls** (`argTypes`) — toggle icons, swap label length, vary width — so the reader learns how to _use_ it.
+- **Cover the edge cases as preset stories** — long/overflowing labels, the narrowest and widest sizes, the icon-less variant. If it can wrap or clip, show it doing so.
+- Keep helpers **un-exported** — a non-story export from a `*.stories.tsx` becomes a broken auto-story.
+
 ### Accessibility
 
 Two hard requirements for every interactive component, no exceptions: it is **fully keyboard operable**, and it **announces state changes to screen readers**. The library makes both the path of least resistance — use it rather than reinventing.
@@ -103,16 +118,18 @@ Two hard requirements for every interactive component, no exceptions: it is **fu
 
 ## Common mistakes
 
-| Mistake                                                        | Do instead                                                                             |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Writing a new util/component without checking what exists      | Walk the reuse ladder; search the relevant `packages/*` first.                         |
-| Wrapping `Field`/`Paragraph` in `flex-col gap-*` / `space-y-*` | They carry their own bottom margin — you'll double the spacing. Let them flow.         |
-| Hand-rolling a confirm/alert modal                             | `useDialog().confirm({ title, description, confirmLabel, onConfirm })`.                |
-| Building a widget from raw `div`s + `onClick`                  | Found it on the matching Base-UI primitive — keyboard handling and ARIA come for free. |
-| Hardcoded colours / shadows / font px                          | Token utilities (`bg-*`, `text-*`, `elevation-*`, `text-lg`).                          |
-| Showing "node"/"alter"/"stage" to participants                 | Protocol label or plain word.                                                          |
-| Drag with no keyboard equivalent                               | Add arrow-key/Enter-Space handling + an `aria-live` announcement.                      |
-| Concatenating sentence fragments for a message                 | Keep whole, externalisable strings so it can localise later.                           |
+| Mistake                                                                               | Do instead                                                                                                           |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Writing a new util/component without checking what exists                             | Walk the reuse ladder; search the relevant `packages/*` first.                                                       |
+| Wrapping `Field`/`Paragraph` in `flex-col gap-*` / `space-y-*`                        | They carry their own bottom margin — you'll double the spacing. Let them flow.                                       |
+| Hand-rolling a confirm/alert modal                                                    | `useDialog().confirm({ title, description, confirmLabel, onConfirm })`.                                              |
+| Building a widget from raw `div`s + `onClick`                                         | Found it on the matching Base-UI primitive — keyboard handling and ARIA come for free.                               |
+| Hardcoded colours / shadows / font px                                                 | Token utilities (`bg-*`, `text-*`, `elevation-*`, `text-lg`).                                                        |
+| Showing "node"/"alter"/"stage" to participants                                        | Protocol label or plain word.                                                                                        |
+| Drag with no keyboard equivalent                                                      | Add arrow-key/Enter-Space handling + an `aria-live` announcement.                                                    |
+| Concatenating sentence fragments for a message                                        | Keep whole, externalisable strings so it can localise later.                                                         |
+| A Storybook story that only renders (bespoke card wrapper, no props/composition docs) | Render bare + `autodocs`: a composition example, a per-part props list, and controls for the meaningful variations.  |
+| Sizing a shared component with viewport breakpoints (`tablet-portrait:` …)            | Container queries (`@container` + `@min-[…]`) with a floor+cap that scale up together — it doesn't own the viewport. |
 
 ## Quick reference
 

--- a/apps/interviewer/src/components/DataView/DataView.tsx
+++ b/apps/interviewer/src/components/DataView/DataView.tsx
@@ -175,7 +175,7 @@ export function DataView({ protocols, onReload, refreshKey }: DataViewProps) {
       initial="hidden"
       animate="visible"
       exit="exit"
-      className="flex min-h-0 w-full flex-1 flex-col gap-6 px-11 pt-8 pb-8"
+      className="tablet-landscape:px-11 flex min-h-0 w-full flex-1 flex-col gap-6 px-6 pt-8 pb-8"
     >
       <DataViewToolbar
         table={table}

--- a/apps/interviewer/src/components/DataView/DataViewToolbar.tsx
+++ b/apps/interviewer/src/components/DataView/DataViewToolbar.tsx
@@ -172,6 +172,7 @@ export function DataViewToolbar({
         <SegmentedSwitcher
           aria-label="Status filter"
           size="md"
+          variant="glass"
           value={chipFilter ?? 'all'}
           onValueChange={setChipFilter}
           options={statusOptions}
@@ -188,7 +189,9 @@ export function DataViewToolbar({
           onChange={(next) => onGlobalFilterChange(next ?? '')}
           placeholder="Search case ID or protocol..."
           aria-label="Search case ID or protocol"
-          className="h-12 min-w-[260px]"
+          // `control-glass` applies the blur/border/shadow, but InputField paints
+          // its own opaque `bg-input`; force the translucent glass fill over it.
+          className="control-glass border-outline bg-surface/50! h-12 min-w-[260px]"
         />
       </motion.div>
 

--- a/apps/interviewer/src/components/HomeModal.tsx
+++ b/apps/interviewer/src/components/HomeModal.tsx
@@ -21,16 +21,31 @@ type HomeModalProps = {
 };
 
 // ModalPopup spreads consumer props before applying its own inline style for borderRadius,
-// which replaces any consumer style. Express maxWidth as a Tailwind arbitrary class so it
-// survives via the className path. Map the discrete values used by callers.
-function maxWidthClass(maxWidth: number): string {
+// which replaces any consumer style. Express the width as Tailwind arbitrary classes so it
+// survives via the className path (arbitrary values must be static strings so Tailwind can
+// see them at build time — never interpolate the pixel value at runtime).
+//
+// DialogPopup itself applies `tablet-portrait:w-auto w-[calc(100%-var(--spacing-base)*8)]
+// max-w-2xl`. At <tablet-portrait our base `w-[calc]` overrides the popup's base width; at
+// ≥tablet-portrait the popup switches to `tablet-portrait:w-auto`, so we must re-assert the
+// fill width AT the same breakpoint (Tailwind emits responsive variants after base utilities,
+// so a bare `w-[…]` here would lose to `tablet-portrait:w-auto` in source order). The result:
+// the dialog fills the viewport minus small (4×base = 16px) side margins at every width —
+// avoiding max-w-2xl's cramped column on iPad portrait — capped by the max-width on large
+// screens.
+const WIDTH_FILL =
+  'w-[calc(100%-var(--spacing-base)*4)] tablet-portrait:w-[calc(100%-var(--spacing-base)*4)]';
+
+function widthClass(maxWidth: number): string {
   switch (maxWidth) {
+    case 1100:
+      return `${WIDTH_FILL} max-w-[1100px]`;
     case 1080:
-      return 'max-w-[1080px]';
+      return `${WIDTH_FILL} max-w-[1080px]`;
     case 1000:
-      return 'max-w-[1000px]';
+      return `${WIDTH_FILL} max-w-[1000px]`;
     default:
-      return 'max-w-[880px]';
+      return `${WIDTH_FILL} max-w-[880px]`;
   }
 }
 
@@ -50,7 +65,7 @@ export function HomeModal({
         if (!nextOpen) onClose();
       }}
     >
-      <DialogPopup className={maxWidthClass(maxWidth)}>
+      <DialogPopup className={widthClass(maxWidth)}>
         <div className="flex shrink-0 items-center justify-between gap-4 px-8 pt-6">
           <BaseDialog.Title
             render={<div className="flex min-w-0 items-center gap-3.5" />}

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCarousel.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCarousel.tsx
@@ -347,16 +347,16 @@ function DeckSlide({
       onTap={handleTap}
       aria-hidden={hidden || undefined}
       inert={hidden}
-      className="absolute inset-0 m-auto origin-[center_bottom] will-change-transform"
+      className={`absolute inset-0 m-auto origin-[center_bottom] will-change-transform ${
+        slide.backdropBlur ? 'backdrop-blur-md' : ''
+      }`}
     >
       <motion.div
         initial={SLIDE_ENTER}
         animate={SLIDE_REST}
         exit={SLIDE_EXIT}
         transition={SLIDE_ENTER_SPRING}
-        className={`h-full w-full ${slide.backdropBlur ? 'backdrop-blur-md' : ''} ${
-          isPresent ? '' : 'pointer-events-none'
-        }`}
+        className={`h-full w-full ${isPresent ? '' : 'pointer-events-none'}`}
       >
         {slide.render(isActive, activate)}
       </motion.div>

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -10,7 +10,6 @@ import type {
 } from '~/lib/db/types';
 import type { PendingImport } from '~/lib/protocol/useProtocolImport';
 
-import { GLASS_PILL } from '../TopActionBar';
 import {
   DeckCarousel,
   type DeckCarouselHandle,
@@ -384,12 +383,12 @@ export function ProtocolDeck({
         >
           <IconButton
             size="xl"
-            variant="text"
+            variant="glass"
             icon={<ChevronLeft strokeWidth={2.8} aria-hidden />}
             aria-label="Previous protocol"
             onClick={() => setActiveIndex(Math.max(0, activeIndex - 1))}
             disabled={atStart}
-            className={GLASS_PILL}
+            className="border-outline"
           />
           <div className="flex items-center gap-2.5">
             {slides.map((slide, i) => (
@@ -407,14 +406,14 @@ export function ProtocolDeck({
           </div>
           <IconButton
             size="xl"
-            variant="text"
+            variant="glass"
             icon={<ChevronRight strokeWidth={2.8} aria-hidden />}
             aria-label="Next protocol"
             onClick={() =>
               setActiveIndex(Math.min(slides.length - 1, activeIndex + 1))
             }
             disabled={atEnd}
-            className={GLASS_PILL}
+            className="border-outline"
           />
         </motion.div>
       )}

--- a/apps/interviewer/src/components/ResumePill.tsx
+++ b/apps/interviewer/src/components/ResumePill.tsx
@@ -67,7 +67,7 @@ export function ResumePillView({
       exit="exit"
       whileHover={{ y: -2 }}
       whileTap={{ scale: 0.98 }}
-      className="border-outline text-text bg-surface/50 effect-shadow-md pointer-events-auto relative inline-flex h-20 cursor-pointer items-center overflow-hidden rounded-full border backdrop-blur-md"
+      className="control-glass border-outline text-text pointer-events-auto relative inline-flex h-20 cursor-pointer items-center overflow-hidden rounded-full"
     >
       {/* Always-visible circle, sized to match the pill height so the
           collapsed state is a true circle. */}

--- a/apps/interviewer/src/components/SettingsDialog.tsx
+++ b/apps/interviewer/src/components/SettingsDialog.tsx
@@ -20,6 +20,7 @@ import SelectField from '@codaco/fresco-ui/form/fields/Select/Native';
 import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
 import ProgressBar from '@codaco/fresco-ui/ProgressBar';
 import { ScrollArea } from '@codaco/fresco-ui/ScrollArea';
+import { Tabs, TabsPanel } from '@codaco/fresco-ui/Tabs';
 import { useToast } from '@codaco/fresco-ui/Toast';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
@@ -67,9 +68,6 @@ type Section =
   | 'privacy'
   | 'security'
   | 'synthetic';
-
-const NAV_BUTTON_BASE =
-  'flex w-full items-center gap-3 px-4 py-3 border-0 rounded-[var(--radius-pill)] font-heading font-extrabold text-sm text-left cursor-pointer';
 
 function StorageProgress({ value }: { value: number }) {
   const clamped = Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
@@ -292,7 +290,7 @@ export function SettingsDialog({
     <HomeModal
       open={open}
       onClose={onClose}
-      maxWidth={1000}
+      maxWidth={1100}
       scroll={false}
       title={
         <Heading level="h3" margin="none">
@@ -300,189 +298,195 @@ export function SettingsDialog({
         </Heading>
       }
     >
-      <div className="grid min-h-0 flex-1 grid-cols-[210px_1fr] gap-7">
-        <nav aria-label="Settings sections" className="flex flex-col gap-1">
-          {NAV_ITEMS.map((item) => {
-            const Icon = item.icon;
-            const active = section === item.id;
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setSection(item.id)}
-                aria-current={active ? 'page' : undefined}
-                className={`${NAV_BUTTON_BASE} ${active ? 'bg-surface-2 text-text' : 'text-text/80 bg-transparent'}`}
-              >
-                <Icon size={18} strokeWidth={2.4} aria-hidden />
-                <span>{item.label}</span>
-              </button>
-            );
-          })}
-        </nav>
-
-        <ScrollArea viewportClassName="pr-4">
-          {section === 'about' && settings ? (
-            <>
-              <SettingsRow
-                title="App version"
-                desc="Network Canvas Interviewer"
-                control={
-                  <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
-                    {APP_VERSION}
-                  </span>
-                }
-              />
-              <SettingsRow
-                title="Storage"
-                desc={storageLabel}
-                control={
-                  storageHasValues ? (
-                    <div className="w-[220px]">
-                      <StorageProgress value={storagePercent} />
-                    </div>
-                  ) : (
-                    <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
-                      —
-                    </span>
-                  )
-                }
-              />
-              {durabilityLabel ? (
+      <Tabs
+        aria-label="Settings sections"
+        value={section}
+        onValueChange={(next) => {
+          const item = NAV_ITEMS.find((i) => i.id === next);
+          if (item) setSection(item.id);
+        }}
+        tabs={NAV_ITEMS.map((item) => ({
+          value: item.id,
+          label: item.label,
+          icon: item.icon,
+        }))}
+        className="min-h-0 flex-1"
+      >
+        <ScrollArea
+          viewportClassName="@container pr-4"
+          className="min-w-0 flex-1"
+        >
+          <TabsPanel value="about">
+            {settings ? (
+              <>
                 <SettingsRow
-                  title="Offline storage"
-                  desc={durabilityLabel}
+                  title="App version"
+                  desc="Network Canvas Interviewer"
                   control={
-                    <span
-                      className={`inline-flex items-center gap-1.5 text-xs ${
-                        storagePersisted ? 'text-text/60' : 'text-warning'
-                      }`}
-                    >
-                      {storagePersisted ? (
-                        <ShieldCheck className="size-3.5" aria-hidden />
-                      ) : (
-                        <ShieldAlert className="size-3.5" aria-hidden />
-                      )}
-                      {storagePersisted ? 'Persisted' : 'Best-effort'}
+                    <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
+                      {APP_VERSION}
                     </span>
                   }
                 />
-              ) : null}
-              <SettingsRow
-                title="Installation ID"
-                desc="Unique per-device identifier"
-                control={
-                  <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
-                    {installationId}
-                  </span>
-                }
-              />
-              <UnconnectedField
-                name="showSampleProtocol"
-                label="Show sample protocol on home screen"
-                hint="Re-shows the one-click sample protocol card next to the Import card."
-                inline
-                component={ToggleField}
-                value={!settings.sampleProtocolDismissed}
-                onChange={(next: boolean | undefined) =>
-                  void persist({ sampleProtocolDismissed: next !== true })
-                }
-              />
-            </>
-          ) : null}
-
-          {section === 'interview' && settings ? (
-            <>
-              <UnconnectedField
-                name="allowStageNavigation"
-                label="Allow stage navigation"
-                hint="Let participants move between stages by tapping the progress bar during an interview, which opens a stages menu."
-                inline
-                component={ToggleField}
-                value={settings.allowStageNavigation}
-                onChange={(next: boolean | undefined) =>
-                  void persist({ allowStageNavigation: next === true })
-                }
-              />
-              <Paragraph intent="smallText" emphasis="muted">
-                When off, participants can only move forwards and backwards one
-                stage at a time. Turning this on lets them jump directly to any
-                stage, which is useful for piloting a protocol but is usually
-                left off for real interviews.
-              </Paragraph>
-            </>
-          ) : null}
-
-          {section === 'data' && settings ? (
-            <>
-              <UnconnectedField
-                name="exportGraphML"
-                label="Export GraphML"
-                hint="Include GraphML files in interview exports."
-                inline
-                component={ToggleField}
-                value={settings.exportGraphML}
-                onChange={(next: boolean | undefined) =>
-                  void persist({ exportGraphML: next === true })
-                }
-              />
-              <UnconnectedField
-                name="exportCSV"
-                label="Export CSV"
-                hint="Include CSV files (attributes, edges, ego) in interview exports."
-                inline
-                component={ToggleField}
-                value={settings.exportCSV}
-                onChange={(next: boolean | undefined) =>
-                  void persist({ exportCSV: next === true })
-                }
-              />
-              <UnconnectedField
-                name="useScreenLayoutCoordinates"
-                label="Export node positions as screen-coordinate pixels"
-                hint="Sociogram node positions are exported in pixel coordinates relative to the layout below."
-                inline
-                component={ToggleField}
-                value={settings.useScreenLayoutCoordinates}
-                onChange={(next: boolean | undefined) =>
-                  void persist({ useScreenLayoutCoordinates: next === true })
-                }
-              />
-              <UnconnectedField
-                inline
-                name="screenLayoutWidth"
-                label="Screen layout width"
-                hint="Pixels"
-                component={InputField}
-                type="number"
-                min={1}
-                value={String(settings.screenLayoutWidth)}
-                onChange={(next: string | undefined) => {
-                  const parsed = Number.parseInt(next ?? '', 10);
-                  if (Number.isFinite(parsed) && parsed > 0) {
-                    void persist({ screenLayoutWidth: parsed });
+                <SettingsRow
+                  title="Storage"
+                  desc={storageLabel}
+                  control={
+                    storageHasValues ? (
+                      // Fluid when the row is stacked (full width), fixed 220px
+                      // once the SettingsRow container is wide enough to go
+                      // two-column — same 26rem threshold as SettingsRow itself.
+                      <div className="w-full @min-[26rem]:w-[220px]">
+                        <StorageProgress value={storagePercent} />
+                      </div>
+                    ) : (
+                      <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
+                        —
+                      </span>
+                    )
                   }
-                }}
-              />
-              <UnconnectedField
-                inline
-                name="screenLayoutHeight"
-                label="Screen layout height"
-                hint="Pixels"
-                component={InputField}
-                type="number"
-                min={1}
-                value={String(settings.screenLayoutHeight)}
-                onChange={(next: string | undefined) => {
-                  const parsed = Number.parseInt(next ?? '', 10);
-                  if (Number.isFinite(parsed) && parsed > 0) {
-                    void persist({ screenLayoutHeight: parsed });
+                />
+                {durabilityLabel ? (
+                  <SettingsRow
+                    title="Offline storage"
+                    desc={durabilityLabel}
+                    control={
+                      <span
+                        className={`inline-flex items-center gap-1.5 text-xs ${
+                          storagePersisted ? 'text-text/60' : 'text-warning'
+                        }`}
+                      >
+                        {storagePersisted ? (
+                          <ShieldCheck className="size-3.5" aria-hidden />
+                        ) : (
+                          <ShieldAlert className="size-3.5" aria-hidden />
+                        )}
+                        {storagePersisted ? 'Persisted' : 'Best-effort'}
+                      </span>
+                    }
+                  />
+                ) : null}
+                <SettingsRow
+                  title="Installation ID"
+                  desc="Unique per-device identifier"
+                  control={
+                    <span className="font-monospace text-text/60 text-xs tracking-[0.02em]">
+                      {installationId}
+                    </span>
                   }
-                }}
-              />
-            </>
-          ) : null}
+                />
+                <UnconnectedField
+                  name="showSampleProtocol"
+                  label="Show sample protocol on home screen"
+                  hint="Re-shows the one-click sample protocol card next to the Import card."
+                  inline
+                  component={ToggleField}
+                  value={!settings.sampleProtocolDismissed}
+                  onChange={(next: boolean | undefined) =>
+                    void persist({ sampleProtocolDismissed: next !== true })
+                  }
+                />
+              </>
+            ) : null}
+          </TabsPanel>
 
-          {section === 'privacy' ? (
+          <TabsPanel value="interview">
+            {settings ? (
+              <>
+                <UnconnectedField
+                  name="allowStageNavigation"
+                  label="Allow stage navigation"
+                  hint="Let participants move between stages by tapping the progress bar during an interview, which opens a stages menu."
+                  inline
+                  component={ToggleField}
+                  value={settings.allowStageNavigation}
+                  onChange={(next: boolean | undefined) =>
+                    void persist({ allowStageNavigation: next === true })
+                  }
+                />
+                <Paragraph intent="smallText" emphasis="muted">
+                  When off, participants can only move forwards and backwards
+                  one stage at a time. Turning this on lets them jump directly
+                  to any stage, which is useful for piloting a protocol but is
+                  usually left off for real interviews.
+                </Paragraph>
+              </>
+            ) : null}
+          </TabsPanel>
+
+          <TabsPanel value="data">
+            {settings ? (
+              <>
+                <UnconnectedField
+                  name="exportGraphML"
+                  label="Export GraphML"
+                  hint="Include GraphML files in interview exports."
+                  inline
+                  component={ToggleField}
+                  value={settings.exportGraphML}
+                  onChange={(next: boolean | undefined) =>
+                    void persist({ exportGraphML: next === true })
+                  }
+                />
+                <UnconnectedField
+                  name="exportCSV"
+                  label="Export CSV"
+                  hint="Include CSV files (attributes, edges, ego) in interview exports."
+                  inline
+                  component={ToggleField}
+                  value={settings.exportCSV}
+                  onChange={(next: boolean | undefined) =>
+                    void persist({ exportCSV: next === true })
+                  }
+                />
+                <UnconnectedField
+                  name="useScreenLayoutCoordinates"
+                  label="Export node positions as screen-coordinate pixels"
+                  hint="Sociogram node positions are exported in pixel coordinates relative to the layout below."
+                  inline
+                  component={ToggleField}
+                  value={settings.useScreenLayoutCoordinates}
+                  onChange={(next: boolean | undefined) =>
+                    void persist({ useScreenLayoutCoordinates: next === true })
+                  }
+                />
+                <UnconnectedField
+                  inline
+                  name="screenLayoutWidth"
+                  label="Screen layout width"
+                  hint="Pixels"
+                  component={InputField}
+                  type="number"
+                  min={1}
+                  value={String(settings.screenLayoutWidth)}
+                  onChange={(next: string | undefined) => {
+                    const parsed = Number.parseInt(next ?? '', 10);
+                    if (Number.isFinite(parsed) && parsed > 0) {
+                      void persist({ screenLayoutWidth: parsed });
+                    }
+                  }}
+                />
+                <UnconnectedField
+                  inline
+                  name="screenLayoutHeight"
+                  label="Screen layout height"
+                  hint="Pixels"
+                  component={InputField}
+                  type="number"
+                  min={1}
+                  value={String(settings.screenLayoutHeight)}
+                  onChange={(next: string | undefined) => {
+                    const parsed = Number.parseInt(next ?? '', 10);
+                    if (Number.isFinite(parsed) && parsed > 0) {
+                      void persist({ screenLayoutHeight: parsed });
+                    }
+                  }}
+                />
+              </>
+            ) : null}
+          </TabsPanel>
+
+          <TabsPanel value="privacy">
             <>
               <UnconnectedField
                 name="analyticsEnabled"
@@ -511,27 +515,29 @@ export function SettingsDialog({
                 </AlertDescription>
               </Alert>
             </>
-          ) : null}
+          </TabsPanel>
 
-          {section === 'security' && settings ? (
-            <>
-              <ManageAuthenticator />
-              {auth.mode !== 'none' ? (
-                <>
-                  <Alert variant="info">
-                    Use the lock button in the top bar to lock immediately.
-                  </Alert>
-                  <SecurityBehaviorControls
-                    value={behavior}
-                    onChange={handleBehaviorChange}
-                  />
-                </>
-              ) : null}
-              <ResetDeviceRow />
-            </>
-          ) : null}
+          <TabsPanel value="security">
+            {settings ? (
+              <>
+                <ManageAuthenticator />
+                {auth.mode !== 'none' ? (
+                  <>
+                    <Alert variant="info">
+                      Use the lock button in the top bar to lock immediately.
+                    </Alert>
+                    <SecurityBehaviorControls
+                      value={behavior}
+                      onChange={handleBehaviorChange}
+                    />
+                  </>
+                ) : null}
+                <ResetDeviceRow />
+              </>
+            ) : null}
+          </TabsPanel>
 
-          {section === 'synthetic' ? (
+          <TabsPanel value="synthetic">
             <>
               <Paragraph intent="smallText" emphasis="muted">
                 Generate synthetic interview sessions to validate the export
@@ -637,9 +643,9 @@ export function SettingsDialog({
                 }
               />
             </>
-          ) : null}
+          </TabsPanel>
         </ScrollArea>
-      </div>
+      </Tabs>
     </HomeModal>
   );
 }

--- a/apps/interviewer/src/components/SettingsRow.tsx
+++ b/apps/interviewer/src/components/SettingsRow.tsx
@@ -10,16 +10,24 @@ type Props = {
 
 export function SettingsRow({ title, desc, control }: Props) {
   return (
-    <div className="flex items-center justify-between gap-6 px-1 py-4">
-      <div className="min-w-0">
-        <Heading level="label" margin="none">
-          {title}
-        </Heading>
-        {desc ? (
-          <div className="text-text/60 mt-0.5 text-sm">{desc}</div>
-        ) : null}
+    // Container query, not a viewport breakpoint: the row stacks (title/desc on
+    // top, full-width control below) when its own container is narrow and lays
+    // out as two columns once it's ≥ 26rem — so it adapts to the dialog's
+    // content-column width rather than the screen.
+    <div className="@container px-1 py-4">
+      <div className="flex flex-col gap-3 @min-[26rem]:flex-row @min-[26rem]:items-center @min-[26rem]:justify-between @min-[26rem]:gap-6">
+        <div className="min-w-0">
+          <Heading level="label" margin="none">
+            {title}
+          </Heading>
+          {desc ? (
+            <div className="text-text/60 mt-0.5 text-sm">{desc}</div>
+          ) : null}
+        </div>
+        <div className="w-full @min-[26rem]:w-auto @min-[26rem]:shrink-0">
+          {control}
+        </div>
       </div>
-      <div className="shrink-0">{control}</div>
     </div>
   );
 }

--- a/apps/interviewer/src/components/StatusRow.tsx
+++ b/apps/interviewer/src/components/StatusRow.tsx
@@ -61,7 +61,7 @@ export function StatusRowView({
   return (
     <motion.div
       variants={variants}
-      className="font-monospace text-text/60 flex items-center justify-between px-11 pb-4 text-xs"
+      className="font-monospace text-text/60 tablet-landscape:px-11 flex items-center justify-between px-6 pb-4 text-xs"
     >
       <Link
         href="/data"

--- a/apps/interviewer/src/components/TopActionBar.tsx
+++ b/apps/interviewer/src/components/TopActionBar.tsx
@@ -5,10 +5,9 @@ import { IconButton } from '@codaco/fresco-ui/Button';
 import { ViewSwitcher } from '~/components/ViewSwitcher';
 import { useAuth } from '~/lib/auth/AuthContext';
 
-// Glass-pill treatment layered over the standard Button: backdrop-blur surface
-// with the theme outline, sized to match BrandHeader's height (h-14).
-export const GLASS_PILL =
-  'border border-outline bg-surface/50 backdrop-blur-md effect-shadow-md uppercase font-black';
+// Icon buttons in the top bar share the SegmentedSwitcher's size token so
+// their heights line up (switcher height == Button height per token).
+const TOP_BAR_SIZE = 'md';
 
 const variants = {
   hidden: { opacity: 0, y: -6 },
@@ -38,11 +37,12 @@ export function TopActionBarView({
           className="inline-flex"
         >
           <IconButton
-            variant="text"
+            variant="glass"
+            size={TOP_BAR_SIZE}
             icon={<Lock size={22} className="stroke-[3px]" aria-hidden />}
             aria-label="Lock app"
             onClick={onLock}
-            className={GLASS_PILL}
+            className="border-outline"
           />
         </motion.span>
       )}
@@ -53,11 +53,12 @@ export function TopActionBarView({
         className="inline-flex"
       >
         <IconButton
-          variant="text"
+          variant="glass"
+          size={TOP_BAR_SIZE}
           icon={<Settings size={22} className="stroke-[3px]" aria-hidden />}
           aria-label="Settings"
           onClick={onOpenSettings}
-          className={GLASS_PILL}
+          className="border-outline"
         />
       </motion.span>
     </div>

--- a/apps/interviewer/src/components/ViewSwitcher.tsx
+++ b/apps/interviewer/src/components/ViewSwitcher.tsx
@@ -35,7 +35,8 @@ export function ViewSwitcher() {
   return (
     <SegmentedSwitcher
       aria-label="Home view"
-      size="lg"
+      size="md"
+      variant="glass"
       value={value}
       onValueChange={() => {
         /* Navigation is handled by each segment's <Link href>; navigating here too would double-push the history stack. */

--- a/apps/interviewer/src/routes/Home.tsx
+++ b/apps/interviewer/src/routes/Home.tsx
@@ -63,6 +63,11 @@ export function HomeRoute() {
     pendingProtocolHash !== null &&
     protocols.some((p) => p.hash === pendingProtocolHash);
 
+  // Mirrors ResumePill's own render predicate (an in-progress session exists).
+  // When it does, the pill occupies the band just below the header in
+  // portrait, so the protocols column reserves top space to clear it.
+  const hasResumableSession = sessions.some((s) => s.finishedAt === null);
+
   // Default the active card to the user's last-used protocol; fall back to
   // the most-recently-imported one if they've never opened a protocol (or
   // the remembered one has since been deleted).
@@ -173,7 +178,7 @@ export function HomeRoute() {
           controls out of the tab order while the new-session form is up. */}
       <InstallBanner />
       <header
-        className="relative flex items-center justify-between px-11 pt-9"
+        className="tablet-landscape:px-11 tablet-landscape:pt-9 relative flex items-center justify-between px-6 pt-6"
         inert={newSessionActive}
       >
         <BrandHeader />
@@ -186,13 +191,16 @@ export function HomeRoute() {
             pass through the empty area to the items below; the pill
             itself opts back in via pointer-events-auto.
 
-            On narrow screens (iPad portrait and below) there isn't room
-            for a centered pill between BrandHeader and TopActionBar, so the
-            expanded pill would cover the protocols/data switcher. Drop it
-            one header-height down (`translate-y-full`) so it sits in the
-            band just below the header — clear of the switcher — and restore
-            the in-header centering once there's room (`tablet-landscape`). */}
-        <div className="tablet-landscape:translate-y-0 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-11 pt-9">
+            In portrait (both iPads) there isn't room for a centered pill
+            between BrandHeader and TopActionBar, so the expanded pill would
+            cover the protocols/data switcher. Drop it one header-height down
+            (`translate-y-full`) so it sits in the band just below the header
+            — clear of the switcher — and restore the in-header centering in
+            landscape, where there's room (`landscape:`). We key this off
+            actual ORIENTATION, not a min-width breakpoint: the 13" iPad's
+            portrait width (~1024px) would otherwise trip a min-width
+            breakpoint and pull the pill up into the header. */}
+        <div className="tablet-landscape:px-11 tablet-landscape:pt-9 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-6 landscape:translate-y-0">
           <AnimatePresence>
             {view === 'protocols' ? (
               <ResumePill key="resume-pill" sessions={sessions} />
@@ -209,7 +217,13 @@ export function HomeRoute() {
             initial="hidden"
             animate="visible"
             exit="exit"
-            className="flex min-h-0 w-full flex-1 flex-col gap-8"
+            // In portrait the resume pill drops into the band just below the
+            // header (see the overlay comment above). Reserve top space so the
+            // protocol deck starts below it — only in portrait, and only when a
+            // resumable session actually renders the pill (pill is h-20 = 80px).
+            className={`flex min-h-0 w-full flex-1 flex-col gap-8 ${
+              hasResumableSession ? 'portrait:pt-24' : ''
+            }`}
           >
             <ProtocolDeck
               protocols={protocols}
@@ -236,7 +250,7 @@ export function HomeRoute() {
             {import.meta.env.DEV && (
               <div
                 inert={newSessionActive}
-                className="flex justify-center px-11"
+                className="tablet-landscape:px-11 flex justify-center px-6"
               >
                 <Button
                   variant="text"

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -132,6 +132,10 @@
       "types": "./dist/Table.d.ts",
       "default": "./dist/Table.js"
     },
+    "./Tabs": {
+      "types": "./dist/Tabs/Tabs.d.ts",
+      "default": "./dist/Tabs/Tabs.js"
+    },
     "./Label": {
       "types": "./dist/Label.d.ts",
       "default": "./dist/Label.js"

--- a/packages/fresco-ui/src/Button.stories.tsx
+++ b/packages/fresco-ui/src/Button.stories.tsx
@@ -105,6 +105,12 @@ export const Variants: Story = {
         <Button {...args} variant="dashed">
           Dashed
         </Button>
+        {/* `glass`: a thicker border, a translucent backdrop-blurred fill, and a
+            shadow — all on the button itself. The blur reads over whatever sits
+            behind it in real use. */}
+        <Button {...args} variant="glass">
+          Glass
+        </Button>
         <Button {...args} variant="link">
           Link
         </Button>

--- a/packages/fresco-ui/src/Button.tsx
+++ b/packages/fresco-ui/src/Button.tsx
@@ -33,6 +33,8 @@ const buttonSpecificVariants = cva({
       text: 'text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
       dashed:
         'border-2 border-dashed border-(--component-text) text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
+      glass:
+        'control-glass border-(--component-text) text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
       link: 'elevation-none hover:elevation-none! text-link h-auto! rounded-none p-0! underline-offset-4 hover:translate-none! hover:enabled:underline',
     },
     color: {
@@ -73,13 +75,13 @@ const buttonSpecificVariants = cva({
     },
     // Default color bg is too light to use as outline or text color
     {
-      variant: ['outline', 'text', 'dashed'],
+      variant: ['outline', 'text', 'dashed', 'glass'],
       color: 'default',
       className:
         'interview:[--component-text:var(--neutral)] [--component-text:var(--neutral-contrast)] hover:enabled:[--component-text:var(--neutral)]',
     },
     {
-      variant: ['outline', 'dashed'],
+      variant: ['outline', 'dashed', 'glass'],
       color: ['dynamic', 'default'],
       className: 'border-current',
     },

--- a/packages/fresco-ui/src/SegmentedSwitcher/SegmentedSwitcher.stories.tsx
+++ b/packages/fresco-ui/src/SegmentedSwitcher/SegmentedSwitcher.stories.tsx
@@ -10,18 +10,85 @@ const ICON_OPTIONS: SegmentedOption<Value>[] = [
   { value: 'data', label: 'Data', icon: Database },
 ];
 
-type StoryArgs = { size: 'sm' | 'md' | 'lg'; disabledSecond: boolean };
+const COMPOSITION_DOC = `
+A single-select segmented control built on Base UI's \`ToggleGroup\`, with a
+spring-animated highlight that slides to the active segment. It never allows an
+empty selection (clicking the active segment is a no-op).
+
+\`\`\`tsx
+import SegmentedSwitcher, {
+  type SegmentedOption,
+} from '@codaco/fresco-ui/SegmentedSwitcher';
+import { Database, Layers } from 'lucide-react';
+
+const options: SegmentedOption<'protocols' | 'data'>[] = [
+  { value: 'protocols', label: 'Protocols', icon: Layers },
+  { value: 'data', label: 'Data', icon: Database },
+];
+
+<SegmentedSwitcher
+  aria-label="Workspace view"
+  options={options}
+  value={value}
+  onValueChange={setValue}
+  size="md"
+  variant="outline"
+/>
+\`\`\`
+
+**Props**
+
+- **\`value\`** (\`T\`) — the currently selected option's \`value\`.
+- **\`onValueChange\`** (\`(value: T) => void\`) — called with the newly picked
+  value. A change that would deselect everything is ignored.
+- **\`options\`** (\`SegmentedOption<T>[]\`) — each is
+  \`{ value: T; label: ReactNode; icon?: LucideIcon; disabled?: boolean; render?: ReactElement }\`.
+  \`render\` is a Base UI escape hatch to render a segment as another element
+  (e.g. a router \`<Link>\`).
+- **\`size\`** (\`'sm' | 'md' | 'lg' | 'xl'\`, default \`'md'\`) — track height is
+  pinned to the matching \`Button\` height at each token, so they line up.
+- **\`variant\`** (\`'outline' | 'glass'\`, default \`'outline'\`) — \`outline\`
+  reads like a normal outline button (2px themed border, no fill); \`glass\` adds
+  a translucent, backdrop-blurred, shadowed surface with a thicker border, for
+  floating over content.
+- **\`aria-label\`** (\`string\`, required) — labels the group for screen readers.
+- **\`className\`** (\`string\`) — merged onto the track.
+
+Keyboard operation and \`role="group"\`/toggle ARIA come from Base UI.
+`;
+
+type StoryArgs = {
+  size: 'sm' | 'md' | 'lg' | 'xl';
+  variant: 'outline' | 'glass';
+  disabledSecond: boolean;
+};
 
 const meta: Meta<StoryArgs> = {
   title: 'Components/SegmentedSwitcher',
-  parameters: { layout: 'centered' },
   tags: ['autodocs'],
-  args: { size: 'lg', disabledSecond: false },
-  argTypes: {
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
-    disabledSecond: { control: 'boolean' },
+  parameters: {
+    layout: 'centered',
+    docs: { description: { component: COMPOSITION_DOC } },
   },
-  render: ({ size, disabledSecond }) => {
+  args: { size: 'lg', variant: 'outline', disabledSecond: false },
+  argTypes: {
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg', 'xl'],
+      description: 'Track height, pinned to the matching Button height.',
+    },
+    variant: {
+      control: 'inline-radio',
+      options: ['outline', 'glass'],
+      description:
+        'Track treatment. See the "Glass" story for the backdrop-blurred variant over content.',
+    },
+    disabledSecond: {
+      control: 'boolean',
+      description: 'Disable the second option to show the disabled state.',
+    },
+  },
+  render: ({ size, variant, disabledSecond }) => {
     const [value, setValue] = useState<Value>('protocols');
     const options = ICON_OPTIONS.map((o, i) =>
       i === 1 && disabledSecond ? { ...o, disabled: true } : o,
@@ -30,6 +97,7 @@ const meta: Meta<StoryArgs> = {
       <SegmentedSwitcher
         aria-label="Demo switcher"
         size={size}
+        variant={variant}
         value={value}
         onValueChange={setValue}
         options={options}
@@ -42,6 +110,27 @@ export default meta;
 type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
+
+// Every size token side by side, so their relative presence can be compared.
+export const Sizes: Story = {
+  render: () => {
+    const [value, setValue] = useState<Value>('protocols');
+    return (
+      <div className="flex flex-col items-start gap-4">
+        {(['sm', 'md', 'lg', 'xl'] as const).map((size) => (
+          <SegmentedSwitcher
+            key={size}
+            aria-label={`Sizes example (${size})`}
+            size={size}
+            value={value}
+            onValueChange={setValue}
+            options={ICON_OPTIONS}
+          />
+        ))}
+      </div>
+    );
+  },
+};
 
 // The status-filter shape: no icons, count embedded in the label, size md.
 export const WithCounts: Story = {
@@ -76,6 +165,31 @@ export const WithCounts: Story = {
         onValueChange={setValue}
         options={options}
       />
+    );
+  },
+};
+
+// The default `outline` variant: a plain 2px themed border, no fill. Rendered
+// bare — no wrapper — since it reads correctly on any background.
+export const Outline: Story = { args: { variant: 'outline' } };
+
+// The `glass` variant is translucent and backdrop-blurred, so it only reads
+// when floating over content. The gradient panel below is a demo backdrop to
+// make the blur/translucency visible — it is NOT part of the component.
+export const Glass: Story = {
+  render: () => {
+    const [value, setValue] = useState<Value>('protocols');
+    return (
+      <div className="from-primary to-accent flex h-64 w-96 items-center justify-center rounded-2xl bg-linear-to-br p-8">
+        <SegmentedSwitcher
+          aria-label="Glass switcher"
+          size="lg"
+          variant="glass"
+          value={value}
+          onValueChange={setValue}
+          options={ICON_OPTIONS}
+        />
+      </div>
     );
   },
 };

--- a/packages/fresco-ui/src/SegmentedSwitcher/SegmentedSwitcher.tsx
+++ b/packages/fresco-ui/src/SegmentedSwitcher/SegmentedSwitcher.tsx
@@ -4,7 +4,6 @@ import type { LucideIcon } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { type ReactElement, type ReactNode, useId } from 'react';
 
-import Surface from '../layout/Surface';
 import { cva, cx } from '../utils/cva';
 
 export type SegmentedOption<T extends string> = {
@@ -20,11 +19,41 @@ export type SegmentedSwitcherProps<T extends string> = {
   'value': T;
   'onValueChange': (value: T) => void;
   'options': SegmentedOption<T>[];
-  'size'?: 'sm' | 'md' | 'lg';
+  'size'?: 'sm' | 'md' | 'lg' | 'xl';
+  /**
+   * Track treatment. `outline` (default) reads like a normal outline button;
+   * `glass` adds the translucent, backdrop-blurred, shadowed glass treatment
+   * with a thicker border.
+   */
+  'variant'?: 'outline' | 'glass';
   'aria-label': string;
   'className'?: string;
 };
 
+// The outer track height is pinned to the matching Button height at each size
+// token (sm h-10=40, md h-12=48, lg h-16=64, xl h-20=80) via `trackHeightClass`
+// so the switcher lines up with Buttons exactly. The segments stretch to fill
+// whatever inner height remains after the border + `p-1` padding, so they stay
+// concentric with the track regardless of the border width (see below).
+const trackHeightClass: Record<'sm' | 'md' | 'lg' | 'xl', string> = {
+  sm: 'h-10',
+  md: 'h-12',
+  lg: 'h-16',
+  xl: 'h-20',
+};
+
+const trackVariantClass: Record<'outline' | 'glass', string> = {
+  // Like a normal outline button: a 2px themed border, no fill.
+  outline: 'border-2 border-outline',
+  // Translucent surface + backdrop blur + shadow + a thicker (control) border.
+  glass: 'control-glass border-outline',
+};
+
+// Segments stretch to fill the track's inner height (the flex chain uses
+// `items-stretch`) rather than taking a fixed height. A `rounded-full` segment
+// that fills the inner box is concentric with the `rounded-full` track — inset
+// uniformly by the border + `p-1` — so the active pill nests cleanly at any
+// size and border width instead of leaving a crescent gap at the rounded ends.
 const segmentVariants = cva({
   base: cx(
     'font-heading relative inline-flex items-center justify-center rounded-full font-extrabold uppercase transition-colors',
@@ -32,18 +61,20 @@ const segmentVariants = cva({
   ),
   variants: {
     size: {
-      sm: 'gap-1.5 px-3.5 py-1.5 text-xs tracking-[0.06em]',
-      md: 'gap-2 px-[18px] py-2.5 text-xs tracking-[0.06em]',
-      lg: 'gap-2 px-5 py-2 text-sm tracking-wide',
+      sm: 'gap-1.5 px-3.5 text-xs tracking-[0.06em]',
+      md: 'gap-2 px-[18px] text-xs tracking-[0.06em]',
+      lg: 'gap-2 px-5 text-sm tracking-wide',
+      xl: 'gap-2.5 px-6 text-base tracking-wide',
     },
   },
   defaultVariants: { size: 'md' },
 });
 
-const iconSizeClass: Record<'sm' | 'md' | 'lg', string> = {
+const iconSizeClass: Record<'sm' | 'md' | 'lg' | 'xl', string> = {
   sm: 'size-3.5',
   md: 'size-4',
   lg: 'size-[18px]',
+  xl: 'size-5',
 };
 
 export default function SegmentedSwitcher<T extends string>({
@@ -51,6 +82,7 @@ export default function SegmentedSwitcher<T extends string>({
   onValueChange,
   options,
   size = 'md',
+  variant = 'outline',
   'aria-label': ariaLabel,
   className,
 }: SegmentedSwitcherProps<T>) {
@@ -58,11 +90,17 @@ export default function SegmentedSwitcher<T extends string>({
   const reduced = useReducedMotion();
 
   return (
-    <Surface
-      floating
-      noContainer
-      spacing="none"
-      className={cx('inline-flex items-center rounded-full p-1', className)}
+    // A plain track rather than a `Surface`: Surface always paints an opaque
+    // depth/floating background that would sit over the translucent
+    // `control-glass` fill and defeat the blur. The segments colour themselves,
+    // so none of Surface's depth/contrast machinery is needed here.
+    <div
+      className={cx(
+        'publish-colors relative inline-flex items-stretch rounded-full p-1',
+        trackVariantClass[variant],
+        trackHeightClass[size],
+        className,
+      )}
     >
       <ToggleGroup
         aria-label={ariaLabel}
@@ -75,7 +113,7 @@ export default function SegmentedSwitcher<T extends string>({
           const picked = options.find((option) => option.value === first);
           if (picked) onValueChange(picked.value);
         }}
-        className="flex items-center"
+        className="flex items-stretch"
       >
         {options.map((option) => {
           const active = option.value === value;
@@ -117,6 +155,6 @@ export default function SegmentedSwitcher<T extends string>({
           );
         })}
       </ToggleGroup>
-    </Surface>
+    </div>
   );
 }

--- a/packages/fresco-ui/src/Table.tsx
+++ b/packages/fresco-ui/src/Table.tsx
@@ -25,7 +25,7 @@ const Table = React.forwardRef<
     <div
       className={cx(
         'w-full max-w-full overflow-x-auto overscroll-x-none',
-        bodyScroll && 'min-h-0 flex-1 overflow-y-auto',
+        bodyScroll && 'min-h-0 flex-1 overflow-y-auto overscroll-y-none',
       )}
     >
       <table

--- a/packages/fresco-ui/src/Tabs/Tabs.stories.tsx
+++ b/packages/fresco-ui/src/Tabs/Tabs.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  FlaskConical,
+  Info,
+  LineChart,
+  type LucideIcon,
+  Route,
+  Shield,
+  Upload,
+} from 'lucide-react';
+import { useState } from 'react';
+
+import { Tabs, TabsPanel } from './Tabs';
+
+const ICONS: LucideIcon[] = [
+  Info,
+  Route,
+  Upload,
+  LineChart,
+  Shield,
+  FlaskConical,
+];
+
+const LABEL_SETS = {
+  short: ['About', 'Setup', 'Export', 'Privacy', 'Security', 'Data'],
+  default: [
+    'About',
+    'Interview',
+    'Data export',
+    'Privacy',
+    'Security',
+    'Synthetic data',
+  ],
+  long: [
+    'About this device',
+    'Interview behaviour & stage navigation',
+    'Data export & archive format',
+    'Privacy & analytics',
+    'Security & authenticators',
+    'Synthetic data generation',
+  ],
+} satisfies Record<string, string[]>;
+
+const BODIES = [
+  'Version, storage and device information for this installation.',
+  'Stage navigation and other in-interview behaviour.',
+  'Export format and archive layout options.',
+  'Analytics and error-reporting preferences.',
+  'Lock behaviour and authenticator management.',
+  'Generate synthetic sessions to validate the export pipeline.',
+];
+
+type StoryArgs = {
+  containerWidth: number;
+  showIcons: boolean;
+  labelLength: keyof typeof LABEL_SETS;
+};
+
+const COMPOSITION_DOC = `
+A compound, Base UI-backed tabs component. \`Tabs\` renders its own rail from a
+\`tabs\` array plus the moving active highlight; you only supply one
+\`TabsPanel\` per tab \`value\`. Both are imported from \`@codaco/fresco-ui/Tabs\`:
+
+\`\`\`tsx
+import { Tabs, TabsPanel } from '@codaco/fresco-ui/Tabs';
+import { Info, LineChart } from 'lucide-react';
+
+<Tabs
+  aria-label="Settings sections"
+  value={section}
+  onValueChange={setSection}
+  tabs={[
+    { value: 'about', label: 'About', icon: Info },
+    { value: 'privacy', label: 'Privacy', icon: LineChart },
+  ]}
+>
+  <TabsPanel value="about">…about content…</TabsPanel>
+  <TabsPanel value="privacy">…privacy content…</TabsPanel>
+</Tabs>
+\`\`\`
+
+**The parts**
+
+- **\`Tabs\`** — root, rail and layout (a container-query flex row). Props:
+  \`tabs\` (\`{ value: string; label: ReactNode; icon?: LucideIcon; disabled?: boolean }[]\`),
+  \`aria-label\`, \`value\`, \`defaultValue\`, \`onValueChange(value: string)\`,
+  \`orientation\` (\`'vertical'\` default), \`className\`, \`style\`. The rail sizes to
+  the widest label, bounded per breakpoint.
+- **\`TabsPanel\`** — content for a tab \`value\`; fills the row and is its own
+  \`@container\`. Props: \`value\`, \`keepMounted?\`, \`className\`.
+
+Accessibility (roving arrow-key focus, \`role=tablist/tab/tabpanel\`,
+\`aria-selected\`, \`aria-controls\`) comes from Base UI.
+`;
+
+const meta: Meta<StoryArgs> = {
+  title: 'Components/Tabs',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: { description: { component: COMPOSITION_DOC } },
+  },
+  args: { containerWidth: 640, showIcons: true, labelLength: 'default' },
+  argTypes: {
+    containerWidth: {
+      control: { type: 'range', min: 240, max: 820, step: 20 },
+      description:
+        'Width of the component (shown with a dashed outline). The tab column grows to fit the widest label; below the breakpoint cap, long labels wrap rather than widening the column further.',
+    },
+    showIcons: {
+      control: 'boolean',
+      description: 'Render a leading icon on each tab.',
+    },
+    labelLength: {
+      control: 'inline-radio',
+      options: ['short', 'default', 'long'],
+      description:
+        'Swap the label set. "long" labels demonstrate multi-line wrapping within the tab column.',
+    },
+  },
+  render: ({ containerWidth, showIcons, labelLength }) => {
+    const [section, setSection] = useState<string>('0');
+    const labels = LABEL_SETS[labelLength];
+    const tabs = labels.map((label, i) => ({
+      value: String(i),
+      label,
+      icon: showIcons ? ICONS[i] : undefined,
+    }));
+    return (
+      <Tabs
+        aria-label="Example sections"
+        value={section}
+        onValueChange={setSection}
+        tabs={tabs}
+        // The dashed outline marks the component's own bounds so its size can be
+        // judged; it is not part of the component.
+        className="outline-text/25 outline-2 outline-offset-8 outline-dashed"
+        style={{ width: '100%', maxWidth: containerWidth }}
+      >
+        {labels.map((label, i) => (
+          <TabsPanel key={i} value={String(i)}>
+            <h3 className="font-heading text-lg font-extrabold">{label}</h3>
+            <p className="text-text/70 mt-2 text-sm">{BODIES[i]}</p>
+          </TabsPanel>
+        ))}
+      </Tabs>
+    );
+  },
+};
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {};
+
+// Long labels wrap to multiple lines within the tab column rather than forcing
+// it ever wider — the tab radius stays a fixed rounded rect, not a stadium.
+export const LongLabels: Story = { args: { labelLength: 'long' } };
+
+// A narrow component: the column has hit its cap, so the default labels sit
+// tight and any long label wraps.
+export const Narrow: Story = { args: { containerWidth: 300 } };
+
+// Text-only tabs, no leading icons.
+export const WithoutIcons: Story = { args: { showIcons: false } };

--- a/packages/fresco-ui/src/Tabs/Tabs.tsx
+++ b/packages/fresco-ui/src/Tabs/Tabs.tsx
@@ -1,0 +1,199 @@
+import { Tabs as BaseTabs } from '@base-ui/react/tabs';
+import type { LucideIcon } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
+
+import { cx } from '../utils/cva';
+
+export type TabItem = {
+  value: string;
+  label: ReactNode;
+  icon?: LucideIcon;
+  disabled?: boolean;
+};
+
+export type TabsProps = {
+  'value'?: string;
+  'defaultValue'?: string;
+  'onValueChange'?: (value: string) => void;
+  'orientation'?: 'vertical' | 'horizontal';
+  /** The tabs to render in the rail. */
+  'tabs': TabItem[];
+  /** Accessible name for the tab rail (`tablist`). */
+  'aria-label': string;
+  'className'?: string;
+  'style'?: CSSProperties;
+  /** One `TabsPanel` per tab `value`. */
+  'children': ReactNode;
+};
+
+/**
+ * A compound tabs component built on Base UI's Tabs (roving arrow-key focus,
+ * `role=tablist/tab/tabpanel`, `aria-selected`/`aria-controls` for free).
+ *
+ * `Tabs` renders the rail itself from its `tabs` array (plus the moving active
+ * highlight); the consumer only supplies one `TabsPanel` per tab `value`:
+ *
+ * ```tsx
+ * <Tabs aria-label="Settings" value={s} onValueChange={setS} tabs={[
+ *   { value: 'about', label: 'About', icon: Info },
+ * ]}>
+ *   <TabsPanel value="about">…</TabsPanel>
+ * </Tabs>
+ * ```
+ *
+ * The root is a container-query context (`@container`) laid out as flex, so the
+ * rail sizes its column to the widest label and each `TabsPanel` adapts to the
+ * panel width rather than the viewport.
+ */
+export function Tabs({
+  value,
+  defaultValue,
+  onValueChange,
+  orientation = 'vertical',
+  tabs,
+  'aria-label': ariaLabel,
+  className,
+  style,
+  children,
+}: TabsProps) {
+  return (
+    <BaseTabs.Root
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={(next) => {
+        if (typeof next === 'string') onValueChange?.(next);
+      }}
+      orientation={orientation}
+      style={style}
+      className={cx(
+        '@container flex min-h-0 gap-6',
+        orientation === 'vertical' ? 'flex-row' : 'flex-col',
+        className,
+      )}
+    >
+      <TabRail tabs={tabs} aria-label={ariaLabel} />
+      {children}
+    </BaseTabs.Root>
+  );
+}
+
+/**
+ * The tab rail. Internal — driven by `Tabs`' `tabs` prop. Renders the tabs plus
+ * the moving active highlight. In the vertical layout it sizes to the widest
+ * label (`w-fit`) bounded by a floor and cap that both step up with the
+ * container width, so the rail gains presence as the component grows and only
+ * wraps a label once it exceeds the cap for that breakpoint.
+ */
+function TabRail({
+  tabs,
+  'aria-label': ariaLabel,
+}: {
+  'tabs': TabItem[];
+  'aria-label': string;
+}) {
+  return (
+    <BaseTabs.List
+      aria-label={ariaLabel}
+      className={cx(
+        'relative flex shrink-0 flex-col gap-1',
+        'w-fit max-w-[11rem] min-w-[7rem]',
+        '@min-[34rem]:max-w-[14rem] @min-[34rem]:min-w-[9rem]',
+        '@min-[48rem]:max-w-[17rem] @min-[48rem]:min-w-[11rem]',
+        '@min-[64rem]:max-w-[20rem] @min-[64rem]:min-w-[13rem]',
+      )}
+    >
+      <TabIndicator />
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.value}
+          value={tab.value}
+          icon={tab.icon}
+          disabled={tab.disabled}
+        >
+          {tab.label}
+        </Tab>
+      ))}
+    </BaseTabs.List>
+  );
+}
+
+// Radius chosen to read as a full pill on a single-line tab (≈ half the
+// single-line height) while staying a fixed rounded rect on a wrapped,
+// multi-line tab — a `rounded-full` here would warp tall tabs into a stadium.
+const TAB_RADIUS = 'rounded-[1.25rem]';
+
+/** A single tab. Internal — consumers describe tabs via `Tabs`' `tabs` prop. */
+function Tab({
+  value,
+  icon: Icon,
+  disabled,
+  children,
+}: {
+  value: string;
+  icon?: LucideIcon;
+  disabled?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <BaseTabs.Tab
+      value={value}
+      disabled={disabled}
+      className={cx(
+        'font-heading focusable relative z-10 flex w-full cursor-pointer items-center gap-3',
+        'border-0 bg-transparent px-4 py-3 text-left text-sm leading-tight font-extrabold',
+        TAB_RADIUS,
+        'text-text/80 data-[selected]:text-text',
+        'disabled:cursor-not-allowed disabled:opacity-40',
+      )}
+    >
+      {Icon ? <Icon aria-hidden className="size-5 shrink-0" /> : null}
+      <span className="min-w-0">{children}</span>
+    </BaseTabs.Tab>
+  );
+}
+
+/**
+ * The moving highlight behind the active tab. Internal — rendered by the rail.
+ * Positions itself from the Base UI `--active-tab-top`/`--active-tab-height`
+ * variables and eases between tabs; the global reduced-motion query zeroes it.
+ */
+function TabIndicator() {
+  return (
+    <BaseTabs.Indicator
+      className={cx(
+        'bg-surface-2 pointer-events-none absolute top-0 left-0 z-0 w-full',
+        TAB_RADIUS,
+        'h-(--active-tab-height) translate-y-(--active-tab-top)',
+        'transition-[translate,height] duration-200 ease-out',
+      )}
+    />
+  );
+}
+
+export type TabsPanelProps = {
+  value: string;
+  className?: string;
+  keepMounted?: boolean;
+  children: ReactNode;
+};
+
+/**
+ * The content pane for a tab. Fills the row beside the rail and is its own
+ * `@container` so panel content can adapt to the panel width.
+ */
+export function TabsPanel({
+  value,
+  className,
+  keepMounted,
+  children,
+}: TabsPanelProps) {
+  return (
+    <BaseTabs.Panel
+      value={value}
+      keepMounted={keepMounted}
+      className={cx('@container min-w-0 flex-1 outline-none', className)}
+    >
+      {children}
+    </BaseTabs.Panel>
+  );
+}

--- a/packages/fresco-ui/src/form/Field/BaseField.tsx
+++ b/packages/fresco-ui/src/form/Field/BaseField.tsx
@@ -61,12 +61,19 @@ export function BaseField({
   return (
     <div
       {...containerProps}
-      className={cx('group w-full grow not-last:mb-8', 'flex flex-col')}
+      className={cx(
+        'group @container w-full grow not-last:mb-8',
+        'flex flex-col',
+      )}
     >
       <div
         className={cx(
+          // `inline` fields lay out as two columns (label | control) once the
+          // field's own CONTAINER is wide enough, and stack when it's narrow —
+          // a container query, not a viewport breakpoint, so a field adapts to
+          // where it's placed (e.g. a narrow sidebar) rather than the screen.
           inline &&
-            'tablet-portrait:flex-row tablet-portrait:align-middle tablet-portrait:items-center tablet-portrait:justify-between tablet-portrait:gap-4',
+            '@min-[28rem]:flex-row @min-[28rem]:items-center @min-[28rem]:justify-between @min-[28rem]:gap-4',
           'flex flex-col',
         )}
       >

--- a/packages/fresco-ui/src/form/fields/InputField.tsx
+++ b/packages/fresco-ui/src/form/fields/InputField.tsx
@@ -60,11 +60,12 @@ const inputWrapperVariants = compose(
       //
       // The wrapper clips to its rounded corners (`overflow-hidden` from
       // `controlVariants`, needed for child backgrounds such as the number
-      // steppers). A focused slot button's offset ring (outline-offset-3 +
-      // outline-2 = 5px) exceeds the ~4px vertical clearance and would be
+      // steppers). A focused slot button's outward offset ring (outline-offset-3
+      // + outline-2 = 5px) exceeds the ~4px vertical clearance and would be
       // clipped, so un-clip while a slot control is focus-visible — the ring
-      // then paints in full. Steppers are `tabIndex={-1}` so they never match
-      // `:focus-visible`, and number fields keep their clipped corners.
+      // then paints in full. Number steppers instead paint an INSET ring (see
+      // `stepperButtonVariants`) so they stay fully visible without depending on
+      // this un-clip, and number fields keep their clipped corners.
       'has-[button:focus-visible]:overflow-visible',
       // Child buttons should have reduced height, but their icons should stay the same size
       '[&_button]:h-10',
@@ -106,6 +107,12 @@ const stepperButtonVariants = cx(
   'bg-input-contrast/5 text-input-contrast',
   'hover:bg-input-contrast/10',
   'disabled:pointer-events-none disabled:opacity-30',
+  // The steppers sit flush against the wrapper edges, which clips its rounded
+  // corners with `overflow-hidden` (from `controlVariants`). The default
+  // outward focus ring (`outline-offset-3`) would be clipped on the top,
+  // bottom and inner edges. Paint the ring INSET instead so it's fully visible
+  // on all four sides without relying on the wrapper un-clipping.
+  'focus-visible:-outline-offset-3',
 );
 
 type InputFieldProps = CreateFormFieldProps<
@@ -193,7 +200,10 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
             }
           }}
           autoComplete="off"
-          className={inputVariants({ className })}
+          // The caller's `className` styles the wrapper (the control container),
+          // not the inner input — otherwise a background/backdrop passed to the
+          // field (e.g. the glass treatment) would double-apply onto the input.
+          className={inputVariants()}
           type={type}
           {...inputProps}
           onChange={(e) => {

--- a/tooling/tailwind/fresco/theme.css
+++ b/tooling/tailwind/fresco/theme.css
@@ -412,6 +412,14 @@
   --radius-3xl: calc(var(--radius) * 4); /* 112px */
   --radius-full: 9999px; /* 9999px */
 
+  /*
+   * Border width for the translucent glass control treatment (the
+   * `control-glass` utility, used by the Button `glass` variant and the
+   * SegmentedSwitcher). Consumed via the `border-control` utility. Other
+   * controls keep their own `border-2`; this is not a global control border.
+   */
+  --control-border-width: 3px;
+
   /* Shadows */
   --shadow-sm: var(--shadow-sm-base);
   --shadow: var(--shadow-base);

--- a/tooling/tailwind/fresco/utilities.css
+++ b/tooling/tailwind/fresco/utilities.css
@@ -102,6 +102,25 @@
 }
 
 /*
+ * Border width for the glass control treatment (see `control-glass` below); the
+ * value lives in the theme as `--control-border-width`. Border COLOR stays
+ * per-component. This is only the glass border — other controls keep `border-2`.
+ */
+@utility border-control {
+  border-width: var(--control-border-width);
+}
+
+/*
+ * Glass control treatment: translucent surface + backdrop blur + the shared
+ * control border + a prominent effect shadow. Single source of truth for the
+ * "glass" look shared by the interviewer home-screen glass Buttons and the
+ * SegmentedSwitcher track. Border colour is left to the consumer.
+ */
+@utility control-glass {
+  @apply bg-surface/50 border-control effect-shadow-md backdrop-blur-md;
+}
+
+/*
  * Foundational themed-surface defaults. Applied to `body` so unthemed page
  * chrome has reasonable defaults, AND to every `ThemedRegion` so the
  * inherited / cascading themed values (font-family, color, --scoped-bg,


### PR DESCRIPTION
## Summary

Two lanes of work (two changesets: library + app).

### `@codaco/fresco-ui` + `@codaco/tailwind-config` (library)
- **New `Tabs` component** — a compound, Base UI-backed vertical tabs (`Tabs` + `TabsPanel`); the rail is driven by a `tabs` array and renders its own active indicator. Container-query sized; keyboard nav + ARIA come from Base UI.
- **Glass control treatment** — a `control-glass` utility + `--control-border-width` token (tailwind-config), surfaced as a Button `glass` variant and a `SegmentedSwitcher` `variant` prop (`outline` default, `glass` opt-in). Switcher height + active-pill radius harmonised with Button; the active pill now nests concentrically; new `xl` size.
- `BaseField` inline layout → container query. `Table` `bodyScroll` → `overscroll-none` (no rubber-band; still scrolls). `InputField` applies the caller `className` to the wrapper only (not the inner `<input>`), so a field-level background/backdrop no longer double-applies onto the input.

### `@codaco/interviewer` (app)
- Harmonise the top-bar switcher / settings / lock / deck controls, the resume pill, the data search field, and the status filter into one consistent glass style.
- Fix the resume-interview pill overlapping the switcher / protocol cards in portrait (now orientation-based, not a min-width breakpoint).
- Reduce page gutters on smaller tablets in portrait; widen + responsively reflow the settings dialog; move the settings nav to the new `Tabs` component.
- Fix a Chrome-only bug where the import-protocol card's backdrop blur didn't render.

Also captures the "build a new shared component" practices (bare stories, container queries, composition/props docs) in the `developing-in-network-canvas` skill.

## Verification
- `pnpm typecheck`, `pnpm knip`, and fresco-ui unit tests (40) pass; `check:changesets` passes (lanes not mixed).
- Verified visually in Storybook and the running interviewer app at iPad-portrait widths (820 / 1032), and across orientations where relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)