### PR TITLE
Add configurable network weave background

### DIFF
--- a/packages/art/package.json
+++ b/packages/art/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./NetworkWeaveBackground": "./src/NetworkWeaveBackground/NetworkWeaveBackground.tsx"
   },
   "scripts": {
     "build-storybook": "node ../../scripts/with-turbo.mjs storybook build",

--- a/packages/art/src/NetworkWeaveBackground/NetworkWeaveBackground.stories.tsx
+++ b/packages/art/src/NetworkWeaveBackground/NetworkWeaveBackground.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import NetworkWeaveBackground from './NetworkWeaveBackground';
+
+const meta = {
+  title: 'Backgrounds/Network Weave',
+  component: NetworkWeaveBackground,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `A deterministic SVG background that gathers a dense network through a compact throat and opens it into a few expressive ribbons around foreground content.
+
+Import \`NetworkWeaveBackground\` from \`@codaco/art/NetworkWeaveBackground\`. Configure the visual with \`seed\`, \`complexity\`, \`strands\`, \`focus\`, \`orientation\`, \`reverse\`, \`colors\`, \`intensity\`, \`flare\`, \`blendMode\`, and the optional motion props.`,
+      },
+    },
+  },
+  argTypes: {
+    seed: { control: 'text' },
+    complexity: { control: { type: 'range', min: 8, max: 64, step: 1 } },
+    strands: { control: { type: 'range', min: 2, max: 6, step: 1 } },
+    focus: { control: 'object' },
+    orientation: {
+      control: 'radio',
+      options: ['horizontal', 'vertical'],
+    },
+    reverse: { control: 'boolean' },
+    colors: { control: 'object' },
+    backgroundColor: { control: 'color' },
+    intensity: { control: { type: 'range', min: 0, max: 1, step: 0.05 } },
+    flare: { control: { type: 'range', min: 0, max: 2, step: 0.05 } },
+    blendMode: {
+      control: 'select',
+      options: [
+        'normal',
+        'multiply',
+        'screen',
+        'overlay',
+        'soft-light',
+        'color-dodge',
+        'plus-lighter',
+      ],
+    },
+    animated: { control: 'boolean' },
+    speedFactor: {
+      control: { type: 'range', min: 0.1, max: 4, step: 0.1 },
+    },
+    className: { table: { disable: true } },
+    style: { table: { disable: true } },
+  },
+  args: {
+    seed: 'simplifying-complex-data',
+    complexity: 28,
+    strands: 4,
+    focus: { x: 0.5, y: 0.45, radius: 0.22 },
+    orientation: 'horizontal',
+    reverse: false,
+    backgroundColor: 'oklch(0.9593 0.009 281)',
+    intensity: 0.7,
+    flare: 1.25,
+    blendMode: 'multiply',
+    animated: true,
+    speedFactor: 1,
+  },
+  render: (args) => (
+    <NetworkWeaveBackground
+      {...args}
+      style={{ display: 'block', width: '100vw', height: '100vh' }}
+    />
+  ),
+} satisfies Meta<typeof NetworkWeaveBackground>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const BehindContent: Story = {
+  render: (args) => (
+    <div
+      style={{
+        position: 'relative',
+        display: 'grid',
+        width: '100vw',
+        height: '100vh',
+        placeItems: 'center',
+        overflow: 'hidden',
+        background: args.backgroundColor,
+      }}
+    >
+      <NetworkWeaveBackground
+        {...args}
+        backgroundColor="transparent"
+        style={{ position: 'absolute', inset: 0 }}
+      />
+      <main
+        style={{
+          position: 'relative',
+          width: 'min(38rem, calc(100vw - 3rem))',
+          padding: '2rem',
+          color: 'oklch(0.3 0.09 281)',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            margin: '0 0 1rem',
+            color: 'oklch(0.5733 0.2584 11.57)',
+            fontSize: '0.8rem',
+            fontWeight: 800,
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Simplifying complex data
+        </p>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: 'clamp(2.8rem, 7vw, 5.8rem)',
+            fontWeight: 900,
+            letterSpacing: '-0.065em',
+            lineHeight: 0.88,
+          }}
+        >
+          Find the signal in the network.
+        </h1>
+        <p
+          style={{
+            maxWidth: '31rem',
+            margin: '1.5rem auto 0',
+            fontSize: 'clamp(1rem, 2vw, 1.25rem)',
+            lineHeight: 1.5,
+          }}
+        >
+          Scattered relationships gather into clear, legible strands while the
+          story stays in focus.
+        </p>
+      </main>
+    </div>
+  ),
+};
+
+export const PortraitFlow: Story = {
+  args: {
+    orientation: 'vertical',
+    focus: { x: 0.5, y: 0.5, radius: 0.2 },
+  },
+};
+
+export const DarkCanvas: Story = {
+  args: {
+    seed: 'interviewer-dark',
+    backgroundColor: 'oklch(0.28 0.09 281)',
+    intensity: 0.9,
+    blendMode: 'screen',
+    complexity: 38,
+    strands: 5,
+  },
+};

