### PR TITLE
Add repo-scoped Codex skills

### DIFF
--- a/.agents/skills/creating-a-changeset/SKILL.md
+++ b/.agents/skills/creating-a-changeset/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: creating-a-changeset
+description: 'Use when finishing a change and preparing to open a PR in the network-canvas monorepo — to decide whether a changeset is needed and author it in the correct lane. Keywords: changeset, do I need a changeset, release notes, pnpm changeset, version bump, before opening a PR, releasable change.'
+---
+
+# Creating a Changeset
+
+## When a changeset is needed
+
+Add a changeset when the change is **consumer- or participant-visible** in a
+released package or app:
+
+- A published library under `packages/*` (e.g. `@codaco/interview`,
+  `@codaco/protocol-validation`) — any behaviour/API/type change consumers see.
+- An app: `@codaco/architect` or `@codaco/interviewer`.
+
+Skip it for docs-only, test-only, CI/tooling-only, or internal refactors with no
+consumer-visible effect. Don't add an empty changeset just to have one.
+
+## Two lanes — never mix them
+
+**A single changeset must target either libraries or an app, never both.** CI
+(`pnpm check:changesets`) rejects a mixed changeset, because `changeset version`
+hard-errors on it and would break the library release. If one PR changes both,
+run `pnpm changeset` twice and write two files.
+
+|           | Library packages (`packages/*`)        | Apps (`architect`, `interviewer`)                                         |
+| --------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| Bump type | Real semver impact (major/minor/patch) | Only **categorises** the notes — base is fixed, `-beta.N` auto-increments |
+| Ships via | The "Version Packages" PR → npm        | The "Release apps (beta)" PR → Netlify prod + GitHub release              |
+
+## How to author
+
+1. Run `pnpm changeset`.
+2. Select the package(s) — for an app, select only that app (plus optionally the
+   other app; never a library alongside it).
+3. Choose the bump type. For libraries this drives the released version; for apps
+   it only groups the entry under Major/Minor/Patch changes.
+4. Write the summary as **reader-facing release notes** — it becomes the
+   changelog / GitHub release text. For app-facing entries use the
+   participant-appropriate tone described in `developing-in-network-canvas`.
+5. Commit the generated `.changeset/*.md` with your PR.
+
+## Notes
+
+- App changesets live in `.changeset/` like everyone else; the library release
+  intentionally leaves them alone (the apps are in the changeset `ignore` list)
+  until the "Release apps" PR consumes them.
+- Full model: `docs/superpowers/specs/2026-07-03-pwa-app-beta-releases-design.md`
+  and each app's `RELEASING.md`.

--- a/.agents/skills/creating-a-changeset/agents/openai.yaml
+++ b/.agents/skills/creating-a-changeset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Creating a Changeset'
+  short_description: 'Decide and author Network Canvas changesets'
+  default_prompt: 'Use $creating-a-changeset to decide whether this Network Canvas change needs release notes.'

