### PR TITLE
fix(interviewer): allow roster blob URLs

### DIFF
--- a/.changeset/fix-interviewer-roster-csp.md
+++ b/.changeset/fix-interviewer-roster-csp.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Fix roster name generator stages failing to load roster data in Interviewer.

--- a/apps/interviewer/src/__tests__/vite.renderer.config.test.ts
+++ b/apps/interviewer/src/__tests__/vite.renderer.config.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { CSP_DIRECTIVES } from '../../vite.renderer.config';
+
+describe('production content security policy', () => {
+  it('permits fetching protocol asset object URLs', () => {
+    expect(CSP_DIRECTIVES).toContain(
+      "connect-src 'self' https://api.github.com https://api.mapbox.com https://events.mapbox.com https://ph-relay.networkcanvas.com blob:",
+    );
+  });
+});

--- a/apps/interviewer/vite.renderer.config.ts
+++ b/apps/interviewer/vite.renderer.config.ts
@@ -57,8 +57,9 @@ const appVersion = JSON.parse(
 // mapbox-gl fetches styles/tiles/glyphs from api.mapbox.com and posts telemetry
 // to events.mapbox.com (Geospatial stages), analytics posts to the PostHog
 // relay, and the app-update indicator fetches release notes from
-// api.github.com. Everything else stays 'self'.
-const CSP_DIRECTIVES = [
+// api.github.com. Protocol roster assets use blob: object URLs. Everything
+// else stays 'self'.
+export const CSP_DIRECTIVES = [
   "default-src 'self'",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
@@ -67,7 +68,7 @@ const CSP_DIRECTIVES = [
   // URLs, so media needs blob: (default-src 'self' would otherwise block it).
   "media-src 'self' blob:",
   "font-src 'self' data:",
-  `connect-src 'self' https://api.github.com https://api.mapbox.com https://events.mapbox.com ${POSTHOG_RELAY_ORIGIN}`,
+  `connect-src 'self' https://api.github.com https://api.mapbox.com https://events.mapbox.com ${POSTHOG_RELAY_ORIGIN} blob:`,
   "worker-src 'self' blob:",
   "base-uri 'none'",
   "object-src 'none'",


### PR DESCRIPTION
Fixes name-generator roster loading blocked by the production CSP. Adds a regression test and interviewer app release note. Verified with pnpm lint:fix, pnpm typecheck, pnpm knip, pnpm test, and the interviewer build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue preventing roster name generator stages from loading roster data.
  - Improved compatibility with roster assets fetched through GitHub protocols.
- **Tests**
  - Added coverage to verify the application’s security policy permits required roster asset connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->