### PR TITLE
fix(architect): protocol-editor UI polish + node-type reset fix

### DIFF
--- a/.changeset/architect-ui-polish.md
+++ b/.changeset/architect-ui-polish.md
@@ -1,0 +1,17 @@
+---
+"@codaco/architect": patch
+---
+
+Fixed a range of protocol-editor UI issues:
+
+- The install banner and the "this protocol is already open in another tab"
+  banner now both appear as strips at the top of the screen, with white,
+  intent-coloured action buttons.
+- The "Create/Edit Field" dialog is split into distinct sections (Variable,
+  Question, Input Control, Categorical/Ordinal Options, Validation), and the
+  Validation list now uses inline editing with a collapsed summary per rule.
+- Categorical/ordinal option rows and the protocol description field use cleaner,
+  consistent styling with no clashing background or border layers.
+- Empty toggleable sections centre their "enable this feature" message correctly.
+- Selecting a node type for a stage no longer clears itself when you edit another
+  field or save, so stages can no longer be saved in an invalid state.

--- a/.changeset/fresco-alert-compact-icon-alignment.md
+++ b/.changeset/fresco-alert-compact-icon-alignment.md
@@ -1,0 +1,7 @@
+---
+"@codaco/fresco-ui": patch
+---
+
+Alert: the icon in `compact`-density alerts is now vertically centred against the
+message text instead of top-aligned, so single-paragraph banners read correctly
+when their text wraps. Default-density alerts keep their top alignment.

--- a/.changeset/tailwind-surface-2-token.md
+++ b/.changeset/tailwind-surface-2-token.md
@@ -1,0 +1,6 @@
+---
+"@codaco/tailwind-config": patch
+---
+
+Adjusted the light theme's `--surface-2` colour token to
+`oklch(0.91 0.01 231.77)`.

