### PR TITLE
Add protocol validation error details dialog

### DIFF
--- a/.changeset/interviewer-validation-error-details.md
+++ b/.changeset/interviewer-validation-error-details.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Interviewer now lets users view and copy protocol validation errors when an import fails, making it easier to request support with the relevant details.

--- a/apps/interviewer/src/lib/protocol/ProtocolValidationDetailsDialog.stories.tsx
+++ b/apps/interviewer/src/lib/protocol/ProtocolValidationDetailsDialog.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useMemo, useState } from 'react';
+
+import Button from '@codaco/fresco-ui/Button';
+
+import {
+  type ProtocolValidationIssue,
+  ProtocolValidationDetailsDialogView,
+} from './ProtocolValidationDetailsDialog';
+
+type IssueSet = 'typical' | 'long' | 'fallback';
+
+type StoryArgs = {
+  issueSet: IssueSet;
+  open: boolean;
+};
+
+const typicalIssues: ProtocolValidationIssue[] = [
+  {
+    path: 'stages.0.label',
+    message: 'Required',
+  },
+  {
+    path: 'codebook.node.person.variables.age.type',
+    message: 'Invalid literal value, expected "number"',
+  },
+  {
+    path: 'stages.2.prompts.0.additionalAttributes',
+    message: 'Unrecognized key: "promptColor"',
+  },
+];
+
+const longIssues: ProtocolValidationIssue[] = Array.from(
+  { length: 18 },
+  (_, index) => ({
+    path: `stages.${index}.prompts.0.variable`,
+    message: `Variable reference "missing_variable_${index + 1}" does not exist in the codebook.`,
+  }),
+);
+
+function getIssues(issueSet: IssueSet) {
+  if (issueSet === 'fallback') return undefined;
+  if (issueSet === 'long') return longIssues;
+  return typicalIssues;
+}
+
+function ValidationDetailsDialogStory({
+  issueSet,
+  open: initialOpen,
+}: StoryArgs) {
+  const [open, setOpen] = useState(initialOpen);
+  const issues = useMemo(() => getIssues(issueSet), [issueSet]);
+
+  useEffect(() => {
+    setOpen(initialOpen);
+  }, [initialOpen, issueSet]);
+
+  return (
+    <div className="flex min-h-96 items-center justify-center">
+      <Button color="primary" onClick={() => setOpen(true)}>
+        View validation details
+      </Button>
+      <ProtocolValidationDetailsDialogView
+        open={open}
+        onClose={() => setOpen(false)}
+        issues={issues}
+        message="Protocol failed schema validation."
+      />
+    </div>
+  );
+}
+
+const meta: Meta<StoryArgs> = {
+  title: 'Protocol Import/ValidationDetailsDialog',
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The dialog opened from the protocol-import failure toast when a protocol fails validation. It shows the validation issues in an inset scroll area and provides a Copy action for support requests.',
+      },
+    },
+  },
+  args: {
+    issueSet: 'typical',
+    open: true,
+  },
+  argTypes: {
+    issueSet: {
+      control: 'inline-radio',
+      options: ['typical', 'long', 'fallback'],
+      description:
+        'Typical renders a short issue list, long exercises the inset scroll area, and fallback shows the message used when no issue array is available.',
+    },
+    open: {
+      control: 'boolean',
+      description: 'Whether the dialog starts open.',
+    },
+  },
+  render: (args) => <ValidationDetailsDialogStory {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {};
+
+export const LongErrorList: Story = {
+  args: {
+    issueSet: 'long',
+  },
+};
+
+export const FallbackMessage: Story = {
+  args: {
+    issueSet: 'fallback',
+  },
+};

--- a/apps/interviewer/src/lib/protocol/ProtocolValidationDetailsDialog.tsx
+++ b/apps/interviewer/src/lib/protocol/ProtocolValidationDetailsDialog.tsx
@@ -1,0 +1,212 @@
+import { Check, Copy } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import Button from '@codaco/fresco-ui/Button';
+import Dialog from '@codaco/fresco-ui/dialogs/Dialog';
+import type useDialog from '@codaco/fresco-ui/dialogs/useDialog';
+import { ScrollArea as ScrollableArea } from '@codaco/fresco-ui/ScrollArea';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import { ExternalLink } from '~/components/ExternalLink';
+
+export type ProtocolValidationIssue = {
+  path: string;
+  message: string;
+};
+
+type ProtocolValidationDetailsDialogOptions = {
+  issues?: ProtocolValidationIssue[];
+  message: string;
+};
+
+type ProtocolValidationDetailsDialogViewProps =
+  ProtocolValidationDetailsDialogOptions & {
+    open: boolean;
+    onClose: () => void;
+  };
+
+const DIALOG_TITLE = 'Protocol validation failed';
+const DIALOG_DESCRIPTION =
+  'Details of the validation errors can be found below:';
+
+function createValidationDetailsDialogId() {
+  return `protocol-validation-details-${globalThis.crypto?.randomUUID?.() ?? Date.now().toString()}`;
+}
+
+function issuePathLabel(path: string) {
+  const trimmedPath = path.trim();
+  return trimmedPath.length > 0 ? trimmedPath : 'protocol';
+}
+
+function formatIssue(issue: ProtocolValidationIssue) {
+  return `${issuePathLabel(issue.path)}: ${issue.message}`;
+}
+
+function displayIssues(
+  issues: ProtocolValidationIssue[] | undefined,
+  fallbackMessage: string,
+): ProtocolValidationIssue[] {
+  if (issues && issues.length > 0) return issues;
+  return [{ path: '', message: fallbackMessage }];
+}
+
+export function getProtocolValidationDetailsCopyText({
+  issues,
+  message,
+}: ProtocolValidationDetailsDialogOptions) {
+  const lines = displayIssues(issues, message).map(
+    (issue, index) => `${index + 1}. ${formatIssue(issue)}`,
+  );
+
+  return ['Protocol validation failed.', '', ...lines].join('\n');
+}
+
+export function ProtocolValidationDetailsDialogBody({
+  issues,
+  message,
+}: ProtocolValidationDetailsDialogOptions) {
+  const visibleIssues = displayIssues(issues, message);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <ScrollableArea
+        aria-label="Protocol validation errors"
+        className="inset-surface bg-surface-1 text-surface-1-contrast publish-colors h-64! flex-none overflow-hidden rounded-sm"
+        fade={false}
+        viewportClassName="my-1.5 mr-1.5 px-4 py-2.5"
+      >
+        <ol className="list-decimal space-y-3 pl-5 text-sm">
+          {visibleIssues.map((issue, index) => (
+            <li key={`${issue.path}-${issue.message}-${index}`}>
+              <div className="font-monospace text-surface-1-contrast/70 text-xs break-all">
+                {issuePathLabel(issue.path)}
+              </div>
+              <div>{issue.message}</div>
+            </li>
+          ))}
+        </ol>
+      </ScrollableArea>
+
+      <Paragraph>
+        If you would like support, post your protocol along with these errors on
+        the{' '}
+        <ExternalLink href="https://community.networkcanvas.com">
+          community forum
+        </ExternalLink>
+        , or email{' '}
+        <ExternalLink href="mailto:info@networkcanvas.com">
+          info@networkcanvas.com
+        </ExternalLink>{' '}
+        with this information.
+      </Paragraph>
+    </div>
+  );
+}
+
+function ProtocolValidationDetailsDialogFooter({
+  copyText,
+  onClose,
+}: {
+  copyText: string;
+  onClose: () => void;
+}) {
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>(
+    'idle',
+  );
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopyStatus('copied');
+    } catch {
+      setCopyStatus('failed');
+    }
+  };
+
+  return (
+    <>
+      <Paragraph
+        aria-live="polite"
+        className="phone-landscape:mr-auto min-h-lh text-sm"
+        emphasis={copyStatus === 'failed' ? 'default' : 'muted'}
+        margin="none"
+      >
+        {copyStatus === 'copied'
+          ? 'Validation errors copied to clipboard.'
+          : null}
+        {copyStatus === 'failed'
+          ? 'Validation errors could not be copied.'
+          : null}
+      </Paragraph>
+      <Button
+        icon={
+          copyStatus === 'copied' ? (
+            <Check aria-hidden="true" />
+          ) : (
+            <Copy aria-hidden="true" />
+          )
+        }
+        onClick={copyToClipboard}
+      >
+        {copyStatus === 'copied' ? 'Copied' : 'Copy'}
+      </Button>
+      <Button color="primary" onClick={onClose}>
+        Close
+      </Button>
+    </>
+  );
+}
+
+export function ProtocolValidationDetailsDialogView({
+  issues,
+  message,
+  open,
+  onClose,
+}: ProtocolValidationDetailsDialogViewProps) {
+  const copyText = useMemo(
+    () => getProtocolValidationDetailsCopyText({ issues, message }),
+    [issues, message],
+  );
+
+  return (
+    <Dialog
+      title={DIALOG_TITLE}
+      description={DIALOG_DESCRIPTION}
+      accent="destructive"
+      open={open}
+      closeDialog={onClose}
+      className="max-w-3xl"
+      footer={
+        <ProtocolValidationDetailsDialogFooter
+          copyText={copyText}
+          onClose={onClose}
+        />
+      }
+    >
+      <ProtocolValidationDetailsDialogBody issues={issues} message={message} />
+    </Dialog>
+  );
+}
+
+export function openProtocolValidationDetailsDialog(
+  dialog: ReturnType<typeof useDialog>,
+  options: ProtocolValidationDetailsDialogOptions,
+) {
+  const dialogId = createValidationDetailsDialogId();
+  const copyText = getProtocolValidationDetailsCopyText(options);
+
+  void dialog.openDialog({
+    id: dialogId,
+    type: 'custom',
+    title: DIALOG_TITLE,
+    description: DIALOG_DESCRIPTION,
+    intent: 'destructive',
+    className: 'max-w-3xl',
+    children: <ProtocolValidationDetailsDialogBody {...options} />,
+    footer: (
+      <ProtocolValidationDetailsDialogFooter
+        copyText={copyText}
+        onClose={() => void dialog.closeDialog(dialogId, null)}
+      />
+    ),
+  });
+}

