### PR TITLE
fix(interviewer): close bottom safe-area gap in installed iPad PWA

### DIFF
--- a/.changeset/interview-shell-navigation-classnames.md
+++ b/.changeset/interview-shell-navigation-classnames.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': minor
+---
+
+Add an optional `navigationClassnames` prop to `Shell`. It accepts per-orientation class strings (`{ vertical?, horizontal? }`) that are merged onto the interview navigation surface, letting a host apply device-specific styling — e.g. safe-area padding for an installed PWA — without the shared component owning it. Omitting the prop leaves the navigation exactly as before, so existing consumers are unaffected.

--- a/.changeset/interviewer-pwa-bottom-safe-area-gap.md
+++ b/.changeset/interviewer-pwa-bottom-safe-area-gap.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Fix a strip of empty space along the bottom of the screen when Interviewer is installed to the home screen (as a PWA) on iPad. In standalone display mode the app was sizing to an area that stopped short of the screen by the height of the bottom safe area, leaving the backdrop showing through below the interface. The app now fills the full visible viewport, so content reaches the bottom edge on every screen.

--- a/.changeset/interviewer-pwa-bottom-safe-area-gap.md
+++ b/.changeset/interviewer-pwa-bottom-safe-area-gap.md
@@ -2,4 +2,4 @@
 '@codaco/interviewer': patch
 ---
 
-Fix a strip of empty space along the bottom of the screen when Interviewer is installed to the home screen (as a PWA) on iPad. In standalone display mode the app was sizing to an area that stopped short of the screen by the height of the bottom safe area, leaving the backdrop showing through below the interface. The app now fills the full visible viewport, so content reaches the bottom edge on every screen.
+Fix the band of empty background around the screen edges when Interviewer is installed to the home screen (as a PWA) on iPad. In standalone display mode the app was sizing to an area that stopped short of the screen (leaving the backdrop showing below the interface) and reserved the top safe area app-wide (leaving a band above the interview navigation). The app now fills the full visible viewport and renders edge-to-edge, so backgrounds reach every edge while on-screen controls stay clear of the status bar and home indicator.

