### PR TITLE
fix(architect): create layout variable from a Narrative stage preset

### DIFF
--- a/.changeset/architect-narrative-preset-layout-var.md
+++ b/.changeset/architect-narrative-preset-layout-var.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Fix creating a new layout variable from a Narrative stage preset. The handler destructured a `dispatch` prop that react-redux's object-shorthand `mapDispatchToProps` never provides, so the action threw; it now calls the already-dispatch-bound action creator directly.

--- a/apps/architect/src/components/sections/NarrativePresets/withPresetProps.tsx
+++ b/apps/architect/src/components/sections/NarrativePresets/withPresetProps.tsx
@@ -6,7 +6,7 @@ import {
   createVariableAsync,
   deleteVariableAsync,
 } from '~/ducks/modules/protocol/codebook';
-import type { AppDispatch, RootState } from '~/ducks/store';
+import type { RootState } from '~/ducks/store';
 
 import { getEdgesForSubject, getNarrativeVariables } from './selectors';
 
@@ -44,31 +44,32 @@ const mapDispatchToProps = {
 type HandlerProps = {
   form: string;
   changeForm: typeof change;
-  createVariable: typeof createVariableAsync;
+  // react-redux's object-shorthand mapDispatchToProps dispatch-binds these
+  // action creators, so calling `createVariable(arg)` returns the dispatched
+  // thunk promise (with `.unwrap()`), not the raw AsyncThunkAction that
+  // `typeof createVariableAsync` describes. Type it to what is actually used.
+  createVariable: (arg: Parameters<typeof createVariableAsync>[0]) => {
+    unwrap: () => Promise<{ variable: string }>;
+  };
   deleteVariable: typeof deleteVariableAsync;
   entity: string;
   type: string;
-  dispatch: AppDispatch;
 };
 
 const variableHandlers = withHandlers({
   handleCreateLayoutVariable:
-    ({
-      form,
-      changeForm,
-      createVariable,
-      dispatch,
-      entity,
-      type,
-    }: HandlerProps) =>
+    ({ form, changeForm, createVariable, entity, type }: HandlerProps) =>
     async (name: string) => {
-      const result = await dispatch(
-        createVariable({
-          entity: entity as 'node' | 'edge' | 'ego',
-          type,
-          configuration: { type: 'layout', name },
-        }),
-      ).unwrap();
+      // `createVariable` is already dispatch-bound by react-redux's
+      // object-shorthand `mapDispatchToProps`, so it is called directly (and
+      // returns the thunk promise). The previous code destructured a `dispatch`
+      // prop that object-shorthand mapDispatchToProps never injects, so
+      // creating a layout variable from a preset threw.
+      const result = await createVariable({
+        entity: entity as 'node' | 'edge' | 'ego',
+        type,
+        configuration: { type: 'layout', name },
+      }).unwrap();
       const { variable } = result;
       changeForm(form, 'layoutVariable', variable);
       return variable;

--- a/apps/architect/src/components/sections/NarrativePresets/withPresetProps.tsx
+++ b/apps/architect/src/components/sections/NarrativePresets/withPresetProps.tsx
@@ -1,11 +1,9 @@
 import { compose, withHandlers } from 'react-recompose';
 import { connect } from 'react-redux';
-import { change, formValueSelector } from 'redux-form';
+import { formValueSelector } from 'redux-form';
 
-import {
-  createVariableAsync,
-  deleteVariableAsync,
-} from '~/ducks/modules/protocol/codebook';
+import type { VariableType } from '@codaco/protocol-validation';
+import withCreateVariableHandler from '~/components/enhancers/withCreateVariableHandler';
 import type { RootState } from '~/ducks/store';
 
 import { getEdgesForSubject, getNarrativeVariables } from './selectors';
@@ -35,57 +33,28 @@ const mapStateToProps = (
   };
 };
 
-const mapDispatchToProps = {
-  createVariable: createVariableAsync,
-  deleteVariable: deleteVariableAsync,
-  changeForm: change,
-};
-
 type HandlerProps = {
-  form: string;
-  changeForm: typeof change;
-  // react-redux's object-shorthand mapDispatchToProps dispatch-binds these
-  // action creators, so calling `createVariable(arg)` returns the dispatched
-  // thunk promise (with `.unwrap()`), not the raw AsyncThunkAction that
-  // `typeof createVariableAsync` describes. Type it to what is actually used.
-  createVariable: (arg: Parameters<typeof createVariableAsync>[0]) => {
-    unwrap: () => Promise<{ variable: string }>;
-  };
-  deleteVariable: typeof deleteVariableAsync;
-  entity: string;
-  type: string;
+  handleCreateVariable: (
+    variableName: string,
+    variableType?: VariableType,
+    field?: string,
+  ) => Promise<string | undefined>;
 };
 
 const variableHandlers = withHandlers({
+  // handleCreateVariable (injected by withCreateVariableHandler) creates the
+  // variable, surfaces failures such as duplicate or invalid names via a
+  // dialog, and writes the new variable id into the given form field on
+  // success — the same pattern the Sociogram layout picker uses.
   handleCreateLayoutVariable:
-    ({ form, changeForm, createVariable, entity, type }: HandlerProps) =>
-    async (name: string) => {
-      // `createVariable` is already dispatch-bound by react-redux's
-      // object-shorthand `mapDispatchToProps`, so it is called directly (and
-      // returns the thunk promise). The previous code destructured a `dispatch`
-      // prop that object-shorthand mapDispatchToProps never injects, so
-      // creating a layout variable from a preset threw.
-      const result = await createVariable({
-        entity: entity as 'node' | 'edge' | 'ego',
-        type,
-        configuration: { type: 'layout', name },
-      }).unwrap();
-      const { variable } = result;
-      changeForm(form, 'layoutVariable', variable);
-      return variable;
-    },
-  handleDeleteVariable:
-    ({ entity, type, deleteVariable }: HandlerProps) =>
-    (variable: string) =>
-      deleteVariable({
-        entity: entity as 'node' | 'edge' | 'ego',
-        type,
-        variable,
-      }),
+    ({ handleCreateVariable }: HandlerProps) =>
+    (name: string) =>
+      handleCreateVariable(name, 'layout', 'layoutVariable'),
 });
 
 const withPresetProps = compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps),
+  withCreateVariableHandler,
   variableHandlers,
 );
 


### PR DESCRIPTION
Creating a **new** layout variable from a Narrative stage preset threw and never created the variable.

`NarrativePresets/withPresetProps.tsx`'s `handleCreateLayoutVariable` destructured a `dispatch` prop and called `dispatch(createVariable(...))`. But `mapDispatchToProps` was object-shorthand, so react-redux **dispatch-binds** `createVariable` (calling it already dispatches) and **never injects a `dispatch` prop** — so `dispatch` was `undefined`.

Fix (after review feedback): drop the bespoke `mapDispatchToProps`/bound-thunk plumbing entirely and reuse the existing `withCreateVariableHandler` enhancer — the same pattern the Sociogram layout picker (`PromptFieldsLayout`) uses. `handleCreateLayoutVariable` now delegates to its `handleCreateVariable(name, 'layout', 'layoutVariable')`, which creates the variable, surfaces duplicate/invalid-name failures via the app's standard dialog, and writes the new variable id into the form field on success.

Independently surfaced while building the Architect e2e suite (the Narrative interface spec in #942 works around it by pre-seeding + selecting a layout variable rather than creating one inline). Once the e2e harness (#939) lands, that spec can be extended to cover the inline-create path directly.

Typecheck + build clean. app-source-only, `@codaco/architect` patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed layout variable creation from Narrative stage presets.
  - Prevented errors when creating variables through preset-based layouts.
  - Improved handling of variable creation results so newly created variables are applied reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
