### PR TITLE
Fix background animation drift

### DIFF
--- a/packages/art/package.json
+++ b/packages/art/package.json
@@ -26,6 +26,7 @@
     "@storybook/addon-docs": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@tailwindcss/vite": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/art/src/BackgroundBlobs/NCBlob.ts
+++ b/packages/art/src/BackgroundBlobs/NCBlob.ts
@@ -16,6 +16,10 @@ const randomInt = (a = 1, b = 0) => {
   return Math.floor(lower + Math.random() * (upper - lower + 1));
 };
 
+const INITIAL_OFFSCREEN_PROBABILITY = 0.5;
+export const MAX_INITIAL_OFFSCREEN_LEAD_SECONDS = 12;
+const MINIMUM_INCOMING_VELOCITY = 0.001;
+
 export class NCBlob {
   layer: 1 | 2 | 3;
   speed: number;
@@ -33,6 +37,7 @@ export class NCBlob {
   cachedGradient: CanvasGradient | null;
   animation: ReturnType<typeof blobs2Animate.canvasPath> | null;
   currentTime: number;
+  hasEntered: boolean;
 
   constructor(
     layer: 1 | 2 | 3,
@@ -65,6 +70,87 @@ export class NCBlob {
     this.cachedGradient = null;
     this.animation = null;
     this.currentTime = 0;
+    this.hasEntered = false;
+  }
+
+  isWithinWrapBounds() {
+    return (
+      this.positionX >= -this.size &&
+      this.positionX <= this.canvasWidth &&
+      this.positionY >= -this.size &&
+      this.positionY <= this.canvasHeight
+    );
+  }
+
+  wrapPosition() {
+    // The blob path is generated inside a 0..size box and translated by
+    // positionX/positionY. When a blob exits, place its centre on the opposite
+    // canvas edge so the replacement is immediately visible instead of waiting
+    // offscreen for the whole blob width to drift back in.
+    if (this.positionX < -this.size) {
+      this.positionX = this.canvasWidth - this.size / 2;
+    } else if (this.positionX > this.canvasWidth) {
+      this.positionX = -this.size / 2;
+    }
+
+    if (this.positionY < -this.size) {
+      this.positionY = this.canvasHeight - this.size / 2;
+    } else if (this.positionY > this.canvasHeight) {
+      this.positionY = -this.size / 2;
+    }
+  }
+
+  placeInitialPosition() {
+    const sides: Array<'left' | 'right' | 'top' | 'bottom'> = [];
+
+    if (this.velocityX > MINIMUM_INCOMING_VELOCITY) sides.push('left');
+    else if (this.velocityX < -MINIMUM_INCOMING_VELOCITY) sides.push('right');
+
+    if (this.velocityY > MINIMUM_INCOMING_VELOCITY) sides.push('top');
+    else if (this.velocityY < -MINIMUM_INCOMING_VELOCITY) sides.push('bottom');
+
+    const shouldSpawnOffscreen =
+      sides.length > 0 && random(0, 1) < INITIAL_OFFSCREEN_PROBABILITY;
+
+    if (!shouldSpawnOffscreen) {
+      this.positionX = random(-this.size / 2, this.canvasWidth - this.size / 2);
+      this.positionY = random(
+        -this.size / 2,
+        this.canvasHeight - this.size / 2,
+      );
+      this.hasEntered = true;
+      return;
+    }
+
+    const side = sides[Math.floor(random(0, sides.length))] ?? sides[0];
+
+    if (side === 'left' || side === 'right') {
+      const speedTowardCanvas = Math.abs(this.velocityX);
+      const distance = random(
+        0,
+        speedTowardCanvas * MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+      );
+      const secondsUntilVisible = distance / speedTowardCanvas;
+      const yWhenVisible = random(-this.size, this.canvasHeight);
+
+      this.positionX =
+        side === 'left' ? -this.size - distance : this.canvasWidth + distance;
+      this.positionY = yWhenVisible - this.velocityY * secondsUntilVisible;
+    } else {
+      const speedTowardCanvas = Math.abs(this.velocityY);
+      const distance = random(
+        0,
+        speedTowardCanvas * MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+      );
+      const secondsUntilVisible = distance / speedTowardCanvas;
+      const xWhenVisible = random(-this.size, this.canvasWidth);
+
+      this.positionX = xWhenVisible - this.velocityX * secondsUntilVisible;
+      this.positionY =
+        side === 'top' ? -this.size - distance : this.canvasHeight + distance;
+    }
+
+    this.hasEntered = this.isWithinWrapBounds();
   }
 
   updatePosition(time: number) {
@@ -83,19 +169,10 @@ export class NCBlob {
     this.positionX += this.velocityX * timeDelta;
     this.positionY += this.velocityY * timeDelta;
 
-    // Wrap around screen boundaries, taking into account shape size.
-    // Branches must be mutually exclusive: a left-exit reset to
-    // (canvasWidth + size) would otherwise re-trigger the right-exit branch.
-    if (this.positionX < 0 - this.size) {
-      this.positionX = this.canvasWidth + this.size;
-    } else if (this.positionX > this.canvasWidth) {
-      this.positionX = -this.size;
-    }
-
-    if (this.positionY < 0 - this.size) {
-      this.positionY = this.canvasHeight + this.size;
-    } else if (this.positionY > this.canvasHeight) {
-      this.positionY = -this.size;
+    if (this.hasEntered) {
+      this.wrapPosition();
+    } else if (this.isWithinWrapBounds()) {
+      this.hasEntered = true;
     }
   }
 
@@ -150,14 +227,7 @@ export class NCBlob {
 
     this.size = sizes[this.layer];
 
-    this.positionX = randomInt(
-      0 - this.size / 2,
-      this.canvasWidth - this.size / 2,
-    );
-    this.positionY = randomInt(
-      0 - this.size / 2,
-      this.canvasHeight - this.size / 2,
-    );
+    this.placeInitialPosition();
 
     if (this.gradient) {
       const grd = ctx.createLinearGradient(0, 0, this.size, 0);

--- a/packages/art/src/BackgroundLights/BackgroundLights.stories.tsx
+++ b/packages/art/src/BackgroundLights/BackgroundLights.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
+
+import BackgroundLights from './BackgroundLights';
+
+const stage: CSSProperties = {
+  position: 'relative',
+  width: 720,
+  height: 420,
+  overflow: 'hidden',
+  background: '#10131f',
+};
+
+const meta: Meta<typeof BackgroundLights> = {
+  title: 'BackgroundLights/Overview',
+  component: BackgroundLights,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    large: { control: { type: 'number', min: 0, max: 6, step: 1 } },
+    medium: { control: { type: 'number', min: 0, max: 12, step: 1 } },
+    small: { control: { type: 'number', min: 0, max: 20, step: 1 } },
+    speedFactor: {
+      control: { type: 'number', min: 0.1, max: 40, step: 0.1 },
+    },
+    colors: { control: 'object' },
+    blendMode: {
+      control: 'select',
+      options: [
+        undefined,
+        'normal',
+        'multiply',
+        'screen',
+        'overlay',
+        'lighten',
+        'color-dodge',
+        'difference',
+      ],
+    },
+  },
+  args: {
+    large: 2,
+    medium: 4,
+    small: 4,
+    speedFactor: 1,
+    blendMode: undefined,
+  },
+  render: (args) => (
+    <div style={stage}>
+      <BackgroundLights {...args} />
+    </div>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Dense: Story = {
+  args: { large: 4, medium: 8, small: 12 },
+};
+
+export const Sparse: Story = {
+  args: { large: 1, medium: 1, small: 2 },
+};
+
+export const Fast: Story = {
+  args: { speedFactor: 10 },
+};
+
+export const Slow: Story = {
+  args: { speedFactor: 0.2 },
+};
+
+const interviewerPalette = [
+  '#f45d48',
+  '#f6c65b',
+  '#23b5d3',
+  '#6c5ce7',
+  '#22c55e',
+  '#f72585',
+] as const;
+
+export const InterviewerMainScreen: Story = {
+  parameters: { layout: 'fullscreen' },
+  args: {
+    large: 0,
+    medium: 4,
+    small: 0,
+    speedFactor: 30,
+    blendMode: 'color-dodge',
+    colors: interviewerPalette,
+  },
+  render: (args) => (
+    <div
+      style={{
+        position: 'relative',
+        width: '100vw',
+        height: '100vh',
+        overflow: 'hidden',
+        background:
+          'linear-gradient(135deg, #111827 0%, #1d2433 45%, #161b2b 100%)',
+      }}
+    >
+      <BackgroundLights {...args} />
+    </div>
+  ),
+};

--- a/packages/art/src/BackgroundLights/BackgroundLights.tsx
+++ b/packages/art/src/BackgroundLights/BackgroundLights.tsx
@@ -37,6 +37,106 @@ type Light = {
   velocityY: number;
 };
 
+type LightRuntime = {
+  x: number;
+  y: number;
+  size: number;
+};
+
+type AnimatedLightRuntime = LightRuntime & {
+  hasEntered: boolean;
+  light: Pick<Light, 'velocityX' | 'velocityY'>;
+};
+
+type RandomFn = (min: number, max: number) => number;
+
+const INITIAL_OFFSCREEN_PROBABILITY = 0.5;
+export const MAX_INITIAL_OFFSCREEN_LEAD_SECONDS = 12;
+const MINIMUM_INCOMING_VELOCITY = 0.001;
+
+export const isDomLightWithinWrapBounds = (
+  entry: LightRuntime,
+  width: number,
+  height: number,
+) =>
+  entry.x >= -entry.size &&
+  entry.x <= width &&
+  entry.y >= -entry.size &&
+  entry.y <= height;
+
+export const wrapDomLightPosition = (
+  entry: LightRuntime,
+  width: number,
+  height: number,
+) => {
+  // These CSS lights are positioned by the element's top-left corner. When a
+  // light exits one side, place that same edge exactly at the opposite viewport
+  // edge so the next frame starts drifting it back onscreen.
+  if (entry.x < -entry.size) entry.x = width;
+  else if (entry.x > width) entry.x = -entry.size;
+
+  if (entry.y < -entry.size) entry.y = height;
+  else if (entry.y > height) entry.y = -entry.size;
+};
+
+export const placeDomLightInitial = (
+  entry: AnimatedLightRuntime,
+  width: number,
+  height: number,
+  randomValue: RandomFn = random,
+) => {
+  const { velocityX, velocityY } = entry.light;
+  const sides: Array<'left' | 'right' | 'top' | 'bottom'> = [];
+
+  if (velocityX > MINIMUM_INCOMING_VELOCITY) sides.push('left');
+  else if (velocityX < -MINIMUM_INCOMING_VELOCITY) sides.push('right');
+
+  if (velocityY > MINIMUM_INCOMING_VELOCITY) sides.push('top');
+  else if (velocityY < -MINIMUM_INCOMING_VELOCITY) sides.push('bottom');
+
+  const shouldSpawnOffscreen =
+    sides.length > 0 && randomValue(0, 1) < INITIAL_OFFSCREEN_PROBABILITY;
+
+  if (!shouldSpawnOffscreen) {
+    entry.x = randomValue(-entry.size / 2, width - entry.size / 2);
+    entry.y = randomValue(-entry.size / 2, height - entry.size / 2);
+    entry.hasEntered = true;
+    return;
+  }
+
+  const sideIndex = Math.min(
+    sides.length - 1,
+    Math.floor(randomValue(0, sides.length)),
+  );
+  const side = sides[sideIndex];
+
+  if (side === 'left' || side === 'right') {
+    const speedTowardViewport = Math.abs(velocityX);
+    const distance = randomValue(
+      0,
+      speedTowardViewport * MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+    );
+    const secondsUntilVisible = distance / speedTowardViewport;
+    const yWhenVisible = randomValue(-entry.size, height);
+
+    entry.x = side === 'left' ? -entry.size - distance : width + distance;
+    entry.y = yWhenVisible - velocityY * secondsUntilVisible;
+  } else {
+    const speedTowardViewport = Math.abs(velocityY);
+    const distance = randomValue(
+      0,
+      speedTowardViewport * MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+    );
+    const secondsUntilVisible = distance / speedTowardViewport;
+    const xWhenVisible = randomValue(-entry.size, width);
+
+    entry.x = xWhenVisible - velocityX * secondsUntilVisible;
+    entry.y = side === 'top' ? -entry.size - distance : height + distance;
+  }
+
+  entry.hasEntered = isDomLightWithinWrapBounds(entry, width, height);
+};
+
 const makeLayer = (
   layer: Layer,
   count: number,
@@ -94,7 +194,13 @@ const BackgroundLights = ({
 
     // Runtime position/size lives outside React state so the animation loop can
     // mutate transforms every frame without triggering a re-render.
-    const runtime = lights.map((light) => ({ light, x: 0, y: 0, size: 0 }));
+    const runtime = lights.map((light) => ({
+      light,
+      x: 0,
+      y: 0,
+      size: 0,
+      hasEntered: false,
+    }));
     let width = 0;
     let height = 0;
     let placed = false;
@@ -127,8 +233,7 @@ const BackgroundLights = ({
     const ensurePlaced = () => {
       if (placed || width <= 0 || height <= 0) return;
       runtime.forEach((entry) => {
-        entry.x = random(-entry.size / 2, width - entry.size / 2);
-        entry.y = random(-entry.size / 2, height - entry.size / 2);
+        placeDomLightInitial(entry, width, height);
       });
       placed = true;
       applyTransforms();
@@ -160,12 +265,13 @@ const BackgroundLights = ({
         runtime.forEach((entry) => {
           entry.x += entry.light.velocityX * dt;
           entry.y += entry.light.velocityY * dt;
-          // Wrap offscreen → reappear on the opposite edge (mirrors NCBlob;
-          // branches stay mutually exclusive so a reset can't re-trigger).
-          if (entry.x < -entry.size) entry.x = width + entry.size;
-          else if (entry.x > width) entry.x = -entry.size;
-          if (entry.y < -entry.size) entry.y = height + entry.size;
-          else if (entry.y > height) entry.y = -entry.size;
+          // Wrap offscreen → reappear on the opposite edge. Branches stay
+          // mutually exclusive so a reset can't re-trigger.
+          if (entry.hasEntered) {
+            wrapDomLightPosition(entry, width, height);
+          } else if (isDomLightWithinWrapBounds(entry, width, height)) {
+            entry.hasEntered = true;
+          }
         });
         applyTransforms();
       }

--- a/packages/art/src/__tests__/BackgroundBlobs.component.test.tsx
+++ b/packages/art/src/__tests__/BackgroundBlobs.component.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import BackgroundBlobs from '../BackgroundBlobs/BackgroundBlobs';
+
+describe('BackgroundBlobs component', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders an aria-hidden full-size canvas', () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+
+    const { container } = render(
+      <BackgroundBlobs
+        large={1}
+        medium={2}
+        small={3}
+        compositeOperation="color-dodge"
+        filter="blur(12px)"
+      />,
+    );
+
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+    expect(canvas?.getAttribute('aria-hidden')).toBe('true');
+    expect(canvas?.style.width).toBe('100%');
+    expect(canvas?.style.height).toBe('100%');
+  });
+});

--- a/packages/art/src/__tests__/BackgroundLights.component.test.tsx
+++ b/packages/art/src/__tests__/BackgroundLights.component.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import BackgroundLights from '../BackgroundLights/BackgroundLights';
+
+describe('BackgroundLights component', () => {
+  it('renders one DOM light per configured blob count', () => {
+    const { container } = render(
+      <BackgroundLights
+        large={1}
+        medium={2}
+        small={3}
+        colors={['#ff0000']}
+        blendMode="color-dodge"
+      />,
+    );
+
+    const root = container.querySelector('[aria-hidden="true"]');
+    expect(root).not.toBeNull();
+    expect(root?.children).toHaveLength(6);
+
+    const lights = [...(root?.children ?? [])] as HTMLElement[];
+    for (const light of lights) {
+      expect(light.style.background).toContain('radial-gradient');
+      expect(light.style.background).toContain('rgb(255, 0, 0)');
+      expect(light.style.mixBlendMode).toBe('color-dodge');
+    }
+  });
+
+  it('renders no light elements when all layer counts are zero', () => {
+    const { container } = render(
+      <BackgroundLights large={0} medium={0} small={0} />,
+    );
+
+    const root = container.querySelector('[aria-hidden="true"]');
+    expect(root).not.toBeNull();
+    expect(root?.children).toHaveLength(0);
+  });
+});

--- a/packages/art/src/__tests__/BackgroundLights.test.ts
+++ b/packages/art/src/__tests__/BackgroundLights.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isDomLightWithinWrapBounds,
+  MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+  placeDomLightInitial,
+  wrapDomLightPosition,
+} from '../BackgroundLights/BackgroundLights';
+
+const sequenceRandom = (values: number[]) => {
+  let index = 0;
+  return (min: number, max: number) => {
+    const value = values[index++] ?? min;
+    expect(value).toBeGreaterThanOrEqual(min);
+    expect(value).toBeLessThanOrEqual(max);
+    return value;
+  };
+};
+
+describe('wrapDomLightPosition', () => {
+  it('wraps a light exiting left to the right viewport edge', () => {
+    const light = { x: -801, y: 100, size: 800 };
+
+    wrapDomLightPosition(light, 1000, 700);
+
+    expect(light.x).toBe(1000);
+    expect(light.y).toBe(100);
+  });
+
+  it('wraps a light exiting top to the bottom viewport edge', () => {
+    const light = { x: 100, y: -801, size: 800 };
+
+    wrapDomLightPosition(light, 1000, 700);
+
+    expect(light.x).toBe(100);
+    expect(light.y).toBe(700);
+  });
+
+  it('wraps right and bottom exits to the negative element size', () => {
+    const light = { x: 1001, y: 701, size: 800 };
+
+    wrapDomLightPosition(light, 1000, 700);
+
+    expect(light.x).toBe(-800);
+    expect(light.y).toBe(-800);
+  });
+
+  it('does not move a light still inside the wrap bounds', () => {
+    const light = { x: -800, y: 700, size: 800 };
+
+    wrapDomLightPosition(light, 1000, 700);
+
+    expect(light).toEqual({ x: -800, y: 700, size: 800 });
+  });
+});
+
+describe('placeDomLightInitial', () => {
+  it('can place a light immediately inside the viewport density band', () => {
+    const light = {
+      light: { velocityX: 10, velocityY: 0 },
+      x: 0,
+      y: 0,
+      size: 200,
+      hasEntered: false,
+    };
+
+    placeDomLightInitial(light, 1000, 700, sequenceRandom([0.75, 300, 250]));
+
+    expect(light.x).toBe(300);
+    expect(light.y).toBe(250);
+    expect(light.hasEntered).toBe(true);
+  });
+
+  it('places a left-side offscreen light on a path that enters the viewport', () => {
+    const light = {
+      light: { velocityX: 10, velocityY: 5 },
+      x: 0,
+      y: 0,
+      size: 200,
+      hasEntered: false,
+    };
+
+    placeDomLightInitial(light, 1000, 700, sequenceRandom([0.25, 0, 30, 200]));
+
+    expect(light.x).toBe(-230);
+    expect(light.y).toBe(185);
+    expect(light.hasEntered).toBe(false);
+
+    const secondsUntilVisible = (-light.size - light.x) / light.light.velocityX;
+    const entryPosition = {
+      ...light,
+      x: light.x + light.light.velocityX * secondsUntilVisible,
+      y: light.y + light.light.velocityY * secondsUntilVisible,
+    };
+
+    expect(secondsUntilVisible).toBe(3);
+    expect(isDomLightWithinWrapBounds(entryPosition, 1000, 700)).toBe(true);
+  });
+
+  it('places a bottom-side offscreen light on a path that enters the viewport', () => {
+    const light = {
+      light: { velocityX: 0, velocityY: -20 },
+      x: 0,
+      y: 0,
+      size: 200,
+      hasEntered: false,
+    };
+
+    placeDomLightInitial(light, 1000, 700, sequenceRandom([0.25, 0, 40, 300]));
+
+    expect(light.x).toBe(300);
+    expect(light.y).toBe(740);
+    expect(light.hasEntered).toBe(false);
+
+    const secondsUntilVisible =
+      (light.y - 700) / Math.abs(light.light.velocityY);
+    const entryPosition = {
+      ...light,
+      x: light.x + light.light.velocityX * secondsUntilVisible,
+      y: light.y + light.light.velocityY * secondsUntilVisible,
+    };
+
+    expect(secondsUntilVisible).toBe(2);
+    expect(isDomLightWithinWrapBounds(entryPosition, 1000, 700)).toBe(true);
+  });
+
+  it('caps the offscreen distance by the maximum initial lead time', () => {
+    const light = {
+      light: { velocityX: 10, velocityY: 0 },
+      x: 0,
+      y: 0,
+      size: 200,
+      hasEntered: false,
+    };
+
+    placeDomLightInitial(
+      light,
+      1000,
+      700,
+      sequenceRandom([0.25, 0, 10 * MAX_INITIAL_OFFSCREEN_LEAD_SECONDS, 200]),
+    );
+
+    const secondsUntilVisible = (-light.size - light.x) / light.light.velocityX;
+
+    expect(secondsUntilVisible).toBe(MAX_INITIAL_OFFSCREEN_LEAD_SECONDS);
+  });
+
+  it('falls back to a visible placement when velocity cannot carry an offscreen light in', () => {
+    const light = {
+      light: { velocityX: 0, velocityY: 0 },
+      x: 0,
+      y: 0,
+      size: 200,
+      hasEntered: false,
+    };
+
+    placeDomLightInitial(light, 1000, 700, sequenceRandom([300, 250]));
+
+    expect(light.x).toBe(300);
+    expect(light.y).toBe(250);
+    expect(light.hasEntered).toBe(true);
+  });
+});

--- a/packages/art/src/__tests__/NCBlob.test.ts
+++ b/packages/art/src/__tests__/NCBlob.test.ts
@@ -1,8 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NCBlob } from '../BackgroundBlobs/NCBlob';
+import {
+  MAX_INITIAL_OFFSCREEN_LEAD_SECONDS,
+  NCBlob,
+} from '../BackgroundBlobs/NCBlob';
 
 const palette = [['#ff0000', '#00ff00']] as const;
+
+const mockRandomSequence = (values: number[]) => {
+  const spy = vi.spyOn(Math, 'random');
+  spy.mockReset();
+  values.forEach((value) => {
+    spy.mockReturnValueOnce(value);
+  });
+  spy.mockReturnValue(0);
+};
 
 describe('NCBlob', () => {
   beforeEach(() => {
@@ -48,6 +60,7 @@ describe('NCBlob', () => {
       expect(blob.positionX).toBe(0);
       expect(blob.positionY).toBe(0);
       expect(blob.size).toBe(0);
+      expect(blob.hasEntered).toBe(false);
     });
 
     it('derives velocity from speed and angle', () => {
@@ -137,8 +150,9 @@ describe('NCBlob', () => {
       blob.positionX = 1001;
       blob.velocityX = 0;
       blob.velocityY = 0;
+      blob.hasEntered = true;
       blob.updatePosition(1000);
-      expect(blob.positionX).toBe(-100);
+      expect(blob.positionX).toBe(-50);
     });
 
     it('wraps past left edge to right', () => {
@@ -148,8 +162,9 @@ describe('NCBlob', () => {
       blob.positionX = -101;
       blob.velocityX = 0;
       blob.velocityY = 0;
+      blob.hasEntered = true;
       blob.updatePosition(1000);
-      expect(blob.positionX).toBe(1100);
+      expect(blob.positionX).toBe(950);
     });
 
     it('wraps past bottom edge to top', () => {
@@ -159,8 +174,9 @@ describe('NCBlob', () => {
       blob.positionY = 801;
       blob.velocityX = 0;
       blob.velocityY = 0;
+      blob.hasEntered = true;
       blob.updatePosition(1000);
-      expect(blob.positionY).toBe(-100);
+      expect(blob.positionY).toBe(-50);
     });
 
     it('wraps past top edge to bottom', () => {
@@ -170,8 +186,126 @@ describe('NCBlob', () => {
       blob.positionY = -101;
       blob.velocityX = 0;
       blob.velocityY = 0;
+      blob.hasEntered = true;
       blob.updatePosition(1000);
-      expect(blob.positionY).toBe(900);
+      expect(blob.positionY).toBe(750);
+    });
+
+    it('lets an initially offscreen blob enter before wrapping normally', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 800;
+      blob.size = 100;
+      blob.positionX = -105;
+      blob.positionY = 100;
+      blob.velocityX = 300;
+      blob.velocityY = 0;
+      blob.hasEntered = false;
+
+      blob.updatePosition(0);
+      blob.updatePosition(1000);
+
+      expect(blob.positionX).toBeGreaterThanOrEqual(-100);
+      expect(blob.hasEntered).toBe(true);
+    });
+  });
+
+  describe('placeInitialPosition', () => {
+    it('can place a blob immediately inside the viewport density band', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 800;
+      blob.size = 200;
+      blob.velocityX = 10;
+      blob.velocityY = 0;
+      mockRandomSequence([0.75, 0.4, 0.5]);
+
+      blob.placeInitialPosition();
+
+      expect(blob.positionX).toBe(300);
+      expect(blob.positionY).toBe(300);
+      expect(blob.hasEntered).toBe(true);
+    });
+
+    it('places a left-side offscreen blob on a path that enters the canvas', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 700;
+      blob.size = 200;
+      blob.velocityX = 10;
+      blob.velocityY = 5;
+      mockRandomSequence([0.25, 0, 0.25, 4 / 9]);
+
+      blob.placeInitialPosition();
+
+      expect(blob.positionX).toBe(-230);
+      expect(blob.positionY).toBe(185);
+      expect(blob.hasEntered).toBe(false);
+
+      const secondsUntilVisible =
+        (-blob.size - blob.positionX) / blob.velocityX;
+      blob.positionX += blob.velocityX * secondsUntilVisible;
+      blob.positionY += blob.velocityY * secondsUntilVisible;
+
+      expect(secondsUntilVisible).toBe(3);
+      expect(blob.isWithinWrapBounds()).toBe(true);
+    });
+
+    it('places a bottom-side offscreen blob on a path that enters the canvas', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 700;
+      blob.size = 200;
+      blob.velocityX = 0;
+      blob.velocityY = -20;
+      mockRandomSequence([0.25, 0, 1 / 6, 5 / 12]);
+
+      blob.placeInitialPosition();
+
+      expect(blob.positionX).toBe(300);
+      expect(blob.positionY).toBe(740);
+      expect(blob.hasEntered).toBe(false);
+
+      const secondsUntilVisible =
+        (blob.positionY - blob.canvasHeight) / Math.abs(blob.velocityY);
+      blob.positionX += blob.velocityX * secondsUntilVisible;
+      blob.positionY += blob.velocityY * secondsUntilVisible;
+
+      expect(secondsUntilVisible).toBe(2);
+      expect(blob.isWithinWrapBounds()).toBe(true);
+    });
+
+    it('caps the offscreen distance by the maximum initial lead time', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 700;
+      blob.size = 200;
+      blob.velocityX = 10;
+      blob.velocityY = 0;
+      mockRandomSequence([0.25, 0, 1, 0.5]);
+
+      blob.placeInitialPosition();
+
+      const secondsUntilVisible =
+        (-blob.size - blob.positionX) / blob.velocityX;
+
+      expect(secondsUntilVisible).toBe(MAX_INITIAL_OFFSCREEN_LEAD_SECONDS);
+    });
+
+    it('falls back to visible placement when velocity cannot carry an offscreen blob in', () => {
+      const blob = new NCBlob(1, 1, palette);
+      blob.canvasWidth = 1000;
+      blob.canvasHeight = 800;
+      blob.size = 200;
+      blob.velocityX = 0;
+      blob.velocityY = 0;
+      mockRandomSequence([0.4, 0.5]);
+
+      blob.placeInitialPosition();
+
+      expect(blob.positionX).toBe(300);
+      expect(blob.positionY).toBe(300);
+      expect(blob.hasEntered).toBe(true);
     });
   });
 

--- a/packages/art/src/__tests__/setup.ts
+++ b/packages/art/src/__tests__/setup.ts
@@ -6,4 +6,38 @@ if (typeof window !== 'undefined') {
     configurable: true,
     value: 1,
   });
+
+  class MockResizeObserver implements ResizeObserver {
+    observe = () => undefined;
+    unobserve = () => undefined;
+    disconnect = () => undefined;
+  }
+
+  Object.defineProperty(window, 'ResizeObserver', {
+    writable: true,
+    configurable: true,
+    value: MockResizeObserver,
+  });
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    configurable: true,
+    value: MockResizeObserver,
+  });
+
+  window.requestAnimationFrame = (callback) =>
+    window.setTimeout(() => callback(performance.now()), 16);
+  window.cancelAnimationFrame = (handle) => window.clearTimeout(handle);
+
+  Object.defineProperty(globalThis, 'requestAnimationFrame', {
+    writable: true,
+    configurable: true,
+    value: window.requestAnimationFrame,
+  });
+
+  Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+    writable: true,
+    configurable: true,
+    value: window.cancelAnimationFrame,
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1389,6 +1389,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.2(vite@8.1.2(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4


### PR DESCRIPTION
## Summary

Fixes the animated background behavior in `@codaco/art` so both `BackgroundLights` and `BackgroundBlobs` continue cycling visibly over time.

## Root Cause

The background elements use translated top-left coordinates, but the wrap logic reset some left/top exits to `edge + size`. That could place elements fully offscreen for long periods. In the interviewer `BackgroundLights` usage, all lights could eventually be waiting offscreen at once, leaving the background empty. `BackgroundBlobs` had the same inherited wrap issue, and small canvas blobs could also appear to vanish because wrapped blobs re-entered fully offscreen.

## Changes

- Adds bounded offscreen initial spawning for `BackgroundLights`, with direction-aware placement so hidden lights drift into view within a capped lead time.
- Ports the same initial spawn behavior to `BackgroundBlobs` via `NCBlob`.
- Fixes wrap behavior for DOM lights and canvas blobs.
- Adds a `BackgroundLights` Storybook story, including an interviewer-style fullscreen variant.
- Adds movement invariant tests and lightweight component smoke tests for both background components.
- Extends the art package test setup for required jsdom browser primitives.

## Validation

- `pnpm --filter @codaco/art test`
- `pnpm --filter @codaco/art typecheck`
- `pnpm exec oxfmt --check packages/art/src/BackgroundBlobs/NCBlob.ts packages/art/src/__tests__/NCBlob.test.ts packages/art/src/__tests__/BackgroundBlobs.component.test.tsx packages/art/src/__tests__/BackgroundLights.component.test.tsx packages/art/src/__tests__/setup.ts packages/art/package.json pnpm-lock.yaml`

Note: pnpm emitted workspace install warnings during local verification after an interrupted dependency refresh, but the art package tests and typecheck completed successfully.
