### PR TITLE
Fix Interviewer narrow-screen shell chrome

### DIFF
--- a/.changeset/fresco-ui-dependency-updates.md
+++ b/.changeset/fresco-ui-dependency-updates.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Updated the Tiptap React and nanoid dependencies used by Fresco UI components.

--- a/.changeset/interviewer-background-animation-stability.md
+++ b/.changeset/interviewer-background-animation-stability.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Improved the animated background on Interviewer screens so lights drift in and wrap smoothly without leaving long empty gaps.

--- a/.changeset/interviewer-compact-small-shell.md
+++ b/.changeset/interviewer-compact-small-shell.md
@@ -1,0 +1,6 @@
+---
+'@codaco/interviewer': patch
+---
+
+Improve the Interviewer start screen on narrow displays by compacting the header
+brand and footer status indicators.

--- a/apps/interviewer/src/components/BrandHeader.tsx
+++ b/apps/interviewer/src/components/BrandHeader.tsx
@@ -12,10 +12,18 @@ const variants = {
 export function BrandHeader() {
   return (
     <motion.div variants={variants} className="flex items-center gap-4">
-      <span className="inline-flex">
-        <img src={ncMarkUrl} alt="" className="size-20" />
+      <span className="inline-flex shrink-0">
+        <img
+          src={ncMarkUrl}
+          alt=""
+          className="tablet-landscape:h-20 h-16 w-auto"
+        />
       </span>
-      <Heading level="h1" margin="none" className="font-black tracking-tight">
+      <Heading
+        level="h1"
+        margin="none"
+        className="tablet-landscape:not-sr-only sr-only font-black tracking-tight"
+      >
         Interviewer
       </Heading>
     </motion.div>

--- a/apps/interviewer/src/components/StatusRow.tsx
+++ b/apps/interviewer/src/components/StatusRow.tsx
@@ -104,6 +104,7 @@ export function StatusRowView({
                 render={
                   <span
                     tabIndex={0}
+                    data-testid="encryption-status-trigger"
                     className={`${statusTriggerClassName} text-warning`}
                   >
                     <ShieldAlert className={statusIconClassName} />
@@ -123,6 +124,7 @@ export function StatusRowView({
                 render={
                   <span
                     tabIndex={0}
+                    data-testid="encryption-status-trigger"
                     className={`${statusTriggerClassName} text-primary`}
                   >
                     <ShieldCheck className={statusIconClassName} />
@@ -148,6 +150,7 @@ export function StatusRowView({
                       ? 0
                       : undefined
                   }
+                  data-testid="storage-status-trigger"
                   className={statusTriggerClassName}
                 >
                   {durability.persisted ? (

--- a/apps/interviewer/src/components/StatusRow.tsx
+++ b/apps/interviewer/src/components/StatusRow.tsx
@@ -49,6 +49,12 @@ const variants = {
   },
 } as const;
 
+const compactLabelClassName =
+  'tablet-landscape:not-sr-only sr-only tablet-landscape:whitespace-nowrap';
+const statusTriggerClassName =
+  'focusable inline-flex items-center gap-1.5 rounded-sm';
+const statusIconClassName = 'tablet-landscape:size-3.5 size-4';
+
 // Pure presentation: the dashboard's bottom-of-screen footer strip. `mode`
 // mirrors useAuth's enrolled security mode; `durability` mirrors the
 // storage-persistence poll (null until the first check resolves).
@@ -70,11 +76,11 @@ export function StatusRowView({
   return (
     <motion.div
       variants={variants}
-      className="font-monospace text-text/60 tablet-landscape:px-11 flex items-center justify-between px-6 pb-4 text-xs"
+      className="font-monospace text-text/60 tablet-landscape:px-11 tablet-landscape:justify-between flex items-center justify-end px-6 pb-4 text-xs"
     >
       <Link
         href="/data"
-        className="inline-flex cursor-pointer items-center gap-3.5 text-current no-underline"
+        className="tablet-landscape:inline-flex hidden cursor-pointer items-center gap-3.5 text-current no-underline"
       >
         <span>
           <strong className="text-text font-bold">{protocolCount}</strong>{' '}
@@ -98,16 +104,17 @@ export function StatusRowView({
                 render={
                   <span
                     tabIndex={0}
-                    className="focusable text-warning inline-flex items-center gap-1.5 rounded-sm"
+                    className={`${statusTriggerClassName} text-warning`}
                   >
-                    <ShieldAlert className="size-3.5" />
-                    Not encrypted
+                    <ShieldAlert className={statusIconClassName} />
+                    <span className={compactLabelClassName}>Not encrypted</span>
                   </span>
                 }
               />
               <TooltipContent>
-                No app security is enrolled — data is stored unencrypted. Enrol
-                a PIN, passphrase, or biometric in Settings to encrypt it.
+                Not encrypted. No app security is enrolled — data is stored
+                unencrypted. Enrol a PIN, passphrase, or biometric in Settings
+                to encrypt it.
               </TooltipContent>
             </Tooltip>
           ) : (
@@ -116,16 +123,16 @@ export function StatusRowView({
                 render={
                   <span
                     tabIndex={0}
-                    className="focusable inline-flex items-center gap-1.5 rounded-sm"
+                    className={`${statusTriggerClassName} text-primary`}
                   >
-                    <ShieldCheck className="size-3.5" />
-                    Encrypted
+                    <ShieldCheck className={statusIconClassName} />
+                    <span className={compactLabelClassName}>Encrypted</span>
                   </span>
                 }
               />
               <TooltipContent>
-                Interview data is encrypted at rest with your enrolled unlock
-                method.
+                Encrypted. Interview data is encrypted at rest with your
+                enrolled unlock method.
               </TooltipContent>
             </Tooltip>
           )
@@ -141,26 +148,32 @@ export function StatusRowView({
                       ? 0
                       : undefined
                   }
-                  className="focusable inline-flex items-center gap-1.5 rounded-sm"
+                  className={statusTriggerClassName}
                 >
                   {durability.persisted ? (
-                    <>
-                      <HardDrive className="size-3.5" />
-                      Storage persistent
-                    </>
+                    <span className="text-primary inline-flex items-center gap-1.5">
+                      <HardDrive className={statusIconClassName} />
+                      <span className={compactLabelClassName}>
+                        Storage persistent
+                      </span>
+                    </span>
                   ) : installed ? (
                     // Installed apps are already partitioned away from
                     // browsing data and exempt from routine cleanup, and no
                     // further user action can flip the grant — a warning here
                     // would alarm without offering a remedy (#886).
                     <>
-                      <HardDrive className="size-3.5" />
-                      Storage best effort
+                      <HardDrive className={statusIconClassName} />
+                      <span className={compactLabelClassName}>
+                        Storage best effort
+                      </span>
                     </>
                   ) : (
                     <span className="text-warning inline-flex items-center gap-1.5">
-                      <HardDrive className="size-3.5" />
-                      Storage not persistent
+                      <HardDrive className={statusIconClassName} />
+                      <span className={compactLabelClassName}>
+                        Storage not persistent
+                      </span>
                     </span>
                   )}
                 </span>
@@ -168,19 +181,28 @@ export function StatusRowView({
             />
             {!durability.persisted && installed ? (
               <TooltipContent>
-                The browser keeps installed-app data separate from browsing data
-                and does not clear it routinely, but it has not guaranteed it
-                against eviction if disk space runs low. Export interviews
-                regularly.
+                Storage best effort. The browser keeps installed-app data
+                separate from browsing data and does not clear it routinely, but
+                it has not guaranteed it against eviction if disk space runs
+                low. Export interviews regularly.
+                {durability.usage !== null
+                  ? ` ${formatBytes(durability.usage)} stored.`
+                  : ''}
+              </TooltipContent>
+            ) : durability.persisted ? (
+              <TooltipContent>
+                Storage persistent.
                 {durability.usage !== null
                   ? ` ${formatBytes(durability.usage)} stored.`
                   : ''}
               </TooltipContent>
             ) : durability.usage !== null ? (
               <TooltipContent>
-                {formatBytes(durability.usage)} stored
+                Storage not persistent. {formatBytes(durability.usage)} stored.
               </TooltipContent>
-            ) : null}
+            ) : (
+              <TooltipContent>Storage not persistent.</TooltipContent>
+            )}
           </Tooltip>
         ) : null}
         {versionSlot}

--- a/apps/interviewer/src/components/__tests__/BrandHeader.test.tsx
+++ b/apps/interviewer/src/components/__tests__/BrandHeader.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BrandHeader } from '../BrandHeader';
+
+describe('BrandHeader', () => {
+  it('keeps the app name accessible but visually compact below tablet landscape', () => {
+    render(<BrandHeader />);
+
+    expect(screen.getByRole('heading', { name: 'Interviewer' })).toHaveClass(
+      'sr-only',
+      'tablet-landscape:not-sr-only',
+    );
+  });
+
+  it('sizes the app mark without forcing a square aspect ratio', () => {
+    const { container } = render(<BrandHeader />);
+    const mark = container.querySelector('img');
+
+    expect(mark).toHaveClass('h-16', 'tablet-landscape:h-20', 'w-auto');
+    expect(mark).not.toHaveClass('size-20');
+  });
+});

--- a/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
+++ b/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
@@ -114,11 +114,8 @@ describe('StatusRow', () => {
       />,
     );
 
-    const encryptedTrigger = screen.getByText('Encrypted').parentElement;
-    const storageTrigger = screen.getByText('Storage persistent').parentElement;
-    if (!encryptedTrigger || !storageTrigger) {
-      throw new Error('Expected tooltip triggers to render');
-    }
+    const encryptedTrigger = screen.getByTestId('encryption-status-trigger');
+    const storageTrigger = screen.getByTestId('storage-status-trigger');
 
     await user.hover(encryptedTrigger);
     await waitFor(() =>

--- a/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
+++ b/apps/interviewer/src/components/__tests__/StatusRow.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { mockEstimateStorage, mockIsPersisted } = vi.hoisted(() => ({
@@ -17,7 +18,19 @@ vi.mock('~/lib/storage', async () => {
 });
 
 vi.mock('wouter', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  Link: ({
+    children,
+    className,
+    href,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    href: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
 }));
 
 const useAuthMock = vi.fn(() => ({ kind: 'unlocked', mode: 'pin' }));
@@ -43,7 +56,7 @@ vi.mock('../AppUpdate/AppUpdatePill', () => ({
 
 import { STORAGE_PERSISTED_EVENT } from '~/lib/storage';
 
-import { StatusRow } from '../StatusRow';
+import { StatusRow, StatusRowView } from '../StatusRow';
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -62,6 +75,60 @@ describe('StatusRow', () => {
     render(<StatusRow protocolCount={3} interviewCount={7} />);
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('hides count and status text below tablet landscape', async () => {
+    mockEstimateStorage.mockResolvedValue({
+      usage: 0,
+      quota: 0,
+      percent: 0,
+    });
+    mockIsPersisted.mockResolvedValue(true);
+    render(<StatusRow protocolCount={3} interviewCount={7} />);
+
+    expect(screen.getByRole('link')).toHaveClass(
+      'hidden',
+      'tablet-landscape:inline-flex',
+    );
+    expect(screen.getByText('Encrypted')).toHaveClass(
+      'sr-only',
+      'tablet-landscape:not-sr-only',
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/storage persistent/i)).toHaveClass(
+        'sr-only',
+        'tablet-landscape:not-sr-only',
+      ),
+    );
+  });
+
+  it('includes compact status labels in tooltip text', async () => {
+    const user = userEvent.setup();
+    render(
+      <StatusRowView
+        protocolCount={0}
+        interviewCount={0}
+        mode="pin"
+        durability={{ persisted: true, usage: null }}
+        installed={false}
+      />,
+    );
+
+    const encryptedTrigger = screen.getByText('Encrypted').parentElement;
+    const storageTrigger = screen.getByText('Storage persistent').parentElement;
+    if (!encryptedTrigger || !storageTrigger) {
+      throw new Error('Expected tooltip triggers to render');
+    }
+
+    await user.hover(encryptedTrigger);
+    await waitFor(() =>
+      expect(screen.getByText(/^Encrypted\./)).toBeInTheDocument(),
+    );
+
+    await user.hover(storageTrigger);
+    await waitFor(() =>
+      expect(screen.getByText(/^Storage persistent\./)).toBeInTheDocument(),
+    );
   });
 
   it('surfaces persisted-storage durability once resolved', async () => {


### PR DESCRIPTION
## Summary
- Compact the Interviewer home header below tablet-landscape by hiding the wordmark and sizing the app mark by height with auto width.
- Hide footer protocol/interview counts on narrow displays.
- Collapse encryption and storage status labels to color-coded icons on narrow displays while keeping the labels available to assistive tech and tooltip users.
- Add unit coverage for the compact header/footer behavior and tooltip label text.

## Test plan
- pnpm --filter @codaco/interviewer test -- --project=unit apps/interviewer/src/components/__tests__/BrandHeader.test.tsx apps/interviewer/src/components/__tests__/StatusRow.test.tsx
- pnpm exec oxlint --threads=1
- pnpm exec oxfmt --check .
- pnpm typecheck
- pnpm knip
- pnpm check:changesets
- pnpm --filter @codaco/interviewer build:web
- Playwright smoke check against preview at 780px and 1100px widths

## Notes
- The default parallel oxlint run segfaulted locally inside tsgolint; rerunning full oxlint with --threads=1 completed successfully with warning-level existing diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the Interviewer start screen for narrow displays by making the header and footer more compact.
  * Updated background animation behavior so lights drift and loop more smoothly.
  * Enhanced status details to show clearer storage and encryption information, including usage where available.

* **Bug Fixes**
  * Refined responsive layout and visibility on tablet-landscape screens for better readability and spacing.

* **Chores**
  * Updated package release notes to include dependency refreshes for Fresco UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->