--- a/.agents/skills/creating-a-network-canvas-interface/SKILL.md
+++ b/.agents/skills/creating-a-network-canvas-interface/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: creating-a-network-canvas-interface
+description: 'Use when adding a NEW Network Canvas interface — a participant-facing interview stage type that does not exist yet (a new sociogram-like, name/edge generator, census, narrative, or informational screen). NOT for changing an existing interface. Keywords: new interface, new stage type, add interface, add a stage type, interview screen, interview stage, stage schema, interfaces/index, getInterface, INTERFACE_TYPES, INTERFACE_CONFIGS, capture story, interface documentation, schema version.'
+---
+
+# Creating a Network Canvas interface
+
+## Overview
+
+A Network Canvas "interface" is the fundamental data-collection unit in a Network Canvas interview. It is participant facing when administered via an interview client, and researcher facing when configured via a protocol builder. It is **one contract — a single stage-type string — realised across four surfaces that must ship together**: the protocol schema (contract), Architect (configuration builder), the interview runtime (instrument), and the documentation site. A new interface wired into only some of them is broken, not a smaller deliverable.
+
+**Core principle:** confirm the schema target _before_ writing anything, build the same stage-type across all four surfaces in sync, reuse existing interface patterns, and prefer researcher configuration for participant-visible text — hardcode only where essential or generic boilerplate.
+
+## When to use
+
+- A researcher wants an interview screen / stage type that does not already exist.
+- NOT for editing an existing interface, or for a non-stage feature — use `developing-in-network-canvas` for those.
+
+## Before you write any code (in order)
+
+1. **Invoke `developing-in-network-canvas` (REQUIRED).** Reuse-first, accessibility, internationalisation, and participant tone are not optional add-ons here — they are the body of the work. This skill assumes you are already following it.
+2. **Brainstorm the interface first.** A new stage type is a new feature; agree the interaction, the data it writes, and the configuration surface before touching files. Use Codex planning or a concise implementation plan when the request leaves behavior or schema shape ambiguous.
+3. **Confirm the schema version with the user. Do not assume.** Ask explicitly: does this target the **current** schema version as a purely additive stage type (no migration), or does it require a **new** schema version (and therefore a migration)? "It's obviously additive" is exactly the assumption to surface to the user, not to make silently. **Determine the current version by reading `CURRENT_SCHEMA_VERSION`** (exported from `packages/protocol-validation/src/schemas/index.ts`) — never hardcode a version number. New stage files live under `src/schemas/<current>/stages/`, where `<current>` is that value. A version bump additionally means a new `schemas/<n>/` directory, a `migration.ts`, and an entry in `SchemaVersionSchema`.
+
+## The four surfaces — all must ship together
+
+The stage-type string (e.g. `'TimelineSorter'`) is the single contract. It is wired by hand in each surface; **the change is incomplete until all four agree.** Read the cited exemplar in each before writing. Below, `<current>` is the value of `CURRENT_SCHEMA_VERSION` (see step 3) — read it, don't assume a number.
+
+| Surface                 | Where                          | What to do                                                                                                                                                                                                                           | Register / anchor at                                                                                                                                                                                                                               | Exemplar                               |
+| ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| **Contract** (schema)   | `packages/protocol-validation` | Create `src/schemas/<current>/stages/<name>.ts` extending `baseStageSchema` with `type: z.literal('<Name>')`; tag every variable reference with `entityAttributeReference(...)`; add tests under `src/schemas/<current>/__tests__/`. | Import + re-export + add to the discriminated-union array in `src/schemas/<current>/stages/index.ts`.                                                                                                                                              | `stages/network-composer.ts`           |
+| **Builder** (configure) | `apps/architect`               | Add the picker entry; build the editor sections researchers use; give it a default name.                                                                                                                                             | `NewStageScreen/interfaceOptions.ts` (`INTERFACE_TYPES`), `StageEditor/Interfaces.tsx` (`INTERFACE_CONFIGS`), new `components/sections/<Name>/*` exported from `components/sections/index.tsx`, `StageEditor/autoStageName/generateStageLabel.ts`. | `components/sections/FamilyPedigree/*` |
+| **Instrument** (run)    | `packages/interview`           | Create `src/interfaces/<Name>/<Name>.tsx`; consume the shared `Prompts` component; add a Capture story and regenerate images.                                                                                                        | `case '<Name>'` in `getInterface` (`src/interfaces/index.tsx`); `<Name>.capture.stories.tsx` → then `pnpm generate:interface-images`.                                                                                                              | any dir under `src/interfaces/`        |
+| **Documentation**       | `apps/documentation`           | Write the per-interface doc page; the sidebar auto-generates from the filesystem + frontmatter.                                                                                                                                      | `docs/desktop/interface-documentation/<name>.en.mdx` with `title:` frontmatter.                                                                                                                                                                    | `sociogram.en.md`, `geospatial.en.mdx` |
+
+**Easy-to-miss sync points** (a stage-type that compiles can still be half-wired):
+
+- **`protocol-utilities` switches on stage type** in `generateNetwork.ts` and `SyntheticInterview.ts` for synthetic-network generation — add a case if the new stage produces, clears, or shapes alter data. (`StageType` is sourced from `@codaco/protocol-validation`, so the type tracks the schema automatically; only the per-stage behaviour needs wiring.)
+- **The Capture story is mandatory, not optional.** Every interface needs a `Capture/` storybook story so timeline/preview images generate. Seed every attribute explicitly in the fixture (`getNetwork()` randomises unset attributes).
+- **Architect variable-usage detection** keys off hand-maintained reference paths. If the stage references variables at non-standard locations, mirror the schema's cross-reference keys or the variables get falsely flagged "unused".
+
+## Essential interface design principles
+
+**Reuse existing interface patterns before inventing new ones.** Most new interfaces are recombinations of patterns that already exist — walk the reuse ladder from `developing-in-network-canvas` at the _interface_ level, not just the component level.
+
+- **Multiple tasks within one stage → the `prompts` concept.** Do not invent a per-stage list of tasks/questions. Use prompts end to end: a `prompts` array in the schema, the shared prompt-list editor in Architect (reuse `EditableList` + `PromptText`, mirror `NameGeneratorPrompts`), and the runtime `Prompts` component (`packages/interview/src/components/Prompts/Prompts.tsx`) which already handles rotation, animation, and screen-reader announcement.
+- **Placement / drag / roster / selection/ and forms** are solved — build on the existing canvas, node, form, field, and collection primitives rather than net-new interaction code.
+
+**Minimise hardcoded participant text; prefer researcher configuration.** Hardcoded participant copy is sometimes unavoidable, but it is **strongly discouraged** unless the text is essential or generic boilerplate. The test before typing a string literal: _would a researcher plausibly want to change this wording for their study?_ If yes — prompt text, instructions, study-specific labels, meaningful empty states — it is a **researcher-authored configuration field**: define it in the stage schema, expose it in the Architect editor, store it in the protocol, and render it from props. Hardcoding is acceptable for **generic UI chrome and boilerplate** (button labels like "Continue", structural/navigational text with no study-specific meaning) and where externalising it genuinely adds no value — and even then prefer the existing shared components, which already carry the right copy and tone.
+
+## Definition of done
+
+- [ ] Schema version confirmed with the user (additive vs. new version + migration).
+- [ ] **Contract:** schema file created, registered in `stages/index.ts`, variable refs tagged, tests pass.
+- [ ] **Builder:** picker entry, editor sections, default name — researcher can fully configure it in Architect.
+- [ ] **Instrument:** runtime component registered in `getInterface`, renders from config, consumes `Prompts`.
+- [ ] **Documentation:** `<name>.en.mdx` page written in `apps/documentation`.
+- [ ] Sync points: `protocol-utilities` behaviour (`generateNetwork`/`SyntheticInterview` case if it shapes data); Capture story added and `pnpm generate:interface-images` run.
+- [ ] Participant copy a researcher would want to control is configuration, not hardcoded (generic/boilerplate chrome excepted).
+- [ ] One stage-type string is identical everywhere it is referenced.
+
+## Common mistakes
+
+| Mistake                                                    | Do instead                                                                                                                      |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Assuming "schema 8, additive, no migration" without asking | Confirm the target schema version with the user before any layer.                                                               |
+| Wiring schema + runtime, forgetting Architect and/or docs  | Treat all four surfaces as one deliverable; use the Definition of done.                                                         |
+| Skipping the documentation page because "code works"       | The `apps/documentation` page is a required surface, not a follow-up.                                                           |
+| Baking study-specific participant copy into the component  | If a researcher would want to change the wording, make it a config field; hardcode only essential/boilerplate chrome.           |
+| Inventing a bespoke per-stage task list                    | Use the `prompts` concept across schema, editor, and runtime.                                                                   |
+| Adding the stage type only where it's declared             | Also wire its runtime behaviour — e.g. a `generateNetwork`/`SyntheticInterview` case in `protocol-utilities` if it shapes data. |
+| Forgetting the Capture story                               | Add `<Name>.capture.stories.tsx`, then `pnpm generate:interface-images`.                                                        |
+
+## Quick reference
+
+- **Schema stages + registry:** `packages/protocol-validation/src/schemas/<current>/stages/` (`index.ts` is the union); read `CURRENT_SCHEMA_VERSION` from `schemas/index.ts` for `<current>`.
+- **Architect editor registry:** `apps/architect/src/components/StageEditor/Interfaces.tsx`; picker in `NewStageScreen/interfaceOptions.ts`; sections in `components/sections/`.
+- **Runtime registry:** `packages/interview/src/interfaces/index.tsx` (`getInterface`); prompts at `src/components/Prompts/Prompts.tsx`.
+- **Docs:** `apps/documentation/docs/desktop/interface-documentation/<name>.en.mdx`.
+- **Sync points:** `packages/protocol-utilities/src/SyntheticInterview.ts` / `generateNetwork.ts` (per-stage behaviour); images via `pnpm generate:interface-images`.

