### PR TITLE
fix(fresco-ui): lay Boolean field options side by side when they fit

### DIFF
--- a/.changeset/dyad-census-boolean-layout.md
+++ b/.changeset/dyad-census-boolean-layout.md
@@ -1,0 +1,6 @@
+---
+'@codaco/fresco-ui': patch
+'@codaco/interview': patch
+---
+
+Boolean fields now lay their options out side by side whenever they fit, wrapping to a stacked layout only when the container is genuinely too narrow for them. This fixes the Dyad Census interface stacking its Yes/No choices vertically even when there was room to show them side by side.

--- a/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
@@ -1,24 +1,52 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
-import Paragraph from '../../typography/Paragraph';
 import BooleanField from './Boolean';
 
-const meta: Meta<typeof BooleanField> = {
+type StoryArgs = React.ComponentProps<typeof BooleanField> & {
+  containerWidth: number;
+};
+
+const meta: Meta<StoryArgs> = {
   title: 'Systems/Form/Fields/BooleanField',
   component: BooleanField,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A radiogroup of option cards for a boolean value. Options sit side by side and wrap to a stack only when their container is too narrow for them — sizing is intrinsic, so the field also works inside fit-content parents. Use the container width control to watch the layout respond, and edit the options to see how label length affects when wrapping happens.',
+      },
+    },
   },
   tags: ['autodocs'],
   argTypes: {
+    'containerWidth': {
+      control: { type: 'range', min: 120, max: 960, step: 10 },
+      description:
+        'Width (px) of the container the field is rendered in. Story-only — not a component prop.',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    'options': {
+      control: 'object',
+      description: 'Label and value for each choice',
+      table: {
+        type: { summary: 'Array<{ label: string; value: boolean }>' },
+        defaultValue: {
+          summary:
+            '[{ label: "Yes", value: true }, { label: "No", value: false }]',
+        },
+      },
+    },
     'value': {
       control: 'radio',
-      options: [true, false, null],
+      options: [true, false, undefined],
       description: 'Current value of the boolean field',
       table: {
-        type: { summary: 'boolean | null' },
-        defaultValue: { summary: 'null' },
+        type: { summary: 'boolean | undefined' },
+        defaultValue: { summary: 'undefined' },
       },
     },
     'disabled': {
@@ -45,17 +73,6 @@ const meta: Meta<typeof BooleanField> = {
         defaultValue: { summary: 'false' },
       },
     },
-    'options': {
-      control: 'object',
-      description: 'Custom options for yes/no buttons',
-      table: {
-        type: { summary: 'Array<{ label: string; value: boolean }>' },
-        defaultValue: {
-          summary:
-            '[{ label: "Yes. I wish to participate in the study in accordance with the terms outlined above.", value: true }, { label: "No. I decline to participate, and wish to immediately withdraw from this study.", value: false }]',
-        },
-      },
-    },
     'aria-invalid': {
       control: 'radio',
       options: [undefined, true, false],
@@ -69,25 +86,18 @@ const meta: Meta<typeof BooleanField> = {
       action: 'onChange',
       description: 'Callback when value changes',
       table: {
-        type: { summary: '(value: boolean | null) => void' },
+        type: { summary: '(value: boolean | undefined) => void' },
       },
     },
   },
   args: {
+    containerWidth: 600,
     disabled: false,
     readOnly: false,
     noReset: false,
     options: [
-      {
-        label:
-          'Yes. I wish to participate in the study in accordance with the terms outlined above.',
-        value: true,
-      },
-      {
-        label:
-          'No. I decline to participate, and wish to immediately withdraw from this study.',
-        value: false,
-      },
+      { label: 'Yes', value: true },
+      { label: 'No', value: false },
     ],
   },
 };
@@ -97,6 +107,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: (args) => {
+    const { containerWidth, ...fieldArgs } = args;
     const [value, setValue] = useState<boolean | undefined>(args.value);
 
     useEffect(() => {
@@ -104,164 +115,15 @@ export const Default: Story = {
     }, [args.value]);
 
     return (
-      <div className="w-full max-w-2xl">
+      <div style={{ width: containerWidth, maxWidth: '100%' }}>
         <BooleanField
-          {...args}
+          {...fieldArgs}
           value={value}
           onChange={(newValue) => {
             setValue(newValue);
             args.onChange?.(newValue);
           }}
         />
-      </div>
-    );
-  },
-};
-
-export const DisabledWithSelection: Story = {
-  render: () => {
-    return (
-      <div className="w-full max-w-2xl space-y-8">
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Disabled with Yes selected:
-          </Paragraph>
-          <BooleanField
-            value={true}
-            disabled
-            options={[
-              { label: 'Yes', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Disabled with No selected:
-          </Paragraph>
-          <BooleanField
-            value={false}
-            disabled
-            options={[
-              { label: 'Yes', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Disabled with no selection:
-          </Paragraph>
-          <BooleanField
-            value={undefined}
-            disabled
-            options={[
-              { label: 'Yes', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
-      </div>
-    );
-  },
-};
-
-export const Invalid: Story = {
-  args: {
-    'aria-invalid': true,
-    'options': [
-      { label: 'Yes', value: true },
-      { label: 'No', value: false },
-    ],
-  },
-  render: (args) => {
-    const [value, setValue] = useState<boolean | undefined>(args.value);
-
-    useEffect(() => {
-      setValue(args.value);
-    }, [args.value]);
-
-    return (
-      <div className="w-full max-w-2xl">
-        <BooleanField
-          {...args}
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-            args.onChange?.(newValue);
-          }}
-        />
-      </div>
-    );
-  },
-};
-
-export const NarrowContainer: Story = {
-  render: (args) => {
-    const [value, setValue] = useState<boolean | undefined>(args.value);
-
-    useEffect(() => {
-      setValue(args.value);
-    }, [args.value]);
-
-    return (
-      <div className="w-56">
-        <BooleanField
-          {...args}
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-            args.onChange?.(newValue);
-          }}
-        />
-      </div>
-    );
-  },
-};
-
-export const ReadOnly: Story = {
-  render: () => {
-    return (
-      <div className="w-full space-y-8">
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Read-only with Yes selected:
-          </Paragraph>
-          <BooleanField
-            value={true}
-            readOnly
-            options={[
-              { label: 'Yessss this is correct', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Read-only with No selected:
-          </Paragraph>
-          <BooleanField
-            value={false}
-            readOnly
-            options={[
-              { label: 'Yes', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
-        <div>
-          <Paragraph margin="none" className="mb-2 text-sm font-medium">
-            Read-only with no selection:
-          </Paragraph>
-          <BooleanField
-            value={undefined}
-            readOnly
-            options={[
-              { label: 'Yes', value: true },
-              { label: 'No', value: false },
-            ]}
-          />
-        </div>
       </div>
     );
   },

--- a/packages/fresco-ui/src/form/fields/Boolean.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.tsx
@@ -189,12 +189,17 @@ export default function BooleanField(props: BooleanFieldProps) {
   const groupState = getInputState(props);
 
   return (
-    <div className={cx('@container flex w-full flex-col gap-2', className)}>
+    <div className={cx('flex w-full flex-col gap-2', className)}>
       <fieldset
         id={id}
         {...rest}
         role="radiogroup"
-        className="flex w-full flex-col items-stretch gap-2 border-0 p-0 *:flex-1 @xs:flex-row"
+        // Options sit side by side and wrap to a stack only when the container
+        // is genuinely too narrow for them. Sizing is intrinsic (no container
+        // query), so this also holds inside fit-content ancestors, where a
+        // container query can never match (inline-size containment collapses
+        // a content-sized container to zero width).
+        className="flex w-full flex-row flex-wrap items-stretch gap-2 border-0 p-0 *:min-w-0 *:grow"
         disabled={disabled}
         aria-label={label ?? rest['aria-label']}
         aria-labelledby={rest['aria-labelledby']}

--- a/packages/interview/src/interfaces/DyadCensus/DyadCensus.tsx
+++ b/packages/interview/src/interfaces/DyadCensus/DyadCensus.tsx
@@ -322,7 +322,6 @@ export default function DyadCensus(props: DyadCensusProps) {
                   exit={{ opacity: 0 }}
                 >
                   <BooleanField
-                    className="w-fit"
                     value={displayedEdge ?? undefined}
                     onChange={setEdge}
                     options={[


### PR DESCRIPTION
## Summary

Fixes the Dyad Census interface showing its Yes/No boolean choice stacked vertically despite there being plenty of room to show the options side by side.

### Root cause

`BooleanField`'s wrapper was a `@container` whose fieldset switched to a row via an `@xs` container query. `container-type: inline-size` (inline-size containment) means a container cannot size itself from its contents, so when DyadCensus passed `className="w-fit"` — which tailwind-merge let replace the wrapper's `w-full` — the container collapsed to **0px**, the query could never match, and the options always stacked, overflowing the collapsed container off-centre.

### Fix

- `packages/fresco-ui/src/form/fields/Boolean.tsx` — replace the container query with intrinsic sizing: options sit in a wrapping flex row (`flex-row flex-wrap` with `*:grow *:min-w-0`) and wrap to a stack only when the container is genuinely too narrow for them. Wrapping is judged by real content against real space (not a 20rem breakpoint proxy), and intrinsic sizing also works inside fit-content ancestors like the census prompt surface, where a container query can never match.
- `packages/interview/src/interfaces/DyadCensus/DyadCensus.tsx` — use the field bare; the `w-fit` workaround that triggered the collapse is removed.
- `packages/fresco-ui/src/form/fields/Boolean.stories.tsx` — stories consolidated into a single Default story with a container-width slider control and editable options, to exercise the wrap point directly.

Note: form usages now follow the same wrap rule — options with long labels stack unless there is room for them side by side with labels unwrapped, where previously they were forced side by side (and cramped) in any container over 320px.

## Test plan

- [x] Reproduced the bug in the DyadCensus story and measured the collapsed 0px container before the fix
- [x] Verified in the rendered story: options side by side, centred under the prompt, in wide and narrow-portrait viewports; answering records and auto-advances
- [x] Verified wrap behaviour in the BooleanField story via the container-width control (side by side at 600px, stacked at 220px)
- [x] `typecheck`, lint, and formatter pass for both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)