### PR TITLE
Add @codaco/tailwind-config to NodeNext declaration specifiers changeset

### DIFF
--- a/.changeset/node-next-declaration-specifiers.md
+++ b/.changeset/node-next-declaration-specifiers.md
@@ -1,0 +1,7 @@
+---
+'@codaco/interview': patch
+'@codaco/protocol-validation': patch
+'@codaco/tailwind-config': patch
+---
+
+Emit NodeNext-compatible relative module specifiers in generated declaration files so TypeScript consumers can resolve package types without a bundled declaration rollup.


### PR DESCRIPTION
### Motivation
- Ensure the Tailwind config package is included in the library changeset so released packages emit NodeNext-compatible relative module specifiers and TypeScript consumers can resolve types correctly.

### Description
- Add `.changeset/node-next-declaration-specifiers.md` which includes `@codaco/tailwind-config` alongside `@codaco/interview` and `@codaco/protocol-validation` and explains the rationale.

### Testing
- Ran `pnpm check:changesets` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a538409898483279631e450f8e13d68)