--- a/packages/art/src/NetworkWeaveBackground/NetworkWeaveBackground.tsx
+++ b/packages/art/src/NetworkWeaveBackground/NetworkWeaveBackground.tsx
@@ -1,0 +1,267 @@
+import { Fragment, type CSSProperties, useId, useMemo } from 'react';
+
+import createNetworkWeaveScene, {
+  clampNetworkWeaveValue,
+  formatNetworkWeaveValue,
+  type NetworkWeaveFocus,
+  NETWORK_WEAVE_HEIGHT,
+  type NetworkWeaveOrientation,
+  NETWORK_WEAVE_WIDTH,
+  resolveNetworkWeaveFocus,
+} from './networkWeaveScene';
+
+const DEFAULT_COMPLEXITY = 28;
+const DEFAULT_STRANDS = 4;
+
+const DEFAULT_COLORS = [
+  'var(--node-1, oklch(0.5733 0.2584 11.57))',
+  'var(--edge-1, oklch(0.81 0.17 86.39))',
+  'var(--ord-1, oklch(0.7 0.2 171.52))',
+  'var(--edge-8, oklch(0.55 0.198 281))',
+  'var(--node-6, oklch(0.5824 0.229 260.09))',
+];
+
+type NetworkWeaveBackgroundProps = {
+  seed?: string;
+  complexity?: number;
+  strands?: number;
+  focus?: NetworkWeaveFocus;
+  orientation?: NetworkWeaveOrientation;
+  reverse?: boolean;
+  colors?: readonly string[];
+  backgroundColor?: string;
+  intensity?: number;
+  flare?: number;
+  blendMode?: CSSProperties['mixBlendMode'];
+  animated?: boolean;
+  speedFactor?: number;
+  className?: string;
+  style?: CSSProperties;
+};
+
+const NetworkWeaveBackground = ({
+  seed = 'network-canvas',
+  complexity = DEFAULT_COMPLEXITY,
+  strands = DEFAULT_STRANDS,
+  focus,
+  orientation = 'horizontal',
+  reverse = false,
+  colors,
+  backgroundColor = 'transparent',
+  intensity = 0.72,
+  flare = 1,
+  blendMode = 'multiply',
+  animated = true,
+  speedFactor = 1,
+  className,
+  style,
+}: NetworkWeaveBackgroundProps) => {
+  const activeColors = colors && colors.length > 0 ? colors : DEFAULT_COLORS;
+  const resolvedComplexity = Math.floor(
+    clampNetworkWeaveValue(complexity, 8, 64, DEFAULT_COMPLEXITY),
+  );
+  const resolvedStrands = Math.floor(
+    clampNetworkWeaveValue(strands, 2, 6, DEFAULT_STRANDS),
+  );
+  const {
+    x: resolvedFocusX,
+    y: resolvedFocusY,
+    radius: resolvedFocusRadius,
+  } = resolveNetworkWeaveFocus(focus);
+  const resolvedIntensity = clampNetworkWeaveValue(intensity, 0, 1, 0.72);
+  const resolvedFlare = clampNetworkWeaveValue(flare, 0, 2, 1);
+  const resolvedSpeedFactor = clampNetworkWeaveValue(speedFactor, 0.1, 4, 1);
+  const rawId = useId().replace(/:/g, '');
+  const ribbonFlowClass = `network-weave-ribbon-flow-${rawId}`;
+  const ribbonFlowKeyframes = `network-weave-ribbon-drift-${rawId}`;
+  const tributaryFlowClass = `network-weave-tributary-flow-${rawId}`;
+  const tributaryFlowKeyframes = `network-weave-tributary-drift-${rawId}`;
+  const ribbonAnimationDuration = formatNetworkWeaveValue(
+    6.5 / resolvedSpeedFactor,
+  );
+  const tributaryAnimationDuration = formatNetworkWeaveValue(
+    9 / resolvedSpeedFactor,
+  );
+  const scene = useMemo(
+    () =>
+      createNetworkWeaveScene({
+        seed,
+        complexity: resolvedComplexity,
+        strands: resolvedStrands,
+        colorCount: activeColors.length,
+        focus: {
+          x: resolvedFocusX,
+          y: resolvedFocusY,
+          radius: resolvedFocusRadius,
+        },
+        orientation,
+        reverse,
+        flare: resolvedFlare,
+      }),
+    [
+      seed,
+      resolvedComplexity,
+      resolvedStrands,
+      activeColors.length,
+      resolvedFocusX,
+      resolvedFocusY,
+      resolvedFocusRadius,
+      orientation,
+      reverse,
+      resolvedFlare,
+    ],
+  );
+
+  return (
+    <svg
+      viewBox={`0 0 ${NETWORK_WEAVE_WIDTH} ${NETWORK_WEAVE_HEIGHT}`}
+      preserveAspectRatio="none"
+      aria-hidden
+      focusable="false"
+      className={className}
+      style={{ width: '100%', height: '100%', ...style, pointerEvents: 'none' }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {animated && (
+        <style>{`
+          .${ribbonFlowClass} { animation: ${ribbonFlowKeyframes} ${ribbonAnimationDuration}s linear infinite; }
+          .${tributaryFlowClass} { animation: ${tributaryFlowKeyframes} ${tributaryAnimationDuration}s linear infinite; }
+          @keyframes ${ribbonFlowKeyframes} { from { offset-distance: 0%; transform: scale(0.55, 0.35); } to { offset-distance: 100%; transform: scale(1.4, 3.8); } }
+          @keyframes ${tributaryFlowKeyframes} { from { stroke-dashoffset: 0; } to { stroke-dashoffset: -159; } }
+          @media (prefers-reduced-motion: reduce) { .${ribbonFlowClass} { animation: none; visibility: hidden; } .${tributaryFlowClass} { animation: none; } }
+        `}</style>
+      )}
+      <defs>
+        {scene.ribbons.map((ribbon, index) => {
+          const color = activeColors[ribbon.colorIndex] ?? DEFAULT_COLORS[0];
+          return (
+            <Fragment key={`ribbon-definition-${index}`}>
+              <linearGradient
+                id={`network-weave-ribbon-${rawId}-${index}`}
+                gradientUnits="userSpaceOnUse"
+                x1={formatNetworkWeaveValue(ribbon.gradientStart.x)}
+                y1={formatNetworkWeaveValue(ribbon.gradientStart.y)}
+                x2={formatNetworkWeaveValue(ribbon.gradientEnd.x)}
+                y2={formatNetworkWeaveValue(ribbon.gradientEnd.y)}
+              >
+                <stop offset="0" stopColor={color} stopOpacity="0.1" />
+                <stop offset="0.38" stopColor={color} stopOpacity="0.78" />
+                <stop offset="0.72" stopColor={color} stopOpacity="0.58" />
+                <stop offset="1" stopColor={color} stopOpacity="0.18" />
+              </linearGradient>
+            </Fragment>
+          );
+        })}
+      </defs>
+
+      <rect
+        width={NETWORK_WEAVE_WIDTH}
+        height={NETWORK_WEAVE_HEIGHT}
+        fill={backgroundColor}
+      />
+
+      <g opacity={formatNetworkWeaveValue(resolvedIntensity)}>
+        <g>
+          {scene.tributaries.map((tributary, index) => (
+            <path
+              key={`tributary-${index}`}
+              className="network-weave__tributary"
+              d={tributary.d}
+              fill="none"
+              stroke={activeColors[tributary.colorIndex]}
+              strokeWidth={formatNetworkWeaveValue(tributary.width)}
+              strokeOpacity={formatNetworkWeaveValue(tributary.opacity)}
+              strokeLinecap="round"
+            />
+          ))}
+        </g>
+
+        {animated && (
+          <g>
+            {scene.tributaries.map((tributary, index) => (
+              <path
+                key={`tributary-flow-${index}`}
+                className={`network-weave__tributary-flow ${tributaryFlowClass}`}
+                d={tributary.d}
+                fill="none"
+                stroke={activeColors[tributary.colorIndex]}
+                strokeWidth={formatNetworkWeaveValue(
+                  Math.max(5.2, tributary.width * 1.25),
+                )}
+                strokeOpacity="0.64"
+                strokeDasharray="1 52"
+                strokeLinecap="round"
+                style={{
+                  animationDelay: `${formatNetworkWeaveValue(
+                    -(index / scene.tributaries.length) *
+                      tributaryAnimationDuration,
+                  )}s`,
+                }}
+              />
+            ))}
+          </g>
+        )}
+
+        <g>
+          {scene.ribbons.map((ribbon, index) => (
+            <path
+              key={`ribbon-${index}`}
+              className="network-weave__ribbon"
+              d={ribbon.d}
+              fill={`url(#network-weave-ribbon-${rawId}-${index})`}
+              style={{ mixBlendMode: blendMode }}
+            />
+          ))}
+        </g>
+
+        <g>
+          {scene.ribbons.map((ribbon, index) => {
+            const color = activeColors[ribbon.colorIndex] ?? DEFAULT_COLORS[0];
+            return (
+              <g key={`ribbon-detail-${index}`}>
+                <path
+                  className="network-weave__ribbon-guide"
+                  d={ribbon.guideD}
+                  data-centerline={ribbon.centerlineD}
+                  fill={color}
+                  fillOpacity="0.18"
+                  style={{ mixBlendMode: blendMode }}
+                />
+                {animated &&
+                  Array.from({ length: 3 }, (_, signalIndex) => {
+                    const phase = (signalIndex / 3 + ribbon.phase / 3) % 1;
+                    return (
+                      <rect
+                        key={`ribbon-flow-${signalIndex}`}
+                        className={`network-weave__ribbon-flow ${ribbonFlowClass}`}
+                        x="-40"
+                        y="-6"
+                        width="80"
+                        height="12"
+                        rx="16"
+                        ry="6"
+                        fill={color}
+                        fillOpacity="0.78"
+                        style={{
+                          offsetPath: `path('${ribbon.centerlineD}')`,
+                          offsetRotate: 'auto',
+                          transformBox: 'fill-box',
+                          transformOrigin: 'center',
+                          animationDelay: `${formatNetworkWeaveValue(
+                            -phase * ribbonAnimationDuration,
+                          )}s`,
+                          mixBlendMode: blendMode,
+                        }}
+                      />
+                    );
+                  })}
+              </g>
+            );
+          })}
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+export default NetworkWeaveBackground;

--- a/packages/art/src/NetworkWeaveBackground/__tests__/NetworkWeaveBackground.test.tsx
+++ b/packages/art/src/NetworkWeaveBackground/__tests__/NetworkWeaveBackground.test.tsx
@@ -1,0 +1,308 @@
+import { render } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import NetworkWeaveBackground from '../NetworkWeaveBackground';
+
+describe('NetworkWeaveBackground', () => {
+  it('renders as a decorative full-size background', () => {
+    const { container } = render(
+      <NetworkWeaveBackground
+        className="custom-background"
+        style={{ opacity: 0.4 }}
+      />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('focusable')).toBe('false');
+    expect(svg?.getAttribute('preserveAspectRatio')).toBe('none');
+    expect(svg?.classList.contains('custom-background')).toBe(true);
+    expect(svg?.style.width).toBe('100%');
+    expect(svg?.style.height).toBe('100%');
+    expect(svg?.style.pointerEvents).toBe('none');
+    expect(svg?.style.opacity).toBe('0.4');
+  });
+
+  it('generates deterministic geometry from the seed', () => {
+    const first = renderToStaticMarkup(
+      <NetworkWeaveBackground seed="research-network" animated={false} />,
+    );
+    const second = renderToStaticMarkup(
+      <NetworkWeaveBackground seed="research-network" animated={false} />,
+    );
+    const different = renderToStaticMarkup(
+      <NetworkWeaveBackground seed="community-network" animated={false} />,
+    );
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(different);
+  });
+
+  it('uses the configured complexity, strands, and colors', () => {
+    const { container } = render(
+      <NetworkWeaveBackground
+        complexity={12}
+        strands={3}
+        colors={['#123456', '#abcdef', '#fedcba']}
+        animated={false}
+      />,
+    );
+
+    expect(
+      container.querySelectorAll('.network-weave__tributary'),
+    ).toHaveLength(12);
+    expect(container.querySelectorAll('.network-weave__ribbon')).toHaveLength(
+      3,
+    );
+    expect(container.innerHTML).toContain('#123456');
+    expect(container.innerHTML).toContain('#abcdef');
+    expect(container.innerHTML).toContain('#fedcba');
+  });
+
+  it('uses tapered ribbons without independent shape marks', () => {
+    const { container } = render(
+      <NetworkWeaveBackground complexity={12} strands={3} animated={false} />,
+    );
+
+    const ribbons = container.querySelectorAll('.network-weave__ribbon');
+    for (const ribbon of ribbons) {
+      const path = ribbon.getAttribute('d');
+      const coordinates =
+        path?.match(/-?\d+(?:\.\d+)?/g)?.map((value) => Number(value)) ?? [];
+      const upperStart = coordinates[1] ?? Number.POSITIVE_INFINITY;
+      const lowerStart = coordinates.at(-1) ?? Number.NEGATIVE_INFINITY;
+
+      expect(path).toMatch(/Z$/);
+      expect(ribbon.getAttribute('fill')).toMatch(/^url\(/);
+      expect(ribbon.getAttribute('stroke')).toBeNull();
+      expect(Math.abs(lowerStart - upperStart)).toBeGreaterThan(5);
+      expect(Math.abs(lowerStart - upperStart)).toBeLessThan(8);
+    }
+
+    for (const tributary of container.querySelectorAll(
+      '.network-weave__tributary',
+    )) {
+      expect(tributary.getAttribute('d')).toMatch(/^M -/);
+      expect(tributary.getAttribute('d')).toContain(' C ');
+    }
+
+    expect(container.querySelector('circle')).toBeNull();
+    expect(container.querySelector('.network-weave__quiet-zone')).toBeNull();
+    expect(container.querySelector('filter')).toBeNull();
+  });
+
+  it('gives the incoming lines and moving flow dots visual weight', () => {
+    const { container } = render(
+      <NetworkWeaveBackground complexity={12} strands={3} />,
+    );
+
+    for (const tributary of container.querySelectorAll(
+      '.network-weave__tributary',
+    )) {
+      expect(Number(tributary.getAttribute('stroke-width'))).toBeGreaterThan(2);
+    }
+    for (const flow of container.querySelectorAll(
+      '.network-weave__tributary-flow',
+    )) {
+      expect(Number(flow.getAttribute('stroke-width'))).toBeGreaterThanOrEqual(
+        5,
+      );
+    }
+  });
+
+  it('uses a growing guide with unclipped rounded flow signals', () => {
+    const { container } = render(
+      <NetworkWeaveBackground complexity={12} strands={3} />,
+    );
+    const guides = container.querySelectorAll('.network-weave__ribbon-guide');
+    const flows = container.querySelectorAll('.network-weave__ribbon-flow');
+
+    expect(guides).toHaveLength(3);
+    expect(flows).toHaveLength(9);
+    guides.forEach((guide) => {
+      const coordinates =
+        guide
+          .getAttribute('d')
+          ?.match(/-?\d+(?:\.\d+)?/g)
+          ?.map(Number) ?? [];
+      const startWidth = Math.abs(
+        (coordinates.at(-1) ?? 0) - (coordinates[1] ?? 0),
+      );
+      const endWidth = Math.abs((coordinates[9] ?? 0) - (coordinates[7] ?? 0));
+
+      expect(endWidth).toBeGreaterThan(startWidth * 5);
+      expect(guide.getAttribute('fill-opacity')).toBe('0.18');
+    });
+    flows.forEach((flow) => {
+      expect(flow.tagName).toBe('rect');
+      expect(flow.getAttribute('mask')).toBeNull();
+      expect(flow.getAttribute('rx')).toBe('16');
+      expect(flow.getAttribute('ry')).toBe('6');
+      expect(flow.getAttribute('fill-opacity')).toBe('0.78');
+      expect(flow.getAttribute('style')).toContain('offset-path: path(');
+      expect(flow.getAttribute('style')).not.toContain("path('M -");
+    });
+    expect(container.querySelector('mask')).toBeNull();
+    expect(container.querySelector('.network-weave__ribbon-flow-reveal')).toBe(
+      null,
+    );
+  });
+
+  it('keeps tributary and ribbon tangents continuous at the join', () => {
+    const verifyTangents = (
+      orientation: 'horizontal' | 'vertical',
+      reverse: boolean,
+    ) => {
+      const { container } = render(
+        <NetworkWeaveBackground
+          complexity={12}
+          strands={3}
+          orientation={orientation}
+          reverse={reverse}
+          animated={false}
+        />,
+      );
+      const tributaries = container.querySelectorAll(
+        '.network-weave__tributary',
+      );
+      const centerlines = container.querySelectorAll(
+        '.network-weave__ribbon-guide',
+      );
+
+      tributaries.forEach((tributary, index) => {
+        const tributaryCoordinates =
+          tributary
+            .getAttribute('d')
+            ?.match(/-?\d+(?:\.\d+)?/g)
+            ?.map(Number) ?? [];
+        const centerlineCoordinates =
+          centerlines[index % 3]
+            ?.getAttribute('data-centerline')
+            ?.match(/-?\d+(?:\.\d+)?/g)
+            ?.map(Number) ?? [];
+        const incomingX =
+          (tributaryCoordinates[6] ?? 0) - (tributaryCoordinates[4] ?? 0);
+        const incomingY =
+          (tributaryCoordinates[7] ?? 0) - (tributaryCoordinates[5] ?? 0);
+        const outgoingX =
+          (centerlineCoordinates[2] ?? 0) - (centerlineCoordinates[0] ?? 0);
+        const outgoingY =
+          (centerlineCoordinates[3] ?? 0) - (centerlineCoordinates[1] ?? 0);
+        const crossProduct = Math.abs(
+          incomingX * outgoingY - incomingY * outgoingX,
+        );
+        const magnitude =
+          Math.hypot(incomingX, incomingY) * Math.hypot(outgoingX, outgoingY);
+
+        expect(crossProduct / magnitude).toBeLessThan(0.001);
+      });
+    };
+
+    verifyTangents('horizontal', false);
+    verifyTangents('vertical', true);
+  });
+
+  it('supports vertical and reversed flows', () => {
+    const horizontal = renderToStaticMarkup(
+      <NetworkWeaveBackground seed="layout" animated={false} />,
+    );
+    const vertical = renderToStaticMarkup(
+      <NetworkWeaveBackground
+        seed="layout"
+        orientation="vertical"
+        animated={false}
+      />,
+    );
+    const reversed = renderToStaticMarkup(
+      <NetworkWeaveBackground seed="layout" reverse animated={false} />,
+    );
+
+    expect(vertical).not.toBe(horizontal);
+    expect(reversed).not.toBe(horizontal);
+  });
+
+  it('configures the trailing flare and ribbon blend mode', () => {
+    const compact = renderToStaticMarkup(
+      <NetworkWeaveBackground flare={0} animated={false} />,
+    );
+    const flared = renderToStaticMarkup(
+      <NetworkWeaveBackground
+        flare={2}
+        blendMode="multiply"
+        animated={false}
+      />,
+    );
+    const { container } = render(
+      <NetworkWeaveBackground blendMode="multiply" animated={false} />,
+    );
+
+    expect(flared).not.toBe(compact);
+    for (const ribbon of container.querySelectorAll('.network-weave__ribbon')) {
+      expect(ribbon.getAttribute('style')).toContain(
+        'mix-blend-mode: multiply',
+      );
+    }
+  });
+
+  it('disables its optional motion for reduced-motion preferences', () => {
+    const animated = renderToStaticMarkup(
+      <NetworkWeaveBackground animated speedFactor={2} />,
+    );
+    const staticMarkup = renderToStaticMarkup(
+      <NetworkWeaveBackground animated={false} />,
+    );
+
+    expect(animated).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(animated).toContain('network-weave-ribbon-drift');
+    expect(animated).toContain('network-weave-tributary-drift');
+    expect(staticMarkup).not.toContain('@keyframes');
+  });
+
+  it('loops flow motion without phase jumps', () => {
+    const { container } = render(<NetworkWeaveBackground animated />);
+    const styles = container.querySelector('style')?.textContent ?? '';
+
+    expect(styles).toContain(
+      'from { offset-distance: 0%; transform: scale(0.55, 0.35); } to { offset-distance: 100%; transform: scale(1.4, 3.8); }',
+    );
+    expect(styles).toContain(
+      'from { stroke-dashoffset: 0; } to { stroke-dashoffset: -159; }',
+    );
+
+    for (const flow of container.querySelectorAll(
+      '.network-weave__tributary-flow',
+    )) {
+      expect(flow.getAttribute('stroke-dasharray')).toBe('1 52');
+    }
+    for (const flow of container.querySelectorAll(
+      '.network-weave__tributary-flow',
+    )) {
+      expect(flow.getAttribute('stroke-dashoffset')).toBeNull();
+    }
+    for (const signal of container.querySelectorAll(
+      '.network-weave__ribbon-flow',
+    )) {
+      expect(signal.getAttribute('mask')).toBeNull();
+    }
+    expect(styles).not.toContain('opacity:');
+    expect(container.innerHTML).toContain('animation-delay: -');
+  });
+
+  it('falls back safely when numeric props are not finite', () => {
+    const markup = renderToStaticMarkup(
+      <NetworkWeaveBackground
+        complexity={Number.NaN}
+        strands={Number.POSITIVE_INFINITY}
+        intensity={Number.NEGATIVE_INFINITY}
+        flare={Number.NaN}
+        speedFactor={Number.NaN}
+        focus={{ x: Number.NaN, y: Number.NaN, radius: Number.NaN }}
+      />,
+    );
+
+    expect(markup).not.toContain('NaN');
+    expect(markup).not.toContain('Infinity');
+  });
+});

--- a/packages/art/src/NetworkWeaveBackground/networkWeaveScene.ts
+++ b/packages/art/src/NetworkWeaveBackground/networkWeaveScene.ts
@@ -1,0 +1,421 @@
+import { seedToRng } from '../Pattern/seed';
+
+export const NETWORK_WEAVE_WIDTH = 1600;
+export const NETWORK_WEAVE_HEIGHT = 900;
+
+export type NetworkWeaveFocus = {
+  x?: number;
+  y?: number;
+  radius?: number;
+};
+
+export type ResolvedNetworkWeaveFocus = {
+  x: number;
+  y: number;
+  radius: number;
+};
+
+export type NetworkWeaveOrientation = 'horizontal' | 'vertical';
+
+type NormalizedPoint = {
+  axis: number;
+  cross: number;
+};
+
+type NetworkWeavePoint = {
+  x: number;
+  y: number;
+};
+
+type NetworkWeavePath = {
+  d: string;
+  colorIndex: number;
+  opacity: number;
+  width: number;
+};
+
+type NetworkWeaveRibbon = {
+  d: string;
+  guideD: string;
+  centerlineD: string;
+  colorIndex: number;
+  gradientStart: NetworkWeavePoint;
+  gradientEnd: NetworkWeavePoint;
+  phase: number;
+};
+
+type NetworkWeaveScene = {
+  tributaries: NetworkWeavePath[];
+  ribbons: NetworkWeaveRibbon[];
+};
+
+type RibbonPoint = {
+  position: NormalizedPoint;
+  halfWidth: number;
+};
+
+type RibbonProfile = {
+  points: [RibbonPoint, RibbonPoint, RibbonPoint, RibbonPoint];
+  colorIndex: number;
+  laneCross: number;
+};
+
+export const clampNetworkWeaveValue = (
+  value: number,
+  minimum: number,
+  maximum: number,
+  fallback = minimum,
+) =>
+  Math.min(
+    maximum,
+    Math.max(minimum, Number.isFinite(value) ? value : fallback),
+  );
+
+export const formatNetworkWeaveValue = (value: number) =>
+  Number.isFinite(value) ? Number(value.toFixed(2)) : 0;
+
+export const resolveNetworkWeaveFocus = (
+  focus?: NetworkWeaveFocus,
+): ResolvedNetworkWeaveFocus => {
+  const x = clampNetworkWeaveValue(focus?.x ?? 0.5, 0.3, 0.7, 0.5);
+  const y = clampNetworkWeaveValue(focus?.y ?? 0.45, 0.3, 0.7, 0.45);
+  const maximumRadius = Math.min(0.28, x - 0.1, 0.9 - x, y - 0.1, 0.9 - y);
+
+  return {
+    x,
+    y,
+    radius: clampNetworkWeaveValue(
+      focus?.radius ?? 0.22,
+      0.08,
+      maximumRadius,
+      0.22,
+    ),
+  };
+};
+
+const pointToString = ({ x, y }: NetworkWeavePoint) =>
+  `${formatNetworkWeaveValue(x)} ${formatNetworkWeaveValue(y)}`;
+
+const createProjector = (
+  orientation: NetworkWeaveOrientation,
+  reverse: boolean,
+) => {
+  return ({ axis, cross }: NormalizedPoint): NetworkWeavePoint => {
+    const directedAxis = reverse ? 1 - axis : axis;
+    if (orientation === 'horizontal') {
+      return {
+        x: directedAxis * NETWORK_WEAVE_WIDTH,
+        y: cross * NETWORK_WEAVE_HEIGHT,
+      };
+    }
+
+    return {
+      x: cross * NETWORK_WEAVE_WIDTH,
+      y: directedAxis * NETWORK_WEAVE_HEIGHT,
+    };
+  };
+};
+
+const createCubicPath = (
+  start: NetworkWeavePoint,
+  firstControl: NetworkWeavePoint,
+  secondControl: NetworkWeavePoint,
+  end: NetworkWeavePoint,
+) =>
+  `M ${pointToString(start)} C ${pointToString(firstControl)} ${pointToString(secondControl)} ${pointToString(end)}`;
+
+const distribute = (count: number, start: number, end: number) => {
+  if (count === 1) return [(start + end) / 2];
+  return Array.from(
+    { length: count },
+    (_, index) => start + (index / (count - 1)) * (end - start),
+  );
+};
+
+const createLaneCrosses = (
+  strands: number,
+  focusCross: number,
+  focusRadius: number,
+) => {
+  const topCount = Math.ceil(strands / 2);
+  const bottomCount = strands - topCount;
+  const topInner = clampNetworkWeaveValue(
+    focusCross - focusRadius - 0.065,
+    0.14,
+    0.36,
+  );
+  const bottomInner = clampNetworkWeaveValue(
+    focusCross + focusRadius + 0.065,
+    0.64,
+    0.86,
+  );
+
+  return [
+    ...distribute(topCount, 0.08, topInner),
+    ...distribute(bottomCount, bottomInner, 0.92),
+  ];
+};
+
+const offsetRibbonPoint = (
+  point: RibbonPoint,
+  direction: -1 | 1,
+  project: (point: NormalizedPoint) => NetworkWeavePoint,
+) =>
+  project({
+    axis: point.position.axis,
+    cross: point.position.cross + point.halfWidth * direction,
+  });
+
+const createRibbonShape = (
+  profile: RibbonProfile,
+  project: (point: NormalizedPoint) => NetworkWeavePoint,
+) => {
+  const upper = profile.points.map((point) =>
+    offsetRibbonPoint(point, -1, project),
+  );
+  const lower = profile.points.map((point) =>
+    offsetRibbonPoint(point, 1, project),
+  );
+  const [u0, u1, u2, u3] = upper;
+  const [l0, l1, l2, l3] = lower;
+
+  if (!u0 || !u1 || !u2 || !u3) return '';
+  if (!l0 || !l1 || !l2 || !l3) return '';
+
+  return [
+    `M ${pointToString(u0)}`,
+    `C ${pointToString(u1)} ${pointToString(u2)} ${pointToString(u3)}`,
+    `L ${pointToString(l3)}`,
+    `C ${pointToString(l2)} ${pointToString(l1)} ${pointToString(l0)}`,
+    'Z',
+  ].join(' ');
+};
+
+const createRibbonProfiles = ({
+  laneCrosses,
+  focusAxis,
+  focusCross,
+  focusRadius,
+  colorCount,
+  orientation,
+  flare,
+}: {
+  laneCrosses: number[];
+  focusAxis: number;
+  focusCross: number;
+  focusRadius: number;
+  colorCount: number;
+  orientation: NetworkWeaveOrientation;
+  flare: number;
+}): RibbonProfile[] => {
+  const mergeAxis = clampNetworkWeaveValue(
+    focusAxis - focusRadius - 0.13,
+    0.12,
+    0.48,
+  );
+  const firstControlAxis = clampNetworkWeaveValue(
+    focusAxis - focusRadius * 0.12,
+    mergeAxis + 0.18,
+    0.68,
+  );
+  const secondControlAxis = 0.96;
+  const crossDimension =
+    orientation === 'horizontal' ? NETWORK_WEAVE_HEIGHT : NETWORK_WEAVE_WIDTH;
+  const width = (pixels: number) => pixels / crossDimension;
+
+  return laneCrosses.map((laneCross, laneIndex) => {
+    const side = laneCross < focusCross ? -1 : 1;
+    const innerBoundary = focusCross + side * (focusRadius + 0.055);
+    const bypassCross = laneCross + (innerBoundary - laneCross) * 0.74;
+    const mergeCross =
+      focusCross + (laneIndex - (laneCrosses.length - 1) / 2) * 0.014;
+    const bandCross = (laneIndex + 0.5) / laneCrosses.length;
+    const positionalFlare = Math.min(1, flare);
+    const endCross = laneCross + (bandCross - laneCross) * positionalFlare;
+    const compactEndWidth = width(0.45);
+    const flaredEndWidth = (0.5 / laneCrosses.length) * 1.1;
+    const endWidth =
+      compactEndWidth + (flaredEndWidth - compactEndWidth) * flare;
+    const secondControlCross =
+      laneCross + (endCross - laneCross) * positionalFlare * 0.16;
+    const secondControlWidth =
+      width(3.2) + (endWidth - width(3.2)) * flare * 0.06;
+
+    return {
+      points: [
+        {
+          position: { axis: mergeAxis, cross: mergeCross },
+          halfWidth: width(3.2),
+        },
+        {
+          position: {
+            axis: firstControlAxis,
+            cross: bypassCross,
+          },
+          halfWidth: width(13),
+        },
+        {
+          position: {
+            axis: secondControlAxis,
+            cross: secondControlCross,
+          },
+          halfWidth: secondControlWidth,
+        },
+        {
+          position: { axis: 1.04, cross: endCross },
+          halfWidth: endWidth,
+        },
+      ],
+      colorIndex: laneIndex % colorCount,
+      laneCross: endCross,
+    };
+  });
+};
+
+const createRibbon = (
+  profile: RibbonProfile,
+  index: number,
+  ribbonCount: number,
+  project: (point: NormalizedPoint) => NetworkWeavePoint,
+): NetworkWeaveRibbon => {
+  const minimumGuideWidth = profile.points[0].halfWidth * 0.24;
+  const createGuidePoint = (point: RibbonPoint): RibbonPoint => ({
+    position: point.position,
+    halfWidth: Math.max(
+      minimumGuideWidth,
+      Math.min(point.halfWidth * 0.06, 0.012),
+    ),
+  });
+  const guideProfile: RibbonProfile = {
+    points: [
+      createGuidePoint(profile.points[0]),
+      createGuidePoint(profile.points[1]),
+      createGuidePoint(profile.points[2]),
+      createGuidePoint(profile.points[3]),
+    ],
+    colorIndex: profile.colorIndex,
+    laneCross: profile.laneCross,
+  };
+  const centerlinePoints = profile.points.map(({ position }) =>
+    project(position),
+  );
+  const [start, firstControl, secondControl, end] = centerlinePoints;
+  const fallback = project({ axis: 0.5, cross: profile.laneCross });
+  const safePoints: [
+    NetworkWeavePoint,
+    NetworkWeavePoint,
+    NetworkWeavePoint,
+    NetworkWeavePoint,
+  ] = [
+    start ?? fallback,
+    firstControl ?? fallback,
+    secondControl ?? fallback,
+    end ?? fallback,
+  ];
+  return {
+    d: createRibbonShape(profile, project),
+    guideD: createRibbonShape(guideProfile, project),
+    centerlineD: createCubicPath(
+      safePoints[0],
+      safePoints[1],
+      safePoints[2],
+      safePoints[3],
+    ),
+    colorIndex: profile.colorIndex,
+    gradientStart: safePoints[0],
+    gradientEnd: safePoints[3],
+    phase: index / ribbonCount,
+  };
+};
+
+const createNetworkWeaveScene = ({
+  seed,
+  complexity,
+  strands,
+  colorCount,
+  focus,
+  orientation,
+  reverse,
+  flare,
+}: {
+  seed: string;
+  complexity: number;
+  strands: number;
+  colorCount: number;
+  focus: ResolvedNetworkWeaveFocus;
+  orientation: NetworkWeaveOrientation;
+  reverse: boolean;
+  flare: number;
+}): NetworkWeaveScene => {
+  const rng = seedToRng(`${seed}::network-weave`);
+  const project = createProjector(orientation, reverse);
+  const focusAxis =
+    orientation === 'horizontal'
+      ? reverse
+        ? 1 - focus.x
+        : focus.x
+      : reverse
+        ? 1 - focus.y
+        : focus.y;
+  const focusCross = orientation === 'horizontal' ? focus.y : focus.x;
+  const laneCrosses = createLaneCrosses(strands, focusCross, focus.radius);
+  const profiles = createRibbonProfiles({
+    laneCrosses,
+    focusAxis,
+    focusCross,
+    focusRadius: focus.radius,
+    colorCount,
+    orientation,
+    flare,
+  });
+  const mergeAxis = profiles[0]?.points[0].position.axis ?? 0.22;
+  const tributaries = Array.from(
+    { length: complexity },
+    (_, index): NetworkWeavePath => {
+      const laneIndex = index % strands;
+      const profile = profiles[laneIndex] ?? profiles[0];
+      const merge = profile?.points[0].position ?? {
+        axis: mergeAxis,
+        cross: 0.5,
+      };
+      const outgoingControl = profile?.points[1].position ?? {
+        axis: merge.axis + 0.35,
+        cross: merge.cross,
+      };
+      const origin = {
+        axis: -0.08 - rng() * 0.28,
+        cross: -0.12 + rng() * 1.24,
+      };
+      const axisSpan = merge.axis - origin.axis;
+      const start = project(origin);
+      const firstControl = project({
+        axis: origin.axis + axisSpan * 0.42,
+        cross:
+          origin.cross +
+          (merge.cross - origin.cross) * 0.08 +
+          (rng() - 0.5) * 0.055,
+      });
+      const secondControl = project({
+        axis: merge.axis - (outgoingControl.axis - merge.axis) * 0.18,
+        cross: merge.cross - (outgoingControl.cross - merge.cross) * 0.18,
+      });
+      const end = project(merge);
+
+      return {
+        d: createCubicPath(start, firstControl, secondControl, end),
+        colorIndex: laneIndex % colorCount,
+        opacity: 0.2 + rng() * 0.16,
+        width: 2.1 + rng() * 2,
+      };
+    },
+  );
+
+  return {
+    tributaries,
+    ribbons: profiles.map((profile, index) =>
+      createRibbon(profile, index, profiles.length, project),
+    ),
+  };
+};
+
+export default createNetworkWeaveScene;


### PR DESCRIPTION
## Summary

- add a deterministic Network Weave background to `@codaco/art`
- expose controls for complexity, focus, orientation, palette, flare, blend mode, and motion
- document foreground, portrait, and dark treatments in Storybook
- cover geometry, configuration, accessibility, and reduced-motion behavior with tests

## Test plan

- [x] `vitest run` for `@codaco/art` — 118 tests
- [x] `tsc -p packages/art/tsconfig.json --noEmit`
- [x] `oxlint packages/art --fix --quiet`
- [x] `knip --exclude catalog`
- [x] Storybook production build
- [x] formatting and `git diff --check`