### PR TITLE
fix(architect): render item preview links as plain text

### DIFF
--- a/.changeset/calm-previews-unlink.md
+++ b/.changeset/calm-previews-unlink.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Show linked text as plain text in item previews to keep it readable against colored backgrounds.

--- a/apps/architect/src/components/Markdown.tsx
+++ b/apps/architect/src/components/Markdown.tsx
@@ -18,11 +18,12 @@ const escapeAngleBracket = (value = '') =>
 type MarkdownProps = {
   label: string;
   className?: string;
+  allowedElements?: readonly string[];
 };
 
-const Markdown = ({ label, className }: MarkdownProps) => (
+const Markdown = ({ label, className, allowedElements }: MarkdownProps) => (
   <RenderMarkdown
-    allowedElements={ALLOWED_MARKDOWN_SECTION_TAGS}
+    allowedElements={allowedElements ?? ALLOWED_MARKDOWN_SECTION_TAGS}
     render={<span className={className} />}
   >
     {escapeAngleBracket(label)}
@@ -33,5 +34,6 @@ export default memo(
   Markdown,
   (prevProps, nextProps) =>
     prevProps.label === nextProps.label &&
-    prevProps.className === nextProps.className,
+    prevProps.className === nextProps.className &&
+    prevProps.allowedElements === nextProps.allowedElements,
 );

--- a/apps/architect/src/components/sections/ContentGrid/ItemPreview.tsx
+++ b/apps/architect/src/components/sections/ContentGrid/ItemPreview.tsx
@@ -1,6 +1,7 @@
 import { get } from 'es-toolkit/compat';
 import { connect } from 'react-redux';
 
+import { ALLOWED_MARKDOWN_SECTION_TAGS } from '@codaco/fresco-ui/RenderMarkdown';
 import Markdown from '~/components/Markdown';
 import type { RootState } from '~/ducks/modules/root';
 import { getAssetManifest } from '~/selectors/protocol';
@@ -8,6 +9,10 @@ import { getAssetManifest } from '~/selectors/protocol';
 import AudioWithUrl from '../../Assets/Audio';
 import BackgroundImageWithUrl from '../../Assets/BackgroundImage';
 import VideoWithUrl from '../../Assets/Video';
+
+const ITEM_PREVIEW_ALLOWED_ELEMENTS = ALLOWED_MARKDOWN_SECTION_TAGS.filter(
+  (tag) => tag !== 'a',
+);
 
 type ItemPreviewProps = {
   content?: string | null;
@@ -42,6 +47,7 @@ const ItemPreview = ({
       return (
         <Markdown
           label={content ?? ''}
+          allowedElements={ITEM_PREVIEW_ALLOWED_ELEMENTS}
           className="[&_li]:my-1 [&_ol]:my-5 [&_ol]:list-decimal [&_ol]:pl-7 [&_ul]:my-5 [&_ul]:list-disc [&_ul]:pl-7"
         />
       );

--- a/apps/architect/src/components/sections/ContentGrid/__tests__/ItemPreview.test.tsx
+++ b/apps/architect/src/components/sections/ContentGrid/__tests__/ItemPreview.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ItemPreview from '../ItemPreview';
+
+describe('ItemPreview', () => {
+  it('shows markdown link text without rendering an interactive anchor', () => {
+    const { container } = render(
+      <ItemPreview.WrappedComponent content="Read [the guide](https://example.com)." />,
+    );
+
+    expect(container.textContent).toContain('the guide');
+    expect(container.querySelector('a')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- render markdown link text without anchors in editable item previews
- preserve normal markdown link behavior everywhere else through a scoped allowed-elements override
- add regression coverage and an Architect patch changeset

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm exec turbo run test --filter=@codaco/architect` (145 files; 835 passed, 4 todo)
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] Manually verify the Mental Health Networks item preview retains citation text and renders no anchors