### PR TITLE
fix(ci): judge cumulative PR diff on opened/reopened in detect

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -73,32 +73,42 @@ jobs:
           # Manual runs may set force_run=true to bypass detection and run
           # every conditional job (replaces the old per-workflow rerun buttons).
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.force_run == true }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
-          # Determine the comparison base — the commit immediately before the
-          # one we're checking. We DON'T use turbo-ignore because it includes
-          # global config (turbo.json, lockfile, root configs) in its hash, so
-          # any unrelated workflow tweak invalidates every package's hash.
+          # Determine the comparison base — the commit range whose diff decides
+          # which conditional jobs run. We DON'T use turbo-ignore because it
+          # includes global config (turbo.json, lockfile, root configs) in its
+          # hash, so any unrelated workflow tweak invalidates every package's
+          # hash.
           #
-          # For PRs we want push-to-push semantics: only RE-RUN jobs whose
-          # packages changed between the prior PR commit and the new tip. The
-          # first push on a PR is a degenerate case — HEAD^2^1 resolves to
-          # the base branch HEAD, so the push diff IS the cumulative PR diff
-          # at that point and every relevant job fires at least once.
-          # Subsequent pushes only re-trigger impacted jobs; jobs that
-          # already ran on earlier PR commits keep their prior status (see
-          # the carry-forward job below) instead of being re-executed.
+          # PR semantics depend on the event action:
+          #   - opened / reopened: no prior verdicts exist on this PR (or, for
+          #     reopened, they may describe a stale base), so judge the
+          #     CUMULATIVE PR diff — merge-base with the base branch to the PR
+          #     tip. The tip's parent is NOT a safe stand-in: it only equals
+          #     the base HEAD for single-commit branches, and a branch pushed
+          #     with its commits already stacked would be judged on its tip
+          #     commit alone (PR #890: a changeset-only tip skipped the
+          #     architect preview on an architect-wide PR).
+          #   - synchronize (subsequent pushes): push-to-push — diff only the
+          #     latest push (prior branch commit → new tip) so only impacted
+          #     jobs re-run; jobs that already ran keep their prior status via
+          #     the carry-forward job below.
           #
           # GH Actions checks out a synthetic merge commit on PRs; HEAD^2 is
-          # the actual PR tip, HEAD^2^1 is the prior commit on the source
-          # branch (or the base branch HEAD on the first PR push).
+          # the actual PR tip.
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             CURR=$(git rev-parse HEAD^2 2>/dev/null || git rev-parse HEAD)
-            PREV=$(git rev-parse "${CURR}^1" 2>/dev/null || true)
+            if [[ "$EVENT_ACTION" == "synchronize" ]]; then
+              PREV=$(git rev-parse "${CURR}^1" 2>/dev/null || true)
+            else
+              PREV=$(git merge-base "$CURR" "origin/${GITHUB_BASE_REF}" 2>/dev/null || true)
+            fi
           else
             CURR=$(git rev-parse HEAD)
             PREV=$(git rev-parse HEAD^1 2>/dev/null || true)
           fi
-          echo "comparing $PREV..$CURR"
+          echo "comparing $PREV..$CURR (event action: ${EVENT_ACTION:-n/a})"
 
           # A change to this CI workflow itself can alter how any conditional job
           # behaves or whether it passes, so a prior run's verdict no longer


### PR DESCRIPTION
## Summary

The `detect` job gates conditional jobs (`deploy-architect-preview`, website/docs previews, chromatic, e2e) with push-to-push semantics: it diffs the PR tip against the tip's parent. The in-file comment assumed the first push of a PR degenerates to the full PR diff because "tip^1 = base branch HEAD" — **but that only holds for single-commit branches.** A branch pushed with its commits already stacked (increasingly the norm for agent-built work) is judged on its **tip commit alone**.

Concrete failure: [#890](https://github.com/complexdatacollective/network-canvas-monorepo/pull/890) overhauls `apps/architect` across ~180 files, but its tip commit was changeset-only — so `detect.outputs.architect` came back `false` and the architect Netlify preview silently skipped, with no prior verdict for carry-forward to republish.

### Fix

On `pull_request` events, choose the comparison base by event action:

- **`opened` / `reopened`** (and any non-`synchronize` action): diff against `git merge-base <tip> origin/<base>` — the cumulative PR diff. No prior verdicts exist at `opened` (and `reopened` verdicts may describe a stale base), so cumulative is both correct and conservative.
- **`synchronize`**: unchanged push-to-push (`tip^1..tip`), preserving the carry-forward contract — only impacted jobs re-run; prior verdicts are republished for the rest.

`github.event.action` is passed via `env:` (not interpolated into the script), and the base ref uses the ambient quoted `$GITHUB_BASE_REF`.

### Scenario verification

| Scenario | Before | After |
| --- | --- | --- |
| First push of a pre-stacked multi-commit branch | judged on tip commit only → jobs silently skip | merge-base diff = full PR → all impacted jobs fire |
| Subsequent single-commit push (`synchronize`) | push-to-push | unchanged |
| Workflow file changed anywhere in the PR | only detected if in the diffed range (same tip-only blind spot at `opened`) | detected at `opened` via cumulative diff → forces all conditional jobs |
| `workflow_dispatch` + `force_run` | bypasses detection (non-PR path) | unchanged |
| `merge-base` fails / no parent | — | `PREV` empty → `flag()` conservatively runs everything (existing behavior) |
| Carry-forward | republishes latest conclusive verdicts | contract unchanged; `opened` now produces a superset of verdicts |

Note: this PR modifies the workflow itself, so its own CI run exercises the `WORKFLOW_CHANGED` force-all path.

## Test plan

- [x] `actionlint` and YAML parse pass
- [x] Scenario table above reasoned against the `flag()`/carry-forward implementation
- [ ] Observe this PR's own detect log line (`comparing <prev>..<curr> (event action: opened)`) resolves to the merge-base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release/CI workflow’s change detection for pull request updates, reducing the chance of incorrect build comparisons.
  * Added smarter handling for different pull request event types so checks use the most relevant code range.
  * Enhanced logging to make comparison results clearer during workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->