### PR TITLE
fix(interviewer): make storage persistence work with Safari's heuristics

### DIFF
--- a/.changeset/safari-storage-persistence.md
+++ b/.changeset/safari-storage-persistence.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Improved the storage-durability indicator for Safari. The app now re-requests persistent storage on your first interaction — Safari grants the request silently based on interaction history, so asking only at startup was routinely denied — and the indicator updates immediately when a grant lands. When running as an installed app, an ungranted request now shows as a calm "Storage best effort" note instead of a warning: installed-app data is kept separate from browsing data and is not subject to the browser's routine cleanup, and there is no further install action to take.

--- a/apps/interviewer/src/components/StatusRow.stories.tsx
+++ b/apps/interviewer/src/components/StatusRow.stories.tsx
@@ -14,6 +14,7 @@ type StoryArgs = {
   interviewCount: number;
   mode: AuthMode;
   persisted: boolean;
+  installed: boolean;
   usage: number;
 };
 
@@ -24,6 +25,7 @@ const meta: Meta<StoryArgs> = {
     interviewCount: 12,
     mode: 'pin',
     persisted: true,
+    installed: false,
     usage: 4.2 * 1024 * 1024,
   },
   argTypes: {
@@ -35,14 +37,29 @@ const meta: Meta<StoryArgs> = {
       control: 'boolean',
       description: 'navigator.storage.persisted(), polled by the container',
     },
+    installed: {
+      control: 'boolean',
+      description:
+        'Running as an installed/standalone app (isRunningInstalled()). ' +
+        'When storage is not persisted, installed swaps the warning for a ' +
+        'calm "best effort" state — there is no install action left to take.',
+    },
     usage: { control: 'number', description: 'Bytes reported by estimate()' },
   },
-  render: ({ protocolCount, interviewCount, mode, persisted, usage }) => (
+  render: ({
+    protocolCount,
+    interviewCount,
+    mode,
+    persisted,
+    installed,
+    usage,
+  }) => (
     <StatusRowView
       protocolCount={protocolCount}
       interviewCount={interviewCount}
       mode={mode}
       durability={{ persisted, usage }}
+      installed={installed}
     />
   ),
 };
@@ -54,4 +71,11 @@ export const Default: Story = {};
 
 export const NotEncryptedNotPersisted: Story = {
   args: { mode: 'none', persisted: false },
+};
+
+// Safari decides persist() from opaque interaction heuristics and may never
+// grant it to an installed app (#886) — installed-but-not-persisted is the
+// steady state there, presented without warning styling.
+export const InstalledBestEffort: Story = {
+  args: { persisted: false, installed: true },
 };

