### PR TITLE
fix(interviewer): protocol name layout priority on deck cards

### DIFF
--- a/.changeset/interviewer-deck-card-name-priority.md
+++ b/.changeset/interviewer-deck-card-name-priority.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Protocol cards on the start screen no longer condense or clip the study name when a card is selected. The name now always renders in full, and the description shrinks (or hides entirely) when the card is short on space — previously it was the other way around, so selecting a card could squeeze a long study name into a single clipped line. On small windows the "enter a case ID" step now scrolls inside the card instead of pushing the Start interview button out of view.

--- a/.changeset/interviewer-deck-card-name-priority.md
+++ b/.changeset/interviewer-deck-card-name-priority.md
@@ -2,4 +2,4 @@
 '@codaco/interviewer': patch
 ---
 
-Protocol cards on the start screen no longer condense or clip the study name when a card is selected. The name now always renders in full, and the description shrinks (or hides entirely) when the card is short on space — previously it was the other way around, so selecting a card could squeeze a long study name into a single clipped line. On small windows the "enter a case ID" step now scrolls inside the card instead of pushing the Start interview button out of view.
+Protocol cards on the start screen no longer condense or clip the study name when a card is selected. The name now always renders in full, and the description shrinks (or hides entirely) when the card is short on space — previously it was the other way around, so selecting a card could squeeze a long study name into a single clipped line. Card text also no longer scales below a legible minimum size on small windows. On small windows the "enter a case ID" step now scrolls inside the card instead of pushing the Start interview button out of view.

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.stories.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.stories.tsx
@@ -216,6 +216,50 @@ export const LongDescription: Story = {
   },
 };
 
