### PR TITLE
fix(interviewer): fall back to download when Web Share rejects an export

### DIFF
--- a/.changeset/interviewer-export-share-fallback.md
+++ b/.changeset/interviewer-export-share-fallback.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Fix data export failing with "Permission denied" on desktop Chrome. When the browser reports that file sharing is available but the system share sheet then refuses the file, the export now falls back to a normal file download instead of failing.

--- a/apps/interviewer/src/lib/files/__tests__/download.test.ts
+++ b/apps/interviewer/src/lib/files/__tests__/download.test.ts
@@ -42,6 +42,57 @@ describe('shareOrDownloadBlob (web)', () => {
     expect(result).toEqual({ saved: false, confirmed: false });
   });
 
+  it('falls back to an object-URL <a download> when share throws NotAllowedError', async () => {
+    // Chromium can report canShare({files}) as true while the OS-level share
+    // backend then rejects with NotAllowedError ("Permission denied") — seen
+    // on desktop Chrome (#889). The archive is already built, so the export
+    // must fall through to the plain download instead of failing.
+    const share = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException('Permission denied', 'NotAllowedError'),
+      );
+    const canShare = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('navigator', { share, canShare });
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL: vi.fn() });
+    const click = vi.fn();
+    const anchor = { href: '', download: '', click, remove: vi.fn() };
+    vi.spyOn(document, 'createElement').mockReturnValue(
+      anchor as unknown as HTMLAnchorElement,
+    );
+    vi.spyOn(document.body, 'appendChild').mockImplementation(
+      (node) => node as never,
+    );
+
+    const result = await shareOrDownloadBlob(makeBlob(), 'export.zip');
+
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ saved: true, confirmed: false });
+  });
+
+  it('falls back to an object-URL <a download> when share fails unexpectedly', async () => {
+    const share = vi.fn().mockRejectedValue(new Error('share target crashed'));
+    const canShare = vi.fn().mockReturnValue(true);
+    vi.stubGlobal('navigator', { share, canShare });
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL: vi.fn() });
+    const anchor = { href: '', download: '', click: vi.fn(), remove: vi.fn() };
+    vi.spyOn(document, 'createElement').mockReturnValue(
+      anchor as unknown as HTMLAnchorElement,
+    );
+    vi.spyOn(document.body, 'appendChild').mockImplementation(
+      (node) => node as never,
+    );
+
+    const result = await shareOrDownloadBlob(makeBlob(), 'export.zip');
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ saved: true, confirmed: false });
+  });
+
   it('falls back to an object-URL <a download> when canShare is false', async () => {
     vi.stubGlobal('navigator', { canShare: vi.fn().mockReturnValue(false) });
     const createObjectURL = vi.fn().mockReturnValue('blob:mock');

--- a/apps/interviewer/src/lib/files/download.ts
+++ b/apps/interviewer/src/lib/files/download.ts
@@ -7,7 +7,11 @@ export type DownloadResult = { saved: boolean; confirmed: boolean };
 // Shares or saves a Blob. Must be called from within a user gesture so
 // Web Share / the download is allowed to proceed. Web Share is preferred when
 // the platform can share files (iOS/Android/desktop Safari + Chrome), otherwise
-// falls back to an object-URL <a download>.
+// falls back to an object-URL <a download>. canShare({files}) only reports
+// that the API accepts the payload, not that the OS can actually present a
+// share sheet — desktop Chromium can pass canShare and then reject share()
+// with NotAllowedError (#889) — so any share failure other than the user
+// cancelling also falls through to the download.
 export async function shareOrDownloadBlob(
   blob: Blob,
   suggestedName: string,
@@ -19,7 +23,6 @@ export async function shareOrDownloadBlob(
       return { saved: true, confirmed: true };
     } catch (cause) {
       if (isShareCanceled(cause)) return { saved: false, confirmed: false };
-      throw cause;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #889 — data export in the Interviewer PWA failed with "Permission denied" on desktop Chrome (both as an installed web app and in a browser tab).

`shareOrDownloadBlob` treated `navigator.canShare({ files })` as a reliable predictor of `navigator.share()` succeeding. It isn't: `canShare` only reports that the API accepts the payload, while desktop Chromium can then reject the actual `share()` call with `NotAllowedError` when the OS-level share backend can't handle it. The catch block only handled user cancellation, so the error re-threw and the export failed — even though the archive was already built and sitting in memory.

Any share failure other than the user cancelling the share sheet now falls through to the object-URL `<a download>` fallback. That path returns an *unconfirmed* save, which already routes through the existing "Did the archive download?" confirmation dialog before sessions are marked exported, so the export-marking safety model is unchanged.

Also checked (per the report's PWA concern): the Web Share API is only used in this one place — `apps/architect` has no share usage, and neither app has Electron/Capacitor remnants; the remaining platform-specific code (install prompt, file launch queue, passkey/swipe workarounds, storage persistence) is all feature-detected with fallbacks.

## Test plan

- [x] New unit test: `share()` rejecting with `NotAllowedError` ("Permission denied") falls back to the object-URL download and reports `{ saved: true, confirmed: false }`
- [x] New unit test: any other unexpected `share()` failure also falls back
- [x] Existing tests unchanged: share success, user cancellation, `canShare` false, missing `canShare`
- [x] `pnpm typecheck`, `pnpm knip`, full interviewer unit suite green