### PR TITLE
build(architect): switch to @vitejs/plugin-react from the workspace catalog

### DIFF
--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -64,7 +64,7 @@
     "@types/recompose": "^0.30.15",
     "@types/redux-form": "^8.3.11",
     "@vite-pwa/assets-generator": "^1.0.2",
-    "@vitejs/plugin-react-swc": "^4.3.1",
+    "@vitejs/plugin-react": "catalog:",
     "jsdom": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -2,7 +2,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import tailwindcss from '@tailwindcss/vite';
-import react from '@vitejs/plugin-react-swc';
+import react from '@vitejs/plugin-react';
 import { loadEnv, type Plugin } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { defineConfig } from 'vitest/config';
@@ -75,7 +75,7 @@ export default defineConfig(({ mode }) => {
         repoRoot,
         enabled: env.VITE_PROTOCOL_SOURCE_AUTHORING === 'true',
       }),
-      react({}),
+      react(),
       tailwindcss(),
       VitePWA({
         registerType: 'prompt',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       '@vite-pwa/assets-generator':
         specifier: ^1.0.2
         version: 1.0.2
-      '@vitejs/plugin-react-swc':
-        specifier: ^4.3.1
-        version: 4.3.1(@swc/helpers@0.5.23)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -7050,12 +7050,6 @@ packages:
     resolution: {integrity: sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg==}
     engines: {node: '>=16.14.0'}
     hasBin: true
-
-  '@vitejs/plugin-react-swc@4.3.1':
-    resolution: {integrity: sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7 || ^8
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -19092,14 +19086,6 @@ snapshots:
       sharp: 0.33.5
       sharp-ico: 0.1.5
       unconfig: 7.5.0
-
-  '@vitejs/plugin-react-swc@4.3.1(@swc/helpers@0.5.23)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      '@swc/core': 1.15.40(@swc/helpers@0.5.23)
-      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Summary

- Replaces `@vitejs/plugin-react-swc` with `@vitejs/plugin-react` in `@codaco/architect`, resolving the rolldown-vite build warning:
  > `[vite:react-swc] We recommend switching to @vitejs/plugin-react for improved performance as no swc plugins are used.`
- Architect passed no SWC options (`react({})`), so nothing needed migrating; the call now matches the sibling configs (`react()`).
- The dependency moves to the workspace catalog pin (`catalog:` → `^6.0.3`), which every other package already uses — this removes the monorepo's last direct reference to the SWC plugin.

No changeset: build-tooling-only change with no consumer-visible effect.

## Test plan

- [x] `turbo run build --filter=@codaco/architect` succeeds with no `react-swc` recommendation warning
- [x] `pnpm typecheck` (22 tasks) passes
- [x] `pnpm knip` clean
- [x] `turbo run test --filter=@codaco/architect` passes (vitest shares the same vite config/plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)