### PR TITLE
Keep interview reloads on active app shell

### DIFF
--- a/.changeset/fresh-load-app-shells.md
+++ b/.changeset/fresh-load-app-shells.md
@@ -3,4 +3,4 @@
 '@codaco/interviewer': patch
 ---
 
-Load the newest app shell on fresh online launches while preserving the precached offline startup path.
+Load the newest app shell on fresh online launches while preserving the precached offline startup path and keeping in-progress interviews on the active offline-safe shell.

--- a/apps/interviewer/scripts/assert-pwa-build.mjs
+++ b/apps/interviewer/scripts/assert-pwa-build.mjs
@@ -71,6 +71,40 @@ if (excluded.length > 0) {
   fail(`critical chunk(s) excluded from precache: ${excluded.join(', ')}`);
 }
 
+const interviewRouteMatches = [
+  ...sw.matchAll(/!?[$\w]+\.pathname\.startsWith\("\/interview\/"\)/g),
+];
+const interviewCacheRoute = interviewRouteMatches.find(
+  (match) => !match[0].startsWith('!'),
+);
+const freshShellRoute = interviewRouteMatches.find((match) =>
+  match[0].startsWith('!'),
+);
+if (!interviewCacheRoute) {
+  fail('missing /interview/ precached-shell navigation route');
+}
+if (!freshShellRoute) {
+  fail('fresh-shell navigation route does not exclude /interview/');
+}
+if (
+  interviewCacheRoute.index === undefined ||
+  freshShellRoute.index === undefined ||
+  interviewCacheRoute.index > freshShellRoute.index
+) {
+  fail('/interview/ navigation route must run before fresh-shell route');
+}
+
+const interviewFallbackIndex = sw.indexOf(
+  'new URL("index.html"',
+  interviewCacheRoute.index,
+);
+if (
+  interviewFallbackIndex === -1 ||
+  interviewFallbackIndex > freshShellRoute.index
+) {
+  fail('/interview/ navigation route must fall back to precached index.html');
+}
+
 console.log(
   `PWA build ok: sw.js + manifest + icons emitted; ${critical.length} critical chunk(s) precached`,
 );

--- a/apps/interviewer/vite.config.ts
+++ b/apps/interviewer/vite.config.ts
@@ -73,14 +73,60 @@ export default defineConfig(() =>
           maximumFileSizeToCacheInBytes: MAX_PRECACHE_BYTES,
           runtimeCaching: [
             {
+              // Active interviews deliberately skip update activation to avoid
+              // interrupting participants. Keep those navigations on the
+              // active worker's precached shell so its HTML and hashed chunks
+              // stay from the same deploy, including after a controlled reload
+              // or deep link under /interview/.
+              urlPattern: ({ request, sameOrigin, url }) =>
+                sameOrigin &&
+                request.mode === 'navigate' &&
+                url.pathname.startsWith('/interview/'),
+              handler: async () => {
+                const cacheStorage: unknown = Reflect.get(globalThis, 'caches');
+                const serviceWorkerLocation: unknown = Reflect.get(
+                  globalThis,
+                  'location',
+                );
+                const cacheMatch: unknown =
+                  typeof cacheStorage === 'object' && cacheStorage !== null
+                    ? Reflect.get(cacheStorage, 'match')
+                    : undefined;
+                const locationHref: unknown =
+                  typeof serviceWorkerLocation === 'object' &&
+                  serviceWorkerLocation !== null
+                    ? Reflect.get(serviceWorkerLocation, 'href')
+                    : undefined;
+
+                if (
+                  typeof cacheMatch !== 'function' ||
+                  typeof locationHref !== 'string'
+                ) {
+                  throw new Error('Unable to read precached interview shell');
+                }
+
+                const fallback: unknown = await cacheMatch.call(
+                  cacheStorage,
+                  new URL('index.html', locationHref).href,
+                  { ignoreSearch: true },
+                );
+                if (fallback instanceof Response) return fallback;
+                throw new Error('Missing precached interview shell');
+              },
+            },
+            {
               // The app shell must be fresh when the app is launched online:
               // a cache-first navigation fallback would render the old HTML
               // first, then refresh once the service-worker update finished.
               // The handler keeps offline launch via the precached fallback
               // while preventing a still-old service worker from caching new
-              // HTML whose matching hashed chunks it has not precached.
-              urlPattern: ({ request, sameOrigin }) =>
-                sameOrigin && request.mode === 'navigate',
+              // HTML whose matching hashed chunks it has not precached. The
+              // /interview/ route above is intentionally excluded because it
+              // cannot activate an update without interrupting an interview.
+              urlPattern: ({ request, sameOrigin, url }) =>
+                sameOrigin &&
+                request.mode === 'navigate' &&
+                !url.pathname.startsWith('/interview/'),
               handler: async ({ request }) => {
                 let timeoutId: ReturnType<typeof setTimeout> | undefined;
 


### PR DESCRIPTION
## Summary
- serve `/interview/` navigations from the active service worker's precached `index.html` so reloads/deep links during an interview do not pair new HTML with an old worker
- keep the fresh app-shell network path for non-interview launches only
- extend the Interviewer PWA build assertion to verify the generated service worker keeps `/interview/` before the fresh-shell route

## Verification
- `node_modules/.bin/tsc --build apps/interviewer/tsconfig.json --noEmit`
- `node_modules/.bin/oxlint apps/interviewer/vite.config.ts apps/interviewer/scripts/assert-pwa-build.mjs`
- `node scripts/check-changeset-app-isolation.mjs`
- `node_modules/.bin/vite build` from `apps/interviewer`
- `node scripts/assert-pwa-build.mjs` from `apps/interviewer`
- `git diff --check`
- pre-push hook strict checks passed locally after refreshing generated protocol-validation declarations

Note: a direct push to `main` was attempted as requested, but GitHub repository rules reject direct main updates and require PR + required checks + merge queue.
