### PR TITLE
Add SplitButton to fresco-ui

### DIFF
--- a/.changeset/split-button-fresco-ui.md
+++ b/.changeset/split-button-fresco-ui.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': minor
+---
+
+Add a `SplitButton` component with a Button-compatible main action API, a required split segment, and nested popover content props.

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -80,6 +80,10 @@
       "types": "./dist/Button.d.ts",
       "default": "./dist/Button.js"
     },
+    "./SplitButton": {
+      "types": "./dist/SplitButton.d.ts",
+      "default": "./dist/SplitButton.js"
+    },
     "./CloseButton": {
       "types": "./dist/CloseButton.d.ts",
       "default": "./dist/CloseButton.js"

--- a/packages/fresco-ui/src/Popover.tsx
+++ b/packages/fresco-ui/src/Popover.tsx
@@ -56,24 +56,30 @@ type PopoverProps = ComponentProps<typeof BasePopover.Root> & {
   children: ReactNode;
 };
 
-function Popover({ children, ...props }: PopoverProps) {
-  const [mounted, setMounted] = useState(false);
+function Popover({
+  children,
+  defaultOpen = false,
+  onOpenChange,
+  open,
+  ...props
+}: PopoverProps) {
+  const [mounted, setMounted] = useState(defaultOpen);
 
-  const controlled = props.open !== undefined;
+  const controlled = open !== undefined;
 
   const handleOpenChange = (
     nextOpen: boolean,
     event: BasePopover.Root.ChangeEventDetails,
   ) => {
     setMounted(nextOpen);
-    props.onOpenChange?.(nextOpen, event);
+    onOpenChange?.(nextOpen, event);
   };
 
   // When open is controlled externally, sync mounted state so
   // PopoverContent renders. base-ui only fires onOpenChange for
   // internal state changes, not when the open prop changes.
-  const effectiveOpen = controlled ? props.open : mounted;
-  const effectiveMounted = controlled ? !!props.open : mounted;
+  const effectiveOpen = controlled ? open : mounted;
+  const effectiveMounted = effectiveOpen;
 
   return (
     <PopoverContext.Provider value={{ mounted: effectiveMounted, setMounted }}>

--- a/packages/fresco-ui/src/SplitButton.stories.tsx
+++ b/packages/fresco-ui/src/SplitButton.stories.tsx
@@ -1,0 +1,400 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Check, ChevronDown, Download, Plus, Settings } from 'lucide-react';
+
+import { BUTTON_COLORS, BUTTON_VARIANTS } from './button-constants';
+import SplitButton, { type SplitButtonProps } from './SplitButton';
+
+const iconMap = {
+  check: <Check aria-hidden="true" />,
+  chevronDown: <ChevronDown aria-hidden="true" />,
+  download: <Download aria-hidden="true" />,
+  none: undefined,
+  plus: <Plus aria-hidden="true" />,
+  settings: <Settings aria-hidden="true" />,
+};
+
+type StoryIcon = keyof typeof iconMap;
+
+type SplitButtonStoryArgs = SplitButtonProps & {
+  buttonIcon: StoryIcon;
+  buttonIconPosition: NonNullable<SplitButtonProps['iconPosition']>;
+  popoverAlign: NonNullable<SplitButtonProps['popover']['align']>;
+  popoverClassName: string;
+  popoverFirstAction: string;
+  popoverSecondAction: string;
+  popoverShowArrow: boolean;
+  popoverSide: NonNullable<SplitButtonProps['popover']['side']>;
+  popoverSideOffset: number;
+  popoverTitle: string;
+  segmentAriaLabel: string;
+  segmentChildren: string;
+  segmentDisabled: boolean;
+  segmentIcon: StoryIcon;
+  segmentIconPosition: NonNullable<SplitButtonProps['segment']['iconPosition']>;
+  segmentPosition: NonNullable<SplitButtonProps['segment']['position']>;
+};
+
+function PopoverActions({
+  firstAction,
+  secondAction,
+  title,
+}: {
+  firstAction: string;
+  secondAction: string;
+  title: string;
+}) {
+  return (
+    <div className="flex w-56 flex-col gap-3">
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        <Settings className="size-4" aria-hidden="true" />
+        {title}
+      </div>
+      <div className="grid gap-2 text-sm">
+        <button
+          className="focusable rounded px-3 py-2 text-left hover:bg-current/10"
+          type="button"
+        >
+          {firstAction}
+        </button>
+        <button
+          className="focusable rounded px-3 py-2 text-left hover:bg-current/10"
+          type="button"
+        >
+          {secondAction}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function renderSplitButton({
+  buttonIcon,
+  buttonIconPosition,
+  popover,
+  popoverAlign,
+  popoverClassName,
+  popoverFirstAction,
+  popoverSecondAction,
+  popoverShowArrow,
+  popoverSide,
+  popoverSideOffset,
+  popoverTitle,
+  segment,
+  segmentAriaLabel,
+  segmentChildren,
+  segmentDisabled,
+  segmentIcon,
+  segmentIconPosition,
+  segmentPosition,
+  ...buttonProps
+}: SplitButtonStoryArgs) {
+  const segmentContent = segmentChildren.trim() || undefined;
+  const icon = iconMap[segmentIcon];
+  const controlledSegment: SplitButtonProps['segment'] = segmentContent
+    ? {
+        ...segment,
+        'aria-label': segmentAriaLabel || undefined,
+        'children': segmentContent,
+        'disabled': segmentDisabled,
+        icon,
+        'iconPosition': segmentIconPosition,
+        'position': segmentPosition,
+      }
+    : {
+        ...segment,
+        'aria-label': segmentAriaLabel || 'Open options',
+        'disabled': segmentDisabled,
+        'icon': icon ?? iconMap.chevronDown,
+        'iconPosition': segmentIconPosition,
+        'position': segmentPosition,
+      };
+
+  return (
+    <SplitButton
+      {...buttonProps}
+      icon={iconMap[buttonIcon]}
+      iconPosition={buttonIconPosition}
+      popover={{
+        ...popover,
+        align: popoverAlign,
+        className: popoverClassName || undefined,
+        content: (
+          <PopoverActions
+            firstAction={popoverFirstAction}
+            secondAction={popoverSecondAction}
+            title={popoverTitle}
+          />
+        ),
+        showArrow: popoverShowArrow,
+        side: popoverSide,
+        sideOffset: popoverSideOffset,
+      }}
+      segment={controlledSegment}
+    />
+  );
+}
+
+const meta = {
+  title: 'Components/SplitButton',
+  component: SplitButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'SplitButton composes `Button` and `Popover` into a grouped control with a continuous outer button shape and a narrow seam between the main action and popover segment. The public API starts from `Button` props: `children`, `className`, `icon`, `variant`, `color`, `size`, and event handlers configure the main action button. The required `segment` prop configures the secondary trigger with `position`, `icon`, `children`, `iconPosition`, `disabled`, and an `aria-label` for icon-only segments. The required `popover` prop supplies `content` and forwards all other props to `PopoverContent`. The controls panel exposes story-only scalar controls that build those nested `segment` and `popover` objects.',
+      },
+    },
+    layout: 'centered',
+  },
+  render: renderSplitButton,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      table: {
+        category: 'Button',
+      },
+    },
+    className: {
+      control: false,
+      table: {
+        category: 'Button',
+      },
+    },
+    color: {
+      control: 'select',
+      options: BUTTON_COLORS,
+      table: {
+        category: 'Button',
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      table: {
+        category: 'Button',
+      },
+    },
+    icon: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    buttonIcon: {
+      control: 'select',
+      options: Object.keys(iconMap),
+      table: {
+        category: 'Button',
+      },
+    },
+    buttonIconPosition: {
+      control: 'inline-radio',
+      options: ['left', 'right'],
+      table: {
+        category: 'Button',
+      },
+    },
+    popover: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    popoverAlign: {
+      control: 'inline-radio',
+      options: ['start', 'center', 'end'],
+      table: {
+        category: 'Popover',
+      },
+    },
+    popoverClassName: {
+      control: 'text',
+      table: {
+        category: 'Popover',
+      },
+    },
+    popoverFirstAction: {
+      control: 'text',
+      table: {
+        category: 'Popover content',
+      },
+    },
+    popoverSecondAction: {
+      control: 'text',
+      table: {
+        category: 'Popover content',
+      },
+    },
+    popoverShowArrow: {
+      control: 'boolean',
+      table: {
+        category: 'Popover',
+      },
+    },
+    popoverSide: {
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+      table: {
+        category: 'Popover',
+      },
+    },
+    popoverSideOffset: {
+      control: 'number',
+      table: {
+        category: 'Popover',
+      },
+    },
+    popoverTitle: {
+      control: 'text',
+      table: {
+        category: 'Popover content',
+      },
+    },
+    segment: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    segmentAriaLabel: {
+      control: 'text',
+      table: {
+        category: 'Segment',
+      },
+    },
+    segmentChildren: {
+      control: 'text',
+      table: {
+        category: 'Segment',
+      },
+    },
+    segmentDisabled: {
+      control: 'boolean',
+      table: {
+        category: 'Segment',
+      },
+    },
+    segmentIcon: {
+      control: 'select',
+      options: Object.keys(iconMap),
+      table: {
+        category: 'Segment',
+      },
+    },
+    segmentIconPosition: {
+      control: 'inline-radio',
+      options: ['left', 'right'],
+      table: {
+        category: 'Segment',
+      },
+    },
+    segmentPosition: {
+      control: 'inline-radio',
+      options: ['left', 'right'],
+      table: {
+        category: 'Segment',
+      },
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'xl'],
+      table: {
+        category: 'Button',
+      },
+    },
+    variant: {
+      control: 'select',
+      options: BUTTON_VARIANTS,
+      table: {
+        category: 'Button',
+      },
+    },
+  },
+  args: {
+    children: 'Save changes',
+    buttonIcon: 'none',
+    buttonIconPosition: 'left',
+    color: 'primary',
+    disabled: false,
+    popover: {
+      content: null,
+    },
+    popoverAlign: 'end',
+    popoverClassName: '',
+    popoverFirstAction: 'Save as draft',
+    popoverSecondAction: 'Save a copy',
+    popoverShowArrow: true,
+    popoverSide: 'bottom',
+    popoverSideOffset: 10,
+    popoverTitle: 'More actions',
+    segment: {
+      'aria-label': 'Open save options',
+      'icon': <ChevronDown aria-hidden="true" />,
+    },
+    segmentAriaLabel: 'Open save options',
+    segmentChildren: '',
+    segmentDisabled: false,
+    segmentIcon: 'chevronDown',
+    segmentIconPosition: 'left',
+    segmentPosition: 'right',
+    size: 'md',
+    variant: 'default',
+  },
+} satisfies Meta<SplitButtonStoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SegmentOnLeft: Story = {
+  args: {
+    children: 'Import',
+    color: 'default',
+    segmentAriaLabel: 'Open import options',
+    segmentPosition: 'left',
+  },
+};
+
+export const TextSegment: Story = {
+  args: {
+    buttonIcon: 'download',
+    children: 'Export',
+    color: 'secondary',
+    segmentChildren: 'More',
+    segmentIcon: 'none',
+  },
+};
+
+export const IconAndTextSegment: Story = {
+  args: {
+    buttonIcon: 'plus',
+    children: 'Create',
+    color: 'success',
+    segmentChildren: 'Options',
+    segmentIcon: 'chevronDown',
+    segmentIconPosition: 'right',
+  },
+};
+
+export const LongLabels: Story = {
+  args: {
+    children: 'Save changes and notify collaborators',
+    color: 'info',
+    popoverClassName: 'w-72',
+    segmentChildren: 'Additional save options',
+    segmentIcon: 'chevronDown',
+    segmentIconPosition: 'right',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    buttonIcon: 'check',
+    children: 'Already saved',
+    color: 'default',
+    disabled: true,
+    segmentAriaLabel: 'Open save options',
+    segmentIcon: 'chevronDown',
+  },
+};

