### PR TITLE
fix(interview): keep quick add open when submit-disabling blurs input

### DIFF
--- a/.changeset/quick-add-stays-open-in-safari.md
+++ b/.changeset/quick-add-stays-open-in-safari.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Fixed the quick add name generator closing its input after each name in Safari when the protocol uses encrypted variables and a passphrase has been set. The input now stays open so multiple people can be added in a row, matching the behaviour without encryption.

--- a/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
@@ -130,6 +130,13 @@ export default function QuickAddField({
 
   const handleBlur = useCallback(
     (e: React.FocusEvent) => {
+      // The form disables its fields while a submission is in flight, and
+      // WebKit blurs a focused control the moment it becomes disabled. That
+      // blur is not the user leaving the field, so it must not close it —
+      // the submit-complete effect above restores focus once re-enabled.
+      if (e.target instanceof HTMLInputElement && e.target.disabled) {
+        return;
+      }
       if (buttonRef.current?.contains(e.relatedTarget)) {
         return;
       }

--- a/packages/interview/src/interfaces/NameGenerator/components/__tests__/QuickAddField.test.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/__tests__/QuickAddField.test.tsx
@@ -1,0 +1,126 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Form from '@codaco/fresco-ui/form/Form';
+
+vi.mock('~/hooks/useCelebrate', () => ({
+  useCelebrate: () => vi.fn(),
+}));
+
+// QuickAddField reads node presentation state through useStageSelector.
+// Dispatch on the selector sentinel exported by the (mocked) selector modules.
+vi.mock('~/selectors/session', () => ({
+  getNodeColorSelector: 'getNodeColorSelector',
+  getNodeTypeDefinition: 'getNodeTypeDefinition',
+  getPromptAdditionalAttributes: 'getPromptAdditionalAttributes',
+  resolveNodeShape: () => 'circle',
+}));
+
+vi.mock('~/selectors/name-generator', () => ({
+  getNodeIconName: 'getNodeIconName',
+}));
+
+vi.mock('~/hooks/useStageSelector', () => ({
+  useStageSelector: (selector: unknown) => {
+    switch (selector) {
+      case 'getNodeColorSelector':
+        return 'node-color-seq-1';
+      case 'getNodeTypeDefinition':
+        return { shape: 'circle' };
+      case 'getPromptAdditionalAttributes':
+        return {};
+      case 'getNodeIconName':
+        return 'add-a-person';
+      default:
+        return undefined;
+    }
+  },
+}));
+
+import QuickAddField from '../QuickAddField';
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const openField = async () => {
+  await userEvent.click(screen.getByTestId('quick-add-toggle'));
+  return screen.findByTestId('quick-add-input');
+};
+
+describe('QuickAddField', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('stays open when blur is caused by the submit-disabled input', async () => {
+    // Simulate a slow submission (e.g. attribute encryption): the form store
+    // renders isSubmitting=true, which disables the input mid-submit. WebKit
+    // then blurs the focused-but-now-disabled input and dispatches that blur
+    // through React. That blur must not close the field.
+    const deferred = createDeferred();
+    const onSubmit = vi.fn(async () => {
+      await deferred.promise;
+      return { success: true };
+    });
+
+    render(
+      <Form onSubmit={onSubmit}>
+        <QuickAddField name="name" placeholder="Type a name" disabled={false} />
+      </Form>,
+    );
+
+    const input = await openField();
+    await userEvent.type(input, 'Alice');
+    fireEvent.submit(input.closest('form')!);
+
+    // The submitting render must have committed before the engine-style blur.
+    await waitFor(() => expect(input).toBeDisabled());
+
+    // jsdom does not blur a control that becomes disabled, so dispatch the
+    // blur WebKit produces in that situation ourselves.
+    fireEvent.blur(input);
+
+    deferred.resolve();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('quick-add-input')).not.toBeDisabled(),
+    );
+
+    // Open, cleared, and ready for the next name.
+    expect(screen.getByTestId('quick-add-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByTestId('quick-add-input')).toHaveValue('');
+  });
+
+  it('closes when the user blurs the enabled input', async () => {
+    render(
+      <Form onSubmit={vi.fn(async () => ({ success: true }))}>
+        <QuickAddField name="name" placeholder="Type a name" disabled={false} />
+      </Form>,
+    );
+
+    const input = await openField();
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('quick-add-toggle')).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

With the encrypted-variables experiment enabled and a passphrase set via the Anonymisation interface, pressing <kbd>Enter</kbd> in the quick add name generator closed the input after every name, forcing the participant to re-open it for each alter. Without encryption the input stays open as designed.

**Root cause.** The form store disables all fields while a submission is in flight (`useField`: `isDisabled = isSubmitting || config.disabled`). Without encryption, `addNode` resolves in microtasks, so the submitting state never reaches the DOM. With encryption, the thunk awaits real key-derivation work (PBKDF2, 100k iterations), so React commits a render in which the focused quick add input becomes `disabled`:

- **Chromium** drops focus but does not dispatch the resulting blur through React — the box stayed open, so the bug was invisible there.
- **WebKit** dispatches that blur through React. `QuickAddField`'s blur handler read it as the user leaving the field and closed it.

**Fix.** `handleBlur` now ignores a blur whose target is a disabled input — that blur can only come from the submit machinery, never from the user tabbing/clicking away. The existing submit-complete effect already restores focus once the field re-enables.

## Test plan

- [x] New unit test: a WebKit-style blur on the submit-disabled input no longer closes the field (red before the fix, green after); user-initiated blur on an enabled input still closes it
- [x] Reproduced and verified end-to-end against the development protocol (Anonymisation → encrypted quick add) via the e2e host in Playwright **WebKit and Chromium**: three alters added consecutively without the input closing; input remains focused and cleared after each Enter
- [x] `vitest --project units` (interview): 127 files / 1118 tests pass
- [x] `pnpm typecheck`, `pnpm knip`, oxlint/oxfmt on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Safari-specific issue where the quick-add field could close unexpectedly during submission, allowing multiple entries to be added without reopening the input.
  * Improved blur handling so the quick-add field stays open when the input becomes disabled mid-submit, while still closing normally when users blur an active input.

* **Tests**
  * Added coverage for both the Safari-like submission flow and the standard blur-to-close behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->