--- a/apps/interviewer/src/lib/protocol/__tests__/ProtocolValidationDetailsDialog.test.tsx
+++ b/apps/interviewer/src/lib/protocol/__tests__/ProtocolValidationDetailsDialog.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getProtocolValidationDetailsCopyText,
+  ProtocolValidationDetailsDialogBody,
+  ProtocolValidationDetailsDialogView,
+} from '../ProtocolValidationDetailsDialog';
+
+describe('ProtocolValidationDetailsDialog', () => {
+  it('formats validation issues for copying', () => {
+    const copyText = getProtocolValidationDetailsCopyText({
+      message: 'Protocol failed schema validation.',
+      issues: [
+        {
+          path: 'stages.0.label',
+          message: 'Required',
+        },
+        {
+          path: '',
+          message: 'Invalid protocol.',
+        },
+      ],
+    });
+
+    expect(copyText).toContain('1. stages.0.label: Required');
+    expect(copyText).toContain('2. protocol: Invalid protocol.');
+  });
+
+  it('renders the validation errors and support text', () => {
+    render(
+      <ProtocolValidationDetailsDialogBody
+        message="Protocol failed schema validation."
+        issues={[
+          {
+            path: 'codebook.node.person.variables.age.type',
+            message: 'Invalid literal value, expected "number"',
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'Protocol validation errors' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('codebook.node.person.variables.age.type'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Invalid literal value, expected "number"'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'community forum' }),
+    ).toHaveAttribute('href', 'https://community.networkcanvas.com');
+    expect(
+      screen.getByRole('link', { name: 'info@networkcanvas.com' }),
+    ).toHaveAttribute('href', 'mailto:info@networkcanvas.com');
+  });
+
+  it('copies the validation errors from the dialog footer', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ProtocolValidationDetailsDialogView
+        open
+        onClose={() => {}}
+        message="Protocol failed schema validation."
+        issues={[
+          {
+            path: 'stages.0.label',
+            message: 'Required',
+          },
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('1. stages.0.label: Required'),
+    );
+    expect(
+      await screen.findByText('Validation errors copied to clipboard.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/interviewer/src/lib/protocol/__tests__/bundledProtocols.test.ts
+++ b/apps/interviewer/src/lib/protocol/__tests__/bundledProtocols.test.ts
@@ -53,4 +53,30 @@ describe('bundled sample protocol', () => {
     expect(throwingFetch).not.toHaveBeenCalled();
     expect(phases).toContain('saving');
   });
+
+  it('returns schema issue details when validation fails', async () => {
+    const result = await importBundledProtocol({
+      name: 'Invalid Protocol',
+      assets: [],
+      document: {
+        schemaVersion: 8,
+        name: 'Invalid Protocol',
+        codebook: {},
+        stages: 'not an array',
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe('validation-failed');
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: 'stages',
+          }),
+        ]),
+      );
+    }
+    expect(saveProtocol).not.toHaveBeenCalled();
+  });
 });

--- a/apps/interviewer/src/lib/protocol/__tests__/useProtocolImport.test.ts
+++ b/apps/interviewer/src/lib/protocol/__tests__/useProtocolImport.test.ts
@@ -3,8 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useProtocolImport } from '../useProtocolImport';
 
+const { dialogOpen, toastAdd } = vi.hoisted(() => ({
+  dialogOpen: vi.fn(),
+  toastAdd: vi.fn(),
+}));
+
 vi.mock('@codaco/fresco-ui/Toast', () => ({
-  useToast: () => ({ add: vi.fn() }),
+  useToast: () => ({ add: toastAdd }),
+}));
+vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
+  default: () => ({ openDialog: dialogOpen, closeDialog: vi.fn() }),
 }));
 vi.mock('~/lib/analytics/AnalyticsProvider', () => ({
   useAnalytics: () => ({ track: vi.fn() }),
@@ -19,9 +27,17 @@ vi.mock('../importProtocol', () => ({
 
 import { importProtocolFromFile } from '../importProtocol';
 
+type ToastCall = {
+  cancelLabel?: string;
+  onCancel?: () => void;
+};
+
 describe('useProtocolImport', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.mocked(importProtocolFromFile).mockImplementation(
+      () => new Promise(() => {}),
+    );
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -48,5 +64,59 @@ describe('useProtocolImport', () => {
       vi.advanceTimersByTime(1000);
     });
     expect(importProtocolFromFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds a details action to validation failure toasts', async () => {
+    vi.mocked(importProtocolFromFile).mockResolvedValueOnce({
+      success: false,
+      error: 'validation-failed',
+      message: 'Protocol failed schema validation.',
+      issues: [
+        {
+          path: 'stages.0.label',
+          message: 'Required',
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useProtocolImport({ onInstalled: () => {} }),
+    );
+
+    await act(async () => {
+      await result.current.startImport({
+        source: 'file',
+        file: new File([new Uint8Array()], 'study.netcanvas'),
+        label: 'study.netcanvas',
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Import failed',
+        description: 'Protocol failed schema validation.',
+        variant: 'destructive',
+        cancelLabel: 'View details',
+      }),
+    );
+
+    const toastCall = toastAdd.mock.calls[0]?.[0] as ToastCall | undefined;
+    expect(toastCall?.onCancel).toEqual(expect.any(Function));
+
+    toastCall?.onCancel?.();
+
+    expect(dialogOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'custom',
+        title: 'Protocol validation failed',
+        description: 'Details of the validation errors can be found below:',
+        intent: 'destructive',
+      }),
+    );
   });
 });

--- a/apps/interviewer/src/lib/protocol/importProtocol.ts
+++ b/apps/interviewer/src/lib/protocol/importProtocol.ts
@@ -8,19 +8,10 @@ import {
   hashProtocol,
   migrateProtocol,
   validateProtocol,
-  type VersionedProtocol,
   VersionedProtocolSchema,
 } from '@codaco/protocol-validation';
 
 import { saveProtocol } from '../db/api';
-
-// `validateProtocol` takes the already-typed `VersionedProtocol` union, but the
-// documents flowing through this module start as `unknown` (parsed JSON from a
-// zip or a bundled asset). Narrow with the same schema `validateProtocol` uses
-// internally, rather than asserting the type.
-function isVersionedProtocol(document: unknown): document is VersionedProtocol {
-  return VersionedProtocolSchema.safeParse(document).success;
-}
 
 const APP_SCHEMA_VERSION = 8;
 
@@ -55,6 +46,55 @@ export type ImportProtocolResult =
   | ImportProtocolSuccess
   | ImportProtocolFailure;
 
+type ValidationIssue = {
+  path: PropertyKey[];
+  message: string;
+};
+
+type AssetManifestEntry = {
+  type: string;
+  name: string;
+  source?: string;
+  value?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isAssetManifestEntry(value: unknown): value is AssetManifestEntry {
+  if (!isRecord(value)) return false;
+  const { type, name, source, value: entryValue } = value;
+  return (
+    typeof type === 'string' &&
+    typeof name === 'string' &&
+    (source === undefined || typeof source === 'string') &&
+    (entryValue === undefined || typeof entryValue === 'string')
+  );
+}
+
+function getAssetManifest(
+  protocol: unknown,
+): Record<string, AssetManifestEntry> {
+  if (!isRecord(protocol) || !isRecord(protocol.assetManifest)) return {};
+
+  return Object.fromEntries(
+    Object.entries(protocol.assetManifest).filter(
+      (entry): entry is [string, AssetManifestEntry] =>
+        isAssetManifestEntry(entry[1]),
+    ),
+  );
+}
+
+function formatValidationIssues(
+  issues: readonly ValidationIssue[],
+): ImportProtocolFailure['issues'] {
+  return issues.map((issue) => ({
+    path: issue.path.map(String).join('.'),
+    message: issue.message,
+  }));
+}
+
 export async function peekProtocolName(
   buffer: Uint8Array,
 ): Promise<string | null> {
@@ -62,7 +102,8 @@ export async function peekProtocolName(
     const zip = await JSZip.loadAsync(buffer);
     const json = await zip.file('protocol.json')?.async('string');
     if (!json) return null;
-    const parsed = JSON.parse(json) as { name?: unknown };
+    const parsed: unknown = JSON.parse(json);
+    if (!isRecord(parsed)) return null;
     if (typeof parsed.name === 'string' && parsed.name.trim().length > 0) {
       return parsed.name;
     }
@@ -80,12 +121,8 @@ async function extractZip(
   if (!protocolJson) {
     throw new Error('protocol.json not found in archive');
   }
-  const protocol = JSON.parse(protocolJson) as Record<string, unknown>;
-  const manifest =
-    (protocol.assetManifest as Record<
-      string,
-      { type: string; name: string; source?: string; value?: string }
-    >) ?? {};
+  const protocol: unknown = JSON.parse(protocolJson);
+  const manifest = getAssetManifest(protocol);
   const assets: ExtractedAsset[] = [];
   for (const [assetId, def] of Object.entries(manifest)) {
     if (def.type === 'apikey') {
@@ -136,24 +173,23 @@ async function importParsedProtocol(
     }
   }
 
-  if (!isVersionedProtocol(migratedDocument)) {
+  const versionedProtocol = VersionedProtocolSchema.safeParse(migratedDocument);
+  if (!versionedProtocol.success) {
     return {
       success: false,
       error: 'validation-failed',
       message: 'Protocol failed schema validation.',
+      issues: formatValidationIssues(versionedProtocol.error.issues),
     };
   }
 
-  const validation = await validateProtocol(migratedDocument);
+  const validation = await validateProtocol(versionedProtocol.data);
   if (!validation.success) {
     return {
       success: false,
       error: 'validation-failed',
       message: 'Protocol failed schema validation.',
-      issues: validation.error.issues.map((i) => ({
-        path: i.path.join('.'),
-        message: i.message,
-      })),
+      issues: formatValidationIssues(validation.error.issues),
     };
   }
 

--- a/apps/interviewer/src/lib/protocol/useProtocolImport.ts
+++ b/apps/interviewer/src/lib/protocol/useProtocolImport.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useToast } from '@codaco/fresco-ui/Toast';
 import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import { updateSettings } from '~/lib/db/api';
@@ -13,6 +14,7 @@ import {
   importProtocolFromFile,
   peekProtocolName,
 } from './importProtocol';
+import { openProtocolValidationDetailsDialog } from './ProtocolValidationDetailsDialog';
 import { SAMPLE_PROTOCOL } from './sampleProtocol';
 
 export type ImportRequest = { source: 'file'; file: File; label: string };
@@ -75,6 +77,7 @@ type UseProtocolImportOptions = {
 
 export function useProtocolImport({ onInstalled }: UseProtocolImportOptions) {
   const toast = useToast();
+  const dialog = useDialog();
   const analytics = useAnalytics();
   const [pendingImports, setPendingImports] = useState<PendingImport[]>([]);
 
@@ -166,10 +169,22 @@ export function useProtocolImport({ onInstalled }: UseProtocolImportOptions) {
             source: request.source,
             reason: result.error,
           });
+          const validationDetails =
+            result.error === 'validation-failed'
+              ? {
+                  issues: result.issues,
+                  message: result.message,
+                }
+              : null;
           toast.add({
             title: 'Import failed',
             description: result.message,
             variant: 'destructive',
+            ...(validationDetails && {
+              cancelLabel: 'View details',
+              onCancel: () =>
+                openProtocolValidationDetailsDialog(dialog, validationDetails),
+            }),
           });
         }
       };
@@ -188,7 +203,7 @@ export function useProtocolImport({ onInstalled }: UseProtocolImportOptions) {
         });
       }, IMPORT_START_DELAY_MS);
     },
-    [analytics, onInstalled, toast],
+    [analytics, dialog, onInstalled, toast],
   );
 
   return { pendingImports, startImport };


### PR DESCRIPTION
## Summary
- Add a protocol validation details dialog with an inset scrollable error list and copy-to-clipboard action.
- Add a View details action to validation failure toasts during protocol import.
- Preserve schema validation issue details during import failures and cover the dialog in Storybook/tests.
- Add an Interviewer app changeset.

## Test plan
- [x] pnpm lint:fix
- [x] pnpm knip
- [x] pnpm typecheck
- [x] pnpm --filter @codaco/interviewer test -- src/lib/protocol/__tests__/bundledProtocols.test.ts src/lib/protocol/__tests__/useProtocolImport.test.ts src/lib/protocol/__tests__/ProtocolValidationDetailsDialog.test.tsx
- [x] pnpm --filter @codaco/interviewer build-storybook
- [x] pnpm check:changesets