### PR TITLE
Confirm before exiting an interview; regroup horizontal navigation

### DIFF
--- a/.changeset/exit-confirm-horizontal-nav.md
+++ b/.changeset/exit-confirm-horizontal-nav.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Ask for confirmation before exiting an interview in progress, and regroup the horizontal navigation bar so previous/next sit together on the right with the progress bar filling the middle.

--- a/packages/interview/.storybook/StoryInterviewShell.tsx
+++ b/packages/interview/.storybook/StoryInterviewShell.tsx
@@ -125,6 +125,9 @@ const StoryInterviewShell = (props: {
   /** Set for capture stories so dev-only UI (e.g. FamilyPedigree's
    * Dump/Load buttons) never appears in screenshots. */
   isDevelopment?: boolean;
+  /** Renders the Navigation exit button when provided, so stories can
+   * demonstrate the exit-confirmation flow. */
+  onExit?: () => void;
 }) => {
   const { payload, initialStep, assetUrls } = useMemo(() => {
     const raw = SuperJSON.parse<RawSyntheticPayload>(props.rawPayload);
@@ -169,6 +172,7 @@ const StoryInterviewShell = (props: {
       hideNavigation={props.hideNavigation}
       navigationOrientation={props.navigationOrientation}
       allowStageNavigation={props.allowStageNavigation}
+      onExit={props.onExit}
     />
   );
 };

--- a/packages/interview/src/components/Navigation.stories.tsx
+++ b/packages/interview/src/components/Navigation.stories.tsx
@@ -171,3 +171,61 @@ export const HorizontalStageNavigation: Story = {
     await openAndAssertMenu(canvasElement, args.stageCount);
   },
 };
+
+const exitAndAssertConfirmation = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement);
+
+  const exitButton = await canvas.findByRole('button', {
+    name: /exit interview/i,
+  });
+  await userEvent.click(exitButton);
+
+  const dialog = await canvas.findByRole('dialog', {
+    name: /exit this interview/i,
+  });
+  const scoped = within(dialog);
+
+  await expect(
+    scoped.getByText(/your answers so far will be saved/i),
+  ).toBeInTheDocument();
+
+  // Cancel rather than confirm, so the story stays on the interview.
+  await userEvent.click(scoped.getByRole('button', { name: /cancel/i }));
+  await waitFor(() => expect(dialog).not.toBeInTheDocument());
+};
+
+export const ExitConfirmation: Story = {
+  name: 'Exit confirmation (vertical rail)',
+  render: ({ stageCount }) => (
+    <div className="flex h-dvh w-full">
+      <StoryInterviewShell
+        rawPayload={getRawPayload(stageCount)}
+        navigationOrientation="vertical"
+        onExit={() => {
+          console.log('Exited the interview.');
+        }}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await exitAndAssertConfirmation(canvasElement);
+  },
+};
+
+export const HorizontalExitConfirmation: Story = {
+  name: 'Exit confirmation (horizontal bar)',
+  render: ({ stageCount }) => (
+    <div className="flex h-dvh w-full">
+      <StoryInterviewShell
+        rawPayload={getRawPayload(stageCount)}
+        navigationOrientation="horizontal"
+        onExit={() => {
+          console.log('Exited the interview.');
+        }}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await exitAndAssertConfirmation(canvasElement);
+  },
+};

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -66,13 +66,15 @@ const containerVariants = {
 const NavigationButton = ({
   disabled,
   className,
+  wrapperClassName,
   buttonRef,
   ...props
 }: ComponentProps<typeof IconButton> & {
   buttonRef?: Ref<HTMLButtonElement>;
+  wrapperClassName?: string;
 }) => {
   return (
-    <motion.div variants={variants}>
+    <motion.div variants={variants} className={wrapperClassName}>
       <IconButton
         ref={buttonRef}
         color="dynamic"
@@ -177,6 +179,22 @@ const Navigation = ({
     [confirm],
   );
 
+  const handleExit = useCallback(async () => {
+    if (!onExit) return;
+    const confirmed = await confirm({
+      title: 'Exit this interview?',
+      description:
+        'Your answers so far will be saved and you can continue later.',
+      confirmLabel: 'Exit interview',
+      cancelLabel: 'Cancel',
+      intent: 'warning',
+      onConfirm: () => {},
+    });
+    if (confirmed === true) {
+      onExit();
+    }
+  }, [confirm, onExit]);
+
   const closeMenu = useCallback(
     (immediate: boolean) => {
       setMenuSettled(false);
@@ -215,14 +233,20 @@ const Navigation = ({
       >
         {onExit && (
           <NavigationButton
-            onClick={onExit}
+            onClick={() => void handleExit()}
             icon={<LogOut />}
             className="[&>.lucide]:h-[1.5em]!"
+            wrapperClassName={
+              orientation === 'horizontal' ? 'order-1' : undefined
+            }
             aria-label="Exit interview"
             data-testid="exit-button"
           />
         )}
         <NavigationButton
+          wrapperClassName={
+            orientation === 'horizontal' ? 'order-3' : undefined
+          }
           onClick={moveBackward}
           disabled={disableMoveBackward}
           icon={<BackIcon />}
@@ -241,6 +265,7 @@ const Navigation = ({
             variants={variants}
             className={cx(
               progressContainerVariants({ orientation }),
+              orientation === 'horizontal' && 'order-2',
               // Wrap the bar directly so the focus ring hugs its pill shape
               // rather than a rectangular wrapper.
               'focusable cursor-pointer appearance-none rounded-full border-0 bg-transparent p-0',
@@ -250,7 +275,10 @@ const Navigation = ({
           </motion.button>
         ) : (
           <motion.div
-            className={progressContainerVariants({ orientation })}
+            className={cx(
+              progressContainerVariants({ orientation }),
+              orientation === 'horizontal' && 'order-2',
+            )}
             variants={variants}
           >
             <ProgressBar percentProgress={progress} orientation={orientation} />
@@ -261,6 +289,9 @@ const Navigation = ({
             pulseNext && 'bg-success hover:enabled:bg-success outline-success',
             pulseNext && !shouldReduceMotion && 'animate-pulse-glow',
           )}
+          wrapperClassName={
+            orientation === 'horizontal' ? 'order-4' : undefined
+          }
           onClick={moveForward}
           disabled={disableMoveForward}
           icon={<ForwardIcon className="size-8" strokeWidth="3px" />}


### PR DESCRIPTION
## Summary
- Exiting an interview mid-session now shows a confirmation dialog (via the existing `useDialog().confirm()` pattern already used for skip-logic overrides) before calling `onExit`.
- In horizontal navigation mode, the leave button stays on the left, the progress bar now fills the middle, and the previous/next buttons are grouped together at the far right (previously the progress bar sat between them).
- Vertical mode layout is unchanged.

## Test plan
- [x] `pnpm --filter @codaco/interview typecheck`
- [x] `pnpm --filter @codaco/interview exec oxlint` / `oxfmt` (via lint-staged on commit)
- [x] `pnpm --filter @codaco/interview exec vitest run --project units src/components`
- [x] Verified horizontal layout visually in Storybook (`Components/Navigation` stories) — previous/next buttons render adjacent at the right edge with the progress bar filling the remaining space.