+// The heading's rendered box must hold every line of the name (no clamp
+// mid-name, no glyphs clipped by the row). Compared in whole lines because
+// scrollHeight on a line-clamped `-webkit-box` overshoots the line grid by
+// a few pixels even when nothing is hidden.
+async function expectFullNameVisible(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const heading = await canvas.findByRole('heading', { level: 2 });
+  await waitFor(() => {
+    const lineHeight = parseFloat(getComputedStyle(heading).lineHeight);
+    const visibleLines = Math.round(heading.clientHeight / lineHeight);
+    const naturalLines = Math.round(heading.scrollHeight / lineHeight);
+    expect(visibleLines).toBeGreaterThanOrEqual(naturalLines);
+    const row = heading.parentElement;
+    if (!row) throw new Error('heading row not found');
+    expect(row.clientHeight).toBeGreaterThanOrEqual(heading.clientHeight - 1);
+  });
+}
+
+/**
+ * Regression for #888: an active card at the size a ~900px-tall window
+ * produces. The old layout flexed the heading and fixed the description at
+ * six lines, so activating the card (divider + Start button mounting)
+ * squeezed the title to a clipped single line. The name now outranks the
+ * description: it always renders in full, and the description takes only
+ * the whole lines that remain.
+ */
+export const SmallActiveCard: Story = {
+  args: {
+    name: 'Mental Health Networks - test',
+    description:
+      'An example template for studying how a personal network both supports ' +
+      'a participant and adds stress while they manage their mental health. ' +
+      'It uses separate name generators for supportive and difficult ' +
+      'relationships, and records who knows about the participant’s ' +
+      'mental health (disclosure).',
+    size: 360,
+    isActive: true,
+  },
+  play: async ({ canvasElement }) => {
+    await expectFullNameVisible(canvasElement);
+    await expectFooterInsideCard(canvasElement);
+  },
+};
+
 /**
  * Long names step the heading size down (8cqi → 6.5cqi → 5cqi by character
  * count) so multi-line names stay inside the heading region instead of
@@ -307,17 +351,35 @@ export const RequiresInternetPill: Story = {
   },
 };
 
-/**
- * The layout the case-ID form needs: the controls row, description, and
- * metadata all clear out (hideControls/hideDescription/hideMetadata), so a
- * long heading and the form share the card. The footer here is a stand-in
- * for NewSessionForm, which needs app providers the story can't host.
- */
-export const CaseIdFormLayout: Story = {
-  args: {
-    name: 'Longitudinal Study of Social Support and Health Resource Access Among Recent Migrant Families',
-  },
-  render: ({ name, size }) => (
+// Stand-in for NewSessionForm (which needs app providers the story can't
+// host), sized like the real thing: intro paragraph, label + hint, input,
+// and the Cancel/submit row.
+function CaseIdFormStandIn() {
+  return (
+    <div className="flex flex-col gap-4 text-base">
+      <span>
+        Before the interview begins, enter a case ID. This will be shown on the
+        resume interview screen to help you quickly identify this session.
+      </span>
+      <div>
+        <div className="font-bold">Case ID</div>
+        <div className="text-current/80">
+          A label used to identify this interview in exports.
+        </div>
+      </div>
+      <div className="border-navy-taupe/40 rounded-full border px-4 py-3">
+        &nbsp;
+      </div>
+      <div className="flex items-center justify-end gap-4">
+        <button type="button">Cancel</button>
+        <button type="button">Start interview</button>
+      </div>
+    </div>
+  );
+}
+
+function renderCaseIdFormLayout({ name, size }: StoryArgs) {
+  return (
     <ResizableFrame size={size}>
       <DeckCard
         protocol={makeProtocol({ name })}
@@ -330,20 +392,59 @@ export const CaseIdFormLayout: Story = {
         hideMetadata
         footer={
           <DeckCardFooter key="new-session">
-            <div className="flex flex-col gap-[2.5cqi] text-[3.5cqi]">
-              <span>
-                Before the interview begins, enter a case ID. This stand-in
-                occupies the space the real case-ID form would.
-              </span>
-              <div className="border-navy-taupe/40 rounded border px-[2.5cqi] py-[2cqi]">
-                Case ID
-              </div>
-            </div>
+            <CaseIdFormStandIn />
           </DeckCardFooter>
         }
       />
     </ResizableFrame>
-  ),
+  );
+}
+
+/**
+ * The layout the case-ID form needs: the controls row, description, and
+ * metadata all clear out (hideControls/hideDescription/hideMetadata), so a
+ * long heading and the form share the card.
+ */
+export const CaseIdFormLayout: Story = {
+  args: {
+    name: 'Longitudinal Study of Social Support and Health Resource Access Among Recent Migrant Families',
+  },
+  render: renderCaseIdFormLayout,
+};
+
+/**
+ * Regression for #888 (form overflow): on a card too small for the whole
+ * form, the footer is capped at the card's leftover budget and scrolls
+ * inside a ScrollArea — the submit row must be reachable by scrolling, never
+ * clipped away by the card edge.
+ */
+export const CaseIdFormSmallCard: Story = {
+  args: {
+    name: 'Sample Protocol',
+    size: 300,
+  },
+  render: renderCaseIdFormLayout,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const submit = await canvas.findByRole('button', {
+      name: 'Start interview',
+    });
+    const card = submit.closest('[aria-label]');
+    if (!card) throw new Error('card root not found');
+    const viewport = card.querySelector('[data-deck-row="footer"] section');
+    if (!(viewport instanceof HTMLElement)) {
+      throw new Error('footer scroll viewport not found');
+    }
+    await waitFor(() => {
+      viewport.scrollTop = viewport.scrollHeight;
+      const submitRect = submit.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      expect(submitRect.height).toBeGreaterThan(0);
+      expect(submitRect.bottom).toBeLessThanOrEqual(cardRect.bottom + 1);
+      expect(submitRect.top).toBeGreaterThanOrEqual(cardRect.top - 1);
+    });
+    await expectFullNameVisible(canvasElement);
+  },
 };
 
 /**

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -243,8 +243,14 @@ function useCardTextBudget({
       let footerMaxHeight: CardTextBudget['footerMaxHeight'] = null;
       if (footerRow) {
         // The description skeletons (no real text yet) count as a fixed row;
-        // the real span occupies exactly its clamped lines.
-        const descriptionShown = descriptionEl !== null && descriptionLines > 0;
+        // the real span occupies exactly its clamped lines. Presence comes
+        // from the IN-FLOW row scan, not descriptionRef — during a footer
+        // swap the exiting description is popped out of the flow but its
+        // ref is still live, and counting it would cap the incoming footer
+        // (the case-ID form) a description's height too short.
+        const descriptionShown =
+          descriptionLines > 0 &&
+          rows.some((el) => el.dataset.deckRow === 'description');
         const descriptionHeight = descriptionShown
           ? descriptionLines * descriptionLineHeight
           : 0;
@@ -282,7 +288,16 @@ function useCardTextBudget({
     // viewport's child.
     const footerContent = footerViewportRef.current?.firstElementChild;
     if (footerContent instanceof HTMLElement) observer.observe(footerContent);
-    return () => observer.disconnect();
+    // An exiting row leaving the DOM (its pop-fade finishing) changes no
+    // observed box — the row was already out of the flow — but it can shift
+    // what the budget should count (a measure taken mid-exit sticks
+    // otherwise). Re-measure on any child list change.
+    const mutations = new MutationObserver(measure);
+    mutations.observe(column, { childList: true });
+    return () => {
+      observer.disconnect();
+      mutations.disconnect();
+    };
   }, [
     name,
     description,

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -80,11 +80,13 @@ function withUnderscoreBreaks(name: string): ReactNode[] {
 // so Tailwind's scanner emits them. Names are identifiers (machine-style
 // names often differ only at the END), so shrinking is preferred over
 // truncation; the fitted line clamp below is only a backstop for
-// pathological lengths.
+// pathological lengths. Each tier carries a pixel floor so the name stays
+// legible on the smallest cards — when text stops shrinking, the budget
+// hook trades description lines away instead.
 function headingSizeClass(name: string): string {
-  if (name.length <= 24) return 'text-[8cqi]';
-  if (name.length <= 48) return 'text-[6.5cqi]';
-  return 'text-[5cqi]';
+  if (name.length <= 24) return 'text-[max(20px,8cqi)]';
+  if (name.length <= 48) return 'text-[max(18px,6.5cqi)]';
+  return 'text-[max(16px,5cqi)]';
 }
 
 // Ceiling on the description even when space allows — beyond this it trails
@@ -92,10 +94,12 @@ function headingSizeClass(name: string): string {
 const DESCRIPTION_MAX_LINES = 6;
 
 // The description's line height as a fraction of the card width —
-// text-[3.5cqi] × leading-tight (1.25) on the span below. Used only until
-// the span has been measured once (a card born too small to ever show the
-// description), so the budget can still tell when enough room has returned
-// for it to re-enter.
+// text-[max(12px,3.5cqi)] × leading-tight (1.25) on the span below. Used
+// only until the span has been measured once (a card born too small to
+// ever show the description), so the budget can still tell when enough
+// room has returned for it to re-enter. Approximate below the 12px floor,
+// where the real line height stops scaling with the card — a ±1-line
+// error in when the description re-enters, nothing more.
 const DESCRIPTION_FALLBACK_LINE_HEIGHT_RATIO = 0.035 * 1.25;
 
 type CardTextBudget = {
@@ -631,7 +635,7 @@ export function DeckCard(props: DeckCardProps) {
                   {protocol.description ? (
                     <span
                       ref={budget.descriptionRef}
-                      className="text-[3.5cqi] leading-tight text-current/80"
+                      className="text-[max(12px,3.5cqi)] leading-tight text-current/80"
                       style={{
                         display: '-webkit-box',
                         WebkitBoxOrient: 'vertical',
@@ -795,7 +799,7 @@ export function DeckCardFooterButton({
       onClick={onClick}
       className={cx(
         buttonVariants({ color }),
-        'flex h-auto items-center justify-center gap-[1.5cqi] border-b-[1.25cqi] p-[2.5cqi] text-[3cqi] font-extrabold tracking-widest uppercase',
+        'flex h-auto items-center justify-center gap-[1.5cqi] border-b-[1.25cqi] p-[max(10px,2.5cqi)] text-[max(12px,3cqi)] font-extrabold tracking-widest uppercase',
         // 3D bottom edge: the translucent black border paints over the
         // button's own background (border-box clipping), darkening whatever
         // the color resolves to in the active theme.
@@ -831,7 +835,7 @@ export function DeckCardProgressFooter({
         label={message ?? 'Loading protocol'}
         className="h-[2cqi] min-h-2"
       />
-      <div className="font-monospace flex min-h-lh items-center justify-between text-[2.8cqi]">
+      <div className="font-monospace flex min-h-lh items-center justify-between text-[max(11px,2.8cqi)]">
         <span>{message}</span>
         {progress !== undefined && (
           <span>{Math.round(Math.min(1, Math.max(0, progress)) * 100)}%</span>

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -147,10 +147,6 @@ function useCardTextBudget({
   const columnRef = useRef<HTMLDivElement | null>(null);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   const descriptionRef = useRef<HTMLSpanElement | null>(null);
-  // The ScrollArea viewport inside the footer row: its scrollHeight is the
-  // footer's natural (uncapped) content height, which the row's own box
-  // stops reporting once the cap is applied.
-  const footerViewportRef = useRef<HTMLElement | null>(null);
   const descriptionLineHeightRatio = useRef<number | null>(null);
   const [budget, setBudget] = useState<CardTextBudget>({
     headingLines: null,
@@ -183,11 +179,14 @@ function useCardTextBudget({
       );
       const footerRow = rows.find((el) => el.dataset.deckRow === 'footer');
       const others = rows.filter((el) => el.dataset.deckRow === undefined);
+      // The footer's natural (uncapped) content height: the ScrollArea
+      // viewport's scrollHeight, which keeps reporting the full content
+      // once the cap is applied. Resolved from the IN-FLOW row (not a ref)
+      // because two footers coexist during a swap — the exiting one is out
+      // of the flow but still mounted, and a shared ref could point at it.
+      const footerViewport = footerRow?.querySelector('section');
       const footerNaturalHeight = footerRow
-        ? Math.max(
-            footerRow.offsetHeight,
-            footerViewportRef.current?.scrollHeight ?? 0,
-          )
+        ? Math.max(footerRow.offsetHeight, footerViewport?.scrollHeight ?? 0)
         : 0;
       const fixedHeight =
         others.reduce((sum, el) => sum + el.offsetHeight, 0) +
@@ -244,6 +243,10 @@ function useCardTextBudget({
             )
           : 0;
 
+      // null = the footer fits; it then renders as a plain (overflow
+      // visible) region so nothing clips its buttons' shadows and no
+      // scroll container exists to grow a scrollbar. A number = genuine
+      // overflow; the footer is capped there and scrolls.
       let footerMaxHeight: CardTextBudget['footerMaxHeight'] = null;
       if (footerRow) {
         // The description skeletons (no real text yet) count as a fixed row;
@@ -258,16 +261,21 @@ function useCardTextBudget({
         const descriptionHeight = descriptionShown
           ? descriptionLines * descriptionLineHeight
           : 0;
-        footerMaxHeight = Math.max(
-          48,
-          Math.floor(
-            contentHeight -
-              (fixedHeight - footerNaturalHeight) -
-              headingHeight -
-              descriptionHeight -
-              gap * (fixedRowCount + (descriptionShown ? 1 : 0)),
-          ),
-        );
+        const footerAvailable =
+          contentHeight -
+          (fixedHeight - footerNaturalHeight) -
+          headingHeight -
+          descriptionHeight -
+          gap * (fixedRowCount + (descriptionShown ? 1 : 0));
+        // 2px tolerance: the natural height is a rounded-up integer
+        // (scrollHeight) compared against a fractional budget, so a
+        // sub-pixel discrepancy must not flip the footer into scroll mode
+        // — a couple of pixels absorbed by the column beats a scrollbar
+        // that scrolls one pixel.
+        footerMaxHeight =
+          footerNaturalHeight <= footerAvailable + 2
+            ? null
+            : Math.max(48, Math.floor(footerAvailable));
       }
 
       setBudget((previous) =>
@@ -289,9 +297,13 @@ function useCardTextBudget({
     }
     // The footer's cap freezes its row box, so content growth inside the
     // scroll viewport (a validation error appearing) is only visible on the
-    // viewport's child.
-    const footerContent = footerViewportRef.current?.firstElementChild;
-    if (footerContent instanceof HTMLElement) observer.observe(footerContent);
+    // viewport's child. Observe every mounted footer's content — during a
+    // swap both the entering and exiting footers exist.
+    for (const content of column.querySelectorAll(
+      '[data-deck-row="footer"] section > *',
+    )) {
+      if (content instanceof HTMLElement) observer.observe(content);
+    }
     // An exiting row leaving the DOM (its pop-fade finishing) changes no
     // observed box — the row was already out of the flow — but it can shift
     // what the budget should count (a measure taken mid-exit sticks
@@ -316,7 +328,6 @@ function useCardTextBudget({
     columnRef,
     headingRef,
     descriptionRef,
-    footerViewportRef,
     ...budget,
   };
 }
@@ -745,17 +756,27 @@ export function DeckCard(props: DeckCardProps) {
                   // card can hold (the case-ID form on a small card) scrolls
                   // inside the ScrollArea — with its edge fade as the "there's
                   // more" hint — instead of pushing the submit button past the
-                  // clipped card edge (#888).
+                  // clipped card edge (#888). While the footer FITS
+                  // (footerMaxHeight null) the viewport is overflow-visible
+                  // with the fade machinery off: a scroll container would
+                  // clip ink overflow (the submit button's shadow) and turn
+                  // rounding noise into a one-pixel scrollbar. Scroll mode
+                  // keeps ScrollArea's own vertical padding so the shadow
+                  // has room at the scroll edges.
                   style={{ maxHeight: budget.footerMaxHeight ?? undefined }}
                   className="flex shrink-0 flex-col"
                 >
                   <ScrollArea
-                    ref={budget.footerViewportRef}
                     // The footer's own controls are the tab stops; the
                     // viewport scrolls them into view on focus, so it needs
                     // no tab stop of its own.
                     tabIndex={-1}
-                    viewportClassName="py-0"
+                    fade={budget.footerMaxHeight !== null}
+                    viewportClassName={
+                      budget.footerMaxHeight === null
+                        ? 'overflow-visible py-0'
+                        : undefined
+                    }
                   >
                     {footer}
                   </ScrollArea>

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -15,6 +15,7 @@ import { Link } from 'wouter';
 import { Pattern } from '@codaco/art';
 import { buttonVariants, IconButton } from '@codaco/fresco-ui/Button';
 import ProgressBar from '@codaco/fresco-ui/ProgressBar';
+import { ScrollArea } from '@codaco/fresco-ui/ScrollArea';
 import { Skeleton } from '@codaco/fresco-ui/Skeleton';
 import { proportionalLucideIconVariants } from '@codaco/fresco-ui/styles/controlVariants';
 import TimeAgo from '@codaco/fresco-ui/TimeAgo';
@@ -86,38 +87,219 @@ function headingSizeClass(name: string): string {
   return 'text-[5cqi]';
 }
 
-// Clamp the heading to however many whole lines fit its flexed region. The
-// region is the column's only flexible row (flex-1 + min-h-0), so this is
-// what guarantees a pathological name can never grow the column past the
-// card edge and evict the footer — and the whole-line count means the
-// backstop never clips text mid-line. A fixed line-clamp can't do this:
-// the budget depends on which siblings (controls row, description,
-// metadata, footer) are present.
-function useFittedHeadingClamp(name: string | undefined) {
-  const regionRef = useRef<HTMLDivElement | null>(null);
+// Ceiling on the description even when space allows — beyond this it trails
+// off with an ellipsis so a long abstract can't dominate the card.
+const DESCRIPTION_MAX_LINES = 6;
+
+// The description's line height as a fraction of the card width —
+// text-[3.5cqi] × leading-tight (1.25) on the span below. Used only until
+// the span has been measured once (a card born too small to ever show the
+// description), so the budget can still tell when enough room has returned
+// for it to re-enter.
+const DESCRIPTION_FALLBACK_LINE_HEIGHT_RATIO = 0.035 * 1.25;
+
+type CardTextBudget = {
+  headingLines: number | null;
+  descriptionLines: number | null;
+  footerMaxHeight: number | null;
+};
+
+// Divide the card column's height between its rows, name first (#888).
+// Fixed rows (controls, metadata, divider) and the footer's NATURAL height
+// are reserved up front; the heading then takes as many whole lines as its
+// name needs and its budget allows (never fewer than one); the description
+// gets whatever remains, hiding entirely (0 lines) when even one line
+// doesn't fit; and the footer is capped at the leftover so an oversized
+// footer (the case-ID form on a small card) scrolls inside the card
+// instead of pushing its submit button past the clipped card edge.
+//
+// A plain flex layout can't express this priority order: making any one
+// row the flexible one sacrifices it to the others (the previous layout
+// flexed the heading, so an active card's footer squeezed the title to a
+// clipped single line).
+//
+// Stability: no output feeds back into its own inputs. Budgets are derived
+// from the column height, the fixed rows' natural sizes, and arithmetic
+// gap terms — never from the heading's, description's, or footer's
+// ALLOCATED boxes — so applying the clamps can't re-trigger different
+// clamps and oscillate.
+function useCardTextBudget({
+  name,
+  description,
+  loading,
+  hideControls,
+  hideMetadata,
+  hideDescription,
+  footerKey,
+}: {
+  name: string | undefined;
+  description: string | undefined;
+  loading: boolean;
+  hideControls: boolean;
+  hideMetadata: boolean;
+  hideDescription: boolean;
+  footerKey: string | null;
+}) {
+  const columnRef = useRef<HTMLDivElement | null>(null);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
-  const [lines, setLines] = useState<number | null>(null);
+  const descriptionRef = useRef<HTMLSpanElement | null>(null);
+  // The ScrollArea viewport inside the footer row: its scrollHeight is the
+  // footer's natural (uncapped) content height, which the row's own box
+  // stops reporting once the cap is applied.
+  const footerViewportRef = useRef<HTMLElement | null>(null);
+  const descriptionLineHeightRatio = useRef<number | null>(null);
+  const [budget, setBudget] = useState<CardTextBudget>({
+    headingLines: null,
+    descriptionLines: null,
+    footerMaxHeight: null,
+  });
 
   useLayoutEffect(() => {
-    const region = regionRef.current;
-    const heading = headingRef.current;
-    if (!region || !heading) return;
+    const column = columnRef.current;
+    if (!column) return undefined;
+
     const measure = () => {
-      const lineHeight = parseFloat(getComputedStyle(heading).lineHeight);
-      if (!Number.isFinite(lineHeight) || lineHeight <= 0) return;
-      const fit = Math.max(1, Math.floor(region.clientHeight / lineHeight));
-      setLines((previous) => (previous === fit ? previous : fit));
+      const columnStyle = getComputedStyle(column);
+      const contentHeight =
+        column.clientHeight -
+        parseFloat(columnStyle.paddingTop) -
+        parseFloat(columnStyle.paddingBottom);
+      const columnWidth = column.clientWidth;
+      // jsdom (and a display:none card) reports zero dimensions — keep the
+      // unclamped defaults rather than clamping everything to nothing.
+      if (contentHeight <= 0 || columnWidth <= 0) return;
+      const gap = parseFloat(columnStyle.rowGap) || 0;
+
+      const rows = Array.from(column.children).filter(
+        (el): el is HTMLElement =>
+          el instanceof HTMLElement &&
+          // popLayout pops exiting rows out of the flow (position:absolute)
+          // at exit start — they no longer take space.
+          getComputedStyle(el).position !== 'absolute',
+      );
+      const footerRow = rows.find((el) => el.dataset.deckRow === 'footer');
+      const others = rows.filter((el) => el.dataset.deckRow === undefined);
+      const footerNaturalHeight = footerRow
+        ? Math.max(
+            footerRow.offsetHeight,
+            footerViewportRef.current?.scrollHeight ?? 0,
+          )
+        : 0;
+      const fixedHeight =
+        others.reduce((sum, el) => sum + el.offsetHeight, 0) +
+        footerNaturalHeight;
+      const fixedRowCount = others.length + (footerRow ? 1 : 0);
+
+      let headingLines: CardTextBudget['headingLines'] = null;
+      let headingHeight = 0;
+      const heading = headingRef.current;
+      if (heading) {
+        const lineHeight = parseFloat(getComputedStyle(heading).lineHeight);
+        if (Number.isFinite(lineHeight) && lineHeight > 0) {
+          const naturalLines = Math.max(
+            1,
+            Math.round(heading.scrollHeight / lineHeight),
+          );
+          // Gaps: the fixed rows plus the heading row itself.
+          const headingBudget =
+            contentHeight - fixedHeight - gap * fixedRowCount;
+          headingLines = Math.min(
+            naturalLines,
+            Math.max(1, Math.floor(headingBudget / lineHeight)),
+          );
+          headingHeight = headingLines * lineHeight;
+        }
+      } else {
+        // Loading: the heading row shows skeletons at a fixed size.
+        const headingRow = rows.find((el) => el.dataset.deckRow === 'heading');
+        headingHeight = headingRow?.offsetHeight ?? 0;
+      }
+
+      const descriptionEl = descriptionRef.current;
+      if (descriptionEl) {
+        const lineHeight = parseFloat(
+          getComputedStyle(descriptionEl).lineHeight,
+        );
+        if (Number.isFinite(lineHeight) && lineHeight > 0) {
+          descriptionLineHeightRatio.current = lineHeight / columnWidth;
+        }
+      }
+      const descriptionLineHeight =
+        (descriptionLineHeightRatio.current ??
+          DESCRIPTION_FALLBACK_LINE_HEIGHT_RATIO) * columnWidth;
+      const descriptionBudget =
+        contentHeight - fixedHeight - headingHeight - gap * (fixedRowCount + 1);
+      const descriptionLines =
+        descriptionLineHeight > 0
+          ? Math.max(
+              0,
+              Math.min(
+                DESCRIPTION_MAX_LINES,
+                Math.floor(descriptionBudget / descriptionLineHeight),
+              ),
+            )
+          : 0;
+
+      let footerMaxHeight: CardTextBudget['footerMaxHeight'] = null;
+      if (footerRow) {
+        // The description skeletons (no real text yet) count as a fixed row;
+        // the real span occupies exactly its clamped lines.
+        const descriptionShown = descriptionEl !== null && descriptionLines > 0;
+        const descriptionHeight = descriptionShown
+          ? descriptionLines * descriptionLineHeight
+          : 0;
+        footerMaxHeight = Math.max(
+          48,
+          Math.floor(
+            contentHeight -
+              (fixedHeight - footerNaturalHeight) -
+              headingHeight -
+              descriptionHeight -
+              gap * (fixedRowCount + (descriptionShown ? 1 : 0)),
+          ),
+        );
+      }
+
+      setBudget((previous) =>
+        previous.headingLines === headingLines &&
+        previous.descriptionLines === descriptionLines &&
+        previous.footerMaxHeight === footerMaxHeight
+          ? previous
+          : { headingLines, descriptionLines, footerMaxHeight },
+      );
     };
+
     measure();
     const observer = new ResizeObserver(measure);
-    // The region resizes when siblings come and go; the heading resizes
-    // when a card-width change alters the computed line height.
-    observer.observe(region);
-    observer.observe(heading);
+    observer.observe(column);
+    // Rows come and go with the effect deps below; heights also move on
+    // their own (the metadata row wraps, the pill appears), so observe each.
+    for (const el of column.children) {
+      if (el instanceof HTMLElement) observer.observe(el);
+    }
+    // The footer's cap freezes its row box, so content growth inside the
+    // scroll viewport (a validation error appearing) is only visible on the
+    // viewport's child.
+    const footerContent = footerViewportRef.current?.firstElementChild;
+    if (footerContent instanceof HTMLElement) observer.observe(footerContent);
     return () => observer.disconnect();
-  }, [name]);
+  }, [
+    name,
+    description,
+    loading,
+    hideControls,
+    hideMetadata,
+    hideDescription,
+    footerKey,
+  ]);
 
-  return { regionRef, headingRef, lines };
+  return {
+    columnRef,
+    headingRef,
+    descriptionRef,
+    footerViewportRef,
+    ...budget,
+  };
 }
 
 // The subset of protocol fields the card renders. In the loading state any
@@ -216,11 +398,7 @@ export function DeckCard(props: DeckCardProps) {
 
   const id = useId();
 
-  const showDescription =
-    !hideDescription && Boolean(protocol.description ?? loading);
   const showMetadata = !hideMetadata;
-
-  const headingClamp = useFittedHeadingClamp(protocol.name);
 
   // The footer group's identity, taken from the consumer's key on the
   // footer element (e.g. "start-interview" → "new-session"). A change
@@ -232,6 +410,25 @@ export function DeckCard(props: DeckCardProps) {
   // no delay.
   const footerKey = isValidElement(footer) ? (footer.key ?? 'footer') : null;
   const renderedFooterKey = isActive && footer != null ? footerKey : null;
+
+  const budget = useCardTextBudget({
+    name: protocol.name,
+    description: protocol.description,
+    loading,
+    hideControls,
+    hideMetadata,
+    hideDescription,
+    footerKey: renderedFooterKey,
+  });
+
+  const showDescription =
+    !hideDescription &&
+    Boolean(protocol.description ?? loading) &&
+    // The budget hides a real description outright when not even one line
+    // fits; skeletons (no text yet) always show.
+    (protocol.description == null ||
+      budget.descriptionLines === null ||
+      budget.descriptionLines > 0);
   const committedFooterKeyRef = useRef<string | null>(renderedFooterKey);
   const isFooterSwap =
     renderedFooterKey !== null &&
@@ -272,7 +469,10 @@ export function DeckCard(props: DeckCardProps) {
 
           <div
             key="content"
-            className="relative z-10 flex size-full flex-col justify-between gap-6 p-[6cqi]"
+            ref={budget.columnRef}
+            // Gap scales with the card (24px at the 720px maximum) so small
+            // cards spend their height on content, not fixed 24px seams.
+            className="relative z-10 flex size-full flex-col justify-between gap-[max(12px,3.3cqi)] p-[6cqi]"
           >
             {/* The whole controls row (pill + delete) leaves while the
                 case-ID form is up — its reserved height goes to the
@@ -291,7 +491,7 @@ export function DeckCard(props: DeckCardProps) {
                   // min-h reserves the delete control's height, so the
                   // control fading in or out (e.g. a pending card becoming
                   // deletable) never reflows the content below the row.
-                  className="flex min-h-[max(40px,10cqi)] items-center justify-end gap-4"
+                  className="flex min-h-[max(40px,10cqi)] shrink-0 items-center justify-end gap-4"
                 >
                   {requiresInternetConnection && (
                     <Pill icon={<Globe />} intent="warning">
@@ -330,18 +530,19 @@ export function DeckCard(props: DeckCardProps) {
                 </motion.div>
               )}
             </AnimatePresence>
-            {/* min-h-0 lets the heading region shrink to the column's real
-                leftover budget (a flex item's implicit min-height: auto
-                would otherwise force the column past the card edge and
-                evict the footer). The fitted clamp keeps the truncation on
-                whole-line boundaries. */}
+            {/* flex-1 makes the heading row the column's spare-space
+                absorber (content stays anchored to the card's top and
+                bottom edges); min-h-fit stops flex from ever squeezing it
+                below the clamped name — the budget hook already sized the
+                clamp so the fixed rows and footer fit, so the NAME is the
+                one row that can't be crushed (#888). */}
             <div
