### PR TITLE
Fix: use github.com/join for account sign-up links in docs

### DIFF
--- a/.changeset/docs-github-signup-link.md
+++ b/.changeset/docs-github-signup-link.md
@@ -1,0 +1,5 @@
+---
+'@codaco/documentation': patch
+---
+
+Updated the "create a GitHub account" links in the Fresco deployment guides to point to a URL that loads reliably.

--- a/apps/documentation/docs/collect-data/fresco/guide-vercel.en.mdx
+++ b/apps/documentation/docs/collect-data/fresco/guide-vercel.en.mdx
@@ -16,7 +16,7 @@ This guide will walk you through the process of deploying your instance of Fresc
 Before you get started, you should:
 
 - Read the [about Fresco](/en/collect-data/fresco/about) article to understand what Fresco is and how it works.
-- Create an account on [GitHub](https://github.com/signup) if you do not already have one.
+- Create an account on [GitHub](https://github.com/join) if you do not already have one.
 - Set aside enough time to complete the deployment process in one sitting.
 
 </PrerequisitesSection>
@@ -32,7 +32,7 @@ This _also_ means that you are responsible for the security and maintenance of y
 
 To deploy Fresco, we will use the following services and technologies:
 
-- **GitHub**: A platform for hosting and sharing code owned and operated by Microsoft. The Fresco code is shared via GitHub, and you will need a GitHub account to deploy it. If you do not have a GitHub account, you can create one for free at <a href="https://github.com/signup" target="_blank">github.com</a>.
+- **GitHub**: A platform for hosting and sharing code owned and operated by Microsoft. The Fresco code is shared via GitHub, and you will need a GitHub account to deploy it. If you do not have a GitHub account, you can create one for free at <a href="https://github.com/join" target="_blank">github.com</a>.
 - **PostgreSQL**: A powerful, open-source relational database system. Fresco uses PostgreSQL to store data about your study, participants, and responses.
 - **Object storage**: Fresco stores protocol assets (such as media files) in an S3-compatible object store. You can use **UploadThing** — a managed service that is the simplest option — or bring your own **S3-compatible bucket** (AWS S3, Cloudflare R2, MinIO, or Backblaze B2).
 

--- a/apps/documentation/docs/collect-data/fresco/guide.en.mdx
+++ b/apps/documentation/docs/collect-data/fresco/guide.en.mdx
@@ -15,7 +15,7 @@ This guide will walk you through the process of deploying your instance of Fresc
 Before you get started, you should:
 
 - Read the [about Fresco](/en/collect-data/fresco/about) article to understand what Fresco is and how it works.
-- Create an account on [GitHub](https://github.com/signup) if you do not already have one.
+- Create an account on [GitHub](https://github.com/join) if you do not already have one.
 - Set aside enough time to complete the deployment process in one sitting.
 
 </PrerequisitesSection>
@@ -31,7 +31,7 @@ This _also_ means that you are responsible for the security and maintenance of y
 
 To deploy Fresco, we will use the following services and technologies:
 
-- **GitHub**: A platform for hosting and sharing code owned and operated by Microsoft. The Fresco code is shared via GitHub, and you will need a GitHub account to deploy it. If you do not have a GitHub account, you can create one for free at <a href="https://github.com/signup" target="_blank">github.com</a>.
+- **GitHub**: A platform for hosting and sharing code owned and operated by Microsoft. The Fresco code is shared via GitHub, and you will need a GitHub account to deploy it. If you do not have a GitHub account, you can create one for free at <a href="https://github.com/join" target="_blank">github.com</a>.
 - **PostgreSQL**: A powerful, open-source relational database system. Fresco uses PostgreSQL to store data about your study, participants, and responses.
 - **Object storage**: Fresco stores protocol assets (such as media files) in an S3-compatible object store. You can use **UploadThing** — a managed service that is the simplest option — or bring your own **S3-compatible bucket** (AWS S3, Cloudflare R2, MinIO, or Backblaze B2).
 


### PR DESCRIPTION
## Summary

`docs-preview-checks` fails on any PR that rebuilds the documentation preview because the dead-link checker gets a **403** from `https://github.com/signup` — GitHub bot-blocks that page for non-browser user agents (reproducible with curl regardless of user agent). It failed this way on [PR #936's run](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/29292572016/job/86960754529), where the only "dead" link was the signup page.

This replaces the four `github.com/signup` links in the Fresco deployment guides with `https://github.com/join`, which serves a 302 redirect to the same sign-up page — readers land in the same place, and the checker records the link as alive (it already treats 3xx as alive for the many other redirecting links in the docs).

Includes a `@codaco/documentation` patch changeset (app lane).

## Test plan

- `curl -o /dev/null -w "%{http_code}" https://github.com/signup` → 403 (any UA); `https://github.com/join` → 302
- `docs-preview-checks` on this PR should come back green

🤖 Generated with [Claude Code](https://claude.com/claude-code)