### PR TITLE
fix(fresco-ui): stack BooleanField options vertically in narrow containers

### DIFF
--- a/.changeset/boolean-field-stack-narrow.md
+++ b/.changeset/boolean-field-stack-narrow.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Fix `BooleanField` so its two options stack vertically instead of overflowing when the container is too narrow to show them side by side.

--- a/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof BooleanField> = {
   title: 'Systems/Form/Fields/BooleanField',
   component: BooleanField,
   parameters: {
-    layout: 'centered',
+    layout: 'padded',
   },
   tags: ['autodocs'],
   argTypes: {
@@ -183,6 +183,29 @@ export const Invalid: Story = {
 
     return (
       <div className="w-full max-w-2xl">
+        <BooleanField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange?.(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+};
+
+export const NarrowContainer: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<boolean | undefined>(args.value);
+
+    useEffect(() => {
+      setValue(args.value);
+    }, [args.value]);
+
+    return (
+      <div className="w-56">
         <BooleanField
           {...args}
           value={value}

--- a/packages/fresco-ui/src/form/fields/Boolean.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.tsx
@@ -188,11 +188,11 @@ export default function BooleanField(props: BooleanFieldProps) {
   const groupState = getInputState(props);
 
   return (
-    <div className={cx('flex w-full flex-col gap-2', className)}>
+    <div className={cx('@container flex w-full flex-col gap-2', className)}>
       <fieldset
         id={id}
         {...rest}
-        className="flex w-full items-stretch gap-2 border-0 p-0 *:flex-1"
+        className="flex w-full flex-col items-stretch gap-2 border-0 p-0 *:flex-1 @xs:flex-row"
         disabled={disabled}
         aria-label={label ?? rest['aria-label']}
         aria-invalid={rest['aria-invalid'] ?? undefined}


### PR DESCRIPTION
## Summary

- `BooleanField` now uses a container query so its two option cards switch from a row to a stacked column layout when the container is too narrow to show them side by side, matching the pattern already used by `RadioGroup`/`CheckboxGroup`/`RadioMatrixField`.
- Added a `NarrowContainer` story, and switched the story `layout` param from `centered` to `padded` — `centered` gives the story an indefinite width, which creates a container-query cyclic dependency that makes the field always render stacked regardless of actual available space (the other container-query fields already use `padded` to avoid this).
- Added a changeset (`@codaco/fresco-ui` patch).

## Test plan

- [x] `pnpm --filter @codaco/fresco-ui typecheck` passes
- [x] `oxlint`/`oxfmt` clean (no new warnings)
- [x] Verified in Storybook: wide container renders options side-by-side, narrow (224px) container stacks them vertically
- [x] Verified click selection and keyboard (arrow key) navigation still work in the stacked layout
