### PR TITLE
fix(interview): restore nav icon width

### DIFF
--- a/.changeset/fix-interview-nav-icon-width.md
+++ b/.changeset/fix-interview-nav-icon-width.md
@@ -2,4 +2,4 @@
 '@codaco/fresco-ui': patch
 ---
 
-Restore proportional Lucide icon width for shared controls so interview navigation and map controls match established visual snapshots.
+Restore proportional Lucide icon sizing for shared controls so interview navigation and map controls match established visual snapshots.

--- a/.changeset/fix-interview-nav-icon-width.md
+++ b/.changeset/fix-interview-nav-icon-width.md
@@ -1,5 +1,5 @@
 ---
-'@codaco/interview': patch
+'@codaco/fresco-ui': patch
 ---
 
-Restore interview navigation icon sizing to match the established visual layout.
+Restore proportional Lucide icon width for shared controls so interview navigation and map controls match established visual snapshots.

--- a/.changeset/fix-interview-nav-icon-width.md
+++ b/.changeset/fix-interview-nav-icon-width.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Restore interview navigation icon sizing to match the established visual layout.

--- a/packages/fresco-ui/src/styles/controlVariants.ts
+++ b/packages/fresco-ui/src/styles/controlVariants.ts
@@ -144,9 +144,9 @@ export const heightVariants = cva({
   },
 });
 
-// Set child SVG icons slightly above 1em to match text height.
+// Keep Lucide icons at text height while preserving their intrinsic ratio.
 export const proportionalLucideIconVariants = cva({
-  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:w-[1.2em] [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
+  base: '[&>.lucide]:h-[1em] [&>.lucide]:max-h-full [&>.lucide]:w-auto [&>.lucide]:shrink-0',
 });
 
 // adds background and border styles for input-like controls

--- a/packages/fresco-ui/src/styles/controlVariants.ts
+++ b/packages/fresco-ui/src/styles/controlVariants.ts
@@ -144,9 +144,9 @@ export const heightVariants = cva({
   },
 });
 
-// Set child SVG icon height slightly above 1em while preserving consumer width overrides
+// Set child SVG icons slightly above 1em to match text height.
 export const proportionalLucideIconVariants = cva({
-  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
+  base: '[&>.lucide]:h-[1.2em] [&>.lucide]:max-h-full [&>.lucide]:w-[1.2em] [&>.lucide]:shrink-0 [&>.lucide]:stroke-[2.5]',
 });
 
 // adds background and border styles for input-like controls

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -79,7 +79,7 @@ const NavigationButton = ({
         ref={buttonRef}
         color="dynamic"
         variant="text"
-        className={cx('[&>.lucide]:h-[2em] [&>.lucide]:w-[1.2em]', className)}
+        className={cx('[&>.lucide]:h-[2em]', className)}
         disabled={disabled}
         {...props}
         size="xl"

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -79,7 +79,7 @@ const NavigationButton = ({
         ref={buttonRef}
         color="dynamic"
         variant="text"
-        className={cx('[&>.lucide]:h-[2em]', className)}
+        className={cx('[&>.lucide]:h-[2em] [&>.lucide]:w-[1.2em]', className)}
         disabled={disabled}
         {...props}
         size="xl"


### PR DESCRIPTION
## Summary
- restore the interview navigation chevron width that was previously inherited from Fresco button icon sizing
- add a patch changeset for @codaco/interview

## Test plan
- pnpm typecheck
- pnpm check:changesets
- pnpm lint
- pnpm knip
- pnpm --filter @codaco/interview exec playwright test --config e2e/playwright.config.ts --project=chromium -g "Stage 0: Welcome"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored the intended width of icons in interview navigation controls.
  - Improved visual consistency by ensuring navigation icons maintain the established layout proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->