### PR TITLE
test(family-pedigree): stable test-id targeting + scenario hint skip

### DIFF
--- a/packages/fresco-ui/src/dialogs/DialogProvider.tsx
+++ b/packages/fresco-ui/src/dialogs/DialogProvider.tsx
@@ -477,6 +477,7 @@ const DialogProvider: React.FC<{ children: React.ReactNode }> = ({
         <Button
           color="primary"
           onClick={() => closeDialog(dialog.id, dialog.actions.primary.value)}
+          data-testid="dialog-primary"
         >
           {dialog.actions.primary.label}
         </Button>
@@ -514,6 +515,7 @@ const DialogProvider: React.FC<{ children: React.ReactNode }> = ({
                 closeDialog(dialog.id, dialog.actions.cancel.value)
               }
               autoFocus={autoFocusButton === 'cancel'}
+              data-testid="dialog-cancel"
             >
               {dialog.actions.cancel.label}
             </Button>
@@ -523,6 +525,7 @@ const DialogProvider: React.FC<{ children: React.ReactNode }> = ({
               onClick={() =>
                 closeDialog(dialog.id, dialog.actions.secondary!.value)
               }
+              data-testid="dialog-secondary"
             >
               {dialog.actions.secondary.label}
             </Button>
@@ -533,6 +536,7 @@ const DialogProvider: React.FC<{ children: React.ReactNode }> = ({
             autoFocus={autoFocusButton === 'primary'}
             disabled={isLoading}
             icon={isLoading ? <Loader2 className="animate-spin" /> : undefined}
+            data-testid="dialog-primary"
           >
             {isLoading ? 'Please wait...' : dialog.actions.primary.label}
           </Button>
@@ -567,10 +571,13 @@ const DialogProvider: React.FC<{ children: React.ReactNode }> = ({
             open={dialog.open}
             footer={
               <>
-                <Button onClick={() => closeDialog(dialog.id, null)}>
+                <Button
+                  onClick={() => closeDialog(dialog.id, null)}
+                  data-testid="dialog-cancel"
+                >
                   {dialog.cancelLabel ?? 'Cancel'}
                 </Button>
-                <SubmitButton form={formId}>
+                <SubmitButton form={formId} data-testid="dialog-submit">
                   {dialog.submitLabel ?? 'Submit'}
                 </SubmitButton>
               </>

--- a/packages/fresco-ui/src/dialogs/useWizardState.tsx
+++ b/packages/fresco-ui/src/dialogs/useWizardState.tsx
@@ -237,7 +237,7 @@ export default function useWizardState({
           )
         )}
         <div className="phone-landscape:flex-row phone-landscape:justify-between flex flex-col gap-8">
-          <Button onClick={handleCancel}>
+          <Button onClick={handleCancel} data-testid="wizard-cancel">
             {dialog.cancelLabel ?? 'Cancel'}
           </Button>
 
@@ -246,6 +246,7 @@ export default function useWizardState({
               <Button
                 onClick={handleBack}
                 disabled={isFirstActive || !backEnabled}
+                data-testid="wizard-back"
               >
                 {currentStep.backLabel ?? 'Back'}
               </Button>
@@ -254,6 +255,7 @@ export default function useWizardState({
               color="primary"
               onClick={() => void handleNext()}
               disabled={!nextEnabled || isNextLoading}
+              data-testid="wizard-next"
             >
               {isNextLoading ? (
                 <Loader2 className="animate-spin" size={16} />

--- a/packages/fresco-ui/src/form/fields/Boolean.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.tsx
@@ -218,6 +218,7 @@ export default function BooleanField(props: BooleanFieldProps) {
               type="button"
               role="radio"
               aria-checked={isSelected}
+              data-value={String(option.value)}
               tabIndex={
                 isSelected || (value === undefined && index === 0) ? 0 : -1
               }

--- a/packages/fresco-ui/src/form/fields/RadioGroup.tsx
+++ b/packages/fresco-ui/src/form/fields/RadioGroup.tsx
@@ -103,6 +103,7 @@ export function RadioItem({
               id={optionId}
               type="button"
               aria-label={label}
+              data-value={optionValue}
               className={radioIndicatorVariants({
                 size,
                 state: indicatorState,

--- a/packages/fresco-ui/src/form/fields/RichSelectGroup.tsx
+++ b/packages/fresco-ui/src/form/fields/RichSelectGroup.tsx
@@ -411,6 +411,7 @@ export default function RichSelectGroupField(props: RichSelectGroupProps) {
           disabled={isOptionDisabled}
           whileTap={isOptionDisabled || readOnly ? undefined : { scale: 0.98 }}
           transition={selectionSpring}
+          data-value={String(option.value)}
           {...ariaProps}
         >
           <span

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.capture.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.capture.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { screen, userEvent } from 'storybook/test';
 
 import CaptureStory, {
   type CaptureParameters,
@@ -10,6 +9,7 @@ import {
   type StoryArgs,
   WithPartnerAndChildren,
 } from './FamilyPedigree.stories';
+import { clickDialogPrimary } from './familyPedigreeWizardHelpers';
 
 /**
  * Screenshot-capture story for the FamilyPedigree interface. Consumed by the
@@ -45,11 +45,6 @@ export const Capture: StoryObj<StoryArgs> = {
     await WithPartnerAndChildren.play?.(ctx);
     // Dismiss the post-wizard "Building the rest of your pedigree" hint so
     // the pedigree canvas itself is pictured.
-    const gotIt = await screen.findByRole(
-      'button',
-      { name: 'Got it' },
-      { timeout: 10_000 },
-    );
-    await userEvent.click(gotIt);
+    await clickDialogPrimary();
   },
 };

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.consanguinity.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.consanguinity.stories.tsx
@@ -1,10 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo } from 'react';
-import { expect, screen, userEvent, within } from 'storybook/test';
+import { expect, screen } from 'storybook/test';
 import SuperJSON from 'superjson';
 
 import { SyntheticInterview } from '@codaco/protocol-utilities';
 import StoryInterviewShell from '~/.storybook/StoryInterviewShell';
+
+import {
+  clickDialogSubmit,
+  clickMenuItem,
+  clickNext,
+  openNodeContextMenu,
+  setFieldInput,
+  WIZARD_TIMEOUT,
+} from './familyPedigreeWizardHelpers';
 
 /**
  * Shared protocol setup: mirrors FamilyPedigree.cousins.stories.tsx so the
@@ -283,95 +292,6 @@ export const ConsanguineousUnionRepresentation: Story = {
 //   3. Asserts the union (Maria still present) and the shared child appear.
 // ---------------------------------------------------------------------------
 
-const WIZARD_TIMEOUT = { timeout: 8000 };
-
-async function findContinueButton() {
-  const buttons = await screen.findAllByRole('button', {});
-  const btn = buttons.find(
-    (b) => b.textContent === 'Finish' || b.textContent === 'Continue',
-  );
-  if (!btn) throw new Error('No Finish or Continue button found');
-  return btn;
-}
-
-async function clickContinue() {
-  await userEvent.click(await findContinueButton());
-}
-
-// The "Add partner" form dialog submits via a button labelled "Add" (its
-// submitLabel) rather than the wizard's "Continue"/"Finish", so it needs its
-// own submitter.
-async function clickAdd() {
-  const dialog = await screen.findByRole('dialog', {}, WIZARD_TIMEOUT);
-  const buttons = await within(dialog).findAllByRole('button', {});
-  const btn = buttons.find((b) => b.textContent === 'Add');
-  if (!btn) throw new Error('No Add button found in the Add-partner dialog');
-  await userEvent.click(btn);
-}
-
-async function getDialog() {
-  return screen.findByRole('dialog', {}, WIZARD_TIMEOUT);
-}
-
-async function setFieldInput(fieldName: string, value: boolean | string) {
-  const dialog = await getDialog();
-  const container = dialog.querySelector(
-    `[data-field-name="${CSS.escape(fieldName)}"]`,
-  );
-  if (!container)
-    throw new Error(`No field found with data-field-name="${fieldName}"`);
-
-  if (typeof value === 'boolean') {
-    const toggle = container.querySelector('[role="switch"]');
-    if (toggle) {
-      const isChecked = toggle.getAttribute('aria-checked') === 'true';
-      if (isChecked !== value) await userEvent.click(toggle);
-      return;
-    }
-    const radios = within(container as HTMLElement).getAllByRole('radio');
-    const target = value ? radios[0] : radios[1];
-    if (!target)
-      throw new Error(`No radio for value=${String(value)} in "${fieldName}"`);
-    await userEvent.click(target);
-    return;
-  }
-
-  // String value — RadioGroup or text input
-  const radios = (container as HTMLElement).querySelectorAll('[role="radio"]');
-  if (radios.length > 0) {
-    const target = Array.from(radios).find(
-      (r) => r.getAttribute('aria-label') === value,
-    );
-    if (target) {
-      await userEvent.click(target);
-      return;
-    }
-    const byValue = Array.from(radios).find((r) => {
-      const input = r.querySelector('input[type="radio"]');
-      return input?.getAttribute('value') === value;
-    });
-    if (byValue) {
-      await userEvent.click(byValue);
-      return;
-    }
-    throw new Error(`No radio option matching "${value}" in "${fieldName}"`);
-  }
-
-  const input = within(container as HTMLElement).getByRole('textbox');
-  await userEvent.clear(input);
-  await userEvent.type(input, value);
-}
-
-async function openNodeContextMenu(nodeName: string) {
-  const nodeBtn = await screen.findByRole(
-    'button',
-    { name: nodeName },
-    WIZARD_TIMEOUT,
-  );
-  await userEvent.click(nodeBtn);
-  await screen.findByRole('menu', {}, WIZARD_TIMEOUT);
-}
-
 export const ConsanguineousUnionCreationViaWizard: Story = {
   render: () => {
     const buildFn = () => {
@@ -491,15 +411,13 @@ export const ConsanguineousUnionCreationViaWizard: Story = {
     // (buildNodeOptions labels ego specially). Selecting it forms the
     // undirected partner edge: the same consanguineous union as ego ⚭ Maria.
     await openNodeContextMenu('Maria');
-    await userEvent.click(
-      await screen.findByText('Add partner', {}, WIZARD_TIMEOUT),
-    );
+    await clickMenuItem('partner');
 
     // AddPersonFields: pick the existing-person branch, then ego ("You") from
     // the candidate picker. The current/ex question defaults to "current".
-    await setFieldInput('partnerType', 'Yes — already in the family tree');
+    await setFieldInput('partnerType', 'existing');
     await setFieldInput('existingPartnerId', 'You');
-    await clickAdd();
+    await clickDialogSubmit();
 
     // The consanguineous union now exists; Maria remains on the canvas.
     await screen.findByRole('button', { name: 'Maria' }, WIZARD_TIMEOUT);
@@ -511,21 +429,20 @@ export const ConsanguineousUnionCreationViaWizard: Story = {
     // as the sperm source, so the child descends from both members of the
     // consanguineous union. ego is re-selected explicitly for robustness.
     await openNodeContextMenu('Maria');
-    await userEvent.click(
-      await screen.findByText('Add child', {}, WIZARD_TIMEOUT),
-    );
+    await clickMenuItem('child');
 
     await setFieldInput('child.name', 'Emma');
-    await setFieldInput('child.gender_identity', 'Woman/girl');
-    await clickContinue(); // Child details → BioTriadStep
+    await setFieldInput('child.biologicalSex', 'female');
+    await setFieldInput('child.gender_identity', 'woman');
+    await clickNext(); // Child details → BioTriadStep
 
     await setFieldInput('sperm-source', 'You');
-    await clickContinue(); // BioTriadStep → Other parents
+    await clickNext(); // BioTriadStep → Other parents
 
     // Both genetic parents (Maria, ego) already exist, so the new-parent
     // partnership step is skipped and this continue finalises the wizard.
     await setFieldInput('hasOtherParents', false);
-    await clickContinue(); // Other parents → done
+    await clickNext(); // Other parents → done
 
     // -----------------------------------------------------------------------
     // Step 3: The union and the shared child render cleanly.

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.cousins.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.cousins.stories.tsx
@@ -6,7 +6,18 @@ import SuperJSON from 'superjson';
 import { SyntheticInterview } from '@codaco/protocol-utilities';
 import StoryInterviewShell from '~/.storybook/StoryInterviewShell';
 
-import { selectBiologicalSex } from './familyPedigreeWizardHelpers';
+import {
+  clickDialogPrimary,
+  clickGetStarted,
+  clickMenuItem,
+  clickNext,
+  getMenuItem,
+  openNodeContextMenu,
+  selectEgoSex,
+  setFieldInput,
+  setPartnership,
+  WIZARD_TIMEOUT,
+} from './familyPedigreeWizardHelpers';
 
 /**
  * Shared protocol setup: mirrors the structure in FamilyPedigree.stories.tsx so
@@ -278,122 +289,6 @@ export const FirstCousinRepresentation: Story = {
 //   7. Assert Emma appears on the pedigree canvas.
 // ---------------------------------------------------------------------------
 
-const WIZARD_TIMEOUT = { timeout: 8000 };
-
-async function clickGetStarted() {
-  const btn = await screen.findByRole('button', {
-    name: 'Build family pedigree',
-  });
-  await userEvent.click(btn);
-  await screen.findByRole('dialog', {}, WIZARD_TIMEOUT);
-}
-
-async function findContinueButton() {
-  const buttons = await screen.findAllByRole('button', {});
-  const btn = buttons.find(
-    (b) => b.textContent === 'Finish' || b.textContent === 'Continue',
-  );
-  if (!btn) throw new Error('No Finish or Continue button found');
-  return btn;
-}
-
-async function clickContinue() {
-  await userEvent.click(await findContinueButton());
-}
-
-async function getDialog() {
-  return screen.findByRole('dialog', {}, WIZARD_TIMEOUT);
-}
-
-async function setFieldInput(fieldName: string, value: boolean | string) {
-  const dialog = await getDialog();
-  const container = dialog.querySelector(
-    `[data-field-name="${CSS.escape(fieldName)}"]`,
-  );
-  if (!container)
-    throw new Error(`No field found with data-field-name="${fieldName}"`);
-
-  if (typeof value === 'boolean') {
-    const toggle = container.querySelector('[role="switch"]');
-    if (toggle) {
-      const isChecked = toggle.getAttribute('aria-checked') === 'true';
-      if (isChecked !== value) await userEvent.click(toggle);
-      return;
-    }
-    const radios = within(container as HTMLElement).getAllByRole('radio');
-    const target = value ? radios[0] : radios[1];
-    if (!target)
-      throw new Error(`No radio for value=${String(value)} in "${fieldName}"`);
-    await userEvent.click(target);
-    return;
-  }
-
-  // String value — RadioGroup or text input
-  const radios = (container as HTMLElement).querySelectorAll('[role="radio"]');
-  if (radios.length > 0) {
-    const target = Array.from(radios).find(
-      (r) => r.getAttribute('aria-label') === value,
-    );
-    if (target) {
-      await userEvent.click(target);
-      return;
-    }
-    const byValue = Array.from(radios).find((r) => {
-      const input = r.querySelector('input[type="radio"]');
-      return input?.getAttribute('value') === value;
-    });
-    if (byValue) {
-      await userEvent.click(byValue);
-      return;
-    }
-    throw new Error(`No radio option matching "${value}" in "${fieldName}"`);
-  }
-
-  const input = within(container as HTMLElement).getByRole('textbox');
-  await userEvent.clear(input);
-  await userEvent.type(input, value);
-}
-
-async function setPartnership(
-  focalId: string,
-  partnerLabel: string,
-  optionLabel: string,
-) {
-  const dialog = await getDialog();
-  const matrix = dialog.querySelector(
-    `[data-field-name="${CSS.escape(`partnerships.${focalId}`)}"]`,
-  );
-  if (!matrix) throw new Error(`No partnership matrix for focal "${focalId}"`);
-  const group = within(matrix as HTMLElement).getByRole('radiogroup', {
-    name: partnerLabel,
-  });
-  await userEvent.click(
-    within(group).getByRole('radio', { name: optionLabel }),
-  );
-}
-
-async function openNodeContextMenu(nodeName: string) {
-  const nodeBtn = await screen.findByRole(
-    'button',
-    { name: nodeName },
-    WIZARD_TIMEOUT,
-  );
-  await userEvent.click(nodeBtn);
-  await screen.findByRole('menu', {}, WIZARD_TIMEOUT);
-}
-
-/**
- * Answer the "About you" (EgoSexStep) biological-sex question and continue. It
- * is the first quick-start step for fixed-framing protocols (no leading
- * Introduction or FramingSelection step). The radios are labelled by their
- * option label (from BIOLOGICAL_SEX_OPTIONS; the default here is "Female").
- */
-async function selectEgoSex(label = 'Female') {
-  const dialog = await getDialog();
-  await selectBiologicalSex(dialog, label);
-  await clickContinue();
-}
-
 export const FirstCousinCreationViaWizard: Story = {
   render: () => {
     const buildFn = () => {
@@ -463,54 +358,38 @@ export const FirstCousinCreationViaWizard: Story = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Robert');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
-    await setPartnership('egg-parent', 'Robert', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Robert', 'current');
+    await clickNext();
 
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
 
     // Dismiss the post-wizard "Building the rest of your pedigree" hint.
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Got it' }, WIZARD_TIMEOUT),
-    );
+    await clickDialogPrimary();
 
     // -----------------------------------------------------------------------
     // Step 2: Assert "Add sibling" is DISABLED on Robert (no parents yet).
     // This is the Feature #2 "before" state.
     // -----------------------------------------------------------------------
     await openNodeContextMenu('Robert');
-    const menuBeforeGrandparents = await screen.findByRole(
-      'menu',
-      {},
-      WIZARD_TIMEOUT,
-    );
+    const addSiblingBefore = getMenuItem('sibling');
 
-    // Inline hint "Add a parent first" is visible.
+    // The menuitem carries aria-disabled="true" and shows the inline hint.
+    expect(addSiblingBefore).toHaveAttribute('aria-disabled', 'true');
     expect(
-      within(menuBeforeGrandparents).getByText(/add a parent first/i),
+      within(addSiblingBefore).getByText(/add a parent first/i),
     ).toBeInTheDocument();
-
-    // The menuitem itself carries aria-disabled="true".
-    const addSiblingBeforeText = within(menuBeforeGrandparents).getByText(
-      'Add sibling',
-    );
-    const addSiblingMenuItemBefore =
-      addSiblingBeforeText.closest('[role="menuitem"]');
-    expect(addSiblingMenuItemBefore).toBeTruthy();
-    expect(addSiblingMenuItemBefore?.getAttribute('aria-disabled')).toBe(
-      'true',
-    );
 
     await userEvent.keyboard('{Escape}');
 
@@ -522,31 +401,25 @@ export const FirstCousinCreationViaWizard: Story = {
     // mark them as current partners.
     // -----------------------------------------------------------------------
     await openNodeContextMenu('Robert');
-    await userEvent.click(
-      await screen.findByText('Add parent', {}, WIZARD_TIMEOUT),
-    );
+    await clickMenuItem('parent');
 
     // DefineParentsWizard opens on BioTriadStep. Robert has no existing parents,
     // so the egg-/sperm-source selectors auto-resolve to "new" (rendered hidden)
     // and we fill the new-person fields. is-donor defaults false and
     // egg-parent-carried defaults true, so those are left at their defaults.
     await setFieldInput('new-egg-source.name', 'Helen');
-    await setFieldInput('new-egg-source.gender_identity', 'Woman/girl');
+    await setFieldInput('new-egg-source.gender_identity', 'woman');
     await setFieldInput('new-sperm-source.name', 'George');
-    await setFieldInput('new-sperm-source.gender_identity', 'Man/boy');
-    await clickContinue(); // BioTriadStep → Other parents
+    await setFieldInput('new-sperm-source.gender_identity', 'man');
+    await clickNext(); // BioTriadStep → Other parents
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue(); // Other parents → Parent partnerships
+    await clickNext(); // Other parents → Parent partnerships
 
     // Helen and George are both newly created, so one partnership question
-    // appears ("Are Helen and George partners?"). The radio options are matched
-    // by their visible label. Mark them current partners.
-    await setFieldInput(
-      'partnership-egg-source-sperm-source',
-      'Current partners',
-    );
-    await clickContinue(); // partnerships → done
+    // appears ("Are Helen and George partners?"). Mark them current partners.
+    await setFieldInput('partnership-egg-source-sperm-source', 'current');
+    await clickNext(); // partnerships → done
 
     await screen.findByRole('button', { name: 'George' }, WIZARD_TIMEOUT);
     await screen.findByRole('button', { name: 'Helen' }, WIZARD_TIMEOUT);
@@ -556,45 +429,33 @@ export const FirstCousinCreationViaWizard: Story = {
     // This is the Feature #2 "after" state — the key regression test.
     // -----------------------------------------------------------------------
     await openNodeContextMenu('Robert');
-    const menuAfterGrandparents = await screen.findByRole(
-      'menu',
-      {},
-      WIZARD_TIMEOUT,
-    );
+    const addSiblingAfter = getMenuItem('sibling');
 
-    // Hint is gone.
+    // Hint is gone and the item is enabled (aria-disabled absent or 'false').
     expect(
-      within(menuAfterGrandparents).queryByText(/add a parent first/i),
+      within(addSiblingAfter).queryByText(/add a parent first/i),
     ).toBeNull();
-
-    // The menuitem is enabled (aria-disabled absent or 'false').
-    const addSiblingAfterText = within(menuAfterGrandparents).getByText(
-      'Add sibling',
-    );
-    const addSiblingMenuItemAfter =
-      addSiblingAfterText.closest('[role="menuitem"]');
-    expect(addSiblingMenuItemAfter).toBeTruthy();
-    const disabledAttr = addSiblingMenuItemAfter?.getAttribute('aria-disabled');
+    const disabledAttr = addSiblingAfter.getAttribute('aria-disabled');
     expect(disabledAttr === null || disabledAttr === 'false').toBe(true);
 
     // -----------------------------------------------------------------------
     // Step 5: "Add sibling" on Robert → AddSiblingWizard → create Carol.
     // -----------------------------------------------------------------------
-    await userEvent.click(addSiblingAfterText);
+    await userEvent.click(addSiblingAfter);
 
     await setFieldInput('sibling.name', 'Carol');
-    await setFieldInput('sibling.biologicalSex', 'Female');
-    await setFieldInput('sibling.gender_identity', 'Woman/girl');
-    await clickContinue(); // Sibling details → BioTriadStep
+    await setFieldInput('sibling.biologicalSex', 'female');
+    await setFieldInput('sibling.gender_identity', 'woman');
+    await clickNext(); // Sibling details → BioTriadStep
 
     // George and Helen are pre-offered as Carol's parents; accept the defaults.
-    await clickContinue(); // BioTriadStep → Other parents
+    await clickNext(); // BioTriadStep → Other parents
 
     await setFieldInput('hasOtherParents', false);
     // Both of Carol's parents already exist (neither is new), so the partnership
     // step is skipped (shouldSkipNewParentPartnerships) — this continue finalises
     // the wizard.
-    await clickContinue(); // Other parents → done
+    await clickNext(); // Other parents → done
 
     await screen.findByRole('button', { name: 'Carol' }, WIZARD_TIMEOUT);
 
@@ -602,30 +463,25 @@ export const FirstCousinCreationViaWizard: Story = {
     // Step 6: "Add child" on Carol → AddChildWizard → create Emma (cousin).
     // -----------------------------------------------------------------------
     await openNodeContextMenu('Carol');
-    await userEvent.click(
-      await screen.findByText('Add child', {}, WIZARD_TIMEOUT),
-    );
+    await clickMenuItem('child');
 
     await setFieldInput('child.name', 'Emma');
-    await setFieldInput('child.biologicalSex', 'Female');
-    await setFieldInput('child.gender_identity', 'Woman/girl');
-    await clickContinue(); // Child details → BioTriadStep
+    await setFieldInput('child.biologicalSex', 'female');
+    await setFieldInput('child.gender_identity', 'woman');
+    await clickNext(); // Child details → BioTriadStep
 
     // Carol is preselected as the egg source. She has no recorded partner, so
     // the sperm source is unset and required — create a new (unknown) person for
     // Emma's other parent so the step can advance.
-    await setFieldInput('sperm-source', 'Create a new person');
-    await clickContinue(); // BioTriadStep → Other parents
+    await setFieldInput('sperm-source', 'new');
+    await clickNext(); // BioTriadStep → Other parents
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue(); // Other parents → Parent partnerships
+    await clickNext(); // Other parents → Parent partnerships
 
     // Carol and the new (unknown) sperm parent form a partnership pair.
-    await setFieldInput(
-      'partnership-egg-source-sperm-source',
-      'Never partners',
-    );
-    await clickContinue(); // done
+    await setFieldInput('partnership-egg-source-sperm-source', 'none');
+    await clickNext(); // done
 
     // -----------------------------------------------------------------------
     // Step 7: Emma (the first cousin) appears on the pedigree.

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.framing.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.framing.stories.tsx
@@ -1,12 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo } from 'react';
-import { expect, screen, userEvent, within } from 'storybook/test';
+import { expect, screen, within } from 'storybook/test';
 import SuperJSON from 'superjson';
 
 import { SyntheticInterview } from '@codaco/protocol-utilities';
 import StoryInterviewShell from '~/.storybook/StoryInterviewShell';
 
-import { selectBiologicalSex } from './familyPedigreeWizardHelpers';
+import {
+  clickGetStarted,
+  clickNext,
+  selectEgoSex,
+  selectFraming,
+  setFieldInput,
+} from './familyPedigreeWizardHelpers';
 
 function buildFramingInterview({
   withIntroScreen = false,
@@ -268,36 +274,6 @@ type Story = StoryObj;
 
 const STEP_TIMEOUT = { timeout: 5000 };
 
-async function clickGetStarted() {
-  const btn = await screen.findByRole('button', {
-    name: 'Build family pedigree',
-  });
-  await userEvent.click(btn);
-  await screen.findByRole('dialog', {});
-}
-
-async function clickContinue() {
-  const dialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const buttons = within(dialog).getAllByRole('button');
-  const continueBtn = buttons.find(
-    (b) => b.textContent === 'Finish' || b.textContent === 'Continue',
-  );
-  if (!continueBtn) throw new Error('No Finish or Continue button found');
-  await userEvent.click(continueBtn);
-}
-
-/**
- * Answer the "About you" (EgoSexStep) biological-sex question and continue. This
- * step always appears after any Introduction/FramingSelection steps and before
- * the egg-parent step. The radios are labelled by their option label (from
- * BIOLOGICAL_SEX_OPTIONS; the default here is "Female").
- */
-async function selectEgoSex(label = 'Female') {
-  const dialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  await selectBiologicalSex(dialog, label);
-  await clickContinue();
-}
-
 /**
  * Complete the minimal quick-start wizard: fill in egg and sperm parents
  * (minimal required fields), skip other parents, skip partnerships (no
@@ -310,49 +286,28 @@ async function selectEgoSex(label = 'Female') {
 async function completeMinimalQuickStart() {
   await clickGetStarted();
 
-  // About you (EgoSexStep) — biological sex required
+  // About you (EgoSexStep) — biological sex required.
   await selectEgoSex();
 
-  // EggParentStep — is-donor required (BooleanField: first radio = true, second = false)
-  const eggDialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const eggRadios = within(eggDialog).getAllByRole('radio');
-  // "is-donor" false: select second radio in the field
-  const isDonorFalse = eggRadios[1];
-  if (isDonorFalse) await userEvent.click(isDonorFalse);
-  // gestationalCarrier true: select first radio
-  // Find the gestational carrier radios after setting is-donor
-  const eggDialog2 = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const allEggRadios = within(eggDialog2).getAllByRole('radio');
-  // There are two BooleanFields: is-donor (2 radios) + gestationalCarrier (2 radios)
-  // gestationalCarrier first radio = true
-  const gestCarrierTrue = allEggRadios[2];
-  if (gestCarrierTrue) await userEvent.click(gestCarrierTrue);
-  await clickContinue();
+  // Egg parent: not a donor, is the gestational carrier.
+  await setFieldInput('egg-parent.is-donor', false);
+  await setFieldInput('egg-parent.gestationalCarrier', true);
+  await clickNext();
 
-  // SpermParentStep — is-donor required (BooleanField: first = true, second = false)
-  const spermDialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const spermRadios = within(spermDialog).getAllByRole('radio');
-  const spermIsDonorFalse = spermRadios[1];
-  if (spermIsDonorFalse) await userEvent.click(spermIsDonorFalse);
-  await clickContinue();
+  // Sperm parent: not a donor.
+  await setFieldInput('sperm-parent.is-donor', false);
+  await clickNext();
 
-  // OtherParentsStep — hasOtherParents: false (second radio)
-  const otherDialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const otherRadios = within(otherDialog).getAllByRole('radio');
-  const noOtherParents = otherRadios[1];
-  if (noOtherParents) await userEvent.click(noOtherParents);
-  await clickContinue();
+  // No other parents.
+  await setFieldInput('hasOtherParents', false);
+  await clickNext();
 
-  // ParentPartnershipsStep — no changes needed, continue
-  await clickContinue();
+  // Parent partnerships — nothing to change.
+  await clickNext();
 
-  // PartnerAndChildrenStep — hasPartner: false (second radio)
-  const partnerDialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-  const partnerRadios = within(partnerDialog).getAllByRole('radio');
-  const noPartner = partnerRadios[1];
-  if (noPartner) await userEvent.click(noPartner);
-  // Finish the wizard
-  await clickContinue();
+  // No partner.
+  await setFieldInput('hasPartner', false);
+  await clickNext();
 }
 
 /**
@@ -365,15 +320,9 @@ export const ParticipantChoiceSelectsGendered: Story = {
   play: async () => {
     await clickGetStarted();
 
-    // Framing selection step: choose the gendered option ("Mother & father").
-    // FramingSelectionStep uses a RichSelectGroupField, so each choice is a
-    // button[role="option"] whose accessible name is the label + description.
-    const dialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-    const genderedOption = within(dialog).getByRole('option', {
-      name: /mother & father/i,
-    });
-    await userEvent.click(genderedOption);
-    await clickContinue();
+    // Framing selection step: choose the gendered ("Mother & father") option.
+    await selectFraming('gendered');
+    await clickNext();
 
     // About you (EgoSexStep) — answer before the parent steps.
     await selectEgoSex();
@@ -400,17 +349,12 @@ export const WithIntroScreenThenFramingSelection: Story = {
 
     // IntroStep: the custom intro-screen text is shown.
     await screen.findByText(/family health history/i, {}, STEP_TIMEOUT);
-    await clickContinue();
+    await clickNext();
 
-    // Framing selection step: choose the gamete option ("Egg parent & sperm
-    // parent"). RichSelectGroupField renders each choice as a
-    // button[role="option"] named by its label + description.
-    const dialog = await screen.findByRole('dialog', {}, STEP_TIMEOUT);
-    const gameteOption = within(dialog).getByRole('option', {
-      name: /egg parent & sperm parent/i,
-    });
-    await userEvent.click(gameteOption);
-    await clickContinue();
+    // Framing selection step: choose the gamete ("Egg parent & sperm parent")
+    // option.
+    await selectFraming('gamete');
+    await clickNext();
 
     // About you (EgoSexStep) — answer before the parent steps.
     await selectEgoSex();
@@ -435,11 +379,9 @@ export const FixedGameteQuickStart: Story = {
   play: async () => {
     await clickGetStarted();
 
-    // The framing-selection step is skipped for fixed framing, so its options
-    // never appear — the wizard opens on the "About you" (EgoSexStep) step.
-    expect(
-      screen.queryByRole('option', { name: /mother & father/i }),
-    ).toBeNull();
+    // The framing-selection step is skipped for fixed framing, so no framing
+    // options appear — the wizard opens on the "About you" (EgoSexStep) step.
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
     await selectEgoSex();
 
     // EggParentStep is now open; multiple elements may contain "Egg Parent"
@@ -465,11 +407,9 @@ export const FixedGenderedQuickStart: Story = {
   play: async () => {
     await clickGetStarted();
 
-    // The framing-selection step is skipped for fixed framing, so its options
-    // never appear — the wizard opens on the "About you" (EgoSexStep) step.
-    expect(
-      screen.queryByRole('option', { name: /egg parent & sperm parent/i }),
-    ).toBeNull();
+    // The framing-selection step is skipped for fixed framing, so no framing
+    // options appear — the wizard opens on the "About you" (EgoSexStep) step.
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
     await selectEgoSex();
 
     // EggParentStep is now open and titled "Mother"; multiple elements may
@@ -493,30 +433,19 @@ export const RequiredBoundaryGrandparentsBlocked: Story = {
     await completeMinimalQuickStart();
 
     // After the wizard finishes, the pedigree canvas is shown. The checklist
-    // widget should appear once the network has nodes (ego + two parents).
-    const checklist = await screen.findByText(
-      'Pedigree Checklist',
-      {},
-      { timeout: 8000 },
-    );
-    expect(checklist).toBeTruthy();
+    // widget appears once the network has nodes (ego + two parents).
+    await screen.findByTestId('pedigree-checklist', {}, { timeout: 8000 });
 
-    // The boundary-grandparents blocker item should be present and required (*)
-    const blocker = await screen.findByText(
-      /record each parent.s two parents/i,
+    // The boundary-grandparents item is present and marked required.
+    const blocker = await screen.findByTestId(
+      'pedigree-checklist-item-boundary-grandparents',
       {},
       STEP_TIMEOUT,
     );
-    expect(blocker).toBeTruthy();
+    expect(blocker).toHaveAttribute('data-required', 'true');
 
-    // The required marker (*) must be visible
-    const checklist$El = blocker.closest('[class]')?.parentElement;
-    expect(checklist$El?.querySelector('.text-destructive')).not.toBeNull();
-
-    // The finalize button must NOT be shown (allDone is false)
-    expect(
-      screen.queryByRole('button', { name: /finalize family pedigree/i }),
-    ).toBeNull();
+    // The finalize button must NOT be shown (allDone is false).
+    expect(screen.queryByTestId('pedigree-checklist-finalize')).toBeNull();
   },
 };
 
@@ -544,26 +473,19 @@ export const RecommendedBoundaryGrandparentsNudge: Story = {
   play: async () => {
     await completeMinimalQuickStart();
 
-    // Wait for checklist
-    await screen.findByText('Pedigree Checklist', {}, { timeout: 8000 });
+    await screen.findByTestId('pedigree-checklist', {}, { timeout: 8000 });
 
-    // The grandparents nudge item should be present
-    const nudge = await screen.findByText(
-      /record each parent.s two parents/i,
+    // The grandparents nudge item is present but WITHOUT the required marker —
+    // this is what distinguishes 'recommended' from 'required' in the checklist.
+    const nudge = await screen.findByTestId(
+      'pedigree-checklist-item-boundary-grandparents',
       {},
       STEP_TIMEOUT,
     );
-    expect(nudge).toBeTruthy();
-
-    // The nudge item must NOT carry a required (*) marker — this is what
-    // distinguishes 'recommended' from 'required' in the checklist.
-    const nudgeParent = nudge.closest('[class]')?.parentElement;
-    expect(nudgeParent?.querySelector('.text-destructive')).toBeNull();
+    expect(nudge).toHaveAttribute('data-required', 'false');
 
     // The finalize button is gated on allDone (all tasks checked), not on
     // boundary severity, so it is absent here — same as the required case.
-    expect(
-      screen.queryByRole('button', { name: /finalize family pedigree/i }),
-    ).toBeNull();
+    expect(screen.queryByTestId('pedigree-checklist-finalize')).toBeNull();
   },
 };

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.stories.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.stories.tsx
@@ -6,7 +6,15 @@ import SuperJSON from 'superjson';
 import { SyntheticInterview } from '@codaco/protocol-utilities';
 import StoryInterviewShell from '~/.storybook/StoryInterviewShell';
 
-import { selectBiologicalSex } from './familyPedigreeWizardHelpers';
+import {
+  clickGetStarted,
+  clickNext,
+  getDialog,
+  selectEgoSex,
+  setFieldInput,
+  setPartnership,
+} from './familyPedigreeWizardHelpers';
+import { SuppressPedigreeHintContext } from './pedigreeHintContext';
 
 function createFamilyPedigreeInterview(seed: number) {
   const si = new SyntheticInterview(seed);
@@ -128,10 +136,14 @@ function FamilyPedigreeStoryWrapper({
     [interview],
   );
 
+  // Scenario stories demonstrate finished pedigrees, so suppress the post-wizard
+  // "Building the rest of your pedigree" hint that would otherwise cover them.
   return (
-    <div className="h-screen">
-      <StoryInterviewShell rawPayload={rawPayload} />
-    </div>
+    <SuppressPedigreeHintContext.Provider value={true}>
+      <div className="h-screen">
+        <StoryInterviewShell rawPayload={rawPayload} />
+      </div>
+    </SuppressPedigreeHintContext.Provider>
   );
 }
 
@@ -344,156 +356,6 @@ export function buildScenarioInterview({ withNomination = false } = {}) {
   return si;
 }
 
-const STEP_TIMEOUT = { timeout: 5000 };
-
-async function clickGetStarted() {
-  const btn = await screen.findByRole('button', {
-    name: 'Build family pedigree',
-  });
-  await userEvent.click(btn);
-  await screen.findByRole('dialog', {});
-}
-
-async function clickContinue() {
-  const buttons = await screen.findAllByRole('button', {});
-  const finishBtn = buttons.find(
-    (b) => b.textContent === 'Finish' || b.textContent === 'Continue',
-  );
-  if (!finishBtn) throw new Error('No Finish or Continue button found');
-  await userEvent.click(finishBtn);
-}
-
-async function getDialog() {
-  return screen.findByRole('dialog', {}, STEP_TIMEOUT);
-}
-
-/**
- * Answer the "About you" (EgoSexStep) biological-sex question and continue. For
- * these fixed-gamete scenarios (no introScreen), it is the wizard's first step;
- * the radios are labelled by their option label (default here is "Female").
- */
-async function selectEgoSex(label = 'Female') {
-  const dialog = await getDialog();
-  await selectBiologicalSex(dialog, label);
-  await clickContinue();
-}
-
-async function setFieldInput(
-  fieldName: string,
-  value: boolean | string | number,
-) {
-  const dialog = await getDialog();
-  const container = dialog.querySelector(
-    `[data-field-name="${CSS.escape(fieldName)}"]`,
-  );
-
-  if (!container)
-    throw new Error(`No field found with data-field-name="${fieldName}"`);
-
-  if (typeof value === 'boolean') {
-    const el = container as HTMLElement;
-
-    // ToggleField: role="switch"
-    const toggle = el.querySelector('[role="switch"]');
-    if (toggle) {
-      const isChecked = toggle.getAttribute('aria-checked') === 'true';
-      if (isChecked !== value) {
-        await userEvent.click(toggle);
-      }
-      return;
-    }
-
-    // BooleanField: two radio buttons — first is "true", second is "false"
-    const radios = within(el).getAllByRole('radio');
-    const target = value ? radios[0] : radios[1];
-    if (!target)
-      throw new Error(`No radio for value=${String(value)} in "${fieldName}"`);
-    await userEvent.click(target);
-    return;
-  }
-
-  if (typeof value === 'number') {
-    // Number InputField: use stepper buttons
-    const input = within(container as HTMLElement).getByRole('spinbutton');
-    const currentValue = Number((input as HTMLInputElement).value) || 0;
-    const diff = value - currentValue;
-    if (diff === 0) return;
-
-    const wrapper = input.parentElement?.parentElement;
-    if (diff > 0) {
-      const incBtn = wrapper?.querySelector(
-        'button[aria-label="Increase value"]',
-      ) as HTMLButtonElement | null;
-      if (!incBtn) throw new Error(`No increment button in "${fieldName}"`);
-      for (let i = 0; i < diff; i++) await userEvent.click(incBtn);
-    } else {
-      const decBtn = wrapper?.querySelector(
-        'button[aria-label="Decrease value"]',
-      ) as HTMLButtonElement | null;
-      if (!decBtn) throw new Error(`No decrement button in "${fieldName}"`);
-      for (let i = 0; i < Math.abs(diff); i++) await userEvent.click(decBtn);
-    }
-    return;
-  }
-
-  // String value — could be RadioGroupField or text InputField
-  const radios = (container as HTMLElement).querySelectorAll('[role="radio"]');
-
-  if (radios.length > 0) {
-    // RadioGroupField: find the radio whose label matches the value
-    const target = Array.from(radios).find(
-      (r) => r.getAttribute('aria-label') === value,
-    );
-
-    if (target) {
-      await userEvent.click(target);
-      return;
-    }
-
-    // Fallback: check for a hidden input with a matching value attribute
-    const byValue = Array.from(radios).find((r) => {
-      const input = r.querySelector('input[type="radio"]');
-      return input?.getAttribute('value') === value;
-    });
-    if (byValue) {
-      await userEvent.click(byValue);
-      return;
-    }
-
-    throw new Error(`No radio option matching "${value}" in "${fieldName}"`);
-  }
-
-  // Text InputField: clear and type
-  const input = within(container as HTMLElement).getByRole('textbox');
-  await userEvent.clear(input);
-  await userEvent.type(input, value);
-}
-
-/**
- * Set one cell of a partnership matrix. The matrix for `focalId` lists every
- * parent below it; `partnerLabel` is the displayed label of the row (a name,
- * or a role fallback like "your sperm parent"). `optionLabel` is one of
- * "Current partner" / "Ex-partner" / "Not a partner or Don't know". Pairs
- * left at the default ("Not a partner or Don't know") need no call.
- */
-async function setPartnership(
-  focalId: string,
-  partnerLabel: string,
-  optionLabel: string,
-) {
-  const dialog = await getDialog();
-  const matrix = dialog.querySelector(
-    `[data-field-name="${CSS.escape(`partnerships.${focalId}`)}"]`,
-  );
-  if (!matrix) throw new Error(`No partnership matrix for focal "${focalId}"`);
-  const group = within(matrix as HTMLElement).getByRole('radiogroup', {
-    name: partnerLabel,
-  });
-  await userEvent.click(
-    within(group).getByRole('radio', { name: optionLabel }),
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Scenario stories
 // ---------------------------------------------------------------------------
@@ -519,36 +381,36 @@ export const NuclearFamily: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Robert');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
-    await setPartnership('egg-parent', 'Robert', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Robert', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', true);
     await setFieldInput('partner.name', 'Sophia');
-    await setFieldInput('partner.biologicalSex', 'Female');
-    await setFieldInput('partner.gender_identity', 'Woman/girl');
+    await setFieldInput('partner.biologicalSex', 'female');
+    await setFieldInput('partner.gender_identity', 'woman');
     await setFieldInput('childrenWithPartnerCount', 2);
-    await clickContinue();
+    await clickNext();
 
     // Children details — name and gender, then confirm parentage defaults
     await setFieldInput('childWithPartner[0].name', 'Olivia');
-    await setFieldInput('childWithPartner[0].biologicalSex', 'Female');
-    await setFieldInput('childWithPartner[0].gender_identity', 'Woman/girl');
+    await setFieldInput('childWithPartner[0].biologicalSex', 'female');
+    await setFieldInput('childWithPartner[0].gender_identity', 'woman');
     await setFieldInput('childWithPartner[1].name', 'Liam');
-    await setFieldInput('childWithPartner[1].biologicalSex', 'Male');
-    await setFieldInput('childWithPartner[1].gender_identity', 'Man/boy');
+    await setFieldInput('childWithPartner[1].biologicalSex', 'male');
+    await setFieldInput('childWithPartner[1].gender_identity', 'man');
 
     // Both children should show the egg/sperm parent selectors; nuclear-family
     // defaults (You → egg, Sophia → sperm) are already valid, so no changes needed.
@@ -556,7 +418,7 @@ export const NuclearFamily: ScenarioStory = {
     expect(within(childrenDialog).getAllByText('Egg Parent')).toHaveLength(2);
     expect(within(childrenDialog).getAllByText('Sperm Parent')).toHaveLength(2);
 
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -573,24 +435,24 @@ export const SingleParent: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step: absent father (not a donor)
     await setFieldInput('sperm-parent.is-donor', false);
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // Other Parents step
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
     // Linda and the absent father are not partners (matrix default)
-    await clickContinue();
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -607,32 +469,32 @@ export const SameSexMothers: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step: anonymous sperm donor
     await setFieldInput('sperm-parent.is-donor', true);
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // OtherParentsStep: Patricia is a social parent
     await setFieldInput('hasOtherParents', true);
     await setFieldInput('otherParentCount', 1);
-    await clickContinue();
+    await clickNext();
 
     // AdditionalParentsStep: Patricia
     await setFieldInput('additional-parent[0].role', 'Parent who raised me');
     await setFieldInput('additional-parent[0].name', 'Patricia');
-    await setFieldInput('additional-parent[0].gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('additional-parent[0].gender_identity', 'woman');
+    await clickNext();
 
     // Patricia is Linda's current partner; the donor partners no one
-    await setPartnership('egg-parent', 'Patricia', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Patricia', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -649,31 +511,31 @@ export const SpermDonor: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step
     await setFieldInput('sperm-parent.is-donor', true);
     await setFieldInput('sperm-parent.name', 'Carlos');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', true);
     await setFieldInput('otherParentCount', 1);
-    await clickContinue();
+    await clickNext();
 
     await setFieldInput('additional-parent[0].role', 'Parent who raised me');
     await setFieldInput('additional-parent[0].name', 'Patricia');
-    await setFieldInput('additional-parent[0].gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('additional-parent[0].gender_identity', 'woman');
+    await clickNext();
 
     // Patricia is Linda's current partner; Carlos partners no one
-    await setPartnership('egg-parent', 'Patricia', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Patricia', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -690,34 +552,34 @@ export const BlendedFamily: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Susan');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step: Robert is sperm parent
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Robert');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // OtherParentsStep: Karen is a step-parent
     await setFieldInput('hasOtherParents', true);
     await setFieldInput('otherParentCount', 1);
-    await clickContinue();
+    await clickNext();
 
     // AdditionalParentsStep: Karen
     await setFieldInput('additional-parent[0].role', 'Step-parent');
     await setFieldInput('additional-parent[0].name', 'Karen');
-    await setFieldInput('additional-parent[0].gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('additional-parent[0].gender_identity', 'woman');
+    await clickNext();
 
     // Susan and Robert are exes; Robert and Karen are current partners
-    await setPartnership('egg-parent', 'Robert', 'Ex-partner');
-    await setPartnership('sperm-parent', 'Karen', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Robert', 'ex');
+    await setPartnership('sperm-parent', 'Karen', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -734,32 +596,32 @@ export const TransParent: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Alex');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'man');
+    await clickNext();
 
     // Sperm parent step: anonymous sperm donor
     await setFieldInput('sperm-parent.is-donor', true);
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // OtherParentsStep: Priya is a social parent
     await setFieldInput('hasOtherParents', true);
     await setFieldInput('otherParentCount', 1);
-    await clickContinue();
+    await clickNext();
 
     // AdditionalParentsStep: Priya
     await setFieldInput('additional-parent[0].role', 'Parent who raised me');
     await setFieldInput('additional-parent[0].name', 'Priya');
-    await setFieldInput('additional-parent[0].gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('additional-parent[0].gender_identity', 'woman');
+    await clickNext();
 
     // Priya is Alex's current partner; the donor partners no one
-    await setPartnership('egg-parent', 'Priya', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Priya', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -777,40 +639,40 @@ export const NonBinaryEgo: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Tomoko');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Kenji');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
-    await setPartnership('egg-parent', 'Kenji', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Kenji', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', true);
     await setFieldInput('partner.name', 'Sam');
-    await setFieldInput('partner.biologicalSex', 'Female');
-    await setFieldInput('partner.gender_identity', 'Non-binary');
+    await setFieldInput('partner.biologicalSex', 'female');
+    await setFieldInput('partner.gender_identity', 'non_binary');
     await setFieldInput('childrenWithPartnerCount', 1);
-    await clickContinue();
+    await clickNext();
 
     // Children details — name and gender, then confirm parentage defaults
     await setFieldInput('childWithPartner[0].name', 'Kai');
-    await setFieldInput('childWithPartner[0].biologicalSex', 'Male');
-    await setFieldInput('childWithPartner[0].gender_identity', 'Non-binary');
+    await setFieldInput('childWithPartner[0].biologicalSex', 'male');
+    await setFieldInput('childWithPartner[0].gender_identity', 'non_binary');
 
     // Confirm the egg/sperm parent selectors are present; defaults are valid.
     const childDialog = await getDialog();
     expect(within(childDialog).getByText('Egg Parent')).toBeTruthy();
     expect(within(childDialog).getByText('Sperm Parent')).toBeTruthy();
 
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -826,28 +688,28 @@ export const AdoptedIn: ScenarioStory = {
     // Egg parent step: unknown bio parent (not a donor, just absent)
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step: unknown bio parent (not a donor, just absent)
     await setFieldInput('sperm-parent.is-donor', false);
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // OtherParentsStep: 2 adoptive parents
     await setFieldInput('hasOtherParents', true);
     await setFieldInput('otherParentCount', 2);
-    await clickContinue();
+    await clickNext();
 
     // AdditionalParentsStep: James and Barbara
     await setFieldInput('additional-parent[0].role', 'Adoptive parent');
     await setFieldInput('additional-parent[0].name', 'James');
-    await setFieldInput('additional-parent[0].gender_identity', 'Man/boy');
+    await setFieldInput('additional-parent[0].gender_identity', 'man');
 
     await setFieldInput('additional-parent[1].role', 'Adoptive parent');
     await setFieldInput('additional-parent[1].name', 'Barbara');
-    await setFieldInput('additional-parent[1].gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('additional-parent[1].gender_identity', 'woman');
+    await clickNext();
 
     // Unnamed bio parents fall back to role labels in the matrix; the focal
     // person frames the question and named parents use their name.
@@ -874,12 +736,12 @@ export const AdoptedIn: ScenarioStory = {
     ).toBeTruthy();
 
     // James and Barbara (the adoptive parents) are current partners
-    await setPartnership('additional-parent-0', 'Barbara', 'Current partner');
-    await clickContinue();
+    await setPartnership('additional-parent-0', 'Barbara', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -896,30 +758,30 @@ export const SingleParentTwoDonors: ScenarioStory = {
     // (gestational carrier) carried, so the conditional carrier step shows next
     await setFieldInput('egg-parent.is-donor', true);
     await setFieldInput('egg-parent.gestationalCarrier', false);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Gestational carrier step: Mum carried using a donor egg
     await setFieldInput('gestational-carrier.name', 'Mum');
-    await setFieldInput('gestational-carrier.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('gestational-carrier.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step: anonymous sperm donor
     await setFieldInput('sperm-parent.is-donor', true);
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     // OtherParentsStep: no additional parents (Mum is the gestational carrier)
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
     // Two anonymous donors and the carrier are none of them partners
     // (matrix default)
-    await clickContinue();
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
   },
 };
 
@@ -944,28 +806,25 @@ export const DiseaseNomination: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Robert');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
-    await setPartnership('egg-parent', 'Robert', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Robert', 'current');
+    await clickNext();
 
     await setFieldInput('hasPartner', false);
-    await clickContinue();
+    await clickNext();
 
-    // The wizard opens a "how to build your pedigree" dialog on completion.
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Got it' }),
-    );
-
+    // The post-wizard hint is suppressed for scenario stories (see
+    // FamilyPedigreeStoryWrapper), so the canvas is interactive immediately.
     // Finalize via the interview's next-stage navigation, which only requires
     // ego to have two parents.
     await userEvent.click(await screen.findByTestId('next-button'));
@@ -1007,36 +866,36 @@ export const WithPartnerAndChildren: ScenarioStory = {
     await setFieldInput('egg-parent.is-donor', false);
     await setFieldInput('egg-parent.name', 'Linda');
     await setFieldInput('egg-parent.gestationalCarrier', true);
-    await setFieldInput('egg-parent.gender_identity', 'Woman/girl');
-    await clickContinue();
+    await setFieldInput('egg-parent.gender_identity', 'woman');
+    await clickNext();
 
     // Sperm parent step
     await setFieldInput('sperm-parent.is-donor', false);
     await setFieldInput('sperm-parent.name', 'Robert');
-    await setFieldInput('sperm-parent.gender_identity', 'Man/boy');
-    await clickContinue();
+    await setFieldInput('sperm-parent.gender_identity', 'man');
+    await clickNext();
 
     await setFieldInput('hasOtherParents', false);
-    await clickContinue();
+    await clickNext();
 
-    await setPartnership('egg-parent', 'Robert', 'Current partner');
-    await clickContinue();
+    await setPartnership('egg-parent', 'Robert', 'current');
+    await clickNext();
 
     // Partner and children
     await setFieldInput('hasPartner', true);
     await setFieldInput('partner.name', 'Jennifer');
-    await setFieldInput('partner.biologicalSex', 'Female');
-    await setFieldInput('partner.gender_identity', 'Woman/girl');
+    await setFieldInput('partner.biologicalSex', 'female');
+    await setFieldInput('partner.gender_identity', 'woman');
     await setFieldInput('childrenWithPartnerCount', 2);
-    await clickContinue();
+    await clickNext();
 
     // Children details — name and gender, then confirm parentage defaults
     await setFieldInput('childWithPartner[0].name', 'Daniel');
-    await setFieldInput('childWithPartner[0].biologicalSex', 'Male');
-    await setFieldInput('childWithPartner[0].gender_identity', 'Man/boy');
+    await setFieldInput('childWithPartner[0].biologicalSex', 'male');
+    await setFieldInput('childWithPartner[0].gender_identity', 'man');
     await setFieldInput('childWithPartner[1].name', 'Emma');
-    await setFieldInput('childWithPartner[1].biologicalSex', 'Female');
-    await setFieldInput('childWithPartner[1].gender_identity', 'Woman/girl');
+    await setFieldInput('childWithPartner[1].biologicalSex', 'female');
+    await setFieldInput('childWithPartner[1].gender_identity', 'woman');
 
     // Both children should show the egg/sperm parent selectors; nuclear-family
     // defaults (You → egg, Jennifer → sperm) are already valid.
@@ -1044,6 +903,6 @@ export const WithPartnerAndChildren: ScenarioStory = {
     expect(within(childrenDialog).getAllByText('Egg Parent')).toHaveLength(2);
     expect(within(childrenDialog).getAllByText('Sperm Parent')).toHaveLength(2);
 
-    await clickContinue();
+    await clickNext();
   },
 };

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@codaco/fresco-ui/Button';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
@@ -31,6 +31,7 @@ import { useFamilyPedigreeStore } from './FamilyPedigreeContext';
 import { FamilyPedigreeProvider } from './FamilyPedigreeProvider';
 import FamilyPedigreePlaceholder from './pedigree-layout/components/FamilyPedigreePlaceholder';
 import PedigreeView from './pedigree-layout/components/PedigreeView';
+import { SuppressPedigreeHintContext } from './pedigreeHintContext';
 import type { VariableConfig } from './store';
 import {
   getEdgeTypeKey,
@@ -86,6 +87,7 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
 
   const dispatch = useAppDispatch();
   const { confirm, openDialog } = useDialog();
+  const suppressHint = useContext(SuppressPedigreeHintContext);
   const { isDevelopment } = useContractFlags();
   const { moveForward } = props.getNavigationHelpers();
   const { updateReady } = useReadyForNextStage();
@@ -555,7 +557,7 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
                 nodes_created: Object.keys(result.batch.nodes ?? {}).length,
                 edges_created: Object.keys(result.batch.edges ?? {}).length,
               });
-              void openDialog(buildPedigreeDialog);
+              if (!suppressHint) void openDialog(buildPedigreeDialog);
             }}
             variableConfig={variableConfig}
           />

--- a/packages/interview/src/interfaces/FamilyPedigree/components/PedigreeChecklist.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/PedigreeChecklist.tsx
@@ -391,6 +391,7 @@ export default function PedigreeChecklist({
       {!dismissed && (
         <MotionSurface
           key="pedigree-checklist"
+          data-testid="pedigree-checklist"
           className="bg-surface/80 absolute bottom-4 left-4 z-20 w-80 cursor-move overflow-hidden border-b-2 shadow-2xl backdrop-blur-md"
           layout
           drag
@@ -419,6 +420,9 @@ export default function PedigreeChecklist({
                 {sortedItems.map((item) => (
                   <motion.li
                     key={item.id}
+                    data-testid={`pedigree-checklist-item-${item.id}`}
+                    data-required={item.required}
+                    data-done={item.done}
                     layout
                     transition={{
                       layout: {
@@ -470,7 +474,11 @@ export default function PedigreeChecklist({
             className="mt-4 flex flex-col justify-between gap-2"
           >
             {allDone && (
-              <Button color="primary" onClick={onFinalize}>
+              <Button
+                color="primary"
+                data-testid="pedigree-checklist-finalize"
+                onClick={onFinalize}
+              >
                 Finalize family pedigree
               </Button>
             )}

--- a/packages/interview/src/interfaces/FamilyPedigree/components/wizards/EgoCellWizard.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/components/wizards/EgoCellWizard.tsx
@@ -192,6 +192,7 @@ export default function EgoCellWizard({
       >
         <ActionButton
           aria-label="Build family pedigree"
+          data-testid="pedigree-get-started"
           iconName="Network"
           onClick={handleClick}
         />

--- a/packages/interview/src/interfaces/FamilyPedigree/familyPedigreeWizardHelpers.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/familyPedigreeWizardHelpers.ts
@@ -1,25 +1,201 @@
-import { userEvent, within } from 'storybook/test';
+import { screen, userEvent, waitFor, within } from 'storybook/test';
+
+import type { NodeContextMenuAction } from './pedigree-layout/components/NodeContextMenu';
 
 /**
- * Shared play-function helpers for the FamilyPedigree quick-start wizard
- * stories. Kept in a plain `.ts` module (not a `*.stories.tsx`) so Storybook
- * does not index it as a story file.
- */
-
-/**
- * Answer the "About you" (EgoSexStep) biological-sex question within an
- * already-open wizard dialog. The radios are labelled by their option label
- * (from BIOLOGICAL_SEX_OPTIONS; the default here is "Female"). Callers own the
- * dialog lookup and the subsequent "Continue" click, which differ per story
+ * Shared play-function helpers for the FamilyPedigree stories. Kept in a plain
+ * `.ts` module (not a `*.stories.tsx`) so Storybook does not index it as a story
  * file.
+ *
+ * Elements are targeted by stable `data-testid` / `data-value` hooks rather than
+ * by visible copy or DOM order: wizard/dialog chrome exposes `data-testid`
+ * (`wizard-next`, `dialog-submit`, …), form options expose `data-value`
+ * (`String(option.value)`) scoped by the field's `data-field-name`, and the
+ * pedigree canvas exposes `pedigree-*` test-ids. This decouples the stories from
+ * label wording and radio ordering, which previously caused churn whenever copy
+ * or field layout changed.
  */
-export async function selectBiologicalSex(
-  dialog: HTMLElement,
-  label = 'Female',
+
+export const WIZARD_TIMEOUT = { timeout: 8000 };
+
+export async function getDialog() {
+  return screen.findByRole('dialog', {}, WIZARD_TIMEOUT);
+}
+
+/** Open the quick-start wizard from its floating get-started button. */
+export async function clickGetStarted() {
+  const btn = await screen.findByTestId(
+    'pedigree-get-started',
+    {},
+    WIZARD_TIMEOUT,
+  );
+  await userEvent.click(btn);
+  await getDialog();
+}
+
+/** Advance a wizard step (the primary button, whether labelled Continue or Finish). */
+export async function clickNext() {
+  const dialog = await getDialog();
+  await userEvent.click(within(dialog).getByTestId('wizard-next'));
+}
+
+/** Submit a form-type dialog (the AddPerson "Add"/"Done" submitter). */
+export async function clickDialogSubmit() {
+  const dialog = await getDialog();
+  await userEvent.click(within(dialog).getByTestId('dialog-submit'));
+}
+
+/** Confirm an acknowledge/choice dialog via its primary action (e.g. "Got it"). */
+export async function clickDialogPrimary() {
+  const dialog = await getDialog();
+  await userEvent.click(within(dialog).getByTestId('dialog-primary'));
+}
+
+/**
+ * Fill one field inside the open dialog, located by its `data-field-name`.
+ *
+ * Option-based fields (Boolean/Radio/RichSelect) are matched by `data-value`
+ * first, falling back to the option's accessible label — the fallback covers
+ * people-pickers whose option values are generated node ids (e.g. ego, listed as
+ * "You"). Booleans map to `data-value="true"|"false"`, numbers drive the
+ * stepper, everything else types into the text input.
+ */
+export async function setFieldInput(
+  fieldName: string,
+  value: boolean | string | number,
 ) {
-  const field = dialog.querySelector('[data-field-name="biologicalSex"]');
-  if (!(field instanceof HTMLElement))
-    throw new Error('No biologicalSex field found (EgoSexStep)');
-  const radio = within(field).getByRole('radio', { name: label });
+  const dialog = await getDialog();
+  const container = dialog.querySelector(
+    `[data-field-name="${CSS.escape(fieldName)}"]`,
+  );
+  if (!(container instanceof HTMLElement))
+    throw new Error(`No field found with data-field-name="${fieldName}"`);
+
+  if (typeof value === 'boolean') {
+    const toggle = container.querySelector('[role="switch"]');
+    if (toggle) {
+      const isChecked = toggle.getAttribute('aria-checked') === 'true';
+      if (isChecked !== value) await userEvent.click(toggle);
+      return;
+    }
+    const target = container.querySelector(
+      `[role="radio"][data-value="${value ? 'true' : 'false'}"]`,
+    );
+    if (!target)
+      throw new Error(`No radio for value=${String(value)} in "${fieldName}"`);
+    await userEvent.click(target);
+    return;
+  }
+
+  if (typeof value === 'number') {
+    const input = within(container).getByRole<HTMLInputElement>('spinbutton');
+    const currentValue = Number(input.value) || 0;
+    const diff = value - currentValue;
+    if (diff === 0) return;
+
+    const wrapper = input.parentElement?.parentElement;
+    const label = diff > 0 ? 'Increase value' : 'Decrease value';
+    const stepBtn = wrapper?.querySelector(`button[aria-label="${label}"]`);
+    if (!stepBtn) throw new Error(`No ${label} button in "${fieldName}"`);
+    for (let i = 0; i < Math.abs(diff); i++) await userEvent.click(stepBtn);
+    return;
+  }
+
+  const options = container.querySelectorAll('[role="radio"], [role="option"]');
+  if (options.length > 0) {
+    const byValue = Array.from(options).find(
+      (o) => o.getAttribute('data-value') === value,
+    );
+    const byLabel = Array.from(options).find(
+      (o) => o.getAttribute('aria-label') === value,
+    );
+    const target = byValue ?? byLabel;
+    if (!target)
+      throw new Error(`No option matching "${value}" in "${fieldName}"`);
+    await userEvent.click(target);
+    return;
+  }
+
+  const input = within(container).getByRole('textbox');
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
+}
+
+/**
+ * Set one cell of a partnership matrix. The matrix for `focalId` lists every
+ * parent below it; `partnerLabel` is the row's displayed label (a name, or a
+ * role fallback like "your sperm parent"). `optionValue` is a matrix option
+ * value (`current` / `ex` / `none`). Rows left at the default need no call.
+ */
+export async function setPartnership(
+  focalId: string,
+  partnerLabel: string,
+  optionValue: string,
+) {
+  const dialog = await getDialog();
+  const matrix = dialog.querySelector(
+    `[data-field-name="${CSS.escape(`partnerships.${focalId}`)}"]`,
+  );
+  if (!(matrix instanceof HTMLElement))
+    throw new Error(`No partnership matrix for focal "${focalId}"`);
+  const group = within(matrix).getByRole('radiogroup', { name: partnerLabel });
+  const radio = group.querySelector(
+    `[role="radio"][data-value="${optionValue}"]`,
+  );
+  if (!radio)
+    throw new Error(
+      `No "${optionValue}" option for partner "${partnerLabel}" under "${focalId}"`,
+    );
   await userEvent.click(radio);
+}
+
+/**
+ * Answer the "About you" (EgoSexStep) biological-sex question and continue. It
+ * follows any Introduction/FramingSelection steps and precedes the parent steps.
+ */
+export async function selectEgoSex(value = 'female') {
+  await setFieldInput('biologicalSex', value);
+  await clickNext();
+}
+
+/** Choose a framing option (`gamete` / `gendered`) on the FramingSelectionStep. */
+export async function selectFraming(value: 'gamete' | 'gendered') {
+  const dialog = await getDialog();
+  const option = dialog.querySelector(`[role="option"][data-value="${value}"]`);
+  if (!option) throw new Error(`No framing option with data-value="${value}"`);
+  await userEvent.click(option);
+}
+
+/** Open a pedigree node's context menu by the node's display name. */
+export async function openNodeContextMenu(nodeName: string) {
+  const nodeBtn = await screen.findByRole(
+    'button',
+    { name: nodeName },
+    WIZARD_TIMEOUT,
+  );
+  await userEvent.click(nodeBtn);
+  await screen.findByRole('menu', {}, WIZARD_TIMEOUT);
+}
+
+/** Locate a node context-menu item by its action (does not click it). */
+export function getMenuItem(action: NodeContextMenuAction) {
+  return screen.getByTestId(`pedigree-menu-${action}`);
+}
+
+/** Click a node context-menu item by its action. */
+export async function clickMenuItem(action: NodeContextMenuAction) {
+  const item = await screen.findByTestId(
+    `pedigree-menu-${action}`,
+    {},
+    WIZARD_TIMEOUT,
+  );
+  // The menu inherits pointer-events:none from its backdrop during the open
+  // animation; wait for the item to become interactive before clicking, or
+  // userEvent rejects the pointer interaction.
+  await waitFor(() => {
+    if (getComputedStyle(item).pointerEvents === 'none') {
+      throw new Error('menu item not yet interactive');
+    }
+  });
+  await userEvent.click(item);
 }

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/components/NodeContextMenu.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigree-layout/components/NodeContextMenu.tsx
@@ -56,24 +56,28 @@ export default function NodeContextMenu({
       <DropdownMenuContent>
         <DropdownMenuItem
           className={menuItemClass}
+          data-testid="pedigree-menu-parent"
           onClick={() => onAction('parent')}
         >
           Add parent
         </DropdownMenuItem>
         <DropdownMenuItem
           className={menuItemClass}
+          data-testid="pedigree-menu-child"
           onClick={() => onAction('child')}
         >
           Add child
         </DropdownMenuItem>
         <DropdownMenuItem
           className={menuItemClass}
+          data-testid="pedigree-menu-partner"
           onClick={() => onAction('partner')}
         >
           Add partner
         </DropdownMenuItem>
         <DropdownMenuItem
           className={menuItemClass}
+          data-testid="pedigree-menu-sibling"
           disabled={!canAddSibling}
           onClick={() => onAction('sibling')}
         >
@@ -89,12 +93,14 @@ export default function NodeContextMenu({
             <DropdownMenuSeparator className="my-1 h-px bg-current/20" />
             <DropdownMenuItem
               className={menuItemClass}
+              data-testid="pedigree-menu-edit"
               onClick={() => onAction('edit')}
             >
               Edit
             </DropdownMenuItem>
             <DropdownMenuItem
               className={destructiveMenuItemClass}
+              data-testid="pedigree-menu-delete"
               onClick={() => onAction('delete')}
             >
               Delete

--- a/packages/interview/src/interfaces/FamilyPedigree/pedigreeHintContext.ts
+++ b/packages/interview/src/interfaces/FamilyPedigree/pedigreeHintContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+/**
+ * When true, suppresses the post-quick-start "Building the rest of your
+ * pedigree" hint dialog. Storybook scenario stories set this so the finished
+ * pedigree is shown without the tutorial overlay; it defaults to false, so the
+ * hint shows normally for participants and in every other context.
+ */
+export const SuppressPedigreeHintContext = createContext(false);


### PR DESCRIPTION
## Summary

The FamilyPedigree Storybook scenarios targeted form fields and controls by **visible copy**, `textContent`, and **positional radio indexing** (`eggRadios[1]`). That coupling caused repeated churn whenever wizard copy or field layout changed. This replaces it with stable `data-testid` / `data-value` hooks and consolidates the four duplicated copies of the play helpers into one shared module.

### `@codaco/fresco-ui` — reusable test hooks (purely additive)
- `data-testid` on the wizard/dialog footer buttons: `wizard-next` / `wizard-back` / `wizard-cancel`, and `dialog-primary` / `dialog-secondary` / `dialog-cancel` / `dialog-submit`.
- `data-value={String(option.value)}` on `RadioGroup`, `Boolean`, and `RichSelectGroup` option buttons, so tests select an option by value (scoped by the field's existing `data-field-name`) rather than by label or DOM order.

### `@codaco/interview`
- Rewrote the five FamilyPedigree story files + `familyPedigreeWizardHelpers` against those hooks; the shared helper now targets by value with an `aria-label` fallback for people-pickers (whose option values are generated node ids).
- `data-testid` on the node context menu (`pedigree-menu-*`), and `data-testid`/`data-required`/`data-done` on the pedigree checklist.
- **`SuppressPedigreeHintContext`** — scenario stories (via `FamilyPedigreeStoryWrapper`) suppress the post-wizard "Building the rest of your pedigree" hint so the finished pedigree is shown without the overlay. Interaction-test stories use their own wrappers and are unaffected.

### Fixes surfaced while running the play functions
- The **consanguinity** story never set the required `child.biologicalSex` field, so its Add-child wizard couldn't advance (the cousins story already set it). Added it.
- `clickMenuItem` now waits out the base-ui menu open-animation (menu items briefly inherit `pointer-events: none` from a backdrop) before clicking.

## Note on changesets

No changeset: the fresco-ui edits are additive `data-*` test attributes (no API/behaviour/type change), the story rewrites are test-only, and the `SuppressPedigreeHintContext` guard is a **no-op in production** (defaults to `false` and is not a public export). Happy to add one if preferred.

## Test plan
- [x] `pnpm typecheck` (fresco-ui + interview) — green
- [x] `pnpm knip` — clean
- [x] `oxlint` on changed files — no new warnings
- [x] Drove the interaction-test + scenario stories in a real browser (the vitest `storybook` project can't run cleanly locally): cousins/consanguinity creation, required-boundary checklist, participant-choice framing, fixed-gamete — all pass; scenario stories (SingleParent, DiseaseNomination) show no hint; cousins still shows+dismisses it.
- [ ] CI `quality` + storybook interaction tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)