### PR TITLE
Fix fresh-load PWA updates

### DIFF
--- a/.changeset/fresh-load-app-shells.md
+++ b/.changeset/fresh-load-app-shells.md
@@ -1,0 +1,6 @@
+---
+'@codaco/architect': patch
+'@codaco/interviewer': patch
+---
+
+Load the newest app shell on fresh online launches while preserving the precached offline startup path.

--- a/.changeset/fresh-load-pwa-helper.md
+++ b/.changeset/fresh-load-pwa-helper.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Add a shared app-start helper for applying a waiting service-worker update before the app mounts, with timeout fallbacks so offline launches continue.

--- a/apps/architect/scripts/assert-pwa-build.mjs
+++ b/apps/architect/scripts/assert-pwa-build.mjs
@@ -66,6 +66,14 @@ const entry = (html.match(/assets\/[^"']+\.js/) || [])[0];
 if (!entry) fail('no entry chunk referenced in dist/index.html');
 if (!precached.has(entry)) fail(`entry chunk excluded from precache: ${entry}`);
 
+if (!/url:"preview\/index\.html"/.test(sw)) {
+  fail('preview/index.html missing from precache manifest');
+}
+
+if (!/new URL\("preview\/index\.html",/.test(sw)) {
+  fail('missing /preview/ offline fallback in generated service worker');
+}
+
 // No globIgnores means every emitted chunk should be precached; an excluded one
 // exceeded the size limit and would 404 offline.
 const excluded = jsAssets.filter((u) => !precached.has(u));

--- a/apps/architect/src/main.tsx
+++ b/apps/architect/src/main.tsx
@@ -16,6 +16,7 @@ import { preloadTimelineImages } from './images/timeline';
 import { warmBundledTemplateAssets } from './templates/warmBundledAssets';
 import { isCriticalOperationInProgress } from './utils/criticalOperation';
 import {
+  hasPendingLaunchFiles,
   initFileLaunchCapture,
   subscribeLaunchFiles,
   takeLaunchFiles,
@@ -53,7 +54,8 @@ const warmCaches = () => {
 async function startApp(): Promise<void> {
   if (
     await applyFreshLoadServiceWorkerUpdate({
-      shouldSkip: isCriticalOperationInProgress,
+      shouldSkip: () =>
+        isCriticalOperationInProgress() || hasPendingLaunchFiles(),
     })
   ) {
     return;

--- a/apps/architect/src/main.tsx
+++ b/apps/architect/src/main.tsx
@@ -4,6 +4,7 @@ import './analytics';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 
+import { applyFreshLoadServiceWorkerUpdate } from '@codaco/fresco-ui/appUpdate/applyFreshLoadServiceWorkerUpdate';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { PortalContainerProvider } from '@codaco/fresco-ui/PortalContainer';
 
@@ -13,6 +14,7 @@ import { openLocalNetcanvas } from './ducks/modules/userActions/userActions';
 import { store } from './ducks/store';
 import { preloadTimelineImages } from './images/timeline';
 import { warmBundledTemplateAssets } from './templates/warmBundledAssets';
+import { isCriticalOperationInProgress } from './utils/criticalOperation';
 import {
   initFileLaunchCapture,
   subscribeLaunchFiles,
@@ -35,66 +37,6 @@ subscribeLaunchFiles(() => {
   if (first) void store.dispatch(openLocalNetcanvas(first));
 });
 
-const root = document.getElementById('root') as Element;
-
-createRoot(root).render(
-  <AppErrorBoundary>
-    <Provider store={store}>
-      {/* PortalContainerProvider outermost so fresco-ui overlays portal into
-          its viewport layer; the `root` (isolation: isolate) wrapper keeps the
-          app's own stacking contexts from competing with that layer. */}
-      <PortalContainerProvider>
-        <DialogProvider>
-          <div className="root h-full">
-            <AppView />
-          </div>
-        </DialogProvider>
-      </PortalContainerProvider>
-    </Provider>
-  </AppErrorBoundary>,
-);
-
-// Matches the boot loader's opacity transition in index.html (400ms), plus a
-// buffer for the removal fallback below.
-const BOOT_LOADER_FADE_MS = 400;
-
-// Fade out and remove the inline boot loader (defined in index.html) once React
-// has committed its first frame. Two nested rAFs wait for the paint that follows
-// the initial commit so the fade begins over real app content, not a blank root.
-const dismissBootLoader = () => {
-  const loader = document.getElementById('boot-loader');
-  // Idempotent: it's scheduled from both a rAF (paint-aligned) and a timer
-  // backstop below, so bail if it's already gone or already fading.
-  if (!loader || loader.classList.contains('boot-loader--hidden')) return;
-
-  const prefersReducedMotion = window.matchMedia(
-    '(prefers-reduced-motion: reduce)',
-  ).matches;
-
-  if (prefersReducedMotion) {
-    loader.remove();
-    return;
-  }
-
-  // Remove on transitionend for a tight hand-off, but also on a timeout so the
-  // loader can never linger if the transition is interrupted or never fires
-  // (e.g. the tab is backgrounded during the fade, which suspends transitions).
-  const remove = () => loader.remove();
-  loader.addEventListener('transitionend', remove, { once: true });
-  setTimeout(remove, BOOT_LOADER_FADE_MS + 100);
-  loader.classList.add('boot-loader--hidden');
-};
-
-requestAnimationFrame(() => {
-  requestAnimationFrame(dismissBootLoader);
-});
-
-// rAF is suspended while a tab is backgrounded, so a tab opened in the background
-// would keep the loader until it's focused. React has already committed by this
-// point, so also dismiss on a timer backstop (idempotent) that still fires when
-// the tab is hidden.
-setTimeout(dismissBootLoader, BOOT_LOADER_FADE_MS + 100);
-
 // During idle time, fetch stage thumbnails so they are already cached when the
 // timeline or stage editor first renders. When running as an installed PWA, also
 // warm the service-worker cache with the bundled template/Sample assets so those
@@ -108,8 +50,85 @@ const warmCaches = () => {
   }
 };
 
-if ('requestIdleCallback' in window) {
-  window.requestIdleCallback(warmCaches);
-} else {
-  setTimeout(warmCaches, 1000);
+async function startApp(): Promise<void> {
+  if (
+    await applyFreshLoadServiceWorkerUpdate({
+      shouldSkip: isCriticalOperationInProgress,
+    })
+  ) {
+    return;
+  }
+
+  const root = document.getElementById('root');
+  if (!root) {
+    throw new Error('Root container #root not found');
+  }
+
+  createRoot(root).render(
+    <AppErrorBoundary>
+      <Provider store={store}>
+        {/* PortalContainerProvider outermost so fresco-ui overlays portal into
+          its viewport layer; the `root` (isolation: isolate) wrapper keeps the
+          app's own stacking contexts from competing with that layer. */}
+        <PortalContainerProvider>
+          <DialogProvider>
+            <div className="root h-full">
+              <AppView />
+            </div>
+          </DialogProvider>
+        </PortalContainerProvider>
+      </Provider>
+    </AppErrorBoundary>,
+  );
+
+  // Matches the boot loader's opacity transition in index.html (400ms), plus a
+  // buffer for the removal fallback below.
+  const BOOT_LOADER_FADE_MS = 400;
+
+  // Fade out and remove the inline boot loader (defined in index.html) once
+  // React has committed its first frame. Two nested rAFs wait for the paint that
+  // follows the initial commit so the fade begins over real app content, not a
+  // blank root.
+  const dismissBootLoader = () => {
+    const loader = document.getElementById('boot-loader');
+    // Idempotent: it's scheduled from both a rAF (paint-aligned) and a timer
+    // backstop below, so bail if it's already gone or already fading.
+    if (!loader || loader.classList.contains('boot-loader--hidden')) return;
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    if (prefersReducedMotion) {
+      loader.remove();
+      return;
+    }
+
+    // Remove on transitionend for a tight hand-off, but also on a timeout so
+    // the loader can never linger if the transition is interrupted or never
+    // fires (e.g. the tab is backgrounded during the fade, which suspends
+    // transitions).
+    const remove = () => loader.remove();
+    loader.addEventListener('transitionend', remove, { once: true });
+    setTimeout(remove, BOOT_LOADER_FADE_MS + 100);
+    loader.classList.add('boot-loader--hidden');
+  };
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(dismissBootLoader);
+  });
+
+  // rAF is suspended while a tab is backgrounded, so a tab opened in the
+  // background would keep the loader until it's focused. React has already
+  // committed by this point, so also dismiss on a timer backstop (idempotent)
+  // that still fires when the tab is hidden.
+  setTimeout(dismissBootLoader, BOOT_LOADER_FADE_MS + 100);
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(warmCaches);
+  } else {
+    setTimeout(warmCaches, 1000);
+  }
 }
+
+void startApp();

--- a/apps/architect/src/utils/__tests__/fileLaunchQueue.test.ts
+++ b/apps/architect/src/utils/__tests__/fileLaunchQueue.test.ts
@@ -49,7 +49,7 @@ const loadModule = async () => {
     consumer?.({ files: handles });
     await settle();
   };
-  return { mod, launch, launchHandles };
+  return { mod, launch, launchHandles, settle };
 };
 
 afterEach(() => {
@@ -94,10 +94,37 @@ describe('fileLaunchQueue', () => {
     const { mod, launch } = await loadModule();
     await launch('a.netcanvas', 'b.netcanvas');
 
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
     const taken = mod.takeLaunchFiles();
     expect(taken.map((f) => f.name)).toEqual(['a.netcanvas', 'b.netcanvas']);
     expect(mod.getLaunchFiles()).toEqual([]);
+    expect(mod.hasPendingLaunchFiles()).toBe(false);
     expect(mod.takeLaunchFiles()).toEqual([]);
+  });
+
+  it('reports pending launch files while OS handles are still being read', async () => {
+    const { mod, launchHandles, settle } = await loadModule();
+    let resolveFile: (file: File) => void = () => {};
+
+    await launchHandles({
+      getFile: () =>
+        new Promise<File>((resolve) => {
+          resolveFile = resolve;
+        }),
+    });
+
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
+
+    resolveFile(new File(['zip'], 'pending.netcanvas'));
+    await settle();
+
+    expect(mod.getLaunchFiles().map((f) => f.name)).toEqual([
+      'pending.netcanvas',
+    ]);
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
+
+    mod.takeLaunchFiles();
+    expect(mod.hasPendingLaunchFiles()).toBe(false);
   });
 
   it('keeps the snapshot identity stable between changes', async () => {

--- a/apps/architect/src/utils/fileLaunchQueue.ts
+++ b/apps/architect/src/utils/fileLaunchQueue.ts
@@ -10,6 +10,7 @@ import { generalErrorDialog } from '~/ducks/modules/userActions/dialogs';
 import { store } from '~/ducks/store';
 
 let pendingFiles: File[] = [];
+let pendingLaunchReads = 0;
 const listeners = new Set<() => void>();
 let initialized = false;
 
@@ -34,6 +35,8 @@ export const initFileLaunchCapture = (): void => {
   const queue = window.launchQueue;
   if (!queue) return;
   queue.setConsumer((params) => {
+    pendingLaunchReads += 1;
+    emit();
     void (async () => {
       // allSettled so one unreadable handle (file moved/deleted, volume
       // unmounted between the OS launch and consumption) doesn't drop the whole
@@ -63,9 +66,14 @@ export const initFileLaunchCapture = (): void => {
       if (netcanvas.length === 0) return;
       pendingFiles = [...pendingFiles, ...netcanvas];
       emit();
-    })().catch((error: unknown) => {
-      console.error('Failed to handle launched files', error);
-    });
+    })()
+      .catch((error: unknown) => {
+        console.error('Failed to handle launched files', error);
+      })
+      .finally(() => {
+        pendingLaunchReads -= 1;
+        emit();
+      });
   });
 };
 
@@ -79,6 +87,9 @@ export const subscribeLaunchFiles = (listener: () => void): (() => void) => {
 // Stable snapshot for useSyncExternalStore: the array identity only changes
 // when the contents change.
 export const getLaunchFiles = (): File[] => pendingFiles;
+
+export const hasPendingLaunchFiles = (): boolean =>
+  pendingLaunchReads > 0 || pendingFiles.length > 0;
 
 // Hand the pending files to a consumer exactly once.
 export const takeLaunchFiles = (): File[] => {

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -119,6 +119,64 @@ export default defineConfig(({ mode }) => {
           maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
           runtimeCaching: [
             {
+              // Preview is a separate HTML entry. With directoryIndex disabled
+              // for fresh root launches, keep /preview/ explicitly mapped to
+              // its own precached shell for fully offline preview starts.
+              urlPattern: ({ request, sameOrigin, url }) =>
+                sameOrigin &&
+                request.mode === 'navigate' &&
+                url.pathname.startsWith('/preview/'),
+              handler: async ({ request }) => {
+                let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+                try {
+                  const networkTimeout = new Promise<Response>((_, reject) => {
+                    timeoutId = setTimeout(
+                      () => reject(new Error('Preview request timed out')),
+                      3_000,
+                    );
+                  });
+
+                  return await Promise.race([fetch(request), networkTimeout]);
+                } catch (error) {
+                  const cacheStorage: unknown = Reflect.get(
+                    globalThis,
+                    'caches',
+                  );
+                  const serviceWorkerLocation: unknown = Reflect.get(
+                    globalThis,
+                    'location',
+                  );
+                  const cacheMatch: unknown =
+                    typeof cacheStorage === 'object' && cacheStorage !== null
+                      ? Reflect.get(cacheStorage, 'match')
+                      : undefined;
+                  const locationHref: unknown =
+                    typeof serviceWorkerLocation === 'object' &&
+                    serviceWorkerLocation !== null
+                      ? Reflect.get(serviceWorkerLocation, 'href')
+                      : undefined;
+
+                  if (
+                    typeof cacheMatch !== 'function' ||
+                    typeof locationHref !== 'string'
+                  ) {
+                    throw error;
+                  }
+
+                  const fallback: unknown = await cacheMatch.call(
+                    cacheStorage,
+                    new URL('preview/index.html', locationHref).href,
+                    { ignoreSearch: true },
+                  );
+                  if (fallback instanceof Response) return fallback;
+                  throw error;
+                } finally {
+                  if (timeoutId !== undefined) clearTimeout(timeoutId);
+                }
+              },
+            },
+            {
               // The app shell must be fresh when the app is launched online:
               // a cache-first navigation fallback would render the old HTML
               // first, then refresh once the service-worker update finished.

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -107,12 +107,31 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ['**/*.{js,css,html}'],
-          navigateFallback: 'index.html',
-          navigateFallbackDenylist: [/^\/preview\//],
+          // vite-plugin-pwa defaults this to index.html; disable it so it
+          // cannot shadow the NetworkFirst navigation route below.
+          navigateFallback: undefined,
           cleanupOutdatedCaches: true,
           clientsClaim: true,
           maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
           runtimeCaching: [
+            {
+              // The app shell must be fresh when the app is launched online:
+              // a cache-first navigation fallback would render the old HTML
+              // first, then refresh once the service-worker update finished.
+              // NetworkFirst keeps offline launch via the precached fallback
+              // while letting a first load use the newest deployed shell.
+              urlPattern: ({ request, sameOrigin, url }) =>
+                sameOrigin &&
+                request.mode === 'navigate' &&
+                !url.pathname.startsWith('/preview/'),
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: `architect-navigation-${version}`,
+                networkTimeoutSeconds: 3,
+                precacheFallback: { fallbackURL: 'index.html' },
+                cacheableResponse: { statuses: [200] },
+              },
+            },
             {
               urlPattern: /\.(?:png|jpg|jpeg|svg|webp|gif)$/i,
               handler: 'CacheFirst',

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -108,8 +108,12 @@ export default defineConfig(({ mode }) => {
         workbox: {
           globPatterns: ['**/*.{js,css,html}'],
           // vite-plugin-pwa defaults this to index.html; disable it so it
-          // cannot shadow the NetworkFirst navigation route below.
+          // cannot shadow the runtime navigation route below.
           navigateFallback: undefined,
+          // Without this, precacheAndRoute maps root launches (`/`) to the
+          // cached index.html before the runtime navigation route can fetch
+          // the newest shell.
+          directoryIndex: null,
           cleanupOutdatedCaches: true,
           clientsClaim: true,
           maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
@@ -118,18 +122,61 @@ export default defineConfig(({ mode }) => {
               // The app shell must be fresh when the app is launched online:
               // a cache-first navigation fallback would render the old HTML
               // first, then refresh once the service-worker update finished.
-              // NetworkFirst keeps offline launch via the precached fallback
-              // while letting a first load use the newest deployed shell.
+              // The handler keeps offline launch via the precached fallback
+              // while preventing a still-old service worker from caching new
+              // HTML whose matching hashed chunks it has not precached.
               urlPattern: ({ request, sameOrigin, url }) =>
                 sameOrigin &&
                 request.mode === 'navigate' &&
                 !url.pathname.startsWith('/preview/'),
-              handler: 'NetworkFirst',
-              options: {
-                cacheName: `architect-navigation-${version}`,
-                networkTimeoutSeconds: 3,
-                precacheFallback: { fallbackURL: 'index.html' },
-                cacheableResponse: { statuses: [200] },
+              handler: async ({ request }) => {
+                let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+                try {
+                  const networkTimeout = new Promise<Response>((_, reject) => {
+                    timeoutId = setTimeout(
+                      () => reject(new Error('Navigation request timed out')),
+                      3_000,
+                    );
+                  });
+
+                  return await Promise.race([fetch(request), networkTimeout]);
+                } catch (error) {
+                  const cacheStorage: unknown = Reflect.get(
+                    globalThis,
+                    'caches',
+                  );
+                  const serviceWorkerLocation: unknown = Reflect.get(
+                    globalThis,
+                    'location',
+                  );
+                  const cacheMatch: unknown =
+                    typeof cacheStorage === 'object' && cacheStorage !== null
+                      ? Reflect.get(cacheStorage, 'match')
+                      : undefined;
+                  const locationHref: unknown =
+                    typeof serviceWorkerLocation === 'object' &&
+                    serviceWorkerLocation !== null
+                      ? Reflect.get(serviceWorkerLocation, 'href')
+                      : undefined;
+
+                  if (
+                    typeof cacheMatch !== 'function' ||
+                    typeof locationHref !== 'string'
+                  ) {
+                    throw error;
+                  }
+
+                  const fallback: unknown = await cacheMatch.call(
+                    cacheStorage,
+                    new URL('index.html', locationHref).href,
+                    { ignoreSearch: true },
+                  );
+                  if (fallback instanceof Response) return fallback;
+                  throw error;
+                } finally {
+                  if (timeoutId !== undefined) clearTimeout(timeoutId);
+                }
               },
             },
             {

--- a/apps/interviewer/src/lib/pwa/__tests__/fileLaunchQueue.test.ts
+++ b/apps/interviewer/src/lib/pwa/__tests__/fileLaunchQueue.test.ts
@@ -17,8 +17,7 @@ const loadModule = async () => {
   if (!consumer) throw new Error('consumer was not registered');
   const settle = async () => {
     // getFile() resolution is async; let the consumer settle.
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
   };
   const launch = async (...names: string[]) => {
     consumer?.({
@@ -32,7 +31,7 @@ const loadModule = async () => {
     consumer?.({ files: handles });
     await settle();
   };
-  return { mod, launch, launchHandles };
+  return { mod, launch, launchHandles, settle };
 };
 
 afterEach(() => {
@@ -75,10 +74,37 @@ describe('fileLaunchQueue', () => {
     const { mod, launch } = await loadModule();
     await launch('a.netcanvas', 'b.netcanvas');
 
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
     const taken = mod.takeLaunchFiles();
     expect(taken.map((f) => f.name)).toEqual(['a.netcanvas', 'b.netcanvas']);
     expect(mod.getLaunchFiles()).toEqual([]);
+    expect(mod.hasPendingLaunchFiles()).toBe(false);
     expect(mod.takeLaunchFiles()).toEqual([]);
+  });
+
+  it('reports pending launch files while OS handles are still being read', async () => {
+    const { mod, launchHandles, settle } = await loadModule();
+    let resolveFile: (file: File) => void = () => {};
+
+    await launchHandles({
+      getFile: () =>
+        new Promise<File>((resolve) => {
+          resolveFile = resolve;
+        }),
+    });
+
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
+
+    resolveFile(new File(['zip'], 'pending.netcanvas'));
+    await settle();
+
+    expect(mod.getLaunchFiles().map((f) => f.name)).toEqual([
+      'pending.netcanvas',
+    ]);
+    expect(mod.hasPendingLaunchFiles()).toBe(true);
+
+    mod.takeLaunchFiles();
+    expect(mod.hasPendingLaunchFiles()).toBe(false);
   });
 
   it('keeps the snapshot identity stable between changes', async () => {

--- a/apps/interviewer/src/lib/pwa/fileLaunchQueue.ts
+++ b/apps/interviewer/src/lib/pwa/fileLaunchQueue.ts
@@ -10,6 +10,7 @@
 
 let pendingFiles: File[] = [];
 let pendingFailureCount = 0;
+let pendingLaunchReads = 0;
 const listeners = new Set<() => void>();
 let initialized = false;
 
@@ -23,6 +24,8 @@ export const initFileLaunchCapture = (): void => {
   const queue = window.launchQueue;
   if (!queue) return;
   queue.setConsumer((params) => {
+    pendingLaunchReads += 1;
+    emit();
     void (async () => {
       // allSettled so one unreadable handle (file moved/deleted, volume
       // unmounted between the OS launch and consumption) doesn't drop the
@@ -56,9 +59,14 @@ export const initFileLaunchCapture = (): void => {
       }
       pendingFiles = [...pendingFiles, ...netcanvas];
       emit();
-    })().catch((error: unknown) => {
-      console.error('Failed to handle launched files', error);
-    });
+    })()
+      .catch((error: unknown) => {
+        console.error('Failed to handle launched files', error);
+      })
+      .finally(() => {
+        pendingLaunchReads -= 1;
+        emit();
+      });
   });
 };
 
@@ -72,6 +80,9 @@ export const subscribeLaunchFiles = (listener: () => void): (() => void) => {
 // Stable snapshot for useSyncExternalStore: the array identity only changes
 // when the contents change.
 export const getLaunchFiles = (): File[] => pendingFiles;
+
+export const hasPendingLaunchFiles = (): boolean =>
+  pendingLaunchReads > 0 || pendingFiles.length > 0;
 
 // Hand the pending files to a consumer exactly once.
 export const takeLaunchFiles = (): File[] => {

--- a/apps/interviewer/src/main.tsx
+++ b/apps/interviewer/src/main.tsx
@@ -4,6 +4,8 @@ import './styles/globals.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { applyFreshLoadServiceWorkerUpdate } from '@codaco/fresco-ui/appUpdate/applyFreshLoadServiceWorkerUpdate';
+
 import App from './App';
 import { initFileLaunchCapture } from './lib/pwa/fileLaunchQueue';
 import { initInstallPromptCapture } from './lib/pwa/installPrompt';
@@ -24,35 +26,50 @@ initSwipeNavigationGuard();
 // React mounts; capture them for Home to import after unlock.
 initFileLaunchCapture();
 
-void requestPersistentStorage();
+async function startApp(): Promise<void> {
+  if (
+    await applyFreshLoadServiceWorkerUpdate({
+      shouldSkip: () => window.location.pathname.startsWith('/interview/'),
+    })
+  ) {
+    return;
+  }
 
-// The startup request above runs before any interaction, which WebKit and
-// Chromium routinely deny (their heuristics key on interaction history) — ask
-// once more on the user's first gesture.
-requestPersistentStorageOnFirstInteraction();
+  void requestPersistentStorage();
 
-// Installing the PWA newly qualifies the origin for persistent storage, but the
-// box is only made non-evictable on an actual persist() call — request it again
-// when the install completes rather than leaving storage evictable until the
-// next reload re-runs the startup request above.
-window.addEventListener('appinstalled', () => void requestPersistentStorage());
+  // The startup request above runs before any interaction, which WebKit and
+  // Chromium routinely deny (their heuristics key on interaction history) — ask
+  // once more on the user's first gesture.
+  requestPersistentStorageOnFirstInteraction();
 
-const container = document.getElementById('root');
-if (!container) {
-  throw new Error('Root container #root not found');
+  // Installing the PWA newly qualifies the origin for persistent storage, but
+  // the box is only made non-evictable on an actual persist() call — request it
+  // again when the install completes rather than leaving storage evictable until
+  // the next reload re-runs the startup request above.
+  window.addEventListener(
+    'appinstalled',
+    () => void requestPersistentStorage(),
+  );
+
+  const container = document.getElementById('root');
+  if (!container) {
+    throw new Error('Root container #root not found');
+  }
+
+  const root = createRoot(container);
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+
+  // Hand off from the static first-paint loader (index.html's #app-loading) to
+  // React. Deferred to after the first commit paints so there's no flash of
+  // blank between the loader disappearing and React's own content (AuthGate's
+  // Spinner, then App's fade-in) painting — the loader cross-fades into the app.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(removeLoadingScreen);
+  });
 }
 
-const root = createRoot(container);
-root.render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
-
-// Hand off from the static first-paint loader (index.html's #app-loading) to
-// React. Deferred to after the first commit paints so there's no flash of blank
-// between the loader disappearing and React's own content (AuthGate's Spinner,
-// then App's fade-in) painting — the loader cross-fades into the app.
-requestAnimationFrame(() => {
-  requestAnimationFrame(removeLoadingScreen);
-});
+void startApp();

--- a/apps/interviewer/src/main.tsx
+++ b/apps/interviewer/src/main.tsx
@@ -7,7 +7,10 @@ import { createRoot } from 'react-dom/client';
 import { applyFreshLoadServiceWorkerUpdate } from '@codaco/fresco-ui/appUpdate/applyFreshLoadServiceWorkerUpdate';
 
 import App from './App';
-import { initFileLaunchCapture } from './lib/pwa/fileLaunchQueue';
+import {
+  hasPendingLaunchFiles,
+  initFileLaunchCapture,
+} from './lib/pwa/fileLaunchQueue';
 import { initInstallPromptCapture } from './lib/pwa/installPrompt';
 import { removeLoadingScreen } from './lib/pwa/loadingScreen';
 import { initSwipeNavigationGuard } from './lib/pwa/swipeNavigationGuard';
@@ -29,7 +32,9 @@ initFileLaunchCapture();
 async function startApp(): Promise<void> {
   if (
     await applyFreshLoadServiceWorkerUpdate({
-      shouldSkip: () => window.location.pathname.startsWith('/interview/'),
+      shouldSkip: () =>
+        window.location.pathname.startsWith('/interview/') ||
+        hasPendingLaunchFiles(),
     })
   ) {
     return;

--- a/apps/interviewer/vite.config.ts
+++ b/apps/interviewer/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
+import { version } from './package.json';
 import { createRendererConfig } from './vite.renderer.config';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -61,11 +62,29 @@ export default defineConfig(() =>
           // generateSW hard-fail the build (not just skip the file) unless
           // it's excluded from the precache glob outright.
           globIgnores: ['**/assets/bundledDevelopmentProtocol-*.js'],
-          navigateFallback: 'index.html',
+          // vite-plugin-pwa defaults this to index.html; disable it so it
+          // cannot shadow the NetworkFirst navigation route below.
+          navigateFallback: undefined,
           cleanupOutdatedCaches: true,
           clientsClaim: true,
           maximumFileSizeToCacheInBytes: MAX_PRECACHE_BYTES,
           runtimeCaching: [
+            {
+              // The app shell must be fresh when the app is launched online:
+              // a cache-first navigation fallback would render the old HTML
+              // first, then refresh once the service-worker update finished.
+              // NetworkFirst keeps offline launch via the precached fallback
+              // while letting a first load use the newest deployed shell.
+              urlPattern: ({ request, sameOrigin }) =>
+                sameOrigin && request.mode === 'navigate',
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: `interviewer-navigation-${version}`,
+                networkTimeoutSeconds: 3,
+                precacheFallback: { fallbackURL: 'index.html' },
+                cacheableResponse: { statuses: [200] },
+              },
+            },
             {
               urlPattern: /\.(?:png|jpg|jpeg|svg|webp|gif)$/i,
               handler: 'CacheFirst',

--- a/apps/interviewer/vite.config.ts
+++ b/apps/interviewer/vite.config.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
-import { version } from './package.json';
 import { createRendererConfig } from './vite.renderer.config';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -63,8 +62,12 @@ export default defineConfig(() =>
           // it's excluded from the precache glob outright.
           globIgnores: ['**/assets/bundledDevelopmentProtocol-*.js'],
           // vite-plugin-pwa defaults this to index.html; disable it so it
-          // cannot shadow the NetworkFirst navigation route below.
+          // cannot shadow the runtime navigation route below.
           navigateFallback: undefined,
+          // Without this, precacheAndRoute maps root launches (`/`) to the
+          // cached index.html before the runtime navigation route can fetch
+          // the newest shell.
+          directoryIndex: null,
           cleanupOutdatedCaches: true,
           clientsClaim: true,
           maximumFileSizeToCacheInBytes: MAX_PRECACHE_BYTES,
@@ -73,16 +76,59 @@ export default defineConfig(() =>
               // The app shell must be fresh when the app is launched online:
               // a cache-first navigation fallback would render the old HTML
               // first, then refresh once the service-worker update finished.
-              // NetworkFirst keeps offline launch via the precached fallback
-              // while letting a first load use the newest deployed shell.
+              // The handler keeps offline launch via the precached fallback
+              // while preventing a still-old service worker from caching new
+              // HTML whose matching hashed chunks it has not precached.
               urlPattern: ({ request, sameOrigin }) =>
                 sameOrigin && request.mode === 'navigate',
-              handler: 'NetworkFirst',
-              options: {
-                cacheName: `interviewer-navigation-${version}`,
-                networkTimeoutSeconds: 3,
-                precacheFallback: { fallbackURL: 'index.html' },
-                cacheableResponse: { statuses: [200] },
+              handler: async ({ request }) => {
+                let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+                try {
+                  const networkTimeout = new Promise<Response>((_, reject) => {
+                    timeoutId = setTimeout(
+                      () => reject(new Error('Navigation request timed out')),
+                      3_000,
+                    );
+                  });
+
+                  return await Promise.race([fetch(request), networkTimeout]);
+                } catch (error) {
+                  const cacheStorage: unknown = Reflect.get(
+                    globalThis,
+                    'caches',
+                  );
+                  const serviceWorkerLocation: unknown = Reflect.get(
+                    globalThis,
+                    'location',
+                  );
+                  const cacheMatch: unknown =
+                    typeof cacheStorage === 'object' && cacheStorage !== null
+                      ? Reflect.get(cacheStorage, 'match')
+                      : undefined;
+                  const locationHref: unknown =
+                    typeof serviceWorkerLocation === 'object' &&
+                    serviceWorkerLocation !== null
+                      ? Reflect.get(serviceWorkerLocation, 'href')
+                      : undefined;
+
+                  if (
+                    typeof cacheMatch !== 'function' ||
+                    typeof locationHref !== 'string'
+                  ) {
+                    throw error;
+                  }
+
+                  const fallback: unknown = await cacheMatch.call(
+                    cacheStorage,
+                    new URL('index.html', locationHref).href,
+                    { ignoreSearch: true },
+                  );
+                  if (fallback instanceof Response) return fallback;
+                  throw error;
+                } finally {
+                  if (timeoutId !== undefined) clearTimeout(timeoutId);
+                }
               },
             },
             {

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -553,6 +553,10 @@
       "types": "./dist/appUpdate/useAppUpdate.d.ts",
       "default": "./dist/appUpdate/useAppUpdate.js"
     },
+    "./appUpdate/applyFreshLoadServiceWorkerUpdate": {
+      "types": "./dist/appUpdate/applyFreshLoadServiceWorkerUpdate.d.ts",
+      "default": "./dist/appUpdate/applyFreshLoadServiceWorkerUpdate.js"
+    },
     "./appUpdate/AppUpdateIndicator": {
       "types": "./dist/appUpdate/AppUpdateIndicator.d.ts",
       "default": "./dist/appUpdate/AppUpdateIndicator.js"

--- a/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
+++ b/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyFreshLoadServiceWorkerUpdate } from '../applyFreshLoadServiceWorkerUpdate';
+
+type FakeWorker = ServiceWorker & { state: ServiceWorkerState };
+
+function createWorker(initialState: ServiceWorkerState) {
+  const target = new EventTarget();
+  const postMessage = vi.fn();
+  const worker = Object.assign(target, {
+    scriptURL: '/sw.js',
+    state: initialState,
+    postMessage,
+  }) as unknown as FakeWorker;
+
+  const setState = (state: ServiceWorkerState) => {
+    worker.state = state;
+    target.dispatchEvent(new Event('statechange'));
+  };
+
+  return { worker, postMessage, setState };
+}
+
+type FakeRegistration = ServiceWorkerRegistration & {
+  waiting: ServiceWorker | null;
+  installing: ServiceWorker | null;
+  update: ReturnType<typeof vi.fn<() => Promise<ServiceWorkerRegistration>>>;
+};
+
+function createRegistration({
+  waiting = null,
+  installing = null,
+}: {
+  waiting?: ServiceWorker | null;
+  installing?: ServiceWorker | null;
+} = {}) {
+  const target = new EventTarget();
+  const update = vi.fn<() => Promise<ServiceWorkerRegistration>>();
+  const registration = Object.assign(target, {
+    waiting,
+    installing,
+    update,
+  }) as unknown as FakeRegistration;
+  update.mockResolvedValue(registration);
+  return registration;
+}
+
+function createServiceWorkerContainer({
+  registration,
+  controller = createWorker('activated').worker,
+}: {
+  registration?: ServiceWorkerRegistration;
+  controller?: ServiceWorker | null;
+}) {
+  const target = new EventTarget();
+  const getRegistration = vi.fn(() => Promise.resolve(registration));
+
+  return {
+    controller,
+    getRegistration,
+    addEventListener: target.addEventListener.bind(target),
+    removeEventListener: target.removeEventListener.bind(target),
+    dispatchControllerChange: () =>
+      target.dispatchEvent(new Event('controllerchange')),
+  };
+}
+
+describe('applyFreshLoadServiceWorkerUpdate', () => {
+  it('skips when the page is not controlled by an existing service worker', async () => {
+    const registration = createRegistration();
+    const serviceWorker = createServiceWorkerContainer({
+      registration,
+      controller: null,
+    });
+
+    const result = await applyFreshLoadServiceWorkerUpdate({
+      serviceWorker,
+      shouldSkip: () => false,
+    });
+
+    expect(result).toBe(false);
+    expect(serviceWorker.getRegistration).not.toHaveBeenCalled();
+    expect(registration.update).not.toHaveBeenCalled();
+  });
+
+  it('skips when the current app state should not be interrupted', async () => {
+    const registration = createRegistration();
+    const serviceWorker = createServiceWorkerContainer({ registration });
+
+    const result = await applyFreshLoadServiceWorkerUpdate({
+      serviceWorker,
+      shouldSkip: () => true,
+    });
+
+    expect(result).toBe(false);
+    expect(serviceWorker.getRegistration).not.toHaveBeenCalled();
+  });
+
+  it('activates an already waiting worker and reloads before app startup continues', async () => {
+    const waiting = createWorker('installed');
+    const registration = createRegistration({ waiting: waiting.worker });
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+
+    const result = applyFreshLoadServiceWorkerUpdate({
+      serviceWorker,
+      reload,
+      shouldSkip: () => false,
+      updateCheckTimeoutMs: 50,
+      activationTimeoutMs: 50,
+    });
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+    expect(waiting.postMessage).toHaveBeenCalledWith({
+      type: 'SKIP_WAITING',
+    });
+
+    serviceWorker.dispatchControllerChange();
+
+    await expect(result).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('waits for an installing update to become waiting before activating it', async () => {
+    const installing = createWorker('installing');
+    const registration = createRegistration({ installing: installing.worker });
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+
+    const result = applyFreshLoadServiceWorkerUpdate({
+      serviceWorker,
+      reload,
+      shouldSkip: () => false,
+      updateCheckTimeoutMs: 50,
+      activationTimeoutMs: 50,
+    });
+
+    await Promise.resolve();
+    expect(installing.postMessage).not.toHaveBeenCalled();
+
+    installing.setState('installed');
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+    expect(installing.postMessage).toHaveBeenCalledWith({
+      type: 'SKIP_WAITING',
+    });
+
+    serviceWorker.dispatchControllerChange();
+
+    await expect(result).resolves.toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('continues startup when the update check fails', async () => {
+    const registration = createRegistration();
+    registration.update.mockRejectedValue(new Error('offline'));
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+
+    await expect(
+      applyFreshLoadServiceWorkerUpdate({
+        serviceWorker,
+        reload,
+        shouldSkip: () => false,
+        updateCheckTimeoutMs: 50,
+        activationTimeoutMs: 50,
+      }),
+    ).resolves.toBe(false);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('continues startup quickly when the update check times out offline', async () => {
+    let resolveUpdate: (
+      registration: ServiceWorkerRegistration,
+    ) => void = () => {};
+    const registration = createRegistration();
+    registration.update.mockReturnValue(
+      new Promise<ServiceWorkerRegistration>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+
+    await expect(
+      applyFreshLoadServiceWorkerUpdate({
+        serviceWorker,
+        reload,
+        shouldSkip: () => false,
+        updateCheckTimeoutMs: 1,
+        activationTimeoutMs: 50,
+      }),
+    ).resolves.toBe(false);
+
+    expect(reload).not.toHaveBeenCalled();
+    resolveUpdate(registration);
+  });
+
+  it('checks the skip predicate again before activating a found update', async () => {
+    const waiting = createWorker('installed');
+    const registration = createRegistration({ waiting: waiting.worker });
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+    const shouldSkip = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    await expect(
+      applyFreshLoadServiceWorkerUpdate({
+        serviceWorker,
+        reload,
+        shouldSkip,
+        updateCheckTimeoutMs: 50,
+        activationTimeoutMs: 50,
+      }),
+    ).resolves.toBe(false);
+
+    expect(waiting.postMessage).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
+++ b/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
@@ -200,6 +200,28 @@ describe('applyFreshLoadServiceWorkerUpdate', () => {
     resolveUpdate(registration);
   });
 
+  it('continues startup when the controller change times out', async () => {
+    const waiting = createWorker('installed');
+    const registration = createRegistration({ waiting: waiting.worker });
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+
+    await expect(
+      applyFreshLoadServiceWorkerUpdate({
+        serviceWorker,
+        reload,
+        shouldSkip: () => false,
+        updateCheckTimeoutMs: 50,
+        activationTimeoutMs: 1,
+      }),
+    ).resolves.toBe(false);
+
+    expect(waiting.postMessage).toHaveBeenCalledWith({
+      type: 'SKIP_WAITING',
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
   it('checks the skip predicate again before activating a found update', async () => {
     const waiting = createWorker('installed');
     const registration = createRegistration({ waiting: waiting.worker });

--- a/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
+++ b/packages/fresco-ui/src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts
@@ -223,4 +223,36 @@ describe('applyFreshLoadServiceWorkerUpdate', () => {
     expect(waiting.postMessage).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
   });
+
+  it('checks the skip predicate again after activation before reloading', async () => {
+    const waiting = createWorker('installed');
+    const registration = createRegistration({ waiting: waiting.worker });
+    const serviceWorker = createServiceWorkerContainer({ registration });
+    const reload = vi.fn();
+    const shouldSkip = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    const result = applyFreshLoadServiceWorkerUpdate({
+      serviceWorker,
+      reload,
+      shouldSkip,
+      updateCheckTimeoutMs: 50,
+      activationTimeoutMs: 50,
+    });
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+    expect(waiting.postMessage).toHaveBeenCalledWith({
+      type: 'SKIP_WAITING',
+    });
+
+    serviceWorker.dispatchControllerChange();
+
+    await expect(result).resolves.toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
 });

--- a/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
+++ b/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
@@ -1,0 +1,155 @@
+const SKIP_WAITING_MESSAGE = { type: 'SKIP_WAITING' } as const;
+const DEFAULT_UPDATE_CHECK_TIMEOUT_MS = 3_000;
+const DEFAULT_ACTIVATION_TIMEOUT_MS = 20_000;
+
+type ServiceWorkerContainerLike = Pick<
+  ServiceWorkerContainer,
+  'addEventListener' | 'controller' | 'getRegistration' | 'removeEventListener'
+>;
+
+type FreshLoadServiceWorkerUpdateOptions = {
+  updateCheckTimeoutMs?: number;
+  activationTimeoutMs?: number;
+  serviceWorker?: ServiceWorkerContainerLike;
+  reload?: () => void;
+  shouldSkip?: () => boolean;
+};
+
+function getServiceWorkerContainer(): ServiceWorkerContainerLike | undefined {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return undefined;
+  }
+  return navigator.serviceWorker;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: T,
+): Promise<T> {
+  return new Promise((resolve) => {
+    const timeoutId = window.setTimeout(() => resolve(fallback), timeoutMs);
+    void (async () => {
+      try {
+        const value = await promise;
+        window.clearTimeout(timeoutId);
+        resolve(value);
+      } catch {
+        window.clearTimeout(timeoutId);
+        resolve(fallback);
+      }
+    })();
+  });
+}
+
+function waitUntilInstalled(
+  worker: ServiceWorker,
+): Promise<ServiceWorker | null> {
+  if (worker.state === 'installed') return Promise.resolve(worker);
+  if (worker.state === 'activated' || worker.state === 'redundant') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const onStateChange = () => {
+      if (worker.state === 'installed') {
+        worker.removeEventListener('statechange', onStateChange);
+        resolve(worker);
+        return;
+      }
+
+      if (worker.state === 'activated' || worker.state === 'redundant') {
+        worker.removeEventListener('statechange', onStateChange);
+        resolve(null);
+      }
+    };
+
+    worker.addEventListener('statechange', onStateChange);
+  });
+}
+
+async function findWaitingWorker(
+  registration: ServiceWorkerRegistration,
+  updateCheckTimeoutMs: number,
+  activationTimeoutMs: number,
+): Promise<ServiceWorker | null> {
+  if (registration.waiting) return registration.waiting;
+
+  const updateChecked = await withTimeout(
+    registration.update(),
+    updateCheckTimeoutMs,
+    null,
+  );
+  if (!updateChecked) return null;
+
+  if (registration.waiting) return registration.waiting;
+  if (registration.installing) {
+    return withTimeout(
+      waitUntilInstalled(registration.installing),
+      activationTimeoutMs,
+      null,
+    );
+  }
+
+  return null;
+}
+
+function waitForControllerChange(
+  serviceWorker: ServiceWorkerContainerLike,
+  activationTimeoutMs: number,
+): Promise<boolean> {
+  return withTimeout(
+    new Promise<boolean>((resolve) => {
+      const onControllerChange = () => {
+        serviceWorker.removeEventListener(
+          'controllerchange',
+          onControllerChange,
+        );
+        resolve(true);
+      };
+
+      serviceWorker.addEventListener('controllerchange', onControllerChange, {
+        once: true,
+      });
+    }),
+    activationTimeoutMs,
+    false,
+  );
+}
+
+export async function applyFreshLoadServiceWorkerUpdate({
+  updateCheckTimeoutMs = DEFAULT_UPDATE_CHECK_TIMEOUT_MS,
+  activationTimeoutMs = DEFAULT_ACTIVATION_TIMEOUT_MS,
+  serviceWorker = getServiceWorkerContainer(),
+  reload = () => window.location.reload(),
+  shouldSkip = () => false,
+}: FreshLoadServiceWorkerUpdateOptions = {}): Promise<boolean> {
+  if (!serviceWorker || !serviceWorker.controller || shouldSkip()) {
+    return false;
+  }
+
+  const registration = await withTimeout(
+    serviceWorker.getRegistration(),
+    updateCheckTimeoutMs,
+    undefined,
+  );
+  if (!registration) return false;
+
+  const waitingWorker = await findWaitingWorker(
+    registration,
+    updateCheckTimeoutMs,
+    activationTimeoutMs,
+  );
+  if (!waitingWorker || shouldSkip()) return false;
+
+  const controllerChange = waitForControllerChange(
+    serviceWorker,
+    activationTimeoutMs,
+  );
+  waitingWorker.postMessage(SKIP_WAITING_MESSAGE);
+
+  if (!(await controllerChange)) return false;
+
+  reload();
+  return true;
+}

--- a/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
+++ b/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
@@ -4,7 +4,7 @@ const DEFAULT_ACTIVATION_TIMEOUT_MS = 20_000;
 
 type ServiceWorkerContainerLike = Pick<
   ServiceWorkerContainer,
-  'addEventListener' | 'controller' | 'getRegistration' | 'removeEventListener'
+  'addEventListener' | 'controller' | 'getRegistration'
 >;
 
 type FreshLoadServiceWorkerUpdateOptions = {
@@ -101,10 +101,6 @@ function waitForControllerChange(
   return withTimeout(
     new Promise<boolean>((resolve) => {
       const onControllerChange = () => {
-        serviceWorker.removeEventListener(
-          'controllerchange',
-          onControllerChange,
-        );
         resolve(true);
       };
 

--- a/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
+++ b/packages/fresco-ui/src/appUpdate/applyFreshLoadServiceWorkerUpdate.ts
@@ -149,6 +149,7 @@ export async function applyFreshLoadServiceWorkerUpdate({
   waitingWorker.postMessage(SKIP_WAITING_MESSAGE);
 
   if (!(await controllerChange)) return false;
+  if (shouldSkip()) return false;
 
   reload();
   return true;


### PR DESCRIPTION
## Summary
- add a shared Fresco app-start helper that applies a waiting service-worker update before React mounts on fresh controlled loads, with timeout fallbacks so offline launches continue
- use that helper in Interviewer and Architect while skipping active/critical flows and pending OS file-launch reads
- update both app service workers so online navigations fetch the latest HTML first, fully offline launches fall back to precached `index.html`, and old service workers do not cache new HTML against stale precached chunks

## Verification
- `node_modules/.bin/vitest run --project=unit -- src/appUpdate/__tests__/applyFreshLoadServiceWorkerUpdate.test.ts` from `packages/fresco-ui`
- `node_modules/.bin/vitest run src/lib/pwa/__tests__/fileLaunchQueue.test.ts` from `apps/interviewer`
- `node_modules/.bin/vitest run src/utils/__tests__/fileLaunchQueue.test.ts` from `apps/architect`
- `node_modules/.bin/tsc --build apps/interviewer/tsconfig.json --noEmit`
- `node_modules/.bin/tsc --build apps/architect/tsconfig.json --noEmit`
- `node_modules/.bin/tsc --build packages/fresco-ui/tsconfig.json --noEmit`
- `node_modules/.bin/tsc -p packages/fresco-ui/tsconfig.node.json --noEmit`
- `node_modules/.bin/vite build && node scripts/assert-pwa-build.mjs` from `apps/interviewer`
- `node_modules/.bin/vite build && node scripts/assert-pwa-build.mjs` from `apps/architect`
- `node scripts/check-changeset-app-isolation.mjs`
- `node_modules/.bin/oxfmt --check` on changed files
- `node_modules/.bin/oxlint` on changed files
- `git diff --check`

CI is being monitored on this PR. The current `interview-e2e` rerun was requested after low-pixel SILOS visual snapshot diffs that do not line up with the PWA update path.
