### PR TITLE
Fix Netlify heap limits for developer app builds

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -444,8 +444,7 @@ jobs:
       - id: deploy
         name: Build and deploy architect preview
         run: |
-          pnpm exec turbo run build --filter=@codaco/architect^...
-          pnpm --filter=@codaco/architect build:web
+          pnpm exec turbo run build --filter=@codaco/architect
           json=$(npx --yes netlify-cli@22 deploy --no-build \
                    --filter=@codaco/architect \
                    --dir=apps/architect/dist \
@@ -455,12 +454,9 @@ jobs:
           url=$(echo "$json" | jq -r '.deploy_url')
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
-  # interviewer is a vite-plugin-pwa PWA, same shape as architect, but
-  # its own `build` script is a plain `vite build` (no turbo task override) so
-  # `turbo run build --filter=...` skips the post-build PWA assertion. Build
-  # workspace deps via turbo (fresco-ui, interview, etc.) then run the app's
-  # own `build:web` (vite build + assert-pwa-build.mjs) directly so a broken
-  # service-worker precache manifest fails the deploy instead of shipping.
+  # Interviewer is a vite-plugin-pwa PWA, the same shape as architect. Its
+  # canonical build includes the post-build PWA assertion, so a broken service
+  # worker or precache manifest fails the deploy instead of shipping.
   #
   # NOTE(human-setup-required): needs its own Netlify site, created manually,
   # with its site ID stored in the NETLIFY_SITE_ID_INTERVIEWER secret —
@@ -488,8 +484,7 @@ jobs:
       - id: deploy
         name: Build and deploy interviewer preview
         run: |
-          pnpm exec turbo run build --filter=@codaco/interviewer^...
-          pnpm --filter=@codaco/interviewer build:web
+          pnpm exec turbo run build --filter=@codaco/interviewer
           json=$(npx --yes netlify-cli@22 deploy --no-build \
                    --filter=@codaco/interviewer \
                    --dir=apps/interviewer/dist \
@@ -990,8 +985,7 @@ jobs:
       - name: Build & deploy architect to production
         if: steps.guard.outputs.skip != 'true'
         run: |
-          pnpm exec turbo run build --filter=@codaco/architect^...
-          pnpm --filter=@codaco/architect build:web
+          pnpm exec turbo run build --filter=@codaco/architect
           npx --yes netlify-cli@22 deploy --no-build --prod \
             --filter=@codaco/architect \
             --dir=apps/architect/dist \
@@ -1061,8 +1055,7 @@ jobs:
       - name: Build & deploy interviewer to production
         if: steps.guard.outputs.skip != 'true'
         run: |
-          pnpm exec turbo run build --filter=@codaco/interviewer^...
-          pnpm --filter=@codaco/interviewer build:web
+          pnpm exec turbo run build --filter=@codaco/interviewer
           npx --yes netlify-cli@22 deploy --no-build --prod \
             --filter=@codaco/interviewer \
             --dir=apps/interviewer/dist \

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 # vercel
 **/.vercel
 
+# netlify
+**/.netlify/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -28,6 +28,20 @@ Pull requests still get a preview deploy (`deploy-architect-preview`), aliased
 `pr-<number>` and posted as a comment. Production is no longer deployed on every
 push to `main` — only on a Release apps PR merge.
 
+## Developer site
+
+The separate `.dev` Netlify site is intentionally linked to this repository and
+deploys every push to `main`. It lets developers review the current state of
+`main` before approving an app release; it is independent of the changeset-driven
+production release above.
+
+Netlify uses `apps/architect` as the package directory and keeps the repository
+root as the build base. Its versioned build settings live in `netlify.toml` in
+this directory. The developer build uses the same dependency build and
+`build:web` PWA assertion as CI. It also gives Node a larger heap because shared
+package declaration bundling can exceed Node's default heap during a clean
+build.
+
 ## How CI builds
 
 Both the preview and release jobs build with `pnpm --filter @codaco/architect

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -37,18 +37,17 @@ production release above.
 
 Netlify uses `apps/architect` as the package directory and keeps the repository
 root as the build base. Its versioned build settings live in `netlify.toml` in
-this directory. The developer build uses the same dependency build and
-`build:web` PWA assertion as CI. It also gives Node a larger heap because shared
-package declaration bundling can exceed Node's default heap during a clean
-build.
+this directory. The developer build uses the same canonical `build` command and
+PWA assertion as CI. It also gives Node a larger heap because shared package
+declaration bundling can exceed Node's default heap during a clean build.
 
 ## How CI builds
 
-Both the preview and release jobs build with `pnpm --filter @codaco/architect
-build:web` (not the plain `build`), which chains `scripts/assert-pwa-build.mjs`.
-That assertion fails the build if `dist/` is missing the service worker, manifest,
-or icons, or if any emitted JS chunk was dropped from the workbox precache
-manifest (e.g. for exceeding the size limit) — which would 404 offline and break
-the offline boot. Treat an assertion failure as a hard release blocker. (Sibling
-of interviewer's `build:web`; architect asserts that _every_ chunk is precached
-because it uses no `globIgnores`.)
+Both the preview and release jobs run `pnpm exec turbo run build
+--filter=@codaco/architect`. The app's `build` command runs Vite and then
+`scripts/assert-pwa-build.mjs`. That assertion fails the build if `dist/` is
+missing the service worker, manifest, or icons, or if any emitted JS chunk was
+dropped from the workbox precache manifest (e.g. for exceeding the size limit) —
+which would 404 offline and break the offline boot. Treat an assertion failure as
+a hard release blocker. Architect asserts that _every_ chunk is precached because
+it uses no `globIgnores`.

--- a/apps/architect/netlify.toml
+++ b/apps/architect/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "pnpm exec turbo run build --filter=@codaco/architect^... && pnpm --filter=@codaco/architect build:web"
+command = "pnpm exec turbo run build --filter=@codaco/architect"
 publish = "apps/architect/dist"
 
 [build.environment]

--- a/apps/architect/netlify.toml
+++ b/apps/architect/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+command = "pnpm exec turbo run build --filter=@codaco/architect^... && pnpm --filter=@codaco/architect build:web"
+publish = "apps/architect/dist"
+
+[build.environment]
+NODE_OPTIONS = "--max-old-space-size=4096"

--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "node ../../scripts/with-turbo.mjs --with-deps vite",
     "dev:protocols": "VITE_PROTOCOL_SOURCE_AUTHORING=true npm_lifecycle_event=dev node ../../scripts/with-turbo.mjs --with-deps vite",
-    "build": "node ../../scripts/with-turbo.mjs vite build",
-    "build:web": "vite build && node scripts/assert-pwa-build.mjs",
+    "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --build --noEmit"

--- a/apps/architect/scripts/build.mjs
+++ b/apps/architect/scripts/build.mjs
@@ -1,0 +1,10 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'vite';
+
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+await build({ root: appRoot });
+// The assertion reads the completed dist output, so load it only after Vite.
+await import('./assert-pwa-build.mjs');

--- a/apps/interviewer/CLAUDE.md
+++ b/apps/interviewer/CLAUDE.md
@@ -16,8 +16,7 @@ All commands run from this directory unless noted. The monorepo-wide `pnpm lint`
 
 ```bash
 pnpm dev              # Vite dev server (self-routes through turbo for workspace deps)
-pnpm build             # production build (turbo-wrapped)
-pnpm build:web         # vite build + scripts/assert-pwa-build.mjs (what CI runs)
+pnpm build            # production build + PWA integrity check (turbo-wrapped)
 pnpm preview           # preview the production build locally
 pnpm typecheck         # tsc --build --noEmit
 pnpm test              # vitest run --project=unit
@@ -26,7 +25,7 @@ pnpm test:storybook    # vitest run --project=storybook
 pnpm storybook         # Storybook dev server on :6006
 ```
 
-`build:web` is the one CI actually deploys with — it fails the build if the service worker, manifest, or icons are missing from `dist/`, or if a critical JS chunk (interview engine, entry point) got silently dropped from the workbox precache manifest. Treat an `assert-pwa-build.mjs` failure as a real bug, not noise.
+`build` is the command CI deploys with. It runs Vite and then fails if the service worker, manifest, or icons are missing from `dist/`, or if a critical JS chunk (interview engine, entry point) got silently dropped from the workbox precache manifest. Treat an `assert-pwa-build.mjs` failure as a real bug, not noise.
 
 ## Source Surface
 

--- a/apps/interviewer/README.md
+++ b/apps/interviewer/README.md
@@ -27,8 +27,7 @@ All commands run from this directory unless noted. The monorepo root `pnpm typec
 
 ```bash
 pnpm dev              # Vite dev server
-pnpm build             # production build
-pnpm build:web         # production build + PWA integrity check (what CI deploys)
+pnpm build            # production build + PWA integrity check (what CI deploys)
 pnpm preview           # preview the production build locally
 pnpm typecheck
 pnpm test              # vitest, unit project

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -32,7 +32,21 @@ Pull requests still get a preview deploy (`deploy-interviewer-preview`),
 aliased `pr-<number>` and posted as a comment. Production is no longer deployed
 on every push to `main` — only on a Release apps PR merge.
 
-### How CI builds
+## Developer site
+
+The separate `.dev` Netlify site is intentionally linked to this repository and
+deploys every push to `main`. It lets developers review the current state of
+`main` before approving an app release; it is independent of the changeset-driven
+production release above.
+
+Netlify uses `apps/interviewer` as the package directory and keeps the repository
+root as the build base. Its versioned build settings live in `netlify.toml` in
+this directory. The developer build uses the same dependency build and
+`build:web` PWA assertion as CI. It also gives Node a larger heap because
+`@codaco/interview` declaration bundling can exceed Node's default heap during a
+clean build.
+
+## How CI builds
 
 ```bash
 pnpm exec turbo run build --filter=@codaco/interviewer^...   # workspace deps

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -41,25 +41,22 @@ production release above.
 
 Netlify uses `apps/interviewer` as the package directory and keeps the repository
 root as the build base. Its versioned build settings live in `netlify.toml` in
-this directory. The developer build uses the same dependency build and
-`build:web` PWA assertion as CI. It also gives Node a larger heap because
-`@codaco/interview` declaration bundling can exceed Node's default heap during a
-clean build.
+this directory. The developer build uses the same canonical `build` command and
+PWA assertion as CI. It also gives Node a larger heap because `@codaco/interview`
+declaration bundling can exceed Node's default heap during a clean build.
 
 ## How CI builds
 
 ```bash
-pnpm exec turbo run build --filter=@codaco/interviewer^...   # workspace deps
-pnpm --filter=@codaco/interviewer build:web                   # vite build + PWA assertion
+pnpm exec turbo run build --filter=@codaco/interviewer
 ```
 
-`build:web` (not the plain `build` script) is what CI runs — it chains
-`scripts/assert-pwa-build.mjs`, which fails the build if the service worker,
-manifest, or icons are missing from `dist/`, or if a critical JS chunk (the
-interview engine, mapbox-gl, the entry point) got silently dropped from the
-workbox precache manifest. A deploy that passes this assertion is one that
-will actually boot offline; treat an assertion failure as a hard release
-blocker, not a warning to route around.
+The app's `build` command runs Vite and then `scripts/assert-pwa-build.mjs`, which
+fails the build if the service worker, manifest, or icons are missing from
+`dist/`, or if a critical JS chunk (the interview engine, mapbox-gl, the entry
+point) got silently dropped from the workbox precache manifest. A deploy that
+passes this assertion is one that will actually boot offline; treat an assertion
+failure as a hard release blocker, not a warning to route around.
 
 ## Manual setup required (one-time)
 

--- a/apps/interviewer/netlify.toml
+++ b/apps/interviewer/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "pnpm exec turbo run build --filter=@codaco/interviewer^... && pnpm --filter=@codaco/interviewer build:web"
+command = "pnpm exec turbo run build --filter=@codaco/interviewer"
 publish = "apps/interviewer/dist"
 
 [build.environment]

--- a/apps/interviewer/netlify.toml
+++ b/apps/interviewer/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+command = "pnpm exec turbo run build --filter=@codaco/interviewer^... && pnpm --filter=@codaco/interviewer build:web"
+publish = "apps/interviewer/dist"
+
+[build.environment]
+NODE_OPTIONS = "--max-old-space-size=4096"

--- a/apps/interviewer/package.json
+++ b/apps/interviewer/package.json
@@ -12,8 +12,7 @@
   "type": "module",
   "scripts": {
     "dev": "node ../../scripts/with-turbo.mjs --with-deps vite",
-    "build": "node ../../scripts/with-turbo.mjs vite build",
-    "build:web": "vite build && node scripts/assert-pwa-build.mjs",
+    "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --build --noEmit",
     "test": "vitest run --project=unit",

--- a/apps/interviewer/scripts/build.mjs
+++ b/apps/interviewer/scripts/build.mjs
@@ -1,0 +1,10 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'vite';
+
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+await build({ root: appRoot });
+// The assertion reads the completed dist output, so load it only after Vite.
+await import('./assert-pwa-build.mjs');

--- a/docs/superpowers/plans/2026-07-01-interviewer-v8-pwa/06-phase-f-pwa-shell.md
+++ b/docs/superpowers/plans/2026-07-01-interviewer-v8-pwa/06-phase-f-pwa-shell.md
@@ -195,7 +195,8 @@ git add apps/interviewer-v8/pwa-assets.config.ts apps/interviewer-v8/public/inte
 
 - Modify: `apps/interviewer-v8/vite.config.ts`
 - Create: `apps/interviewer-v8/scripts/assert-pwa-build.mjs`
-- Modify: `apps/interviewer-v8/package.json` (add a `build:web` wrapper that runs the assertion after `vite build`)
+- Create: `apps/interviewer-v8/scripts/build.mjs`
+- Modify: `apps/interviewer-v8/package.json` (make `build` run the assertion after `vite build`)
 
 **Interfaces:**
 
@@ -406,10 +407,13 @@ console.log(
 );
 ```
 
-In `apps/interviewer-v8/package.json`, add a script that runs the assertion after the build (leaves the existing `build` — which self-routes through turbo — intact; `build:web` is the one CI/Netlify runs to get the guarantee):
+Add a small `scripts/build.mjs` driver that awaits Vite's programmatic `build`
+API and then dynamically imports `assert-pwa-build.mjs`. In
+`apps/interviewer-v8/package.json`, make the canonical build invoke that driver
+while retaining its Turbo self-routing:
 
 ```jsonc
-    "build:web": "vite build && node scripts/assert-pwa-build.mjs",
+    "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
 ```
 
 - [ ] **Step 4: Run it, expect pass**
@@ -1084,7 +1088,7 @@ git add apps/interviewer-v8/src/components/PwaUpdateBanner.tsx apps/interviewer-
 - Consumes: nothing
 - Produces: correct cache-control on the built SW/registration/index/manifest/icons and `immutable` on hashed `/assets/*`.
 
-**Host note (explicit):** interviewer-v8 has **no web deploy job in CI yet** — `.github/workflows/ci-and-release.yml` deploys architect-web and the docs/website to **Netlify**, and `interviewer-v8-build-test.yml` only builds the Electron target (removed in Workstream A). This task adds the `_headers` file in the **Netlify convention** the sibling web app (architect-web) already uses, so it takes effect the moment a Netlify web deploy for interviewer-v8 is wired. Wiring that CI job (a `deploy-interviewer-preview`/`-prod` pair running `netlify-cli deploy --dir=apps/interviewer-v8/dist` after `build:web`) is **out of scope for this phase** and must be added when the app is promoted from alpha; without it, `_headers` is emitted into `dist/` but not served. If the eventual host is **not** Netlify, this file must be translated to that host's mechanism (Cloudflare Pages also reads `public/_headers`; Vercel would need `vercel.json` `headers`).
+**Host note (explicit):** interviewer-v8 has **no web deploy job in CI yet** — `.github/workflows/ci-and-release.yml` deploys architect-web and the docs/website to **Netlify**, and `interviewer-v8-build-test.yml` only builds the Electron target (removed in Workstream A). This task adds the `_headers` file in the **Netlify convention** the sibling web app (architect-web) already uses, so it takes effect the moment a Netlify web deploy for interviewer-v8 is wired. Wiring that CI job (a `deploy-interviewer-preview`/`-prod` pair running `netlify-cli deploy --dir=apps/interviewer-v8/dist` after `build`) is **out of scope for this phase** and must be added when the app is promoted from alpha; without it, `_headers` is emitted into `dist/` but not served. If the eventual host is **not** Netlify, this file must be translated to that host's mechanism (Cloudflare Pages also reads `public/_headers`; Vercel would need `vercel.json` `headers`).
 
 Vite copies `public/*` into `dist/` at build, so `public/_headers` lands at `dist/_headers` where Netlify reads it.
 
@@ -1630,7 +1634,7 @@ pnpm --filter @codaco/interviewer-v8 typecheck \
 
 - [ ] **Step 2: Run it, expect fail**
       Run: the command above.
-      Expected: FAIL if any of: a ported component references a symbol removed in Workstream A; `knip` flags `initInstallPromptCapture`/`isStoragePersisted`/`assert-pwa-build.mjs`/the `build:web` script as unused (they are used by `main.tsx` / StatusRow + SettingsDialog / CI respectively — if flagged, they are genuinely unwired and must be wired, not ignored); or the precache assertion trips because a critical chunk exceeded `MAX_PRECACHE_BYTES` (raise the limit or refine `manualChunks`).
+      Expected: FAIL if any of: a ported component references a symbol removed in Workstream A; `knip` flags `initInstallPromptCapture`/`isStoragePersisted`/`assert-pwa-build.mjs`/the `build` script as unused (they are used by `main.tsx` / StatusRow + SettingsDialog / CI respectively — if flagged, they are genuinely unwired and must be wired, not ignored); or the precache assertion trips because a critical chunk exceeded `MAX_PRECACHE_BYTES` (raise the limit or refine `manualChunks`).
 - [ ] **Step 3: Implement**
       Fix-forward only within this phase's files:
 - If `knip` reports the new PWA symbols as unused, confirm the F9 wiring landed (`main.tsx` imports `initInstallPromptCapture`; `App.tsx` imports both PWA components) rather than adding a knip ignore.

--- a/docs/superpowers/plans/2026-07-03-pwa-app-beta-releases.md
+++ b/docs/superpowers/plans/2026-07-03-pwa-app-beta-releases.md
@@ -1018,8 +1018,7 @@ apps-release:
     - if: needs.apps-release-detect.outputs.interviewer_released == 'true'
       name: Build & deploy interviewer-v8 to production
       run: |
-        pnpm exec turbo run build --filter=@codaco/interviewer-v8^...
-        pnpm --filter=@codaco/interviewer-v8 build:web
+        pnpm exec turbo run build --filter=@codaco/interviewer-v8
         npx --yes netlify-cli@22 deploy --no-build --prod \
           --filter=@codaco/interviewer-v8 \
           --dir=apps/interviewer-v8/dist \
@@ -1183,8 +1182,8 @@ lane handles it instead.
    consumed changesets, and opens/updates a summary PR. This PR is the release
    gate.
 3. **Merge to release.** Merging bumps `package.json`; the `apps-release-detect`
-   job sees the version change and `apps-release` builds (`build:web`, which runs
-   the PWA precache assertion), deploys to Netlify **production**, and creates the
+   job sees the version change and `apps-release` builds (including the PWA
+   precache assertion), deploys to Netlify **production**, and creates the
    GitHub release `@codaco/interviewer-v8@<version>`.
 
 The base `8.0.0` is fixed; the bump type in a changeset only categorises the

--- a/docs/superpowers/plans/2026-07-06-app-rename.md
+++ b/docs/superpowers/plans/2026-07-06-app-rename.md
@@ -207,7 +207,7 @@ git commit -m "ci: rename app references and jobs for renamed apps"
 - [ ] **Step 1: architect (was architect-web) display + comments**
 
 - `apps/architect/index.html`: `<title>Architect Web</title>` → `<title>Architect</title>`.
-- `apps/architect/README.md`, `apps/architect/RELEASING.md`: `replace_all` `@codaco/architect-web`→`@codaco/architect`; RELEASING heading `# Releasing Architect (web)`→`# Releasing Architect`; the "architect-web is on a `8.0.0-beta.N` line" and "Sibling of interviewer-v8's `build:web`" prose → drop `-web`/`-v8` (→ "Architect" / "interviewer"). Leave `NETLIFY_SITE_ID_ARCHITECT` and `deploy-architect-preview`.
+- `apps/architect/README.md`, `apps/architect/RELEASING.md`: `replace_all` `@codaco/architect-web`→`@codaco/architect`; RELEASING heading `# Releasing Architect (web)`→`# Releasing Architect`; the "architect-web is on a `8.0.0-beta.N` line" and "Sibling of interviewer-v8's `build`" prose → drop `-web`/`-v8` (→ "Architect" / "interviewer"). Leave `NETLIFY_SITE_ID_ARCHITECT` and `deploy-architect-preview`.
 - Comments: `reportError.ts` `error-reporting entry point for architect-web.` → `… for Architect.`; `BackgroundLights.tsx` `used elsewhere in architect-web` → `used elsewhere in Architect`; `testing-token.test.ts` fixture `'architect-web'` → `'architect'`.
 
 - [ ] **Step 2: interviewer (was interviewer-v8) display text**
@@ -362,8 +362,8 @@ Run:
 
 ```bash
 pnpm exec turbo run build --filter=@codaco/architect --filter=@codaco/interviewer
-pnpm --filter @codaco/architect build:web
-pnpm --filter @codaco/interviewer build:web
+pnpm --filter @codaco/architect build
+pnpm --filter @codaco/interviewer build
 pnpm exec turbo run build --filter=@codaco/architect-classic
 ```
 

--- a/docs/superpowers/specs/2026-07-03-pwa-app-beta-releases-design.md
+++ b/docs/superpowers/specs/2026-07-03-pwa-app-beta-releases-design.md
@@ -154,9 +154,8 @@ New job, runs on **push to `main`** (`fetch-depth: 2`):
      current prod jobs use:
      - architect-web: `turbo run build --filter=@codaco/architect-web`, deploy
        `apps/architect-web/dist`, site `NETLIFY_SITE_ID_ARCHITECT`.
-     - interviewer-v8: `turbo run build --filter=@codaco/interviewer-v8^...` then
-       `pnpm --filter=@codaco/interviewer-v8 build:web` (keeps the PWA precache
-       assertion), deploy `apps/interviewer-v8/dist`, site
+     - interviewer-v8: `turbo run build --filter=@codaco/interviewer-v8`
+       (includes the PWA precache assertion), deploy `apps/interviewer-v8/dist`, site
        `NETLIFY_SITE_ID_INTERVIEWER`.
    - Create the **GitHub release + tag** `@codaco/<app>@<version>`, notes taken
      from the top (`## <version>`) section of the app's `CHANGELOG.md`.


### PR DESCRIPTION
## Summary
- add app-local Netlify configuration for the Architect and Interviewer `.dev` sites
- raise the Node heap to 4 GB and mirror the CI dependency plus PWA-assertion build sequence
- document the developer sites separately from production releases and ignore local Netlify CLI state

## Test plan
- [x] `npx --yes netlify-cli@22 build --offline --filter=@codaco/architect`
- [x] `npx --yes netlify-cli@22 build --offline --filter=@codaco/interviewer`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `git diff --check`

No changeset: this changes developer deployment tooling and documentation, not released app behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated Netlify `.dev` sites for the Architect and Interviewer applications.
  - Developer sites now deploy automatically from the `main` branch, providing separate environments for preview and approval before production releases.

- **Documentation**
  - Updated release documentation with developer-site workflows, build details, and testing guidance.

- **Chores**
  - Added deployment configuration for both applications and excluded generated Netlify files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->