--- a/.agents/skills/creating-a-network-canvas-interface/agents/openai.yaml
+++ b/.agents/skills/creating-a-network-canvas-interface/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Creating a Network Canvas Interface'
+  short_description: 'Add a complete Network Canvas stage type'
+  default_prompt: 'Use $creating-a-network-canvas-interface to plan and implement a new Network Canvas interview stage type.'

--- a/.agents/skills/developing-in-network-canvas/SKILL.md
+++ b/.agents/skills/developing-in-network-canvas/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: developing-in-network-canvas
+description: 'Use when developing any feature, fix, or change anywhere in the Network Canvas monorepo — before writing code — and especially when building or changing any user-facing UI (component, page, interview stage, dialog, form, styling). Applies whether the work is UI, a package, a schema, a worker, or a utility. Keywords: feature development, monorepo, reuse existing code, DRY, existing pattern, package, utility, fresco-ui, Base UI, accessibility, a11y, keyboard, screen reader, aria-live, internationalisation, i18n, participant, tone, voice, design tokens, theme, motion, reduced-motion.'
+---
+
+# Developing in Network Canvas
+
+## Overview
+
+Two failure modes this guards against: **rebuilding things that already exist**, and **shipping features that ignore the project's priorities**. Both are cheapest to prevent before code is written.
+
+**Core principle:** reuse what's already there before building new, and treat accessibility, internationalisation, and participant experience as design factors from the start — never retrofits.
+
+## When to use
+
+Any feature, fix, or change in the monorepo, before writing code. **Steps 1 and 2 apply to everything** — packages, schemas, workers, utilities, UI. The **Building UI** section adds depth for anything that renders an interface.
+
+Read the repository root `AGENTS.md` at the start of Network Canvas repository tasks for the repo's current commands, architecture map, committing/PR expectations, and code standards.
+
+## Step 1 — Reuse before you build (every feature)
+
+Walk the ladder before writing new code of any kind — a component, a utility, a validator, an exporter:
+
+1. **Reuse** an existing package/module/component as-is.
+2. **Compose** existing pieces into the new thing.
+3. **Extend** something close (add a param/prop/variant).
+4. **Build new** only as a last resort — and put reusable code where the next feature will find it (the right shared package), not inline.
+
+If you build new, state in one line _what you checked and why nothing fit_. "Faster to write inline," "close but not exact," and "didn't want to touch shared code" are how duplication gets created — they are not reasons.
+
+**Find what exists first:**
+
+- Code lives under `packages/*` and `apps/*` (see the repo-level `AGENTS.md` for the architecture map). Shared types/consts → `@codaco/shared-consts`; protocol schemas & migrations → `@codaco/protocol-validation`; network generation → `@codaco/protocol-utilities`; UI → `@codaco/fresco-ui`.
+- Search for an existing helper or pattern before adding one, and mirror the conventions of the closest existing code.
+
+## Step 2 — Project priorities are design factors (every feature)
+
+Weigh these in any feature, even non-UI — an exporter emitting user-facing text, an error a participant will see, a date format:
+
+- **Accessibility** — anything a person operates must be usable by keyboard and expose its state to assistive technology. (UI specifics below.)
+- **Internationalisation** — there is no i18n layer yet, but design so copy _can_ be localised: keep whole, externalisable strings (no fragment concatenation, no grammar interpolation), and leave room for text expansion and right-to-left. Treat "how would this localise?" as a real design question.
+- **Participant experience** — if a participant will read or use it, apply the tone rules below and never leak internal vocabulary (`node`, `edge`, `ego`, `alter`, `stage`, `prompt`, `sociogram`) to them.
+
+## Building UI
+
+Everything below applies when the work renders an interface. Participant-facing = the `@codaco/interview` runtime (`packages/interview`) in `apps/interviewer-classic`, `apps/interviewer`, Fresco. Researcher-facing = Architect (`apps/architect-classic`, `apps/architect`). Tone is participant-facing only; the rest applies to all UI.
+
+### Reuse fresco-ui first
+
+Apply the Step 1 ladder to components: new UI is **assembled from `@codaco/fresco-ui`**, not hand-rolled — its components already encode the accessibility, theming, and motion conventions below.
+
+**Discover the surface (don't trust this doc's list — it drifts):**
+
+- Authoritative component list: `packages/fresco-ui/package.json` → `exports` (one subpath per component).
+- Behaviour/props: the component's co-located `*.stories.tsx`.
+- Imports are per-file subpaths, no barrels: `import Button from '@codaco/fresco-ui/Button'`, `import useDialog from '@codaco/fresco-ui/dialogs/useDialog'`.
+
+**Common starting points** (verify the import path in `exports`; the full set is larger):
+
+| Need                   | Reach for                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Action / submit        | `Button`, `form/SubmitButton`, `CloseButton`, `IconButton`                                                     |
+| Confirm / alert dialog | `useDialog().confirm()` (imperative, promise-based) — don't render a bespoke modal                             |
+| Generic overlay        | `Modal` / `Modal/ModalPopup`, `Popover`, `Tooltip`, `DropdownMenu`                                             |
+| Any form               | `Form` + `form/fields/*` (Input, TextArea, Checkbox, RadioGroup, Select, Combobox, DatePicker, LikertScale, …) |
+| Status / feedback      | `Alert`, `Toast`, `Spinner`, `Skeleton`, `ProgressBar`, `Badge`                                                |
+| Text / layout          | `typography/Heading`, `typography/Paragraph`, `layout/Surface`, `ScrollArea`                                   |
+| Lists / tables         | `collection/*` (virtualized, searchable, DnD), `Table`, `DataTable`                                            |
+| Markdown / rich text   | `RenderMarkdown`, `RichTextRenderer`                                                                           |
+| Network entities       | `Node`                                                                                                         |
+
+If you must build a new component, it is **founded on a Base-UI primitive** and mirrors the closest fresco-ui component's patterns (prop shape, variants, token usage) — never raw `div`s + click handlers.
+
+### Building a new shared component
+
+When the reuse ladder bottoms out and you add a new `@codaco/fresco-ui` component:
+
+- **Mirror the existing export style.** Compound components are **named exports from one file** (see `DropdownMenu`), named after the underlying Base-UI parts (`Tabs`, `TabsList`, `TabsTab`, `TabsPanel`, `TabsIndicator`) — not a barrel, not a `.`-namespace. Add the subpath to `packages/fresco-ui/package.json` `exports`, and rebuild the package (`pnpm --filter @codaco/fresco-ui build`) before a consuming app's typecheck will see it — apps resolve fresco-ui from `dist`, not `src`.
+- **Size with container queries, never viewport breakpoints.** A shared component doesn't know the viewport, only its container — key responsive layout off `@container` + `@min-[…]`, and make the component (or the relevant part) an `@container` so its own descendants can query it. Give size-flexible parts a floor **and** a cap that _both_ step up across breakpoints, so the part gains presence as its container grows and only wraps/clips once content exceeds the cap (e.g. a rail that is `w-fit` between a per-breakpoint `min-w`/`max-w`).
+- **Never fix a height/size that clips content.** Let content flow; a fixed `h-*`/`max-w` that cuts off items or wraps a label unexpectedly is a bug, not a constraint.
+
+**Write a Storybook story that documents, not just renders** (co-located `*.stories.tsx`, `tags: ['autodocs']`):
+
+- **Render the component bare.** No decorative wrapper (card, padding, background, fixed frame) that isn't part of the component — it misrepresents the API and hides real behaviour. Drive size/context through the component's own props (`style`, `className`), not an outer `<div>`.
+- **Document composition and props, not just appearance.** Put a real composition example (imports + the full nesting) and a per-part props list in `parameters.docs.description.component`; expose the meaningful variations as **controls** (`argTypes`) — toggle icons, swap label length, vary width — so the reader learns how to _use_ it.
+- **Cover the edge cases as preset stories** — long/overflowing labels, the narrowest and widest sizes, the icon-less variant. If it can wrap or clip, show it doing so.
+- Keep helpers **un-exported** — a non-story export from a `*.stories.tsx` becomes a broken auto-story.
+
+### Accessibility
+
+Two hard requirements for every interactive component, no exceptions: it is **fully keyboard operable**, and it **announces state changes to screen readers**. The library makes both the path of least resistance — use it rather than reinventing.
+
+- **Build on Base-UI primitives.** `Modal`, `Popover`, `Tooltip`, `DropdownMenu`, `DatePicker` wrap Base-UI, which provides focus traps, Escape handling, roving focus, and ARIA roles for free. A net-new interactive component must be founded on the matching Base-UI primitive — never raw `div`s with click handlers, which are invisible to keyboard and screen-reader users.
+- **Fully keyboard operable.** Every action reachable and triggerable without a mouse: logical tab order, Enter/Space to activate, Escape to dismiss overlays, arrow keys for composite widgets (lists, menus, canvas). A pointer-only interaction is a bug. Example: canvas drag has arrow-key nudge + Enter/Space (`interview/src/canvas/useCanvasDrag.ts`).
+- **Screen-reader announcements for anything that changes without a reload** — drag state, prompt rotation, counts, async results, validation. Use an `aria-live` region (`fresco-ui/src/dnd/useAccessibilityAnnouncements.ts`, `interview/src/components/Prompts/Prompts.tsx`). A silent state change does not exist for a screen-reader user. But throttle frequently-updating values (timers, counters, progress) to meaningful thresholds — a live region that fires every tick floods the screen reader.
+- **Visible focus:** interactive elements get the `focusable` utility class for a consistent `:focus-visible` ring (`fresco-ui/src/Button.tsx`).
+- **Forms:** let `Form`/`Field` wire `aria-invalid` and `aria-describedby` (`form/utils/getInputState.ts`); use `focusFirstError` on submit failure.
+- **Decorative SVGs/icons:** `aria-hidden`. Icon-only buttons: `aria-label`.
+
+### Participant-facing tone & copy
+
+- **Voice:** plain, calm, respectful; assume an adult participant. Second-person imperative for actions ("Finish interview", "Add a person"); third-person for status ("Your responses cannot be changed").
+- **Consequences, not threats:** "Your responses cannot be changed after you finish the interview" — not "This is final and permanent."
+- **Never leak internal vocabulary** to participants (see Step 2). Use the protocol-supplied label or a plain word ("person", "connection"). Stage labels are deliberately hidden from participants (#663).
+- **Most participant text comes from the protocol**, authored by the researcher. Hardcode UI chrome (nav, errors, empty states) only; keep it short and actionable ("Nothing matched your search term.", "External data could not be loaded." — never "404"/"ENOENT").
+- **Rich text:** render participant markdown through `RenderMarkdown` (prompts allow `em/strong/ul/ol/li` only; Information stages allow headings). Never `dangerouslySetInnerHTML`.
+
+### Visual style
+
+- **Style with tokens, never hardcoded values.** Colours are CSS variables: semantic (`--color-primary` + `--color-primary-contrast`, `--color-destructive`, …), surfaces (`--surface`, `--surface-1..3`), inputs/selection (`--input`, `--selected`), data viz (`--node-1..8`, `--edge-1..10`, `--cat-*`, `--ord-*`). Use the Tailwind utilities that map to them (`bg-primary`, `text-text`) — no hex, no `rgb()`.
+- **Elevation:** `elevation-low | medium | high` (shadows auto-tint to the parent surface via `--published-bg`). Don't write custom `box-shadow`.
+- **Type & spacing:** the responsive `text-*` scale (fluid via `clamp`) and the spacing base unit (`p-*`, `gap-*`); radius via `rounded-*`. No raw `px` font sizes.
+- **The interview theme is dark-only**, scoped by `ThemedRegion` (`data-theme-interview`, `scheme-dark`). Don't assume a light background; read colours from the themed region.
+
+### Interaction & motion
+
+- **Animate with `motion/react` + the spring presets.** Use `MotionSpring` tokens (`spring-short | medium | long`) / Tailwind spring utilities rather than ad-hoc `duration`/`ease`.
+- **Always respect reduced motion.** The global media query zeroes durations; for JS-driven animation use `useSafeAnimate`, and gate optional flourishes on `useReducedMotion()` (`interview/src/components/Navigation.tsx`).
+- **Touch/drag:** ~5px drag threshold to distinguish tap from drag, `touchAction: 'none'` on draggable canvases, generous hit targets (sizes scale with the type-scale). Orientation-dependent layout keys off aspect ratio, not a hard 1:1 (`interview/src/Shell.tsx`).
+
+## Common mistakes
+
+| Mistake                                                                               | Do instead                                                                                                           |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Writing a new util/component without checking what exists                             | Walk the reuse ladder; search the relevant `packages/*` first.                                                       |
+| Wrapping `Field`/`Paragraph` in `flex-col gap-*` / `space-y-*`                        | They carry their own bottom margin — you'll double the spacing. Let them flow.                                       |
+| Hand-rolling a confirm/alert modal                                                    | `useDialog().confirm({ title, description, confirmLabel, onConfirm })`.                                              |
+| Building a widget from raw `div`s + `onClick`                                         | Found it on the matching Base-UI primitive — keyboard handling and ARIA come for free.                               |
+| Hardcoded colours / shadows / font px                                                 | Token utilities (`bg-*`, `text-*`, `elevation-*`, `text-lg`).                                                        |
+| Showing "node"/"alter"/"stage" to participants                                        | Protocol label or plain word.                                                                                        |
+| Drag with no keyboard equivalent                                                      | Add arrow-key/Enter-Space handling + an `aria-live` announcement.                                                    |
+| Concatenating sentence fragments for a message                                        | Keep whole, externalisable strings so it can localise later.                                                         |
+| A Storybook story that only renders (bespoke card wrapper, no props/composition docs) | Render bare + `autodocs`: a composition example, a per-part props list, and controls for the meaningful variations.  |
+| Sizing a shared component with viewport breakpoints (`tablet-portrait:` …)            | Container queries (`@container` + `@min-[…]`) with a floor+cap that scale up together — it doesn't own the viewport. |
+
+## Quick reference
+
+- **Packages map:** repo-level `AGENTS.md` "Architecture Overview" — what each `packages/*` and `apps/*` is for.
+- **Component list:** `packages/fresco-ui/package.json` `exports` + co-located `*.stories.tsx`.
+- **Tokens:** `Colors.stories.tsx`, `Elevation.stories.tsx`, `MotionSpring.stories.tsx`; theme files under `tooling/tailwind/fresco/`.
+- **Participant copy & a11y exemplars:** `packages/interview/src/interfaces/FinishSession.tsx`, `components/Navigation.tsx`, `components/Prompts/Prompts.tsx`, `canvas/useCanvasDrag.ts`.

--- a/.agents/skills/developing-in-network-canvas/agents/openai.yaml
+++ b/.agents/skills/developing-in-network-canvas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Developing in Network Canvas'
+  short_description: 'Repo guidance for Network Canvas changes'
+  default_prompt: 'Use $developing-in-network-canvas before making a Network Canvas monorepo change.'

--- a/.agents/skills/shipping-a-pull-request/SKILL.md
+++ b/.agents/skills/shipping-a-pull-request/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: shipping-a-pull-request
+description: "Use when a change in this repo is implemented and verified (types, lint, knip, and relevant tests pass) and it's time to open a pull request — opens the PR using the repo's own conventions, then watches it until it's mergeable, fixing CI failures and addressing review feedback as they arrive. Keywords: open a PR, ship this, create pull request, done with the change, watch CI, respond to review, fix CI failures, address PR comments, PR is red."
+---
+
+# Shipping a Pull Request
+
+## Overview
+
+Two phases: **open** the PR correctly, then **stay attached to it** until it's
+mergeable — CI green, no unresolved review feedback. Don't open a PR and walk
+away; a red check or a review comment left unanswered is unfinished work.
+
+**Precondition:** verification already passed (types, lint, `knip`, tests) per
+this repo's `AGENTS.md` and the current Codex instructions. If verification
+hasn't run yet, do that first; this skill starts from "ready to ship." Commit,
+push, and open the PR when the user has asked to ship/open a PR or the current
+thread context clearly authorizes those actions.
+
+## Phase 1 — Open the PR
+
+1. **Changeset** — invoke `creating-a-changeset` to decide whether one is
+   needed and, if so, author it in the correct lane (library vs app). Commit it
+   with the rest of the change.
+2. **Commit** — stage the relevant files (never `-A`/`.`) and commit with a
+   message describing _why_, following this repo's commit conventions. Do not
+   add AI co-author trailers unless the user explicitly requests them.
+3. **Push and open the PR**:
+
+   ```bash
+   git push -u origin <branch>
+   gh pr create --title "..." --body "$(cat <<'EOF'
+   ## Summary
+   - ...
+
+   ## Test plan
+   - [ ] ...
+   EOF
+   )"
+   ```
+
+   Look for a PR template (`pull_request_template.md` or
+   `.github/PULL_REQUEST_TEMPLATE/`) first and follow it if one exists. Keep the
+   title under ~70 characters; put detail in the body.
+
+4. Capture the PR number from the `gh pr create` output — every command below
+   needs it.
+
+## Phase 2 — Monitor until mergeable
+
+Loop the two checks below until both are clear, fixing anything that surfaces.
+Use available Codex automation/thread-wakeup tooling between polls when present,
+or report pending external state and stop rather than running a busy `sleep`
+loop. Poll at reasonable intervals while checks are actively running.
+
+### Check CI
+
+```bash
+gh pr checks <number> --json name,state,bucket,link
+```
+
+- All `bucket: pass` (or `skipping`) → CI is clear.
+- Any `bucket: fail` → pull the failing job's log and diagnose the _root
+  cause_. Do not guess-and-check:
+  ```bash
+  gh run view <run-id> --log-failed
+  ```
+  Fix, re-verify locally (the same types/lint/knip/test commands from
+  `AGENTS.md`), commit, push. The push re-triggers CI — go back to polling.
+- Any `bucket: pending` → not done yet, reschedule a check.
+
+### Check review feedback
+
+```bash
+gh pr view <number> --json reviews,latestReviews,mergeStateStatus
+gh api repos/{owner}/{repo}/pulls/<number>/comments
+```
+
+- A review with `state: CHANGES_REQUESTED`, or unresolved inline comments →
+  take a code-review stance before touching code: verify each piece of feedback
+  is technically correct rather than implementing it reflexively.
+  Apply the fixes that hold up, reply to (or resolve) the threads, push.
+- `APPROVED` with no unresolved threads and CI green → the PR is mergeable.
+  Report this to the user and stop — **do not merge it yourself**; merging is
+  a hard-to-reverse, outward-facing action that needs explicit confirmation
+  each time, not implied by having opened the PR.
+
+### Stopping conditions
+
+- **Done:** checks green, reviews approved (or no review requested), no
+  unresolved comments. Tell the user it's ready to merge.
+- **Blocked on a human:** a reviewer asks a question, requests a design change
+  you're not confident about, or the failure isn't something a code fix
+  resolves (flaky infra, missing permissions, a merge-queue rule). Surface it
+  and stop polling rather than looping indefinitely.
+- **Repeated failure:** the same check fails after a fix and a re-push more
+  than twice — stop and hand back to the user with what you tried, instead of
+  guessing again.
+
+## Common mistakes
+
+| Mistake                                            | Do instead                                                                     |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Opening the PR then ending the turn                | Move straight into Phase 2 monitoring — that's the point of this skill.        |
+| Busy-polling with `sleep` in a loop                | Use available wakeup/automation tooling when present, or report pending state. |
+| Applying every review comment verbatim             | Verify the feedback before implementing.                                       |
+| Force-pushing to satisfy a check                   | Fix root cause and push a normal commit; don't rewrite history reflexively.    |
+| Merging once checks go green                       | Merging is the user's call — report readiness, don't merge automatically.      |
+| Re-guessing the same fix after two failed attempts | Stop and hand back to the user with the failure history.                       |

--- a/.agents/skills/shipping-a-pull-request/agents/openai.yaml
+++ b/.agents/skills/shipping-a-pull-request/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Shipping a Pull Request'
+  short_description: 'Open and monitor a Network Canvas PR'
+  default_prompt: 'Use $shipping-a-pull-request to prepare, open, and monitor a Network Canvas pull request.'

--- a/.agents/skills/validating-a-protocol/SKILL.md
+++ b/.agents/skills/validating-a-protocol/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: validating-a-protocol
+description: Use when a protocol.json or .netcanvas file needs to be checked for validity against the Network Canvas protocol schema, when interpreting protocol validation errors, or when the validation CLI exits 1 with no output.
+---
+
+# Validating a Protocol
+
+## Overview
+
+`@codaco/protocol-validation` ships a CLI at `packages/protocol-validation/scripts/cli.js` that validates a `protocol.json` or `.netcanvas` file against the versioned Zod schema, including cross-reference (codebook) validation. Use it — do not write ad-hoc runner scripts against `src/`.
+
+## Recipe (from the repo root)
+
+```bash
+# 1. Build the package once per checkout — the CLI imports from dist/
+pnpm --filter @codaco/protocol-validation build
+
+# 2. Validate (accepts .json or .netcanvas)
+node packages/protocol-validation/scripts/cli.js path/to/protocol.json; echo "exit: $?"
+```
+
+## Interpreting the result
+
+Always capture the exit code — a valid protocol prints **nothing**.
+
+| Exit | Output                        | Meaning                                                                                                                                                           |
+| ---- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | none                          | Valid. Silence is success (the CLI's success message is stubbed out).                                                                                             |
+| 1    | ZodError issue list on stderr | Validation failed. Each issue has a `path` (JSON path into the protocol) and `message`. A stack trace follows the issue list — that's normal output, not a crash. |
+| 1    | none                          | Infrastructure error, silently swallowed by the CLI — see below.                                                                                                  |
+
+### Silent exit 1 — diagnosis checklist
+
+The CLI's catch block discards errors, so these all exit 1 with no output:
+
+1. No argument, or the file doesn't exist.
+2. Extension is not `.json` or `.netcanvas`.
+3. Malformed JSON — check with `jq empty <file>`.
+4. `dist/` missing or stale — rebuild (step 1 above).
+5. `.netcanvas` extraction failed: the zip must contain `protocol.json` at its root, and every file referenced by the `assetManifest` must exist under `assets/`.
+
+To surface the real extraction error, call the library directly (the path arrives as `process.argv[1]` after `--`):
+
+```bash
+node -e "import('./packages/protocol-validation/dist/index.js').then(async (m) => {
+  const fs = await import('node:fs');
+  await m.extractProtocol(fs.readFileSync(process.argv[1]));
+}).catch((e) => { console.error(e.message); process.exit(1); })" -- path/to/file.netcanvas
+```
+
+Extraction **fails fast** — it reports only the first missing asset. To enumerate everything wrong with a broken `.netcanvas`:
+
+```bash
+# All filenames the manifest expects (stored in the zip under assets/) vs. what's actually there
+unzip -p file.netcanvas protocol.json | jq -r '.assetManifest[].source'
+zipinfo -1 file.netcanvas
+
+# Validate the embedded protocol independently — tells you whether re-zipping alone will fix it
+unzip -p file.netcanvas protocol.json > /tmp/embedded.json
+node packages/protocol-validation/scripts/cli.js /tmp/embedded.json; echo "exit: $?"
+```
+
+## Gotchas
+
+- Only `schemaVersion` 7 and 8 are validatable (`VersionedProtocolSchema`). Older protocols fail the `schemaVersion` discriminator and must be migrated first (migration lives in the same package).
+- An invalid stage `type` is a discriminated-union failure, so that stage's _contents_ were never checked — fix the `type` and re-run; more errors may surface inside the stage.
+- Protocol files are often minified to one line. Locate errors with the issue's `path` array and `jq`, not line numbers.
+- A `.netcanvas` is a zip with `protocol.json` and `assets/` at the root. To build one for testing: `cd <dir> && zip -r out.netcanvas protocol.json assets`.
+- Programmatic use: import `validateProtocol` from `packages/protocol-validation/dist/index.js`; it returns a Zod `safeParseAsync` result (`{ success, error }`).

--- a/.agents/skills/validating-a-protocol/agents/openai.yaml
+++ b/.agents/skills/validating-a-protocol/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Validating a Protocol'
+  short_description: 'Validate Network Canvas protocol files'
+  default_prompt: 'Use $validating-a-protocol to check this Network Canvas protocol file.'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code and Codex when working with code in this repository. `AGENTS.md` is a symlink to this file for Codex compatibility.
 
 ## Committing and opening PRs
 


### PR DESCRIPTION
## Summary
- add repo-scoped Codex skills under `.agents/skills`
- add `AGENTS.md` as a symlink to `CLAUDE.md` for Codex project guidance discovery
- update `CLAUDE.md` intro to document the shared Claude/Codex guidance file

## Test plan
- [x] `for skill in .agents/skills/*; do /Users/jmh629/.codex/venvs/skill-validation/bin/python /Users/jmh629/.codex/skills/.system/skill-creator/scripts/quick_validate.py "$skill" || exit 1; done`
- [x] fresh Codex subagent verified all five repo skills were available from initial context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added several new guides for working in the repository, including creating changesets, building new interfaces, validating protocols, developing in the app, and shipping pull requests.
  * Added clearer setup and workflow notes for common repository tasks.

* **Chores**
  * Added new agent skill configurations to support these workflows.
  * Updated repository guidance so the main agent instructions now point to the shared reference file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->