### PR TITLE
fix(interviewer): attach the file-picker input to the DOM for Safari

### DIFF
--- a/.changeset/safari-protocol-import.md
+++ b/.changeset/safari-protocol-import.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Fixed protocol import on Safari: selecting a `.netcanvas` file from the file picker now imports correctly, including when Interviewer is installed as an app (Add to Dock). Previously the picker could silently fail because Safari discards a file input that isn't part of the page while the picker is open.

--- a/apps/interviewer/src/lib/files/__tests__/pickFile.test.ts
+++ b/apps/interviewer/src/lib/files/__tests__/pickFile.test.ts
@@ -39,4 +39,28 @@ describe('pickProtocolFile (browser input)', () => {
     input.oncancel?.(new Event('cancel'));
     await expect(pending).resolves.toBeNull();
   });
+
+  // Safari (notably installed/standalone PWAs) can suspend or GC a file input
+  // that is not in the document while the system picker is open, so change/
+  // cancel never fire (#886).
+  it('is attached to the document when clicked, and detached after selection', async () => {
+    let connectedAtClick = false;
+    vi.spyOn(input, 'click').mockImplementation(() => {
+      connectedAtClick = input.isConnected;
+    });
+    const file = new File([new Uint8Array()], 'study.netcanvas');
+    const pending = pickProtocolFile();
+    expect(connectedAtClick).toBe(true);
+    Object.defineProperty(input, 'files', { value: [file], writable: true });
+    input.onchange?.(new Event('change'));
+    await pending;
+    expect(input.isConnected).toBe(false);
+  });
+
+  it('detaches from the document after cancel', async () => {
+    const pending = pickProtocolFile();
+    input.oncancel?.(new Event('cancel'));
+    await pending;
+    expect(input.isConnected).toBe(false);
+  });
 });

--- a/apps/interviewer/src/lib/files/pickFile.ts
+++ b/apps/interviewer/src/lib/files/pickFile.ts
@@ -11,11 +11,21 @@ export async function pickProtocolFile(): Promise<PickedFile | null> {
     // the Files picker. Hint the extension only and rely on post-selection zip
     // validation (extractZip in importProtocol) to reject non-protocol files.
     input.accept = '.netcanvas';
+    input.style.display = 'none';
+    const finish = (picked: PickedFile | null) => {
+      input.remove();
+      resolve(picked);
+    };
     input.onchange = () => {
       const file = input.files?.[0];
-      resolve(file ? { name: file.name, file } : null);
+      finish(file ? { name: file.name, file } : null);
     };
-    input.oncancel = () => resolve(null);
+    input.oncancel = () => finish(null);
+    // Safari — most reliably as an installed/standalone PWA — can suspend or
+    // GC a file input that is not in the document while the system picker is
+    // open, so change/cancel never fire (#886). Keep the input attached for
+    // the duration of the pick.
+    document.body.appendChild(input);
     input.click();
   });
 }


### PR DESCRIPTION
## Summary

Fixes #886 — Safari (reported from the installed/standalone PWA, "Add to Dock") fails to import a protocol via the file picker.

`pickProtocolFile()` created a detached `<input type="file">`, wired `change`/`cancel`, and clicked it without ever attaching it to the document. Safari can suspend or GC a file input that isn't in the document while the system picker is open, so the events never fire and the import flow dies. Architect works in the identical Safari environment because `react-dropzone` renders its input into the DOM — this change gives the Interviewer's ephemeral input the same load-bearing property by appending it (hidden) to `document.body` for the duration of the pick and removing it once the picker resolves.

Adopting `react-dropzone` in the Interviewer (the broader option floated in the issue) was deliberately not done: the drop path in `ImportTriggerCard` already works (native DOM events on a mounted element), so the dependency would buy nothing beyond this one-line property, at the cost of restructuring the deck.

The "storage not persistent" note in the issue is a separate Safari behaviour (Safari doesn't grant `navigator.storage.persist()` the way Chromium does) and is not addressed here.

## Test plan

- [x] New unit tests: input is connected to the document when clicked, and detached after both selection and cancel (watched fail before the fix, pass after)
- [x] Full interviewer unit suite passes (62 files, 359 tests)
- [x] Turbo-wrapped typecheck passes
- [x] End-to-end in headless Chromium against the dev server: clicked the "Import a protocol" card → real file chooser opened → selected a zipped development protocol → import completed and the protocol card rendered ("1 protocols"), picker input removed from the DOM, zero console errors
- [ ] Confirm the fix in the original repro environment. Note: the bug did not reproduce for a maintainer on the currently released version in Safari — consistent with a GC-timing-dependent failure that only some environments hit — so confirmation needs the original reporter, who hits it reliably