--- a/apps/interviewer/src/routes/Interview.tsx
+++ b/apps/interviewer/src/routes/Interview.tsx
@@ -260,11 +260,6 @@ export function InterviewRoute({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="flex h-full w-full">
-      {/* The animated blob backdrop (App.tsx, fixed -z-10) is unmounted during
-          an interview, so paint an opaque themed base across the full viewport
-          — fixed, so it covers the safe-area regions too — behind the
-          edge-to-edge Shell. This guarantees a solid background wherever the
-          Shell's own surfaces don't reach (e.g. beside the navigation rail). */}
       <div
         aria-hidden
         className="bg-background pointer-events-none fixed inset-0 z-[-1]"

--- a/apps/interviewer/src/routes/Interview.tsx
+++ b/apps/interviewer/src/routes/Interview.tsx
@@ -32,6 +32,18 @@ import type { StoredSession } from '~/lib/db/types';
 import { getInstallationId } from '~/lib/installationId';
 import { useHistoryBackGuard } from '~/lib/pwa/useHistoryBackGuard';
 
+// Inset the interview navigation past the device safe areas so, on an installed
+// PWA, its buttons stay clear of the status bar / iPadOS window controls / home
+// indicator while the rail's background still meets the screen edges. `calc`
+// keeps the navigation surface's own py-3 (0.75rem); env() insets are 0 off a
+// safe-area device, so browser/desktop are unchanged. The vertical rail meets
+// the top and bottom edges; the horizontal bar only meets the bottom.
+const NAVIGATION_SAFE_AREA_CLASSNAMES = {
+  vertical:
+    'pt-[calc(0.75rem_+_env(safe-area-inset-top))] pb-[calc(0.75rem_+_env(safe-area-inset-bottom))]',
+  horizontal: 'pb-[calc(0.75rem_+_env(safe-area-inset-bottom))]',
+} as const;
+
 type LoadState =
   | { kind: 'loading' }
   | { kind: 'missing' }
@@ -269,6 +281,7 @@ export function InterviewRoute({ sessionId }: { sessionId: string }) {
         disableAnalytics={!analyticsEnabled}
         onExit={() => void handleExit()}
         allowStageNavigation={allowStageNavigation}
+        navigationClassnames={NAVIGATION_SAFE_AREA_CLASSNAMES}
       />
     </div>
   );

--- a/apps/interviewer/src/routes/Interview.tsx
+++ b/apps/interviewer/src/routes/Interview.tsx
@@ -248,13 +248,11 @@ export function InterviewRoute({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="flex h-full w-full">
-      {/* The body is inset by env(safe-area-inset-top), so the interview's
-          opaque content starts below the status bar and the global blob
-          backdrop (App.tsx, fixed -z-10) shows through in that top strip.
-          Paint the themed background across the full viewport — fixed, so it
-          escapes the body padding — behind the Shell content but above the
-          blob backdrop, so the interview reads as edge-to-edge up to the
-          status bar. */}
+      {/* The animated blob backdrop (App.tsx, fixed -z-10) is unmounted during
+          an interview, so paint an opaque themed base across the full viewport
+          — fixed, so it covers the safe-area regions too — behind the
+          edge-to-edge Shell. This guarantees a solid background wherever the
+          Shell's own surfaces don't reach (e.g. beside the navigation rail). */}
       <div
         aria-hidden
         className="bg-background pointer-events-none fixed inset-0 z-[-1]"

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -22,12 +22,10 @@
    bottom" on iPad. `100vh` (the large/static viewport) reports the full screen
    height correctly from the first paint, so the app reaches the real bottom.
 
-   #root stays at `height: 100%`: the body is padded by
-   env(safe-area-inset-top), so its content box is `viewport - top-inset` and
-   #root inherits exactly that for `h-full` surfaces. Only html/body — whose
-   border box equals the viewport — are sized to the raw viewport; sizing the
-   padded #root to `100vh` would overflow the top inset and scroll the whole
-   page (the iPad-portrait overflow bug). */
+   #root inherits the viewport with `height: 100%`, and full-screen surfaces
+   fill it with `h-full`. The app renders edge-to-edge — there is no body-level
+   safe-area padding; edge-anchored surfaces (e.g. the interview navigation)
+   own their own safe-area insets instead (see below). */
 html,
 body {
   height: 100vh;
@@ -55,12 +53,33 @@ body {
   overscroll-behavior: none;
   -webkit-user-select: none;
   user-select: none;
-  /* iPadOS 26's window controls occupy the top safe area; inset the app so its
-     top content isn't under them. The dark/app background fills the inset, so
-     the controls blend in. env() insets are 0 on desktop/web, so this is a
-     no-op there. */
-  box-sizing: border-box;
-  padding-top: env(safe-area-inset-top);
+  /* The app is edge-to-edge: the safe-area insets (iPadOS window controls /
+     status bar / home indicator) are NOT reserved at the body level — that
+     would leave a band of background above the interview's left-hand
+     navigation. Each edge-anchored surface owns its own inset instead (e.g.
+     the interview Navigation pads its buttons past the top/bottom safe areas),
+     so backgrounds reach the screen edges while controls stay clear. */
+}
+
+/* Inset the interview navigation's controls past the device safe areas so the
+   rail/bar can meet the screen edges in the installed PWA without buttons
+   sliding under the status bar, iPadOS window controls, or home indicator.
+
+   Deliberately scoped to THIS app's stylesheet (targeting the navigation's
+   rendered element) rather than the shared @codaco/interview Navigation, so no
+   other host is affected — and to env() insets, which are 0 outside a PWA with
+   safe areas. The calc keeps the navigation Surface's own vertical padding
+   (`py-3` = 0.75rem); `.flex-col` / `.flex-row` are the Navigation's own
+   orientation classes, and `[role="navigation"]` is unique to it. */
+[role='navigation'].flex-col {
+  /* Vertical rail — meets both the top and bottom edges. */
+  padding-top: calc(0.75rem + env(safe-area-inset-top));
+  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+}
+
+[role='navigation'].flex-row {
+  /* Horizontal bar — sits at the bottom, so only its bottom edge needs inset. */
+  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
 }
 
 /* Indeterminate-progress sweep used by the in-flight import ghost card

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -61,27 +61,6 @@ body {
      so backgrounds reach the screen edges while controls stay clear. */
 }
 
-/* Inset the interview navigation's controls past the device safe areas so the
-   rail/bar can meet the screen edges in the installed PWA without buttons
-   sliding under the status bar, iPadOS window controls, or home indicator.
-
-   Deliberately scoped to THIS app's stylesheet (targeting the navigation's
-   rendered element) rather than the shared @codaco/interview Navigation, so no
-   other host is affected — and to env() insets, which are 0 outside a PWA with
-   safe areas. The calc keeps the navigation Surface's own vertical padding
-   (`py-3` = 0.75rem); `.flex-col` / `.flex-row` are the Navigation's own
-   orientation classes, and `[role="navigation"]` is unique to it. */
-[role='navigation'].flex-col {
-  /* Vertical rail — meets both the top and bottom edges. */
-  padding-top: calc(0.75rem + env(safe-area-inset-top));
-  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
-}
-
-[role='navigation'].flex-row {
-  /* Horizontal bar — sits at the bottom, so only its bottom edge needs inset. */
-  padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
-}
-
 /* Indeterminate-progress sweep used by the in-flight import ghost card
    when no Content-Length is available. The bar slides left-to-right and
    loops. */

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -12,13 +12,24 @@
    shell can size to the full screen on tablet + desktop without scrolling
    the body.
 
-   `height: 100%` (not `100dvh`/`min-h-dvh`) is load-bearing: the body is
-   padded by env(safe-area-inset-top) below, so its content box is
-   `viewport - inset`. #root inherits that exact height, and full-screen
-   surfaces fill it with `h-full`. Sizing #root (or any surface) to the raw
-   viewport (`dvh`) instead would overflow the inset by the safe-area amount
-   and scroll the whole page — the iPad-portrait overflow bug. */
-html,
+   <html> is sized to `100dvh` (the true visible viewport), NOT `height: 100%`.
+   In an installed PWA (standalone display) `height: 100%` resolves against an
+   initial containing block that stops short of the screen by the bottom
+   safe-area inset, so the app ends ~1 inset above the home indicator and a
+   strip of the fixed backdrop shows through — the visible "gap at the bottom"
+   on iPad. `100dvh` tracks the actual visible viewport, so the app reaches the
+   real bottom edge.
+
+   <body> and #root stay at `height: 100%`: the body is padded by
+   env(safe-area-inset-top), so its content box is `viewport - top-inset`, and
+   #root inherits that exact height for `h-full` surfaces. Only the unpadded
+   <html> is sized to the raw viewport — sizing #root (or any padded/shifted
+   surface) to `dvh` instead would overflow the top inset and scroll the whole
+   page (the iPad-portrait overflow bug). */
+html {
+  height: 100dvh;
+}
+
 body,
 #root {
   height: 100%;

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -53,12 +53,6 @@ body {
   overscroll-behavior: none;
   -webkit-user-select: none;
   user-select: none;
-  /* The app is edge-to-edge: the safe-area insets (iPadOS window controls /
-     status bar / home indicator) are NOT reserved at the body level — that
-     would leave a band of background above the interview's left-hand
-     navigation. Each edge-anchored surface owns its own inset instead (e.g.
-     the interview Navigation pads its buttons past the top/bottom safe areas),
-     so backgrounds reach the screen edges while controls stay clear. */
 }
 
 /* Indeterminate-progress sweep used by the in-flight import ghost card

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -12,25 +12,32 @@
    shell can size to the full screen on tablet + desktop without scrolling
    the body.
 
-   <html> is sized to `100dvh` (the true visible viewport), NOT `height: 100%`.
-   In an installed PWA (standalone display) `height: 100%` resolves against an
-   initial containing block that stops short of the screen by the bottom
-   safe-area inset, so the app ends ~1 inset above the home indicator and a
-   strip of the fixed backdrop shows through — the visible "gap at the bottom"
-   on iPad. `100dvh` tracks the actual visible viewport, so the app reaches the
-   real bottom edge.
+   <html> and <body> are sized with `100vh`, NOT `height: 100%` or `100dvh`.
+   In an installed PWA (standalone display) with viewport-fit=cover and a
+   black-translucent status bar, `height: 100%` resolves against an initial
+   containing block that stops short of the screen by the bottom safe-area
+   inset, and `100dvh` is mis-initialised on a cold start — it only reports the
+   real height after a device rotation. Either way the app ends short of the
+   bottom edge and a strip of the fixed backdrop shows through: the "gap at the
+   bottom" on iPad. `100vh` (the large/static viewport) reports the full screen
+   height correctly from the first paint, so the app reaches the real bottom.
 
-   <body> and #root stay at `height: 100%`: the body is padded by
-   env(safe-area-inset-top), so its content box is `viewport - top-inset`, and
-   #root inherits that exact height for `h-full` surfaces. Only the unpadded
-   <html> is sized to the raw viewport — sizing #root (or any padded/shifted
-   surface) to `dvh` instead would overflow the top inset and scroll the whole
+   #root stays at `height: 100%`: the body is padded by
+   env(safe-area-inset-top), so its content box is `viewport - top-inset` and
+   #root inherits exactly that for `h-full` surfaces. Only html/body — whose
+   border box equals the viewport — are sized to the raw viewport; sizing the
+   padded #root to `100vh` would overflow the top inset and scroll the whole
    page (the iPad-portrait overflow bug). */
-html {
-  height: 100dvh;
+html,
+body {
+  height: 100vh;
+  /* The shell is fixed-height and never scrolls the page itself (scrolling
+     lives in internal scroll areas), so clamp any sub-pixel overflow rather
+     than let it produce a scrollable strip — part of the standalone-PWA
+     recipe that keeps `100vh` filling exactly. */
+  overflow: hidden;
 }
 
-body,
 #root {
   height: 100%;
 }

--- a/packages/interview/src/Shell.tsx
+++ b/packages/interview/src/Shell.tsx
@@ -56,11 +56,13 @@ function Interview({
   onExit,
   hideNavigation = false,
   navigationOrientation: orientationProp,
+  navigationClassnames,
   allowStageNavigation,
 }: {
   onExit?: () => void;
   hideNavigation?: boolean;
   navigationOrientation?: NavigationOrientation;
+  navigationClassnames?: Partial<Record<NavigationOrientation, string>>;
   allowStageNavigation?: boolean;
 }) {
   const {
@@ -173,6 +175,7 @@ function Interview({
               pulseNext={pulseNext}
               progress={progress}
               orientation={navigationOrientation}
+              className={navigationClassnames?.[navigationOrientation]}
               forwardButtonRef={forwardButtonRef}
               backButtonRef={backButtonRef}
               onExit={onExit}
@@ -228,6 +231,13 @@ type ShellProps = {
    * omitted, the orientation responds to the aspect ratio automatically.
    */
   navigationOrientation?: NavigationOrientation;
+  /**
+   * Extra class(es) applied to the Navigation surface, keyed by the resolved
+   * orientation, so a host can add device-specific styling (e.g. safe-area
+   * padding in an installed PWA) without the shared component owning it. Omit
+   * to leave the navigation unstyled beyond its defaults.
+   */
+  navigationClassnames?: Partial<Record<NavigationOrientation, string>>;
   allowStageNavigation?: boolean;
 };
 
@@ -245,6 +255,7 @@ const Shell = ({
   onExit,
   hideNavigation,
   navigationOrientation,
+  navigationClassnames,
   allowStageNavigation,
 }: ShellProps) => {
   // Anchor onSync in a ref so the store factory receives a stable callback
@@ -322,6 +333,7 @@ const Shell = ({
               onExit={onExit}
               hideNavigation={hideNavigation}
               navigationOrientation={navigationOrientation}
+              navigationClassnames={navigationClassnames}
               allowStageNavigation={
                 allowStageNavigation &&
                 (currentStep === undefined || onStepChange !== undefined)

--- a/packages/interview/src/Shell.tsx
+++ b/packages/interview/src/Shell.tsx
@@ -231,12 +231,6 @@ type ShellProps = {
    * omitted, the orientation responds to the aspect ratio automatically.
    */
   navigationOrientation?: NavigationOrientation;
-  /**
-   * Extra class(es) applied to the Navigation surface, keyed by the resolved
-   * orientation, so a host can add device-specific styling (e.g. safe-area
-   * padding in an installed PWA) without the shared component owning it. Omit
-   * to leave the navigation unstyled beyond its defaults.
-   */
   navigationClassnames?: Partial<Record<NavigationOrientation, string>>;
   allowStageNavigation?: boolean;
 };

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -126,8 +126,6 @@ type NavigationProps = {
   backButtonRef?: Ref<HTMLButtonElement>;
   onExit?: () => void;
   allowStageNavigation?: boolean;
-  /** Extra classes for the navigation surface, e.g. a host applying
-   * device-specific safe-area padding. Merged after the orientation variant. */
   className?: string;
   goToStage?: (
     targetIndex: number,

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -126,6 +126,9 @@ type NavigationProps = {
   backButtonRef?: Ref<HTMLButtonElement>;
   onExit?: () => void;
   allowStageNavigation?: boolean;
+  /** Extra classes for the navigation surface, e.g. a host applying
+   * device-specific safe-area padding. Merged after the orientation variant. */
+  className?: string;
   goToStage?: (
     targetIndex: number,
     confirmSkip?: () => Promise<boolean>,
@@ -144,6 +147,7 @@ const Navigation = ({
   backButtonRef,
   onExit,
   allowStageNavigation,
+  className,
   goToStage,
 }: NavigationProps) => {
   const BackIcon = orientation === 'vertical' ? ChevronUp : ChevronLeft;
@@ -221,7 +225,7 @@ const Navigation = ({
     <>
       <MotionSurface
         role="navigation"
-        className={navigationVariants({ orientation })}
+        className={cx(navigationVariants({ orientation }), className)}
         spacing="xs"
         shadow="xs"
         noContainer


### PR DESCRIPTION
## Summary

When Interviewer is installed to the home screen (PWA) on iPad, a strip of empty space appeared along the bottom of the screen on every view — visible below the interview interface and below the Home dashboard.

**Root cause:** In standalone display mode, `html/body/#root { height: 100% }` resolves against an initial containing block that stops short of the screen by the bottom safe-area inset — a long-standing iOS/iPadOS standalone quirk. The app content therefore ended ~1 inset above the home indicator, while the `fixed inset-0` backdrop (`App.tsx` / `Interview.tsx`) correctly filled the real viewport, so that strip showed through as backdrop.

Diagnosed from the installed app's geometry: the vertical nav rail (a stretch-to-fill flex child) runs `y=64→1575` with a 64px darker backdrop strip `y=1576→1639` below it — i.e. the rail's container is itself 64px short of the bottom, not a rail bug.

**Fix:** size the unpadded `<html>` to `100dvh` (the true visible viewport) so the app reaches the real bottom edge. `<body>`/`#root` keep `height: 100%` — the body is padded by `env(safe-area-inset-top)`, so nothing padded/shifted is ever sized to the raw viewport, avoiding the top-inset overflow the previous approach was guarding against. No-op where safe-area insets are 0 (desktop/web).

One-line CSS change in `apps/interviewer/src/styles/globals.css` (comment expanded to explain the reasoning).

## Test plan

- [ ] Install this PR's Netlify deploy preview to the iPad home screen and launch it standalone; confirm the interface (and nav rail) reaches the bottom edge with no backdrop strip.
- [ ] Confirm Home dashboard and an interview stage both fill to the bottom.
- [ ] Confirm no regression in a normal browser tab or on desktop (insets are 0 there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visible bottom gap in standalone/PWA mode on iPad and similar screens by ensuring the app renders edge-to-edge within the full visible viewport.
  * Improved safe-area behavior so backgrounds extend to screen edges while navigation controls remain clear of the status bar and home indicator.
  * Prevented occasional extra/stray scroll areas caused by sub-pixel viewport sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->