--- a/packages/fresco-ui/src/SplitButton.test.tsx
+++ b/packages/fresco-ui/src/SplitButton.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChevronDown } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+
+import SplitButton from './SplitButton';
+
+const defaultSegment = {
+  'aria-label': 'Open options',
+  'icon': <ChevronDown />,
+};
+
+describe('SplitButton', () => {
+  it('uses Button props for the main action segment', () => {
+    render(
+      <SplitButton
+        className="opacity-90"
+        popover={{ content: <div>More save options</div> }}
+        segment={defaultSegment}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    const mainButton = screen.getByRole('button', { name: 'Save' });
+    expect(mainButton).toHaveClass('opacity-90');
+  });
+
+  it('squares the internal edge for right and left popover segments', () => {
+    const { rerender } = render(
+      <SplitButton
+        popover={{ content: <div>More save options</div> }}
+        segment={defaultSegment}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveClass(
+      'rounded-r-none!',
+    );
+    expect(screen.getByRole('button', { name: 'Open options' })).toHaveClass(
+      'rounded-l-none!',
+    );
+
+    rerender(
+      <SplitButton
+        popover={{ content: <div>More save options</div> }}
+        segment={{ ...defaultSegment, position: 'left' }}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toHaveClass(
+      'rounded-l-none!',
+    );
+    expect(screen.getByRole('button', { name: 'Open options' })).toHaveClass(
+      'rounded-r-none!',
+    );
+  });
+
+  it('fires the main button action without opening the popover', async () => {
+    const onClick = vi.fn();
+    render(
+      <SplitButton
+        onClick={onClick}
+        popover={{ content: <div>More save options</div> }}
+        segment={{
+          'aria-label': 'Open save options',
+          'icon': <ChevronDown />,
+        }}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(screen.queryByText('More save options')).not.toBeInTheDocument();
+  });
+
+  it('opens popover content from the split segment', async () => {
+    render(
+      <SplitButton
+        popover={{ content: <div>More save options</div> }}
+        segment={defaultSegment}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Open options' });
+    expect(trigger).toHaveAttribute('aria-haspopup');
+
+    await userEvent.click(trigger);
+
+    expect(await screen.findByText('More save options')).toBeInTheDocument();
+  });
+
+  it('disables both segments when the split button is disabled', () => {
+    render(
+      <SplitButton
+        disabled
+        popover={{ content: <div>More save options</div> }}
+        segment={defaultSegment}
+      >
+        Saved
+      </SplitButton>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Open options' })).toBeDisabled();
+  });
+});

--- a/packages/fresco-ui/src/SplitButton.test.tsx
+++ b/packages/fresco-ui/src/SplitButton.test.tsx
@@ -99,7 +99,7 @@ describe('SplitButton', () => {
     expect(await screen.findByText('More save options')).toBeInTheDocument();
   });
 
-  it('disables both segments when the split button is disabled', () => {
+  it('disables both segments when the split button is disabled', async () => {
     render(
       <SplitButton
         disabled
@@ -111,6 +111,11 @@ describe('SplitButton', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Saved' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Open options' })).toBeDisabled();
+    const segmentButton = screen.getByRole('button', { name: 'Open options' });
+    expect(segmentButton).toBeDisabled();
+
+    await userEvent.click(segmentButton);
+
+    expect(screen.queryByText('More save options')).not.toBeInTheDocument();
   });
 });

--- a/packages/fresco-ui/src/SplitButton.test.tsx
+++ b/packages/fresco-ui/src/SplitButton.test.tsx
@@ -99,6 +99,35 @@ describe('SplitButton', () => {
     expect(await screen.findByText('More save options')).toBeInTheDocument();
   });
 
+  it('opens popover content by default when requested', () => {
+    render(
+      <SplitButton
+        defaultOpen
+        popover={{ content: <div>More save options</div> }}
+        segment={defaultSegment}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    expect(screen.getByText('More save options')).toBeInTheDocument();
+  });
+
+  it('treats an empty segment label as missing content', async () => {
+    render(
+      <SplitButton
+        popover={{ content: <div>More save options</div> }}
+        segment={{ children: '', icon: <ChevronDown /> }}
+      >
+        Save
+      </SplitButton>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open options' }));
+
+    expect(await screen.findByText('More save options')).toBeInTheDocument();
+  });
+
   it('disables both segments when the split button is disabled', async () => {
     render(
       <SplitButton

--- a/packages/fresco-ui/src/SplitButton.tsx
+++ b/packages/fresco-ui/src/SplitButton.tsx
@@ -62,7 +62,23 @@ export type SplitButtonProps = Omit<ButtonProps, 'asChild' | 'popover'> &
   };
 
 function hasVisibleContent(children: React.ReactNode): boolean {
-  return children !== undefined && children !== null && children !== false;
+  if (
+    children === undefined ||
+    children === null ||
+    typeof children === 'boolean'
+  ) {
+    return false;
+  }
+
+  if (typeof children === 'string') {
+    return children.trim().length > 0;
+  }
+
+  if (Array.isArray(children)) {
+    return children.some(hasVisibleContent);
+  }
+
+  return true;
 }
 
 function getPopoverContentProps<T extends { content: React.ReactNode }>({

--- a/packages/fresco-ui/src/SplitButton.tsx
+++ b/packages/fresco-ui/src/SplitButton.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button, type ButtonProps } from './Button';
+import { Popover, PopoverContent, PopoverTrigger } from './Popover';
+import { cx } from './utils/cva';
+
+type SplitButtonSegmentPosition = 'left' | 'right';
+
+type SplitButtonPopoverOpenProps = Pick<
+  React.ComponentProps<typeof Popover>,
+  'defaultOpen' | 'onOpenChange' | 'open'
+>;
+
+type SplitButtonPopoverProps = Omit<
+  React.ComponentProps<typeof PopoverContent>,
+  'children' | 'content'
+> & {
+  content: React.ReactNode;
+};
+
+type SplitButtonSegmentBaseProps = Omit<
+  ButtonProps,
+  | 'aria-label'
+  | 'asChild'
+  | 'children'
+  | 'color'
+  | 'icon'
+  | 'iconPosition'
+  | 'popover'
+  | 'size'
+  | 'type'
+  | 'variant'
+> & {
+  iconPosition?: ButtonProps['iconPosition'];
+  position?: SplitButtonSegmentPosition;
+};
+
+export type SplitButtonSegmentProps =
+  | (SplitButtonSegmentBaseProps & {
+      'aria-label': string;
+      'children'?: undefined;
+      'icon': React.ReactNode;
+    })
+  | (SplitButtonSegmentBaseProps & {
+      'aria-label'?: string;
+      'children': React.ReactNode;
+      'icon'?: React.ReactNode;
+    });
+
+export type SplitButtonProps = Omit<ButtonProps, 'asChild' | 'popover'> &
+  SplitButtonPopoverOpenProps & {
+    /**
+     * Popover shown when the split segment is activated.
+     */
+    popover: SplitButtonPopoverProps;
+    /**
+     * Content, position, and accessible name for the split segment.
+     */
+    segment: SplitButtonSegmentProps;
+  };
+
+function hasVisibleContent(children: React.ReactNode): boolean {
+  return children !== undefined && children !== null && children !== false;
+}
+
+function getPopoverContentProps<T extends { content: React.ReactNode }>({
+  content: _content,
+  ...contentProps
+}: T): Omit<T, 'content'> {
+  return contentProps;
+}
+
+function splitSegmentPaddingClass(size: ButtonProps['size']): string {
+  switch (size) {
+    case undefined:
+      return 'px-4!';
+    case 'sm':
+      return 'px-3!';
+    case 'lg':
+      return 'px-5!';
+    case 'xl':
+      return 'px-6!';
+    case 'md':
+    default:
+      return 'px-4!';
+  }
+}
+
+function splitButtonGapClass(size: ButtonProps['size']): string {
+  switch (size) {
+    case 'sm':
+      return 'gap-[0.16em] text-sm';
+    case 'lg':
+      return 'gap-[0.16em] text-lg';
+    case 'xl':
+      return 'gap-[0.16em] text-xl';
+    case undefined:
+    case 'md':
+    default:
+      return 'gap-[0.16em] text-base';
+  }
+}
+
+function mainButtonRadiusClass(
+  segmentPosition: SplitButtonSegmentPosition,
+): string {
+  return segmentPosition === 'left' ? 'rounded-l-none!' : 'rounded-r-none!';
+}
+
+function popoverSegmentRadiusClass(
+  segmentPosition: SplitButtonSegmentPosition,
+): string {
+  return segmentPosition === 'left' ? 'rounded-r-none!' : 'rounded-l-none!';
+}
+
+function iconOnlySegmentAlignmentClass(
+  segmentPosition: SplitButtonSegmentPosition,
+): string {
+  return segmentPosition === 'left'
+    ? '[&>.lucide]:translate-x-0.5'
+    : '[&>.lucide]:-translate-x-0.5';
+}
+
+const SplitButton = React.forwardRef<HTMLButtonElement, SplitButtonProps>(
+  (
+    {
+      children,
+      className,
+      color,
+      defaultOpen,
+      disabled,
+      icon,
+      iconPosition,
+      onOpenChange,
+      open,
+      popover,
+      segment,
+      size = 'md',
+      type = 'button',
+      variant,
+      ...buttonProps
+    },
+    ref,
+  ) => {
+    const popoverContentProps = getPopoverContentProps(popover);
+    const {
+      'aria-label': segmentAriaLabel,
+      className: segmentClassName,
+      children: segmentChildren,
+      disabled: segmentOwnDisabled,
+      icon: segmentIcon,
+      iconPosition: segmentIconPosition,
+      position: segmentPositionProp,
+      ...segmentProps
+    } = segment;
+    const segmentPosition = segmentPositionProp ?? 'right';
+    const segmentHasVisibleContent = hasVisibleContent(segmentChildren);
+    const segmentDisabled = disabled || segmentOwnDisabled;
+    const segmentLabel = segmentHasVisibleContent
+      ? segmentAriaLabel
+      : (segmentAriaLabel ?? 'Open options');
+
+    const mainButton = (
+      <Button
+        ref={ref}
+        color={color}
+        disabled={disabled}
+        icon={icon}
+        iconPosition={iconPosition}
+        size={size}
+        type={type}
+        variant={variant}
+        className={cx(
+          'relative focus-visible:z-10',
+          mainButtonRadiusClass(segmentPosition),
+          className,
+        )}
+        {...buttonProps}
+      >
+        {children}
+      </Button>
+    );
+
+    const popoverSegmentButton = (
+      <Button
+        aria-label={segmentLabel}
+        color={color}
+        disabled={segmentDisabled}
+        icon={segmentIcon}
+        iconPosition={segmentIconPosition}
+        size={size}
+        type="button"
+        variant={variant}
+        className={cx(
+          'relative focus-visible:z-10',
+          segmentHasVisibleContent
+            ? splitSegmentPaddingClass(size)
+            : 'aspect-square p-0!',
+          segmentHasVisibleContent
+            ? undefined
+            : iconOnlySegmentAlignmentClass(segmentPosition),
+          popoverSegmentRadiusClass(segmentPosition),
+          segmentClassName,
+        )}
+        {...segmentProps}
+      >
+        {segmentHasVisibleContent ? segmentChildren : null}
+      </Button>
+    );
+
+    return (
+      <Popover
+        defaultOpen={defaultOpen}
+        onOpenChange={onOpenChange}
+        open={open}
+      >
+        <div
+          className={cx(
+            'inline-flex shrink-0 items-stretch',
+            splitButtonGapClass(size),
+          )}
+        >
+          {segmentPosition === 'left' ? (
+            <PopoverTrigger
+              disabled={segmentDisabled}
+              render={popoverSegmentButton}
+            />
+          ) : null}
+          {mainButton}
+          {segmentPosition === 'right' ? (
+            <PopoverTrigger
+              disabled={segmentDisabled}
+              render={popoverSegmentButton}
+            />
+          ) : null}
+        </div>
+        <PopoverContent
+          {...popoverContentProps}
+          align={
+            popoverContentProps.align ??
+            (segmentPosition === 'left' ? 'start' : 'end')
+          }
+          side={popoverContentProps.side ?? 'bottom'}
+        >
+          {popover.content}
+        </PopoverContent>
+      </Popover>
+    );
+  },
+);
+SplitButton.displayName = 'SplitButton';
+
+export default SplitButton;
+export { SplitButton };

--- a/packages/fresco-ui/src/styles/controlVariants.ts
+++ b/packages/fresco-ui/src/styles/controlVariants.ts
@@ -144,9 +144,9 @@ export const heightVariants = cva({
   },
 });
 
-// Set the size of any child SVG icons to slightly above 1em to match text height
+// Set child SVG icon height slightly above 1em while preserving consumer width overrides
 export const proportionalLucideIconVariants = cva({
-  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:w-[1.2em] [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
+  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
 });
 
 // adds background and border styles for input-like controls

--- a/packages/fresco-ui/src/styles/controlVariants.ts
+++ b/packages/fresco-ui/src/styles/controlVariants.ts
@@ -146,7 +146,7 @@ export const heightVariants = cva({
 
 // Set the size of any child SVG icons to slightly above 1em to match text height
 export const proportionalLucideIconVariants = cva({
-  base: '[&>.lucide]:h-[1em] [&>.lucide]:max-h-full [&>.lucide]:w-auto [&>.lucide]:shrink-0',
+  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:w-[1.2em] [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
 });
 
 // adds background and border styles for input-like controls


### PR DESCRIPTION
## Summary
- Add a Button-compatible SplitButton component with a required configurable segment and nested popover props.
- Add Storybook stories/controls and unit coverage for the main action, segment trigger, disabled state, and split shape.
- Increase shared Button Lucide icon size and stroke for clearer icon rendering.

## Test plan
- pnpm lint:fix
- pnpm typecheck
- pnpm knip
- pnpm check:changesets
- pnpm test
- pnpm build
- pnpm --filter @codaco/fresco-ui test
- pnpm --filter @codaco/fresco-ui build-storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new split button component with a primary action and a secondary options segment.
  * Included Storybook examples for different split button layouts, labels, and disabled states.
* **Bug Fixes**
  * Improved button segment sizing so icons display more consistently.
* **Tests**
  * Added coverage for main action clicks, options opening, segment placement, and disabled behavior.
* **Chores**
  * Registered the new component for package export and marked the release as a minor update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->