### PR TITLE
fix(interviewer): disable analytics in e2e Docker runs (gate + run.sh)

### DIFF
--- a/apps/interviewer/e2e/scripts/run.sh
+++ b/apps/interviewer/e2e/scripts/run.sh
@@ -24,8 +24,18 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
+# VITE_DISABLE_ANALYTICS=true skips client.ts's posthog.init entirely.
+# Without it, PostHog's client attempts a `<script src="…surveys.js">` load
+# against connect-src's ph-relay.networkcanvas.com host, which the app's own
+# CSP meta tag (vite.config.ts) allows for connect-src but blocks under
+# script-src — an expected, permanent CSP violation, not a bug, but its timing
+# is non-deterministic, so it can occasionally interleave with a spec's own
+# page.evaluate/addStyleTag calls and surface as a spurious action failure.
+# Reuse the app's build-time analytics gate so the build under test never
+# initializes PostHog at all.
 docker run --rm \
   -e CI=true \
+  -e VITE_DISABLE_ANALYTICS=true \
   -v "$(pwd)":/workspace \
   -v interviewer-e2e-node-modules:/workspace/node_modules \
   -w /workspace \

--- a/apps/interviewer/src/lib/analytics/client.ts
+++ b/apps/interviewer/src/lib/analytics/client.ts
@@ -14,6 +14,13 @@ export function getAnalyticsClient(): Promise<PostHog | null> {
 }
 
 async function initClient(): Promise<PostHog | null> {
+  // Skip analytics entirely when disabled at build time (e2e / CI / preview
+  // builds). This also prevents posthog-js's dynamic surveys.js `<script>`
+  // load — blocked by the app CSP under script-src — whose non-deterministic
+  // console error can otherwise flake Playwright actions.
+  if (import.meta.env.VITE_DISABLE_ANALYTICS === 'true') {
+    return null;
+  }
   try {
     const { default: posthog } = await import('posthog-js');
     return posthog.init(


### PR DESCRIPTION
Interviewer's PostHog client attempts a dynamic `surveys.js` `<script>` load that the app CSP blocks under `script-src` — a permanent, by-design CSP violation whose non-deterministic timing can race a Playwright action and cause spurious e2e failures (hit while generating Architect visual-snapshot baselines).

Interviewer's `run.sh` didn't pass `VITE_DISABLE_ANALYTICS=true` (unlike Architect's), **and** its analytics client didn't gate on it, so the flag was a no-op. This:
- Adds the `VITE_DISABLE_ANALYTICS` early-return gate to `initClient()` (mirrors Architect's `analytics.ts`), so posthog-js is never dynamically imported when disabled.
- Passes `-e VITE_DISABLE_ANALYTICS=true` in the Dockerized e2e run.

Production builds (flag unset) are unchanged. Verified: interviewer e2e ran twice in Docker via the fixed runner, **26/26 passing** each, no posthog/surveys.js/CSP lines in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)