--- a/apps/interviewer/src/components/StatusRow.tsx
+++ b/apps/interviewer/src/components/StatusRow.tsx
@@ -12,10 +12,12 @@ import {
 import { APP_VERSION } from '~/lib/appVersion';
 import type { AuthMode } from '~/lib/auth/api';
 import { useAuth } from '~/lib/auth/AuthContext';
+import { isRunningInstalled } from '~/lib/pwa/isRunningInstalled';
 import {
   estimateStorage,
   formatBytes,
   isStoragePersisted,
+  STORAGE_PERSISTED_EVENT,
 } from '~/lib/storage';
 
 import AppUpdatePill from './AppUpdate/AppUpdatePill';
@@ -55,12 +57,14 @@ export function StatusRowView({
   interviewCount,
   mode,
   durability,
+  installed,
   versionSlot = <span>Interviewer {APP_VERSION}</span>,
 }: {
   protocolCount: number;
   interviewCount: number;
   mode: AuthMode | undefined;
   durability: Durability | null;
+  installed: boolean;
   versionSlot?: React.ReactNode;
 }) {
   return (
@@ -131,13 +135,27 @@ export function StatusRowView({
             <TooltipTrigger
               render={
                 <span
-                  tabIndex={durability.usage !== null ? 0 : undefined}
+                  tabIndex={
+                    durability.usage !== null ||
+                    (!durability.persisted && installed)
+                      ? 0
+                      : undefined
+                  }
                   className="focusable inline-flex items-center gap-1.5 rounded-sm"
                 >
                   {durability.persisted ? (
                     <>
                       <HardDrive className="size-3.5" />
                       Storage persistent
+                    </>
+                  ) : installed ? (
+                    // Installed apps are already partitioned away from
+                    // browsing data and exempt from routine cleanup, and no
+                    // further user action can flip the grant — a warning here
+                    // would alarm without offering a remedy (#886).
+                    <>
+                      <HardDrive className="size-3.5" />
+                      Storage best effort
                     </>
                   ) : (
                     <span className="text-warning inline-flex items-center gap-1.5">
@@ -148,7 +166,17 @@ export function StatusRowView({
                 </span>
               }
             />
-            {durability.usage !== null ? (
+            {!durability.persisted && installed ? (
+              <TooltipContent>
+                The browser keeps installed-app data separate from browsing data
+                and does not clear it routinely, but it has not guaranteed it
+                against eviction if disk space runs low. Export interviews
+                regularly.
+                {durability.usage !== null
+                  ? ` ${formatBytes(durability.usage)} stored.`
+                  : ''}
+              </TooltipContent>
+            ) : durability.usage !== null ? (
               <TooltipContent>
                 {formatBytes(durability.usage)} stored
               </TooltipContent>
@@ -169,6 +197,9 @@ type StatusRowProps = {
 export function StatusRow({ protocolCount, interviewCount }: StatusRowProps) {
   const { mode } = useAuth();
   const [durability, setDurability] = useState<Durability | null>(null);
+  // Static per page load, like InstallBanner: installing mid-session still
+  // requires launching the installed app.
+  const [installed] = useState(isRunningInstalled);
 
   useEffect(() => {
     let active = true;
@@ -182,18 +213,22 @@ export function StatusRow({ protocolCount, interviewCount }: StatusRowProps) {
     read();
 
     // A persist() grant can land after this component mounts: main.tsx requests
-    // it at startup and on install, and the auth enrol path requests it when
-    // encryption is enabled. Re-read on the events that follow such a grant so
-    // the durability label updates without a reload — focus/visibility for a
-    // late startup grant, appinstalled for the install grant.
+    // it at startup, on the first user gesture, and on install, and the auth
+    // enrol path requests it when encryption is enabled. Re-read on the events
+    // that follow such a grant so the durability label updates without a
+    // reload — focus/visibility for a late startup grant, appinstalled for the
+    // install grant, and the storage module's own event for any fresh grant it
+    // observes directly.
     window.addEventListener('focus', read);
     document.addEventListener('visibilitychange', read);
     window.addEventListener('appinstalled', read);
+    window.addEventListener(STORAGE_PERSISTED_EVENT, read);
     return () => {
       active = false;
       window.removeEventListener('focus', read);
       document.removeEventListener('visibilitychange', read);
       window.removeEventListener('appinstalled', read);
+      window.removeEventListener(STORAGE_PERSISTED_EVENT, read);
     };
   }, []);
 
@@ -219,6 +254,7 @@ export function StatusRow({ protocolCount, interviewCount }: StatusRowProps) {
       interviewCount={interviewCount}
       mode={mode}
       durability={durability}
+      installed={installed}
       versionSlot={<AppUpdatePill />}
     />
   );

--- a/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
+++ b/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
@@ -25,6 +25,13 @@ vi.mock('~/lib/auth/AuthContext', () => ({
   useAuth: () => useAuthMock(),
 }));
 
+const { mockIsRunningInstalled } = vi.hoisted(() => ({
+  mockIsRunningInstalled: vi.fn(() => false),
+}));
+vi.mock('~/lib/pwa/isRunningInstalled', () => ({
+  isRunningInstalled: mockIsRunningInstalled,
+}));
+
 // The version slot renders AppUpdatePill, which reads the app-wide
 // AppUpdateProvider context (service-worker registration + update state) that
 // isn't mounted in these unit tests. Stub it out — the update indicator has its
@@ -34,11 +41,14 @@ vi.mock('../AppUpdate/AppUpdatePill', () => ({
   default: () => <span>Interviewer test</span>,
 }));
 
+import { STORAGE_PERSISTED_EVENT } from '~/lib/storage';
+
 import { StatusRow } from '../StatusRow';
 
 afterEach(() => {
   vi.clearAllMocks();
   useAuthMock.mockReturnValue({ kind: 'unlocked', mode: 'pin' });
+  mockIsRunningInstalled.mockReturnValue(false);
 });
 
 describe('StatusRow', () => {
@@ -143,6 +153,41 @@ describe('StatusRow', () => {
     // grant when the event fires, without waiting for a reload.
     mockIsPersisted.mockResolvedValue(true);
     window.dispatchEvent(new Event('appinstalled'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/storage persistent/i)).toBeInTheDocument(),
+    );
+  });
+
+  // An installed app's data is partitioned away from browsing data and exempt
+  // from routine cleanup, and there is no further user action that could flip
+  // the grant — so the alarming warning is replaced by a calm best-effort
+  // state (#886).
+  it('shows a calm best-effort state instead of the warning when installed', async () => {
+    mockEstimateStorage.mockResolvedValue({ usage: 0, quota: 0, percent: 0 });
+    mockIsPersisted.mockResolvedValue(false);
+    mockIsRunningInstalled.mockReturnValue(true);
+    render(<StatusRow protocolCount={0} interviewCount={0} />);
+    await waitFor(() =>
+      expect(screen.getByText(/storage best effort/i)).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/storage not persistent/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('re-reads persistence when a late grant announces itself', async () => {
+    mockEstimateStorage.mockResolvedValue({ usage: 0, quota: 0, percent: 0 });
+    mockIsPersisted.mockResolvedValue(false);
+    render(<StatusRow protocolCount={0} interviewCount={0} />);
+    await waitFor(() =>
+      expect(screen.getByText(/storage not persistent/i)).toBeInTheDocument(),
+    );
+
+    // requestPersistentStorage() dispatches this event on a fresh grant (e.g.
+    // the first-interaction retry succeeding) with no focus/visibility change.
+    mockIsPersisted.mockResolvedValue(true);
+    window.dispatchEvent(new Event(STORAGE_PERSISTED_EVENT));
 
     await waitFor(() =>
       expect(screen.getByText(/storage persistent/i)).toBeInTheDocument(),

--- a/apps/interviewer/src/lib/__tests__/storage.test.ts
+++ b/apps/interviewer/src/lib/__tests__/storage.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  requestPersistentStorage,
+  requestPersistentStorageOnFirstInteraction,
+  STORAGE_PERSISTED_EVENT,
+} from '../storage';
+
+function stubStorageManager({
+  persisted,
+  persist,
+}: {
+  persisted: boolean;
+  persist: boolean;
+}) {
+  const persistedMock = vi.fn().mockResolvedValue(persisted);
+  const persistMock = vi.fn().mockResolvedValue(persist);
+  Object.defineProperty(navigator, 'storage', {
+    value: { persisted: persistedMock, persist: persistMock },
+    configurable: true,
+  });
+  return { persistedMock, persistMock };
+}
+
+describe('requestPersistentStorage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // WebKit and Chromium can grant persist() silently long after boot (their
+  // heuristics key on interaction history), so a fresh grant announces itself
+  // for live UI (StatusRow) to re-read without waiting for a focus change.
+  it('dispatches the persisted event on a fresh grant', async () => {
+    stubStorageManager({ persisted: false, persist: true });
+    const listener = vi.fn();
+    window.addEventListener(STORAGE_PERSISTED_EVENT, listener);
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(STORAGE_PERSISTED_EVENT, listener);
+  });
+
+  it('does not dispatch the persisted event when the request is denied', async () => {
+    stubStorageManager({ persisted: false, persist: false });
+    const listener = vi.fn();
+    window.addEventListener(STORAGE_PERSISTED_EVENT, listener);
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(STORAGE_PERSISTED_EVENT, listener);
+  });
+
+  it('does not dispatch the persisted event when already persisted', async () => {
+    const { persistMock } = stubStorageManager({
+      persisted: true,
+      persist: true,
+    });
+    const listener = vi.fn();
+    window.addEventListener(STORAGE_PERSISTED_EVENT, listener);
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(persistMock).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(STORAGE_PERSISTED_EVENT, listener);
+  });
+});
+
+describe('requestPersistentStorageOnFirstInteraction', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requests persistence once on the first pointer interaction only', async () => {
+    const { persistMock } = stubStorageManager({
+      persisted: false,
+      persist: false,
+    });
+    requestPersistentStorageOnFirstInteraction();
+    expect(persistMock).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event('pointerdown'));
+    await vi.waitFor(() => expect(persistMock).toHaveBeenCalledTimes(1));
+
+    window.dispatchEvent(new Event('pointerdown'));
+    window.dispatchEvent(new Event('keydown'));
+    // Give any (incorrect) extra requests a tick to land.
+    await Promise.resolve();
+    expect(persistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a key press as the first interaction too', async () => {
+    const { persistMock } = stubStorageManager({
+      persisted: false,
+      persist: false,
+    });
+    requestPersistentStorageOnFirstInteraction();
+    window.dispatchEvent(new Event('keydown'));
+    await vi.waitFor(() => expect(persistMock).toHaveBeenCalledTimes(1));
+  });
+
+  // Firefox pops a permission dialog on persist(); the startup request already
+  // asked once this session, so an automatic second ask would nag the user.
+  it('does not arm on Firefox', async () => {
+    const { persistMock } = stubStorageManager({
+      persisted: false,
+      persist: true,
+    });
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0',
+    );
+    requestPersistentStorageOnFirstInteraction();
+    window.dispatchEvent(new Event('pointerdown'));
+    await Promise.resolve();
+    expect(persistMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/interviewer/src/lib/storage.ts
+++ b/apps/interviewer/src/lib/storage.ts
@@ -4,6 +4,10 @@ export type StorageEstimate = {
   percent: number | null;
 };
 
+// Dispatched on window when a persist() request is freshly granted, so live UI
+// (StatusRow) can re-read durability without waiting for a focus change.
+export const STORAGE_PERSISTED_EVENT = 'interviewer:storage-persisted';
+
 export async function requestPersistentStorage(): Promise<boolean> {
   if (typeof navigator === 'undefined' || !navigator.storage?.persist) {
     return false;
@@ -11,10 +15,34 @@ export async function requestPersistentStorage(): Promise<boolean> {
   try {
     const already = await navigator.storage.persisted?.();
     if (already) return true;
-    return await navigator.storage.persist();
+    const granted = await navigator.storage.persist();
+    if (granted && typeof window !== 'undefined') {
+      window.dispatchEvent(new Event(STORAGE_PERSISTED_EVENT));
+    }
+    return granted;
   } catch {
     return false;
   }
+}
+
+// WebKit and Chromium decide persist() silently from the user's interaction
+// history, so the startup request — made before any interaction, and for a
+// freshly installed app in a data store with no history at all — is routinely
+// denied (#886). Ask once more on the first gesture, when there is finally
+// interaction history to judge. Firefox is excluded: it pops a permission
+// dialog on every ask, and the startup request already asked this session.
+export function requestPersistentStorageOnFirstInteraction(): void {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return;
+  }
+  if (navigator.userAgent.includes('Firefox')) return;
+  const request = () => {
+    window.removeEventListener('pointerdown', request);
+    window.removeEventListener('keydown', request);
+    void requestPersistentStorage();
+  };
+  window.addEventListener('pointerdown', request);
+  window.addEventListener('keydown', request);
 }
 
 export async function isStoragePersisted(): Promise<boolean> {

--- a/apps/interviewer/src/main.tsx
+++ b/apps/interviewer/src/main.tsx
@@ -9,7 +9,10 @@ import { initFileLaunchCapture } from './lib/pwa/fileLaunchQueue';
 import { initInstallPromptCapture } from './lib/pwa/installPrompt';
 import { removeLoadingScreen } from './lib/pwa/loadingScreen';
 import { initSwipeNavigationGuard } from './lib/pwa/swipeNavigationGuard';
-import { requestPersistentStorage } from './lib/storage';
+import {
+  requestPersistentStorage,
+  requestPersistentStorageOnFirstInteraction,
+} from './lib/storage';
 
 // The beforeinstallprompt event fires early and is one-shot; capture it before
 // React mounts so PwaInstallNudge can offer a real one-tap install.
@@ -22,6 +25,11 @@ initSwipeNavigationGuard();
 initFileLaunchCapture();
 
 void requestPersistentStorage();
+
+// The startup request above runs before any interaction, which WebKit and
+// Chromium routinely deny (their heuristics key on interaction history) — ask
+// once more on the user's first gesture.
+requestPersistentStorageOnFirstInteraction();
 
 // Installing the PWA newly qualifies the origin for persistent storage, but the
 // box is only made non-evictable on an actual persist() call — request it again


### PR DESCRIPTION
## Summary

Addresses the secondary report in #886: the installed Safari (Dock) app permanently shows an orange "Storage not persistent" warning. (The primary report — protocol import failing in Safari — is fixed separately in #894.)

Two root causes, two prongs:

**The grant was never realistically obtainable in Safari.** WebKit (and Chromium) decide `navigator.storage.persist()` silently from the user's interaction history. The app asked only at startup — before any interaction, and, for an installed app, inside a freshly-partitioned data store with no history at all — plus on `appinstalled` (a Chromium-only event Safari never fires) and on security enrolment (which never runs when the researcher picks "no security"). Now the app also re-asks once on the first user gesture, and `requestPersistentStorage()` dispatches a `STORAGE_PERSISTED_EVENT` on a fresh grant so the StatusRow indicator updates immediately, without waiting for a focus change. Firefox is excluded from the retry because it prompts a permission dialog on every ask (the startup request already asked once).

**The warning had no remedy in an installed app.** When the grant still isn't given (Safari's heuristics are opaque and may never grant it), an installed app now shows a calm "Storage best effort" state instead of the orange warning: installed-app data is partitioned away from browsing data and exempt from the browser's routine cleanup, and the warning's implied action — install the app — is already done. A tooltip explains the residual risk and advises exporting interviews regularly. Browser tabs keep the orange warning, where installing is the genuine remedy (and the install banner sits directly above).

## Test plan

- [x] New unit tests (TDD, watched fail first): grant event dispatched on fresh grant only; first-interaction retry fires exactly once (pointer or key) and not on Firefox; StatusRow shows "Storage best effort" when installed and re-reads on the grant event
- [x] Full interviewer unit suite passes (63 files, 365 tests); turbo-wrapped typecheck and `pnpm knip` clean
- [x] Live in headless Chromium (dev server): boot request denied → one synthetic first interaction → exactly one `persist()` call → indicator flipped to "Storage persistent" with no focus change
- [x] Live with emulated installed context (`display-mode: standalone` + permanently-denying `persist()`): footer shows neutral "Storage best effort", no warning, no install banner, tooltip renders the explanation with usage
- [x] Storybook: `installed` control added to StatusRow stories plus an `InstalledBestEffort` preset story
- [ ] Confirm on-device in Safari standalone (Add to Dock) — needs the original repro environment

Refs #886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent storage is now retried on the user’s first interaction, improving reliability on Safari and similar browsers.
  * Installed-app mode now shows a clearer storage status when persistence is unavailable.
  * The storage indicator updates immediately when persistence is granted.

* **Bug Fixes**
  * Fixed cases where storage persistence could be missed at startup.
  * Improved behavior after app install and during status changes so the UI reflects the latest storage state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->