--- a/apps/architect/src/components/EditorLayout/Section.tsx
+++ b/apps/architect/src/components/EditorLayout/Section.tsx
@@ -125,7 +125,7 @@ const Section = ({
     <>
       {isOpen && children}
       {toggleable && !isOpen && layout !== 'vertical' && (
-        <div className="bg-surface-2/75 text-text/70 max-tablet-landscape:hidden absolute inset-0 flex h-full w-full items-center justify-center font-semibold italic">
+        <div className="text-text/70 max-tablet-landscape:hidden flex min-h-32 w-full items-center justify-center font-semibold italic">
           Click the toggle to enable this feature...
         </div>
       )}

--- a/apps/architect/src/components/InstallBanner.tsx
+++ b/apps/architect/src/components/InstallBanner.tsx
@@ -105,9 +105,9 @@ const InstallBanner = () => {
         <span className="flex-1">{bannerMessage(deferredPrompt !== null)}</span>
         {deferredPrompt !== null && (
           <Button
-            color="primary"
+            color="warning"
             size="sm"
-            className="text-sm"
+            className="bg-warning-contrast text-warning text-sm"
             onClick={() => void promptInstall()}
           >
             <Download />

--- a/apps/architect/src/components/Options/Option.tsx
+++ b/apps/architect/src/components/Options/Option.tsx
@@ -1,6 +1,7 @@
 import { toNumber } from 'es-toolkit/compat';
-import { Trash2 } from 'lucide-react';
+import { Check, Pencil, Trash2 } from 'lucide-react';
 import type { ComponentType } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { IconButton } from '@codaco/fresco-ui/Button';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
@@ -33,9 +34,18 @@ const optionLabelFromRedux = (value: unknown) =>
 const optionLabelToRedux = (value: unknown) =>
   richTextContentToMarkdown(value as RichTextContent | undefined, true);
 
+const isValueEmpty = (value: unknown) =>
+  value === undefined || value === null || value === '';
+
+// Background and rounding live on the ArrayField item Surface (see Options.tsx
+// itemClasses); this inner wrapper only owns layout + the error-state border.
+const ROW_CLASSES =
+  'w-full border-2 border-transparent p-5 transition-colors duration-300 ease-in-out';
+
 type OptionProps = FrescoReduxArrayFieldItemProps<OptionValue>;
 
 const Option = ({
+  item,
   fieldName,
   index,
   itemCount,
@@ -43,12 +53,29 @@ const Option = ({
   dragControls,
   onMove,
   onDelete,
+  onEdit,
+  onCancel,
+  isBeingEdited,
   disabled,
   readOnly,
   showErrors,
 }: OptionProps) => {
   const { confirm } = useDialog();
   const interactionDisabled = disabled || readOnly;
+
+  // immediateAdd (see Options.tsx) commits a new option straight into the
+  // array via ArrayField's addItem, which never marks it as "being edited" —
+  // that only happens through onEdit/startEditing. Enter edit mode ourselves
+  // the first time this row mounts still blank, so a freshly added option
+  // opens directly into the inline editor instead of an empty summary line.
+  const hasAutoOpenedRef = useRef(false);
+  useEffect(() => {
+    if (hasAutoOpenedRef.current || isBeingEdited) return;
+    if (item.label || !isValueEmpty(item.value)) return;
+    hasAutoOpenedRef.current = true;
+    onEdit();
+  }, [isBeingEdited, item.label, item.value, onEdit]);
+
   const handleDelete = () => {
     void confirm({
       title: 'Remove option',
@@ -60,15 +87,19 @@ const Option = ({
     });
   };
 
-  return (
-    <div
-      className={cx(
-        'text-sortable-contrast bg-form-control z-1 flex w-full rounded-xl border-2 border-transparent transition-colors duration-300 ease-in-out',
-        showErrors && 'border-destructive',
-      )}
-    >
-      {isSortable && (
-        <div className="flex grow-0 items-center p-5">
+  if (!isBeingEdited) {
+    const hasLabel = typeof item.label === 'string' && item.label.length > 0;
+    const hasValue = !isValueEmpty(item.value);
+
+    return (
+      <div
+        className={cx(
+          'flex items-center gap-3',
+          ROW_CLASSES,
+          showErrors && 'border-destructive',
+        )}
+      >
+        {isSortable && (
           <ArrayFieldDragHandle
             dragControls={dragControls}
             index={index}
@@ -76,55 +107,72 @@ const Option = ({
             onMove={onMove}
             disabled={interactionDisabled}
             label={`Reorder option ${index + 1} of ${itemCount}`}
-            className="text-sortable-contrast"
           />
+        )}
+        <div className="min-w-0 flex-1 truncate">
+          <span className={!hasLabel ? 'text-current/50 italic' : undefined}>
+            {hasLabel ? item.label : 'Untitled option'}
+          </span>
+          <span className="text-current/50"> — </span>
+          <span
+            className={cx(
+              'font-monospace',
+              !hasValue && 'text-current/50 italic',
+            )}
+          >
+            {hasValue ? String(item.value) : 'No value'}
+          </span>
         </div>
-      )}
-      <div className="flex flex-1">
-        <div className="my-5 flex-1">
-          <ValidatedField
-            component={FrescoReduxField}
-            componentProps={{
-              fieldComponent: FrescoRichTextEditorField,
-              label: 'Label',
-              placeholder: 'Enter a label...',
-              changeMode: 'input',
-              toolbarOptions: {
-                headings: false,
-                history: true,
-                links: false,
-                lists: false,
-                thematicBreak: false,
-              },
-              fromReduxValue: optionLabelFromRedux,
-              toReduxValue: optionLabelToRedux,
-            }}
-            name={`${fieldName}.label`}
-            validation={{ required: true, uniqueArrayAttribute: true }}
+        <div className="flex shrink-0 items-center gap-1">
+          <IconButton
+            icon={<Pencil />}
+            aria-label={`Edit option ${index + 1}`}
+            size="sm"
+            variant="text"
+            color="dynamic"
+            disabled={interactionDisabled}
+            onClick={onEdit}
           />
-        </div>
-        <div className="my-5 ml-5 flex-1">
-          <ValidatedField
-            component={FrescoReduxField}
-            componentProps={{
-              fieldComponent: FrescoInputField,
-              label: 'Value',
-              placeholder: 'Enter a value...',
-              toReduxValue: parseOptionValue,
-            }}
-            name={`${fieldName}.value`}
-            validation={{
-              required: true,
-              uniqueArrayAttribute: true,
-              allowedVariableName: 'option value',
-            }}
+          <IconButton
+            icon={<Trash2 />}
+            aria-label={`Remove option ${index + 1}`}
+            size="sm"
+            variant="text"
+            color="destructive"
+            disabled={interactionDisabled}
+            onClick={handleDelete}
           />
         </div>
       </div>
-      <div className="flex grow-0 p-5">
+    );
+  }
+
+  return (
+    <div
+      className={cx(
+        'flex flex-col gap-4',
+        ROW_CLASSES,
+        showErrors && 'border-destructive',
+      )}
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape') return;
+        event.stopPropagation();
+        onCancel();
+      }}
+    >
+      <div className="flex items-center justify-end gap-1">
+        <IconButton
+          icon={<Check />}
+          aria-label="Finish editing option"
+          size="sm"
+          variant="text"
+          color="primary"
+          disabled={interactionDisabled}
+          onClick={onCancel}
+        />
         <IconButton
           icon={<Trash2 />}
-          aria-label="Remove option"
+          aria-label={`Remove option ${index + 1}`}
           size="sm"
           variant="text"
           color="destructive"
@@ -132,6 +180,41 @@ const Option = ({
           onClick={handleDelete}
         />
       </div>
+      <ValidatedField
+        component={FrescoReduxField}
+        componentProps={{
+          fieldComponent: FrescoRichTextEditorField,
+          label: 'Label',
+          placeholder: 'Enter a label...',
+          changeMode: 'input',
+          toolbarOptions: {
+            headings: false,
+            history: true,
+            links: false,
+            lists: false,
+            thematicBreak: false,
+          },
+          fromReduxValue: optionLabelFromRedux,
+          toReduxValue: optionLabelToRedux,
+        }}
+        name={`${fieldName}.label`}
+        validation={{ required: true, uniqueArrayAttribute: true }}
+      />
+      <ValidatedField
+        component={FrescoReduxField}
+        componentProps={{
+          fieldComponent: FrescoInputField,
+          label: 'Value',
+          placeholder: 'Enter a value...',
+          toReduxValue: parseOptionValue,
+        }}
+        name={`${fieldName}.value`}
+        validation={{
+          required: true,
+          uniqueArrayAttribute: true,
+          allowedVariableName: 'option value',
+        }}
+      />
     </div>
   );
 };

--- a/apps/architect/src/components/Options/Options.tsx
+++ b/apps/architect/src/components/Options/Options.tsx
@@ -24,7 +24,7 @@ const Options = ({ name, label = '' }: OptionsProps) => (
     label={label}
     itemComponent={Option}
     itemTemplate={() => ({})}
-    itemClasses="p-0! shadow-none"
+    itemClasses="bg-surface-3 text-surface-3-contrast p-0! shadow-none"
     addButtonLabel="Add new"
     emptyStateMessage="No options have been added yet."
     immediateAdd

--- a/apps/architect/src/components/ProjectNav/ProjectLayout.tsx
+++ b/apps/architect/src/components/ProjectNav/ProjectLayout.tsx
@@ -3,7 +3,6 @@ import type React from 'react';
 import { useLocation } from 'wouter';
 
 import ProjectNav from '~/components/ProjectNav/ProjectNav';
-import ProtocolOpenElsewhereBanner from '~/components/ProtocolOpenElsewhereBanner';
 import StorageUnavailableBanner from '~/components/StorageUnavailableBanner';
 import { cx } from '~/utils/cva';
 import { getScrollPosition, setScrollPosition } from '~/utils/scrollPositions';
@@ -47,7 +46,6 @@ const ProjectLayout = ({ children, className }: ProjectLayoutProps) => {
     >
       <ProjectNav />
       <StorageUnavailableBanner />
-      <ProtocolOpenElsewhereBanner />
       {children}
       <ProjectActions
         readOnly={isSummary}

--- a/apps/architect/src/components/ProtocolInfoCard.tsx
+++ b/apps/architect/src/components/ProtocolInfoCard.tsx
@@ -116,24 +116,22 @@ const ProtocolInfoCard = () => {
           aria-label="Protocol name"
         />
 
-        <div className="border-platinum-dark/60 focus-within:border-primary overflow-hidden rounded-sm border bg-white/45 backdrop-blur-sm transition-colors">
-          <TextAreaField
-            aria-label="Protocol description"
-            className="[&>textarea]:field-sizing-content [&>textarea]:max-h-52 [&>textarea]:min-h-24 [&>textarea]:rounded-none [&>textarea]:border-0 [&>textarea]:bg-transparent [&>textarea]:focus:border-0 [&>textarea]:focus:ring-0"
-            placeholder="Enter a description for your protocol..."
-            value={localDescription}
-            onChange={(value) => setLocalDescription(value ?? '')}
-            onBlur={() => {
-              if (localDescription !== description) {
-                dispatch(
-                  updateProtocolDescription({
-                    description: localDescription,
-                  }),
-                );
-              }
-            }}
-          />
-        </div>
+        <TextAreaField
+          aria-label="Protocol description"
+          className="[&>textarea]:field-sizing-content [&>textarea]:max-h-52 [&>textarea]:min-h-24"
+          placeholder="Enter a description for your protocol..."
+          value={localDescription}
+          onChange={(value) => setLocalDescription(value ?? '')}
+          onBlur={() => {
+            if (localDescription !== description) {
+              dispatch(
+                updateProtocolDescription({
+                  description: localDescription,
+                }),
+              );
+            }
+          }}
+        />
 
         <div className="text-navy-taupe/70 font-monospace flex flex-wrap items-center gap-2 text-xs tracking-wide uppercase">
           <span>

--- a/apps/architect/src/components/ProtocolOpenElsewhereBanner.tsx
+++ b/apps/architect/src/components/ProtocolOpenElsewhereBanner.tsx
@@ -19,9 +19,9 @@ const ProtocolOpenElsewhereBanner = () => {
 
   return (
     <Alert
-      variant="warning"
+      variant="info"
       density="compact"
-      className="my-0 rounded-none! px-7 py-2.5 shadow-none!"
+      className="border-outline my-0 shrink-0 rounded-none! border-x-0 border-t-0 border-b px-7 py-2.5 shadow-none!"
     >
       <AlertDescription className="flex items-center justify-between gap-5 text-sm">
         <span>
@@ -29,7 +29,12 @@ const ProtocolOpenElsewhereBanner = () => {
           edits, changes here won&apos;t be saved. Continue editing in the other
           tab, or return to the start screen.
         </span>
-        <Button size="sm" color="primary" onClick={() => setLocation('/')}>
+        <Button
+          size="sm"
+          color="info"
+          className="bg-info-contrast text-info"
+          onClick={() => setLocation('/')}
+        >
           Return to start screen
         </Button>
       </AlertDescription>

--- a/apps/architect/src/components/Validations/Validation.tsx
+++ b/apps/architect/src/components/Validations/Validation.tsx
@@ -1,5 +1,6 @@
 import { map } from 'es-toolkit/compat';
-import { Trash2 } from 'lucide-react';
+import { Check, Pencil, Trash2, X } from 'lucide-react';
+import { useEffect, useState, type KeyboardEvent } from 'react';
 
 import { IconButton } from '@codaco/fresco-ui/Button';
 import InputField from '@codaco/fresco-ui/form/fields/InputField';
@@ -13,8 +14,10 @@ import {
   MULTI_SELECT_RULE_CLASSES,
 } from '../Form/MultiSelect';
 import {
+  getValidationLabel,
   isValidationWithListValue,
   isValidationWithNumberValue,
+  isValidationWithoutValue,
 } from './options';
 
 type ValidationOption = {
@@ -22,20 +25,23 @@ type ValidationOption = {
   value: string;
 };
 
+type ValidationValue = boolean | number | string | null;
+
 type ValidationProps = {
   onDelete?: (itemKey: string) => void;
-  onUpdate?: (
-    key: string,
-    value: boolean | number | string | null,
-    itemKey: string,
-  ) => void;
+  onUpdate?: (key: string, value: ValidationValue, itemKey: string) => void;
+  onEdit?: () => void;
+  onCancel?: () => void;
   options?: ValidationOption[];
   itemKey?: string;
-  itemValue?: boolean | number | string | null;
+  itemValue?: ValidationValue;
   existingVariables: Record<string, Pick<Variable, 'name' | 'type'>>;
+  isBeingEdited?: boolean;
 };
 
 const noop = () => {};
+
+const ROW_CLASSES = `group ${MULTI_SELECT_RULE_CLASSES}`;
 
 const parseNumberInput = (value: unknown) => {
   if (typeof value === 'number') {
@@ -51,42 +57,120 @@ const parseNumberInput = (value: unknown) => {
   return Number.isNaN(parsed) ? null : parsed;
 };
 
+/**
+ * Human-readable summary for a validation rule's collapsed row, e.g.
+ * "Minimum value: 2" or "Same as: Alex".
+ */
+export const summarizeValidation = (
+  key: string,
+  value: ValidationValue,
+  existingVariables: Record<string, Pick<Variable, 'name' | 'type'>>,
+): string => {
+  if (!key) {
+    return 'New validation rule';
+  }
+
+  const label = getValidationLabel(key);
+
+  if (isValidationWithoutValue(key)) {
+    return label;
+  }
+
+  if (isValidationWithListValue(key)) {
+    const variableName =
+      typeof value === 'string' ? existingVariables[value]?.name : undefined;
+    return `${label}: ${variableName ?? 'No variable selected'}`;
+  }
+
+  if (isValidationWithNumberValue(key)) {
+    return typeof value === 'number' ? `${label}: ${value}` : `${label}: —`;
+  }
+
+  return label;
+};
+
+// A draft is only worth saving once it has a rule type, and (when that rule
+// type needs one) a value.
+const isDraftComplete = (key: string, value: ValidationValue): boolean => {
+  if (!key) {
+    return false;
+  }
+  if (isValidationWithoutValue(key)) {
+    return true;
+  }
+  if (isValidationWithNumberValue(key)) {
+    return typeof value === 'number';
+  }
+  if (isValidationWithListValue(key)) {
+    return typeof value === 'string' && value.length > 0;
+  }
+  return false;
+};
+
 const Validation = ({
   onDelete = noop,
   onUpdate = noop,
+  onEdit = noop,
+  onCancel = noop,
   options = [],
   itemKey = '',
   itemValue = null,
   existingVariables,
+  isBeingEdited = false,
 }: ValidationProps) => {
+  const isNewItem = itemKey === '';
+  const [draftKey, setDraftKey] = useState(itemKey);
+  const [draftValue, setDraftValue] = useState<ValidationValue>(itemValue);
+
+  // Reset the draft to the committed value every time a row (re)starts an
+  // edit session, so edits abandoned via Cancel never leak into the next
+  // session.
+  useEffect(() => {
+    if (isBeingEdited) {
+      setDraftKey(itemKey);
+      setDraftValue(itemValue);
+    }
+  }, [isBeingEdited, itemKey, itemValue]);
+
   const handleKeyChange = (option: string | null) => {
-    onUpdate(option || '', itemValue, itemKey || '');
+    const newKey = option ?? '';
+    // Mirror getAutoValue's rule for immediate UI feedback: a value only
+    // survives a rule-type change if the previous and new types are
+    // value-compatible. The authoritative recompute (relative to the
+    // originally committed key) happens in withUpdateHandlers on save.
+    setDraftValue((currentValue) => {
+      if (!newKey) return null;
+      if (isValidationWithoutValue(newKey)) return true;
+      if (
+        isValidationWithNumberValue(newKey) &&
+        isValidationWithNumberValue(draftKey)
+      ) {
+        return currentValue;
+      }
+      if (
+        isValidationWithListValue(newKey) &&
+        isValidationWithListValue(draftKey)
+      ) {
+        return currentValue;
+      }
+      return null;
+    });
+    setDraftKey(newKey);
   };
 
-  const handleNumberValueChange = (newValue: number | null) => {
-    onUpdate(itemKey || '', newValue, itemKey || '');
+  const handleSave = () => {
+    if (!isDraftComplete(draftKey, draftValue)) {
+      return;
+    }
+    onUpdate(draftKey, draftValue, itemKey);
+    onCancel();
   };
 
-  const handleListValueChange = (newValue: string | null) => {
-    onUpdate(itemKey || '', newValue, itemKey || '');
-  };
-
-  const keyInputProps = {
-    name: 'validation-key',
-    value: itemKey ?? null,
-    onChange: handleKeyChange,
-  };
-
-  const numberValueInputProps = {
-    name: 'validation-value',
-    value: typeof itemValue === 'number' ? itemValue : null,
-    onChange: handleNumberValueChange,
-  };
-
-  const listValueInputProps = {
-    name: 'validation-value',
-    value: typeof itemValue === 'string' ? itemValue : null,
-    onChange: handleListValueChange,
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onCancel();
+    }
   };
 
   const existingVariableOptions = map(
@@ -96,43 +180,76 @@ const Validation = ({
       value: variableKey,
     }),
   );
+
+  if (!isBeingEdited) {
+    const label = getValidationLabel(itemKey);
+    return (
+      <div className={ROW_CLASSES}>
+        <div className={MULTI_SELECT_OPTIONS_CLASSES}>
+          <p className="truncate">
+            {summarizeValidation(itemKey, itemValue, existingVariables)}
+          </p>
+        </div>
+        <div className={MULTI_SELECT_CONTROL_CLASSES}>
+          <IconButton
+            icon={<Pencil />}
+            aria-label={`Edit ${label} validation rule`}
+            variant="text"
+            color="dynamic"
+            onClick={onEdit}
+          />
+          <IconButton
+            icon={<Trash2 />}
+            aria-label={`Delete ${label} validation rule`}
+            variant="text"
+            color="destructive"
+            onClick={() => onDelete(itemKey)}
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className={`group ${MULTI_SELECT_RULE_CLASSES}`}>
+    <div className={ROW_CLASSES} onKeyDown={handleKeyDown}>
       <div className={MULTI_SELECT_OPTIONS_CLASSES}>
         <div className={MULTI_SELECT_OPTION_CLASSES}>
           <NativeSelectField
             options={options}
-            name={keyInputProps.name}
-            value={keyInputProps.value ?? undefined}
+            name="validation-key"
+            value={draftKey || undefined}
             onChange={(value) =>
-              keyInputProps.onChange(typeof value === 'string' ? value : null)
+              handleKeyChange(typeof value === 'string' ? value : null)
             }
             placeholder="Select validation rule"
+            autoFocus
           />
         </div>
-        {itemKey && isValidationWithNumberValue(itemKey) && (
+        {draftKey && isValidationWithNumberValue(draftKey) && (
           <div className={MULTI_SELECT_OPTION_CLASSES}>
             <InputField
-              name={numberValueInputProps.name}
-              value={numberValueInputProps.value?.toString() ?? undefined}
+              name="validation-value"
+              value={
+                typeof draftValue === 'number'
+                  ? draftValue.toString()
+                  : undefined
+              }
               onChange={(value: unknown) =>
-                numberValueInputProps.onChange(parseNumberInput(value))
+                setDraftValue(parseNumberInput(value))
               }
               type="number"
               step="any"
             />
           </div>
         )}
-        {itemKey && isValidationWithListValue(itemKey) && (
+        {draftKey && isValidationWithListValue(draftKey) && (
           <div className={MULTI_SELECT_OPTION_CLASSES}>
             <NativeSelectField
               options={existingVariableOptions}
-              name={listValueInputProps.name}
-              value={listValueInputProps.value ?? undefined}
+              name="validation-value"
+              value={typeof draftValue === 'string' ? draftValue : undefined}
               onChange={(value) =>
-                listValueInputProps.onChange(
-                  typeof value === 'string' ? value : null,
-                )
+                setDraftValue(typeof value === 'string' ? value : null)
               }
               placeholder="Select comparison variable"
             />
@@ -141,13 +258,21 @@ const Validation = ({
       </div>
       <div className={MULTI_SELECT_CONTROL_CLASSES}>
         <IconButton
-          icon={<Trash2 />}
-          aria-label="Delete validation rule"
-          size="sm"
+          icon={<Check />}
+          aria-label={
+            isNewItem ? 'Add validation rule' : 'Save validation rule'
+          }
+          variant="text"
+          color="success"
+          disabled={!isDraftComplete(draftKey, draftValue)}
+          onClick={handleSave}
+        />
+        <IconButton
+          icon={<X />}
+          aria-label="Cancel editing validation rule"
           variant="text"
           color="destructive"
-          className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
-          onClick={() => onDelete(itemKey || '')}
+          onClick={onCancel}
         />
       </div>
     </div>

--- a/apps/architect/src/components/Validations/Validations.tsx
+++ b/apps/architect/src/components/Validations/Validations.tsx
@@ -1,6 +1,6 @@
 import { keys as getKeys, isNull, toPairs } from 'es-toolkit/compat';
 import { Plus } from 'lucide-react';
-import { useId, type ReactNode, type ComponentProps } from 'react';
+import { useId, useState, type ReactNode, type ComponentProps } from 'react';
 import { Field } from 'redux-form';
 
 import Button from '@codaco/fresco-ui/Button';
@@ -70,6 +70,8 @@ type ValidationsFieldProps = {
     error?: string;
   };
   children?: ReactNode;
+  editingKey: string | null;
+  onEditKey: (key: string | null) => void;
   onUpdate?: (key: string, value: unknown, itemKey: string) => void;
   onDelete?: (itemKey: string) => void;
 };
@@ -80,6 +82,8 @@ const ValidationsField = ({
   existingVariables,
   meta: { submitFailed, error },
   children = null,
+  editingKey,
+  onEditKey,
   ...rest
 }: ValidationsFieldProps) => {
   const hasError = !!(submitFailed && error);
@@ -100,6 +104,9 @@ const ValidationsField = ({
             itemValue={value}
             options={options}
             existingVariables={existingVariables}
+            isBeingEdited={key === editingKey}
+            onEdit={() => onEditKey(key)}
+            onCancel={() => onEditKey(null)}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...rest}
           />
@@ -134,12 +141,35 @@ const Validations = ({
   handleDelete,
   handleAddNew,
 }: ValidationsProps) => {
+  // Only one row (existing or the "add new" draft) is ever open for editing
+  // at a time.
+  const [editingKey, setEditingKey] = useState<string | null>(null);
   const usedOptions = getKeys(value);
   const availableOptions = getOptionsWithUsedDisabled(
     validationOptions,
     usedOptions,
   );
   const isFull = usedOptions.length === availableOptions.length;
+  const isEditingSomething = addNew || editingKey !== null;
+
+  const handleSaveExisting = (
+    key: string,
+    itemValue: unknown,
+    itemKey: string,
+  ) => {
+    handleChange(key, itemValue, itemKey);
+    setEditingKey(null);
+  };
+
+  const handleDeleteExisting = (itemKey: string) => {
+    handleDelete(itemKey);
+    setEditingKey((current) => (current === itemKey ? null : current));
+  };
+
+  const handleStartAddNew = () => {
+    setEditingKey(null);
+    setAddNew(true);
+  };
 
   return (
     <div className="flex w-full flex-col gap-5 [--rule-bg:oklch(var(--slate-blue))] [&_button]:m-0">
@@ -149,21 +179,26 @@ const Validations = ({
         format={format}
         options={availableOptions}
         existingVariables={existingVariables}
-        onUpdate={handleChange}
-        onDelete={handleDelete}
+        onUpdate={handleSaveExisting}
+        onDelete={handleDeleteExisting}
+        editingKey={editingKey}
+        onEditKey={setEditingKey}
         validate={validate}
       >
         {addNew && (
           <Validation
+            isBeingEdited
             onUpdate={handleAddNew}
-            onDelete={() => setAddNew(false)}
+            onCancel={() => setAddNew(false)}
             options={availableOptions}
             existingVariables={existingVariables}
           />
         )}
       </Field>
 
-      {!isFull && <AddItem onClick={() => setAddNew(true)} />}
+      {!isFull && (
+        <AddItem onClick={handleStartAddNew} disabled={isEditingSomething} />
+      )}
     </div>
   );
 };

--- a/apps/architect/src/components/Validations/__tests__/Validation.test.tsx
+++ b/apps/architect/src/components/Validations/__tests__/Validation.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import Validation from '../Validation';
+import Validation, { summarizeValidation } from '../Validation';
 
 const options = [
   { label: 'Minimum value', value: 'minValue' },
@@ -9,7 +9,7 @@ const options = [
 ];
 
 describe('Validation', () => {
-  it('uses a labeled semantic delete action without changing the rule', () => {
+  it('renders a collapsed summary row with edit and delete actions', () => {
     const onDelete = vi.fn();
     const onUpdate = vi.fn();
 
@@ -24,19 +24,43 @@ describe('Validation', () => {
       />,
     );
 
-    const remove = screen.getByRole('button', {
-      name: 'Delete validation rule',
-    });
-    expect(remove).toHaveClass('group-focus-within:opacity-100');
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Save validation rule' }),
+    ).not.toBeInTheDocument();
 
+    const remove = screen.getByRole('button', {
+      name: 'Delete Required validation rule',
+    });
     fireEvent.click(remove);
 
     expect(onDelete).toHaveBeenCalledWith('required');
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it('preserves decimal values for numeric validation rules', () => {
+  it('reveals inline edit controls when the edit action is used', () => {
+    const onEdit = vi.fn();
+
+    render(
+      <Validation
+        itemKey="required"
+        itemValue
+        options={options}
+        existingVariables={{}}
+        onEdit={onEdit}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edit Required validation rule' }),
+    );
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('only commits a changed value once the save action is used', () => {
     const onUpdate = vi.fn();
+    const onCancel = vi.fn();
 
     render(
       <Validation
@@ -45,6 +69,8 @@ describe('Validation', () => {
         options={options}
         existingVariables={{}}
         onUpdate={onUpdate}
+        onCancel={onCancel}
+        isBeingEdited
       />,
     );
 
@@ -52,6 +78,78 @@ describe('Validation', () => {
       target: { value: '3.14' },
     });
 
+    // Editing the value alone must not write to the redux-form field yet.
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save validation rule' }),
+    );
+
     expect(onUpdate).toHaveBeenCalledWith('minValue', 3.14, 'minValue');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('discards edits and exits editing mode when cancelled', () => {
+    const onUpdate = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <Validation
+        itemKey="minValue"
+        itemValue={1}
+        options={options}
+        existingVariables={{}}
+        onUpdate={onUpdate}
+        onCancel={onCancel}
+        isBeingEdited
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('spinbutton'), {
+      target: { value: '3.14' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel editing validation rule' }),
+    );
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('cancels editing on Escape', () => {
+    const onCancel = vi.fn();
+
+    render(
+      <Validation
+        itemKey="minValue"
+        itemValue={1}
+        options={options}
+        existingVariables={{}}
+        onCancel={onCancel}
+        isBeingEdited
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('spinbutton'), { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});
+
+describe('summarizeValidation', () => {
+  it('summarizes a rule with no value', () => {
+    expect(summarizeValidation('required', true, {})).toBe('Required');
+  });
+
+  it('summarizes a rule with a number value', () => {
+    expect(summarizeValidation('minValue', 2, {})).toBe('Minimum value: 2');
+  });
+
+  it('summarizes a rule with a variable-reference value', () => {
+    expect(
+      summarizeValidation('sameAs', 'var-1', {
+        'var-1': { name: 'Alex', type: 'text' },
+      }),
+    ).toBe('Same as: Alex');
   });
 });

--- a/apps/architect/src/components/Validations/options.ts
+++ b/apps/architect/src/components/Validations/options.ts
@@ -1,4 +1,4 @@
-import { get, without } from 'es-toolkit/compat';
+import { get, startCase, without } from 'es-toolkit/compat';
 
 import { VARIABLE_REFERENCE_VALIDATIONS } from '@codaco/protocol-validation';
 
@@ -67,6 +67,29 @@ const VALIDATIONS_WITH_NUMBER_VALUES = [
 
 const VALIDATIONS_WITHOUT_VALUES = ['required', 'unique'];
 
+// Human-readable labels for the "Select validation rule" dropdown and for the
+// collapsed-row summary text. Anything not listed here (there shouldn't be
+// any) falls back to a start-cased version of the key.
+const VALIDATION_LABELS: Record<string, string> = {
+  required: 'Required',
+  unique: 'Must be unique',
+  minLength: 'Minimum length',
+  maxLength: 'Maximum length',
+  minValue: 'Minimum value',
+  maxValue: 'Maximum value',
+  minSelected: 'Minimum selected',
+  maxSelected: 'Maximum selected',
+  differentFrom: 'Different from',
+  sameAs: 'Same as',
+  lessThanVariable: 'Less than',
+  greaterThanVariable: 'Greater than',
+  lessThanOrEqualToVariable: 'Less than or equal to',
+  greaterThanOrEqualToVariable: 'Greater than or equal to',
+};
+
+const getValidationLabel = (validation: string): string =>
+  VALIDATION_LABELS[validation] ?? startCase(validation);
+
 const isValidationWithoutValue = (validation: string): boolean =>
   VALIDATIONS_WITHOUT_VALUES.includes(validation);
 
@@ -93,11 +116,12 @@ const getValidationOptionsForVariableType = (
     getValidationsForVariableType(variableType),
     entity,
   ).map((validation) => ({
-    label: validation,
+    label: getValidationLabel(validation),
     value: validation,
   }));
 
 export {
+  getValidationLabel,
   getValidationOptionsForVariableType,
   isValidationWithListValue,
   isValidationWithNumberValue,

--- a/apps/architect/src/components/Validations/withUpdateHandlers.tsx
+++ b/apps/architect/src/components/Validations/withUpdateHandlers.tsx
@@ -1,55 +1,16 @@
 import { omit } from 'es-toolkit/compat';
 import { withHandlers } from 'react-recompose';
 
-import {
-  isValidationWithListValue,
-  isValidationWithNumberValue,
-  isValidationWithoutValue,
-} from './options';
-
 type ValidationValue = boolean | number | string | null;
 
 /**
- * Function called when a validation is added or updated. Returns a value
- * based on the validation type, and the previous value (if any).
- *
- * @param {string} type - The validation type.
- * @param {string} oldType - The previous validation type.
- * @param {string} value - The current value.
- * @returns {string} The new value.
+ * Applies a committed (key, value) pair to the validation map, renaming the
+ * row from `oldKey` if given. `Validation.tsx` owns deciding whether a value
+ * survives a rule-type change (and forces `true` for value-less rule types)
+ * before this is ever called, via its own draft state and `isDraftComplete`
+ * gate — so the value handed in here is already final and is stored as-is,
+ * with no further "does this look stale" heuristic re-applied.
  */
-const getAutoValue = (
-  type: string,
-  oldType: string | null,
-  value: ValidationValue,
-): ValidationValue => {
-  // If the validation type doesn't require a value, return true.
-  if (isValidationWithoutValue(type)) {
-    return true;
-  }
-
-  // If the new type and the old type are both numbers, keep the value
-  if (
-    isValidationWithNumberValue(type) &&
-    oldType &&
-    isValidationWithNumberValue(oldType)
-  ) {
-    return value;
-  }
-
-  // If the new type and the old type both reference variables, keep the value.
-  if (
-    isValidationWithListValue(type) &&
-    oldType &&
-    isValidationWithListValue(oldType)
-  ) {
-    return value;
-  }
-
-  // Otherwise, set an empty value to force the user to enter a value.
-  return null;
-};
-
 export const getUpdatedValue = (
   previousValue: Record<string, ValidationValue>,
   key: string,
@@ -64,15 +25,13 @@ export const getUpdatedValue = (
     return previousValue;
   }
 
-  const autoValue = getAutoValue(key, oldKey, value);
-
   if (!oldKey) {
-    return { ...previousValue, [key]: autoValue };
+    return { ...previousValue, [key]: value };
   }
 
   return {
     ...omit(previousValue, oldKey),
-    [key]: autoValue,
+    [key]: value,
   };
 };
 

--- a/apps/architect/src/components/ViewManager/views/App.tsx
+++ b/apps/architect/src/components/ViewManager/views/App.tsx
@@ -8,6 +8,7 @@ import InstallBanner from '~/components/InstallBanner';
 import { JsonPreviewOverlay } from '~/components/JsonPreviewOverlay';
 import ProtocolGuardedRouter from '~/components/ProtocolGuardedRouter';
 import { showProtocolOpenResultDialog } from '~/components/protocolOpenDialogs';
+import ProtocolOpenElsewhereBanner from '~/components/ProtocolOpenElsewhereBanner';
 import ProtocolValidationDialogReporter from '~/components/ProtocolValidationDialogReporter';
 import Routes from '~/components/Routes';
 import ScrollToTop from '~/components/ScrollToTop';
@@ -146,6 +147,9 @@ const AppContents = () => {
         {/* The install banner urges installation when running in a browser tab;
             it self-hides (rendering nothing) when installed or dismissed. */}
         <InstallBanner />
+        {/* Sits directly beneath the install banner (both are shrink-0 strips);
+            self-hides unless the open protocol is also open in another tab. */}
+        <ProtocolOpenElsewhereBanner />
         <div className="min-h-0 flex-1">
           <Routes />
         </div>

--- a/apps/architect/src/components/sections/Form/FieldFields.tsx
+++ b/apps/architect/src/components/sections/Form/FieldFields.tsx
@@ -9,7 +9,7 @@ import NativeSelectField from '@codaco/fresco-ui/form/fields/Select/Native';
 import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
-import { Section, Subsection } from '~/components/EditorLayout';
+import { Section } from '~/components/EditorLayout';
 import RichText from '~/components/Form/Fields/RichText/Field';
 import FrescoReduxField from '~/components/Form/FrescoReduxField';
 import ValidatedField from '~/components/Form/ValidatedField';
@@ -74,8 +74,8 @@ const PromptFields = ({
   );
   const lockedOptions = getLockedOptions(existingVariables, variable);
   return (
-    <Section layout="vertical">
-      <Subsection id={getFieldId('variable')} title="Variable">
+    <>
+      <Section layout="vertical" id={getFieldId('variable')} title="Variable">
         {variable && !isNewVariable && (
           <Alert variant="info" className="my-7">
             <AlertDescription>
@@ -97,9 +97,10 @@ const PromptFields = ({
             onChange: handleChangeVariable,
           }}
         />
-      </Subsection>
+      </Section>
 
-      <Subsection
+      <Section
+        layout="vertical"
         id={getFieldId('prompt')}
         title="Question"
         summary={
@@ -161,9 +162,10 @@ const PromptFields = ({
             className="shrink-0"
           />
         </div>
-      </Subsection>
+      </Section>
 
-      <Subsection
+      <Section
+        layout="vertical"
         id={getFieldId('component')}
         title="Input Control"
         disabled={!variable}
@@ -229,10 +231,11 @@ const PromptFields = ({
               />
             </div>
           )}
-      </Subsection>
+      </Section>
 
       {isOrdinalOrCategoricalType(variableType) && (
-        <Subsection
+        <Section
+          layout="vertical"
           id={getFieldId('options')}
           title="Categorical/Ordinal options"
           summary={
@@ -255,25 +258,33 @@ const PromptFields = ({
           ) : (
             <Options name="options" label="Options" />
           )}
-        </Subsection>
+        </Section>
       )}
       {isBooleanWithOptions(component) && (
         // BooleanChoice writes to the `options` field, so anchor it there (it is
-        // mutually exclusive with the Categorical/Ordinal options subsection
+        // mutually exclusive with the Categorical/Ordinal options section
         // above, so the shared id never collides at runtime).
-        <Subsection id={getFieldId('options')} title="BooleanChoice Options">
+        <Section
+          layout="vertical"
+          id={getFieldId('options')}
+          title="BooleanChoice Options"
+        >
           <BooleanChoice form={form} />
-        </Subsection>
+        </Section>
       )}
       {isVariableTypeWithParameters(variableType) && (
-        <Subsection id={getFieldId('parameters')} title="Input Options">
+        <Section
+          layout="vertical"
+          id={getFieldId('parameters')}
+          title="Input Options"
+        >
           <Parameters
             type={variableType}
             component={component ?? ''}
             name="parameters"
             form={form}
           />
-        </Subsection>
+        </Section>
       )}
 
       <ValidationSection
@@ -285,7 +296,7 @@ const PromptFields = ({
         }
         existingVariables={omit(existingVariables, variable)}
       />
-    </Section>
+    </>
   );
 };
 export default PromptFields;

--- a/apps/architect/src/components/sections/NodeType.tsx
+++ b/apps/architect/src/components/sections/NodeType.tsx
@@ -24,6 +24,10 @@ export const SUBJECT_INDEPENDENT_FIELDS = [
   'label',
   'interviewScript',
   'introductionPanel',
+  // The subject field itself never depends on its own value — omitting it
+  // here meant handleResetStage nulled the just-selected subject out from
+  // under the user on every change, including the very first selection.
+  'subject',
 ];
 type NodeTypeProps = StageEditorSectionProps & {
   withFilter?: boolean;
@@ -35,7 +39,6 @@ const NodeType = (props: NodeTypeProps) => {
     getFormValues(form)(state),
   );
   const fields = keys(formValues);
-  const _currentSubject = get(formValues, 'subject');
   const handleResetStage = useCallback(() => {
     const fieldsToReset = difference(fields, SUBJECT_INDEPENDENT_FIELDS);
     fieldsToReset.forEach((field) => {

--- a/apps/architect/src/components/sections/ValidationSection.tsx
+++ b/apps/architect/src/components/sections/ValidationSection.tsx
@@ -1,18 +1,16 @@
 import type { UnknownAction } from '@reduxjs/toolkit';
 import { createSelector } from '@reduxjs/toolkit';
 import { get, pickBy } from 'es-toolkit/compat';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { change, formValueSelector } from 'redux-form';
 
-import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import type { Variable } from '@codaco/protocol-validation';
-import { Subsection } from '~/components/EditorLayout';
+import { Section } from '~/components/EditorLayout';
 import Validations from '~/components/Validations';
 import { useAppDispatch } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/modules/root';
-import { cx } from '~/utils/cva';
 
 import { getFieldId } from '../../utils/issues';
 type ValidationSectionProps = {
@@ -39,19 +37,11 @@ const ValidationSection = ({
     );
   }, [form]);
   const hasValidation = useSelector(hasValidationSelector);
-  const [isEnabled, setIsEnabled] = useState(!!hasValidation);
-  // Keep the toggle in sync when the underlying validation is set/cleared
-  // elsewhere (e.g. a form reset). Adding a rule sets hasValidation, removing
-  // the last rule clears it; enabling the toggle before adding a rule keeps
-  // hasValidation false, so this only fires on an actual change.
-  useEffect(() => {
-    setIsEnabled(!!hasValidation);
-  }, [hasValidation]);
-  const handleToggle = (nextState: boolean) => {
-    setIsEnabled(nextState);
+  const handleToggleChange = (nextState: boolean) => {
     if (!nextState) {
       dispatch(change(form, 'validation', null) as UnknownAction);
     }
+    return true;
   };
   const existingVariablesForType = useMemo(
     () =>
@@ -62,7 +52,8 @@ const ValidationSection = ({
     [existingVariables, variableType],
   );
   return (
-    <Subsection
+    <Section
+      layout="vertical"
       id={getFieldId('validation')}
       title="Validation"
       summary={
@@ -71,29 +62,18 @@ const ValidationSection = ({
         </Paragraph>
       }
       disabled={disabled}
-      action={
-        <ToggleField
-          title="Turn validation on or off"
-          value={isEnabled}
-          onChange={(checked) => handleToggle(!!checked)}
-          disabled={disabled}
-          className={cx(
-            'shrink-0',
-            disabled && 'cursor-not-allowed opacity-50',
-          )}
-        />
-      }
+      toggleable
+      startExpanded={!!hasValidation}
+      handleToggleChange={handleToggleChange}
     >
-      {isEnabled && (
-        <Validations
-          form={form}
-          name="validation"
-          variableType={variableType}
-          entity={entity}
-          existingVariables={existingVariablesForType}
-        />
-      )}
-    </Subsection>
+      <Validations
+        form={form}
+        name="validation"
+        variableType={variableType}
+        entity={entity}
+        existingVariables={existingVariablesForType}
+      />
+    </Section>
   );
 };
 export default ValidationSection;

--- a/apps/architect/src/components/sections/__tests__/NodeType.test.tsx
+++ b/apps/architect/src/components/sections/__tests__/NodeType.test.tsx
@@ -1,0 +1,90 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import {
+  reducer as formReducer,
+  reduxForm,
+  type InjectedFormProps,
+} from 'redux-form';
+import { describe, expect, it } from 'vitest';
+
+import NodeType from '../NodeType';
+
+type FormValues = {
+  subject?: { entity: string; type: string | null };
+  form?: unknown;
+  prompts?: unknown;
+};
+
+const Harness = (_props: InjectedFormProps<FormValues>) => (
+  <NodeType
+    form="edit-stage"
+    stagePath={null}
+    stagePosition={0}
+    interfaceType={'NameGeneratorForms' as never}
+  />
+);
+
+const ReduxHarness = reduxForm<FormValues>({ form: 'edit-stage' })(Harness);
+
+const setup = (initialValues: FormValues = {}) => {
+  const store = configureStore({
+    reducer: {
+      form: formReducer,
+      activeProtocol: () => ({
+        present: {
+          codebook: {
+            node: {
+              person: {
+                name: 'Person',
+                color: 'node-color-seq-1',
+                shape: { default: 'circle' },
+                variables: {},
+              },
+            },
+            edge: {},
+            ego: { variables: {} },
+          },
+          stages: [],
+        },
+      }),
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }),
+  });
+
+  render(
+    <Provider store={store}>
+      <ReduxHarness initialValues={initialValues} />
+    </Provider>,
+  );
+
+  const getValues = () =>
+    store.getState().form['edit-stage']?.values as FormValues | undefined;
+
+  return { getValues };
+};
+
+describe('NodeType', () => {
+  it('keeps the selected subject on a fresh stage instead of resetting it to null', () => {
+    const { getValues } = setup();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Person' }));
+
+    expect(getValues()?.subject).toEqual({ entity: 'node', type: 'person' });
+  });
+
+  it('clears dependent fields, but not the subject itself, when the subject changes', () => {
+    const { getValues } = setup({
+      form: { title: 'Add a person' },
+      prompts: [{ id: 'prompt-1', text: 'Who do you turn to?' }],
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Person' }));
+
+    const values = getValues();
+    expect(values?.subject).toEqual({ entity: 'node', type: 'person' });
+    expect(values?.form).toBeNull();
+    expect(values?.prompts).toBeNull();
+  });
+});

--- a/apps/architect/src/styles/architect-theme.css
+++ b/apps/architect/src/styles/architect-theme.css
@@ -48,7 +48,6 @@
     --timeline-contrast: oklch(var(--white));
     --sortable-contrast: oklch(var(--white));
     --table-row-tint: oklch(var(--sea-serpent) / 5%);
-    --form-control: oklch(var(--sea-serpent));
     --action: oklch(var(--sea-green));
     --muted: oklch(var(--cyber-grape) / 60%);
     --active: oklch(var(--sea-green));
@@ -66,7 +65,6 @@
   --color-timeline-contrast: var(--timeline-contrast);
   --color-sortable-contrast: var(--sortable-contrast);
   --color-table-row-tint: var(--table-row-tint);
-  --color-form-control: var(--form-control);
   --color-action: var(--action);
   --color-muted: var(--muted);
   --color-active: var(--active);

--- a/packages/fresco-ui/src/Alert.tsx
+++ b/packages/fresco-ui/src/Alert.tsx
@@ -11,7 +11,7 @@ import { paragraphVariants } from './typography/Paragraph';
 import { cva, cx, type VariantProps } from './utils/cva';
 
 const alertVariants = cva({
-  base: 'my-6 flex w-full items-start rounded first:mt-0 last:mb-0',
+  base: 'my-6 flex w-full rounded first:mt-0 last:mb-0',
   variants: {
     variant: {
       default: '',
@@ -34,8 +34,8 @@ const alertVariants = cva({
       soft: '',
     },
     density: {
-      default: 'gap-4',
-      compact: 'gap-3',
+      default: 'items-start gap-4',
+      compact: 'items-center gap-3',
     },
   },
   // Override the --link primitive (not the --color-link @theme inline alias, which

--- a/tooling/tailwind/fresco/themes/default.css
+++ b/tooling/tailwind/fresco/themes/default.css
@@ -109,7 +109,7 @@
     --surface-contrast: var(--text);
     --surface-1: oklch(97% 0.02 var(--base-hue));
     --surface-1-contrast: var(--text);
-    --surface-2: oklch(95% 0.025 var(--base-hue));
+    --surface-2: oklch(0.91 0.01 231.77);
     --surface-2-contrast: var(--text);
     --surface-3: oklch(93% 0.03 var(--base-hue));
     --surface-3-contrast: var(--text);


### PR DESCRIPTION
## Summary

A batch of Architect protocol-editor UI fixes, plus one data-loss bug fix and two small shared-package changes.

**Architect app**
- **Banners** — the install banner and the "this protocol is already open in another tab" banner both render as strips at the top of the screen. The latter moved to the app shell (so it sits directly beneath the install banner) and now uses the `info` variant. Both action buttons are white with intent-coloured text.
- **Edit Field dialog** — split into distinct top-level Sections (Variable, Question, Input Control, Categorical/Ordinal Options, Validation). The Validation list and the categorical/ordinal Options list now use the shared inline-editing pattern (collapsed summary per item + inline edit), and their rows drop the clashing background / border / rounding layers so the item Surface styles show through cleanly.
- **Fixed a value-reset bug** in validation rules where choosing e.g. "Different from" + a variable then saving showed "No variable selected".
- **Protocol description field** — removed the redundant decorative wrapper so fresco-ui's `TextArea` provides its own styling; only size constraints remain.
- **Empty toggleable sections** centre their "enable this feature" placeholder correctly (previously an absolutely-positioned box overflowed the card).
- **Node-type reset (data-loss)** — selecting a node type for a stage reset itself whenever another field was edited or the stage was saved, because `subject` was missing from `SUBJECT_INDEPENDENT_FIELDS`, so `handleResetStage` nulled the just-set value. This let stages be saved in an invalid state. Fixed + regression test added.

**Shared packages**
- `@codaco/fresco-ui` — `Alert` now vertically centres the icon in `compact`-density alerts (default density keeps top alignment).
- `@codaco/tailwind-config` — light-theme `--surface-2` token updated.

## Test plan

- [x] `pnpm typecheck` — 22/22 pass
- [x] `pnpm lint` — clean (no new warnings in touched files), formatting clean
- [x] `pnpm knip` — clean
- [x] `pnpm check:changesets` — app/library lanes isolated
- [x] Affected unit tests pass (47 architect tests across NodeType, Validation, withUpdateHandlers, InstallBanner, ProtocolInfoCard, Options)
- [x] Manually verified in the browser: banner placement + button colours, lightbulb centring, description field, Options/Validation styling, and node-type selection surviving edits

Changesets: one app-lane (`@codaco/architect`), two library-lane (`@codaco/fresco-ui`, `@codaco/tailwind-config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer inline editing for field options and validation rules, with summaries, save/cancel controls, and improved labels.
  * Improved organization and presentation of protocol field settings and descriptions.
* **Bug Fixes**
  * Prevented stage subject selections from being cleared during edits.
  * Improved banner placement, button styling, and compact alert icon alignment.
  * Centered empty toggleable sections for better visibility.
* **Style**
  * Refined light-theme surface colors and styling consistency across options, alerts, and protocol editor controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->