-              ref={headingClamp.regionRef}
-              className="flex min-h-0 flex-1 items-center justify-start overflow-hidden"
+              data-deck-row="heading"
+              className="flex min-h-fit flex-1 items-center justify-start overflow-hidden"
             >
               {protocol.name ? (
                 <MotionHeading
-                  ref={headingClamp.headingRef}
+                  ref={budget.headingRef}
                   level="h2"
                   title={protocol.name}
                   className={cx(
@@ -353,12 +554,12 @@ export function DeckCard(props: DeckCardProps) {
                   // class here silently has no effect.
                   style={{
                     lineHeight: 1.05,
-                    ...(headingClamp.lines === null
+                    ...(budget.headingLines === null
                       ? undefined
                       : {
                           display: '-webkit-box',
                           WebkitBoxOrient: 'vertical',
-                          WebkitLineClamp: headingClamp.lines,
+                          WebkitLineClamp: budget.headingLines,
                           overflow: 'hidden',
                         }),
                   }}
@@ -382,14 +583,15 @@ export function DeckCard(props: DeckCardProps) {
                 with the fade instead of waiting for the unmount. */}
             <AnimatePresence mode="popLayout" initial={false}>
               {showDescription && (
-                // Description shows up to six lines, then trails off.
-                // line-clamp must be a static utility class so Tailwind's
-                // scanner emits it — a dynamic `line-clamp-${n}` would never
-                // be generated. The inner span carries the clamp (line-clamp
-                // makes it a `-webkit-box`); the wrapper is a normal block
-                // flex item pinned with `shrink-0` so the column — whose
-                // heading claims `flex-1` — can't squeeze the description
-                // below its six lines.
+                // The description takes whatever whole lines the budget hook
+                // left after the heading (capped at DESCRIPTION_MAX_LINES),
+                // and unmounts entirely when not even one fits — the NAME
+                // outranks it (#888). The inner span carries the clamp
+                // (line-clamp makes it a `-webkit-box`); the wrapper is a
+                // normal block flex item pinned with `shrink-0`. The
+                // data-deck-row tag marks the row as budget-managed only
+                // when it holds real text — the loading skeletons are a
+                // fixed row like any other.
                 // layout="position" (not full layout) on the swappable text
                 // regions: full layout animations interpolate size with a
                 // scale transform, which visibly stretches text when a
@@ -399,6 +601,9 @@ export function DeckCard(props: DeckCardProps) {
                 <motion.div
                   key="description"
                   layout="position"
+                  data-deck-row={
+                    protocol.description ? 'description' : undefined
+                  }
                   initial={PRESENCE_INITIAL}
                   animate={PRESENCE_ENTER}
                   exit={PRESENCE_EXIT}
@@ -406,7 +611,17 @@ export function DeckCard(props: DeckCardProps) {
                   className="shrink-0 text-left"
                 >
                   {protocol.description ? (
-                    <span className="line-clamp-6 text-[3.5cqi] leading-tight text-current/80">
+                    <span
+                      ref={budget.descriptionRef}
+                      className="text-[3.5cqi] leading-tight text-current/80"
+                      style={{
+                        display: '-webkit-box',
+                        WebkitBoxOrient: 'vertical',
+                        WebkitLineClamp:
+                          budget.descriptionLines ?? DESCRIPTION_MAX_LINES,
+                        overflow: 'hidden',
+                      }}
+                    >
                       {protocol.description}
                     </span>
                   ) : (
@@ -433,7 +648,7 @@ export function DeckCard(props: DeckCardProps) {
                   animate={PRESENCE_ENTER}
                   exit={PRESENCE_EXIT}
                   transition={REGION_TRANSITION}
-                  className="font-monospace flex items-center justify-between gap-4 text-[2.5cqi]"
+                  className="font-monospace flex shrink-0 items-center justify-between gap-4 text-[2.5cqi]"
                 >
                   {protocol.importedAt ? (
                     <span className="flex items-center gap-2">
@@ -484,13 +699,14 @@ export function DeckCard(props: DeckCardProps) {
                   animate={PRESENCE_ENTER}
                   exit={PRESENCE_EXIT}
                   transition={REGION_TRANSITION}
-                  className="my-0"
+                  className="my-0 shrink-0"
                 />
               )}
               {isActive && footer != null && (
                 <motion.div
                   key={footerKey}
                   layout="position"
+                  data-deck-row="footer"
                   initial={PRESENCE_INITIAL}
                   animate={{
                     ...PRESENCE_ENTER,
@@ -503,9 +719,24 @@ export function DeckCard(props: DeckCardProps) {
                   }}
                   exit={PRESENCE_EXIT}
                   transition={REGION_TRANSITION}
-                  className="flex flex-col"
+                  // Capped at the budget's leftover: a footer taller than the
+                  // card can hold (the case-ID form on a small card) scrolls
+                  // inside the ScrollArea — with its edge fade as the "there's
+                  // more" hint — instead of pushing the submit button past the
+                  // clipped card edge (#888).
+                  style={{ maxHeight: budget.footerMaxHeight ?? undefined }}
+                  className="flex shrink-0 flex-col"
                 >
-                  {footer}
+                  <ScrollArea
+                    ref={budget.footerViewportRef}
+                    // The footer's own controls are the tab stops; the
+                    // viewport scrolls them into view on focus, so it needs
+                    // no tab stop of its own.
+                    tabIndex={-1}
+                    viewportClassName="py-0"
+                  >
+                    {footer}
+                  </ScrollArea>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -449,7 +449,10 @@ export function DeckCard(props: DeckCardProps) {
         // style={{ borderColor: seedToPatternPalette(protocol.name).backgroundTop }}
         className={cx(
           cardBase(),
-          'min-h-[300px] min-w-[325px]',
+          // No minimum size of its own: the card always fills the box it's
+          // given (the text budget degrades content gracefully), so it can
+          // never overflow its carousel slot or a story frame. The deck's
+          // readability floor lives in ProtocolDeck's card-size computation.
           'text-navy-taupe bg-platinum publish-colors',
           'effect-shadow-xl @container relative h-full w-full overflow-clip rounded',
           isActive && 'spring-medium effect-shadow-2xl',

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckSlotCard.stories.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckSlotCard.stories.tsx
@@ -72,7 +72,7 @@ function ResizableFrame({
 }
 
 type StoryArgs = {
-  kind: 'protocol' | 'sample' | 'pending';
+  kind: 'protocol' | 'sample' | 'development' | 'pending';
   isActive: boolean;
   sessionCount: number;
   size: number;
@@ -88,6 +88,8 @@ function entryForKind(
       return { kind: 'protocol', protocol: makeProtocol() };
     case 'sample':
       return { kind: 'sample' };
+    case 'development':
+      return { kind: 'development' };
     case 'pending':
       return {
         kind: 'pending',
@@ -124,7 +126,7 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     kind: {
       control: 'inline-radio',
-      options: ['protocol', 'sample', 'pending'],
+      options: ['protocol', 'sample', 'development', 'pending'],
       description: 'Which DeckEntry kind fills this slot',
     },
     isActive: {
@@ -148,6 +150,7 @@ const meta: Meta<StoryArgs> = {
         onDeleteProtocol={() => {}}
         onDismissSample={() => {}}
         onInstallSample={() => {}}
+        onInstallDevelopment={() => {}}
       />
     </ResizableFrame>
   ),
@@ -165,6 +168,15 @@ export const Default: Story = {};
 
 export const SampleTeaser: Story = {
   args: { kind: 'sample' },
+};
+
+/**
+ * The dev-only Development-protocol teaser: same ghost presentation as the
+ * sample card (loading style, install footer) but with no dismiss control —
+ * it only ever renders in development builds.
+ */
+export const DevelopmentTeaser: Story = {
+  args: { kind: 'development' },
 };
 
 export const PendingImport: Story = {

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckSlotCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckSlotCard.tsx
@@ -1,6 +1,7 @@
 import { Download } from 'lucide-react';
 
 import type { StoredSession } from '~/lib/db/types';
+import { DEVELOPMENT_PROTOCOL } from '~/lib/protocol/developmentProtocol';
 import type { ImportPhase } from '~/lib/protocol/importProtocol';
 import { protocolRequiresInternet } from '~/lib/protocol/protocolRequiresInternet';
 import { SAMPLE_PROTOCOL } from '~/lib/protocol/sampleProtocol';
@@ -31,6 +32,7 @@ type DeckSlotCardProps = {
   onDeleteProtocol: (hash: string) => void;
   onDismissSample: () => void;
   onInstallSample: () => void;
+  onInstallDevelopment: () => void;
   // When set, the case-ID form replaces the protocol card's footer.
   newSession?: {
     onCancel: () => void;
@@ -46,6 +48,7 @@ function slotCardProps({
   onDeleteProtocol,
   onDismissSample,
   onInstallSample,
+  onInstallDevelopment,
   newSession,
 }: DeckSlotCardProps): DeckCardProps {
   if (entry.kind === 'protocol') {
@@ -105,6 +108,37 @@ function slotCardProps({
             onClick={onInstallSample}
           >
             Install sample protocol
+          </DeckCardFooterButton>
+        </DeckCardFooter>
+      ) : undefined,
+    };
+  }
+  if (entry.kind === 'development') {
+    // Dev-only teaser (never in the deck in production builds — see Home's
+    // showDevelopmentCard). No dismiss control: it exists for developers,
+    // and installing it replaces the slot anyway.
+    return {
+      loading: true,
+      protocol: {
+        name: DEVELOPMENT_PROTOCOL.name,
+        description: DEVELOPMENT_PROTOCOL.description,
+      },
+      isActive,
+      hideMetadata: true,
+      onActivate: activate,
+      footer: isActive ? (
+        <DeckCardFooter key="install-development">
+          <DeckCardFooterButton
+            color="primary"
+            icon={
+              <Download
+                aria-hidden
+                className="size-[max(14px,3.5cqi)] shrink-0"
+              />
+            }
+            onClick={onInstallDevelopment}
+          >
+            Install development protocol
           </DeckCardFooterButton>
         </DeckCardFooter>
       ) : undefined,

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -22,6 +22,12 @@ import { useDeckKeyboard } from './useDeckKeyboard';
 
 // Cards are square; height is measured from the section, width follows.
 const CARD_ASPECT = 1 / 1;
+// Readability floor: below this the card's container-query type becomes too
+// small to read, so the deck stops shrinking and lets the section clip
+// symmetrically instead. Lives here (not on DeckCard) so the slides and the
+// card always agree on size — a card bigger than its slot broke the deck
+// geometry and clipped card content (#888).
+const MIN_CARD_EDGE_PX = 300;
 // Top/bottom inset so the deck sits below the header instead of hugging it,
 // and so the card's drop shadow has room to render. Scaled with section
 // height: short viewports (Electron default 1280×800 leaves ~470px) get a
@@ -310,7 +316,10 @@ export function ProtocolDeck({
   const { cardWidth, cardHeight } = useMemo(() => {
     const padding = computeSectionPadding(sectionHeight);
     const innerHeight = Math.max(0, sectionHeight - padding * 2);
-    const ch = Math.round(innerHeight);
+    // The floor applies only once the section has been measured at all —
+    // cardHeight 0 still means "don't render the carousel yet".
+    const ch =
+      innerHeight > 0 ? Math.round(Math.max(innerHeight, MIN_CARD_EDGE_PX)) : 0;
     const cw = Math.round(ch * CARD_ASPECT);
     return { cardHeight: ch, cardWidth: cw };
   }, [sectionHeight]);

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -49,6 +49,8 @@ type ProtocolDeckProps = {
   sessions: StoredSessionLite[];
   initialProtocolHash?: string;
   showSampleCard?: boolean;
+  // Dev-only teaser slot for the bundled Development protocol.
+  showDevelopmentCard?: boolean;
   pendingImports?: PendingImport[];
   onImport: () => void;
   onImportFile: (file: File) => void;
@@ -56,6 +58,7 @@ type ProtocolDeckProps = {
   onDeleteProtocol: (hash: string) => void;
   onInstallSample?: () => void;
   onDismissSample?: () => void;
+  onInstallDevelopment?: () => void;
   // When set, the matching card is rendered in its "new session" state: the
   // case-ID form replaces the description, metadata, and Start button in the
   // card footer, and swipe/keyboard navigation is locked.
@@ -103,6 +106,7 @@ export function ProtocolDeck({
   sessions,
   initialProtocolHash,
   showSampleCard = false,
+  showDevelopmentCard = false,
   pendingImports = [],
   onImport,
   onImportFile,
@@ -110,6 +114,7 @@ export function ProtocolDeck({
   onDeleteProtocol,
   onInstallSample = () => {},
   onDismissSample = () => {},
+  onInstallDevelopment = () => {},
   newSessionProtocolHash,
   onCancelNewSession,
   onSessionCreated,
@@ -121,8 +126,14 @@ export function ProtocolDeck({
   const [sectionHeight, setSectionHeight] = useState(0);
 
   const deck = useMemo(
-    () => buildDeck({ protocols, showSampleCard, pendingImports }),
-    [protocols, showSampleCard, pendingImports],
+    () =>
+      buildDeck({
+        protocols,
+        showSampleCard,
+        showDevelopmentCard,
+        pendingImports,
+      }),
+    [protocols, showSampleCard, showDevelopmentCard, pendingImports],
   );
 
   // Per-protocol session count, hoisted here so DeckCard doesn't take the
@@ -169,7 +180,9 @@ export function ProtocolDeck({
               ? () => onStartInterview(entry.protocol.hash)
               : entry.kind === 'sample'
                 ? onInstallSample
-                : undefined,
+                : entry.kind === 'development'
+                  ? onInstallDevelopment
+                  : undefined,
           render: (isActive: boolean, activate: () => void) => (
             <DeckSlotCard
               entry={entry}
@@ -183,6 +196,7 @@ export function ProtocolDeck({
               onDeleteProtocol={onDeleteProtocol}
               onDismissSample={onDismissSample}
               onInstallSample={onInstallSample}
+              onInstallDevelopment={onInstallDevelopment}
               newSession={newSession}
             />
           ),
@@ -197,6 +211,7 @@ export function ProtocolDeck({
       onStartInterview,
       onInstallSample,
       onDismissSample,
+      onInstallDevelopment,
       onDeleteProtocol,
       onCancelNewSession,
       onSessionCreated,

--- a/apps/interviewer/src/components/ProtocolCarousel/__tests__/DeckSlotCard.test.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/__tests__/DeckSlotCard.test.tsx
@@ -42,6 +42,7 @@ const baseProps = {
   onDeleteProtocol: noop,
   onDismissSample: noop,
   onInstallSample: noop,
+  onInstallDevelopment: noop,
 };
 
 describe('DeckSlotCard', () => {
@@ -81,6 +82,26 @@ describe('DeckSlotCard', () => {
       screen.getByRole('button', { name: 'Install sample protocol' }),
     );
     expect(onInstallSample).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the development teaser with an install button and no dismiss control', () => {
+    const onInstallDevelopment = vi.fn();
+    render(
+      <DeckSlotCard
+        {...baseProps}
+        entry={{ kind: 'development' }}
+        onInstallDevelopment={onInstallDevelopment}
+      />,
+    );
+
+    expect(screen.getByText('Development Protocol')).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Install development protocol' }),
+    );
+    expect(onInstallDevelopment).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('button', { name: /dismiss/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders the pending card with the phase label and metadata skeletons', () => {

--- a/apps/interviewer/src/components/ProtocolCarousel/__tests__/deckEntries.test.ts
+++ b/apps/interviewer/src/components/ProtocolCarousel/__tests__/deckEntries.test.ts
@@ -61,6 +61,7 @@ describe('buildDeck', () => {
     const deck = buildDeck({
       protocols: [],
       showSampleCard: false,
+      showDevelopmentCard: false,
       pendingImports: [],
     });
     expect(deck).toEqual([{ kind: 'import' }]);
@@ -74,6 +75,7 @@ describe('buildDeck', () => {
         makeProtocol('beta'),
       ],
       showSampleCard: true,
+      showDevelopmentCard: false,
       pendingImports: [],
     });
     expect(deck.map((e) => entryKey(e))).toEqual([
@@ -92,6 +94,7 @@ describe('buildDeck', () => {
         makeProtocol('MyStudy', 'hash-new'),
       ],
       showSampleCard: false,
+      showDevelopmentCard: false,
       pendingImports: [],
     });
     expect(deck.map((e) => entryKey(e))).toEqual([
@@ -105,6 +108,7 @@ describe('buildDeck', () => {
     const deck = buildDeck({
       protocols: [],
       showSampleCard: true,
+      showDevelopmentCard: false,
       pendingImports: [makePending('Sample Protocol')],
     });
     expect(deck).toHaveLength(2);
@@ -115,6 +119,7 @@ describe('buildDeck', () => {
     const deck = buildDeck({
       protocols: [makeProtocol('Study A')],
       showSampleCard: false,
+      showDevelopmentCard: false,
       pendingImports: [makePending('Study A')],
     });
     expect(deck).toHaveLength(2);
@@ -125,9 +130,35 @@ describe('buildDeck', () => {
     const deck = buildDeck({
       protocols: [makeProtocol('Sample Protocol')],
       showSampleCard: true,
+      showDevelopmentCard: false,
       pendingImports: [],
     });
     expect(deck).toHaveLength(2);
     expect(deck[0]?.kind).toBe('sample');
+  });
+
+  it('includes the development teaser in its own name slot when requested', () => {
+    const deck = buildDeck({
+      protocols: [],
+      showSampleCard: true,
+      showDevelopmentCard: true,
+      pendingImports: [],
+    });
+    expect(deck.map((e) => entryKey(e))).toEqual([
+      'slot:Development Protocol',
+      'slot:Sample Protocol',
+      'import',
+    ]);
+  });
+
+  it('lets a pending import shadow the development teaser in the same slot', () => {
+    const deck = buildDeck({
+      protocols: [],
+      showSampleCard: false,
+      showDevelopmentCard: true,
+      pendingImports: [makePending('Development Protocol')],
+    });
+    expect(deck).toHaveLength(2);
+    expect(deck[0]?.kind).toBe('pending');
   });
 });

--- a/apps/interviewer/src/components/ProtocolCarousel/deckEntries.ts
+++ b/apps/interviewer/src/components/ProtocolCarousel/deckEntries.ts
@@ -1,4 +1,5 @@
 import type { ProtocolWithCounts } from '~/lib/db/types';
+import { DEVELOPMENT_PROTOCOL } from '~/lib/protocol/developmentProtocol';
 import { SAMPLE_PROTOCOL } from '~/lib/protocol/sampleProtocol';
 import type { PendingImport } from '~/lib/protocol/useProtocolImport';
 
@@ -6,23 +7,26 @@ import type { PendingImport } from '~/lib/protocol/useProtocolImport';
 export type DeckEntry =
   | { kind: 'protocol'; protocol: ProtocolWithCounts }
   | { kind: 'sample' }
+  | { kind: 'development' }
   | { kind: 'pending'; pending: PendingImport }
   | { kind: 'import' };
 
 // Slot identity. An installed protocol is keyed by its content hash — the same
 // identity the DB uses — so two protocols sharing a name but differing in hash
 // each get their own card and stay independently reachable (and deletable).
-// Pending imports and the sample teaser are keyed by name instead: they have no
-// resulting hash yet, so name is the only identity available to let their card
-// morph in place into the installed protocol (see the name-based shadowing in
-// `buildDeck`). The `slot:`/`hash:` namespaces keep the import entry's key from
-// ever colliding with a protocol name or hash.
+// Pending imports and the bundled teasers are keyed by name instead: they have
+// no resulting hash yet, so name is the only identity available to let their
+// card morph in place into the installed protocol (see the name-based
+// shadowing in `buildDeck`). The `slot:`/`hash:` namespaces keep the import
+// entry's key from ever colliding with a protocol name or hash.
 export function entryKey(entry: DeckEntry): string {
   switch (entry.kind) {
     case 'protocol':
       return `hash:${entry.protocol.hash}`;
     case 'sample':
       return `slot:${SAMPLE_PROTOCOL.name}`;
+    case 'development':
+      return `slot:${DEVELOPMENT_PROTOCOL.name}`;
     case 'pending':
       return `slot:${entry.pending.label}`;
     case 'import':
@@ -31,24 +35,27 @@ export function entryKey(entry: DeckEntry): string {
 }
 
 // The display name each entry occupies a name-slot under, used to let a pending
-// import or the sample teaser shadow the installed protocol they will become.
+// import or a bundled teaser shadow the installed protocol they will become.
 function entryName(entry: Exclude<DeckEntry, { kind: 'import' }>): string {
   switch (entry.kind) {
     case 'protocol':
       return entry.protocol.name;
     case 'sample':
       return SAMPLE_PROTOCOL.name;
+    case 'development':
+      return DEVELOPMENT_PROTOCOL.name;
     case 'pending':
       return entry.pending.label;
   }
 }
 
-// Pending wins over sample wins over protocol when entries share a name-slot
-// (e.g. a sample-source pending and the sample card, or a freshly-imported
-// protocol overlapping its just-cleared pending entry).
+// Pending wins over the bundled teasers wins over protocol when entries share
+// a name-slot (e.g. a sample-source pending and the sample card, or a
+// freshly-imported protocol overlapping its just-cleared pending entry).
 const KIND_PRIORITY = {
   pending: 3,
   sample: 2,
+  development: 2,
   protocol: 1,
   import: 0,
 } as const;
@@ -56,15 +63,17 @@ const KIND_PRIORITY = {
 type BuildDeckArgs = {
   protocols: ProtocolWithCounts[];
   showSampleCard: boolean;
+  showDevelopmentCard: boolean;
   pendingImports: PendingImport[];
 };
 
-// Merge protocols, the sample teaser, and in-flight imports into slot-keyed
+// Merge protocols, the bundled teasers, and in-flight imports into slot-keyed
 // entries sorted by name; the import trigger is always the last card and
 // never participates in slot merging.
 export function buildDeck({
   protocols,
   showSampleCard,
+  showDevelopmentCard,
   pendingImports,
 }: BuildDeckArgs): DeckEntry[] {
   const candidates: Exclude<DeckEntry, { kind: 'import' }>[] = protocols.map(
@@ -74,18 +83,19 @@ export function buildDeck({
     }),
   );
   if (showSampleCard) candidates.push({ kind: 'sample' });
+  if (showDevelopmentCard) candidates.push({ kind: 'development' });
   for (const pending of pendingImports) {
     candidates.push({ kind: 'pending', pending });
   }
 
-  // A pending import (or the sample teaser) shadows every installed protocol
+  // A pending import (or a bundled teaser) shadows every installed protocol
   // that shares its name, so the card morphs in place instead of the deck
   // showing both the installing card and the finished protocol at once. Two
   // installed protocols with the same name but different hashes keep separate
   // slots, so neither becomes unreachable.
   const shadowingNames = new Set<string>();
   for (const candidate of candidates) {
-    if (candidate.kind === 'pending' || candidate.kind === 'sample') {
+    if (candidate.kind !== 'protocol') {
       shadowingNames.add(entryName(candidate));
     }
   }

--- a/apps/interviewer/src/lib/protocol/developmentProtocol.ts
+++ b/apps/interviewer/src/lib/protocol/developmentProtocol.ts
@@ -1,0 +1,13 @@
+// Card-facing metadata for the dev-only Development protocol teaser.
+// Deliberately NOT imported from bundledDevelopmentProtocol.ts: that module
+// statically inlines the protocol's large media (a 23MB video), and is only
+// ever loaded via the dynamic `import()` behind the `import.meta.env.DEV`
+// guard in useProtocolImport.ts. The name must match the one
+// loadBundledDevelopmentProtocol returns so the pending-import card and the
+// installed protocol shadow this teaser's deck slot.
+export const DEVELOPMENT_PROTOCOL = {
+  name: 'Development Protocol',
+  description:
+    'The Network Canvas development protocol — exercises every stage type ' +
+    'and is bundled into development builds for testing.',
+} as const;

--- a/apps/interviewer/src/routes/Home.tsx
+++ b/apps/interviewer/src/routes/Home.tsx
@@ -2,7 +2,6 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { useLocation } from 'wouter';
 
-import Button from '@codaco/fresco-ui/Button';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useToast } from '@codaco/fresco-ui/Toast';
 import { BrandHeader } from '~/components/BrandHeader';
@@ -16,6 +15,7 @@ import { TopActionBar } from '~/components/TopActionBar';
 import { deleteProtocol, updateSettings } from '~/lib/db/api';
 import type { StoredSession } from '~/lib/db/types';
 import { pickProtocolFile } from '~/lib/files/pickFile';
+import { DEVELOPMENT_PROTOCOL } from '~/lib/protocol/developmentProtocol';
 import { useProtocolImport } from '~/lib/protocol/useProtocolImport';
 import { useLaunchedProtocolImport } from '~/lib/pwa/useLaunchedProtocolImport';
 import { useLaunchFailureToast } from '~/lib/pwa/useLaunchFailureToast';
@@ -98,8 +98,9 @@ export function HomeRoute() {
     void startImport({ source: 'sample' });
   }, [startImport]);
 
-  // Dev-only: installs the Development protocol (exercises every stage type)
-  // without leaving a teaser card in production builds.
+  // Dev-only: installs the Development protocol (exercises every stage
+  // type) from its teaser card in the deck; the card never renders in
+  // production builds (see showDevelopmentCard below).
   const handleInstallDevelopment = useCallback(() => {
     if (!import.meta.env.DEV) return;
     void startImport({ source: 'development' });
@@ -235,6 +236,14 @@ export function HomeRoute() {
                     !pendingImports.some((p) => p.source === 'sample')
                   : false
               }
+              showDevelopmentCard={
+                // Dev-only teaser; disappears once the Development protocol
+                // is installed (or while its import is in flight — the
+                // pending card shadows the slot during the install itself).
+                import.meta.env.DEV &&
+                !protocols.some((p) => p.name === DEVELOPMENT_PROTOCOL.name) &&
+                !pendingImports.some((p) => p.source === 'development')
+              }
               pendingImports={pendingImports}
               onImport={() => void handleChooseFile()}
               onImportFile={handleImportFile}
@@ -242,25 +251,11 @@ export function HomeRoute() {
               onDeleteProtocol={handleDeleteProtocol}
               onInstallSample={handleInstallSample}
               onDismissSample={handleDismissSample}
+              onInstallDevelopment={handleInstallDevelopment}
               newSessionProtocolHash={pendingProtocolHash}
               onCancelNewSession={closeNewSession}
               onSessionCreated={handleSessionCreated}
             />
-
-            {import.meta.env.DEV && (
-              <div
-                inert={newSessionActive}
-                className="tablet-landscape:px-11 flex justify-center px-6"
-              >
-                <Button
-                  variant="text"
-                  size="sm"
-                  onClick={handleInstallDevelopment}
-                >
-                  Install development protocol
-                </Button>
-              </div>
-            )}
 
             <div inert={newSessionActive} className="contents">
               <StatusRow


### PR DESCRIPTION
## Summary

Fixes #888 ([Interviewer-web] Study Protocol title condensed on splash screen).

Two symptoms, one root cause. The deck card's column had exactly one flexible row — the heading — while the controls row, a fixed six-line description clamp, metadata, divider, and footer were all rigid. Activating a card mounted the divider + Start button, squeezing the heading region below one line-height: the fitted clamp bottomed out at 1 line and `overflow-hidden` clipped the glyphs mid-height ("condensed" titles). On short windows, the case-ID form footer exceeded the whole card and `overflow-clip` cut the submit button off entirely (reproduced at 104px past the card edge on a 300px card).

This PR inverts the priorities with a measured budget (`useCardTextBudget`), name first:

- **The protocol name always renders in full.** Fixed rows and the footer's natural height are reserved up front; the heading takes every whole line its name needs (its row gains `min-h-fit` so flex can never crush it). The existing size-step + whole-line-clamp backstop for pathological names is preserved.
- **The description yields.** Its line clamp is now computed (0–6 whole lines from the leftover budget) and the row unmounts entirely when not even one line fits.
- **The footer scrolls instead of clipping.** It's capped at the remaining budget and wrapped in fresco-ui's `ScrollArea`, so the case-ID form scrolls (with edge-fade affordance) and Cancel/Start interview stay reachable on any card size.
- Column gaps scale with the card (`max(12px,3.3cqi)`, still 24px at the 720px max) so small cards spend height on content rather than fixed seams.

Budget stability: no output feeds back into its own inputs (budgets derive from the column height, fixed rows' natural sizes, and arithmetic gap terms), so the clamps can't oscillate.

### Before/after at the reported size (~360px card, active)

| | Before | After |
|---|---|---|
| Title | 1 line, glyphs clipped (5px region) | Full name, 2 lines |
| Description | 6 lines (fixed) | 6 → fewer lines as space shrinks |
| Case-ID submit button | Clipped off-card at 100% zoom | Visible / scroll-reachable |

## Test plan

- [x] Storybook regression stories with play assertions: `SmallActiveCard` (issue's exact name/description at 360px — full name visible + footer inside card) and `CaseIdFormSmallCard` (300px card — submit row scroll-reachable, never clipped)
- [x] Existing pathological-name guards (`ExtremelyLongName`, `ExtremelyLongNameAndDescription`) still pass
- [x] All ProtocolCarousel storybook tests (29) and interviewer unit tests (357) pass
- [x] `pnpm typecheck`, `oxlint` on touched files, `pnpm knip`, `pnpm check:changesets` clean
- [x] Verified in the running app at 1464×700 and 1464×845 (reporter's viewport): title visible on active cards, case-ID form usable with submit button inside the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Start screen cards now keep study names fully visible when selected, instead of truncating them.
  * On smaller windows, the case ID step now scrolls within the card so the start button stays accessible.

* **Bug Fixes**
  * Improved card sizing and content flow so text, descriptions, and footer actions fit more reliably in tight layouts.
  * Added a minimum card size for better readability in the interview deck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->