### PR TITLE
Improve website background focus and surface styling

### DIFF
--- a/.changeset/violet-ends-wear.md
+++ b/.changeset/violet-ends-wear.md
@@ -1,0 +1,6 @@
+---
+"@codaco/fresco-ui": patch
+"@codaco/tailwind-config": patch
+---
+
+Derive default surface colors from the page background and align table headers to the bottom.

--- a/apps/documentation/components/Layout.tsx
+++ b/apps/documentation/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useLocale } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
-import { PageBackground } from '@codaco/art';
+import { PageBackgroundProvider } from '@codaco/art';
 import { cx } from '@codaco/fresco-ui/utils/cva';
 import { Sidebar } from '~/components/Sidebar';
 import WorkflowNav from '~/components/WorkflowNav';
@@ -17,9 +17,22 @@ export function LayoutComponent({ children }: { children: React.ReactNode }) {
   const locale = useLocale();
   const workflowNavSentinelRef = useRef<HTMLDivElement>(null);
   const [isWorkflowNavStuck, setIsWorkflowNavStuck] = useState(false);
+  const [fallbackConvergence, setFallbackConvergence] = useState({
+    x: 0.5,
+    y: 0.6,
+  });
 
   // Check if we are on the home page by comparing the pathname to our supported locals
   const isHomePage = pathname === `/${locale}`;
+
+  useEffect(() => {
+    if (isHomePage) return;
+
+    setFallbackConvergence({
+      x: 0.08 + Math.random() * 0.84,
+      y: 0.12 + Math.random() * 0.76,
+    });
+  }, [isHomePage, pathname]);
 
   useEffect(() => {
     const sentinel = workflowNavSentinelRef.current;
@@ -44,45 +57,51 @@ export function LayoutComponent({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="relative isolate flex min-h-dvh w-full flex-auto flex-col">
-      <PageBackground />
-      <div className="relative z-10 flex min-h-dvh w-full flex-auto flex-col">
-        <SharedNav />
-        {!isHomePage && (
-          <>
-            <div
-              ref={workflowNavSentinelRef}
-              aria-hidden="true"
-              className="-mb-px h-px"
-            />
-            <WorkflowNav
-              variant="collapsed"
-              className={cx(
-                'sticky top-0 z-40 w-full px-4 py-2',
-                isWorkflowNavStuck && 'bg-background',
-              )}
-            />
-          </>
-        )}
-        <main
-          className={cx(
-            'flex h-full w-full flex-auto justify-center',
-            // Space content away from the nav on content pages; the margin scales
-            // down on smaller viewports.
-            isHomePage
-              ? 'mt-4'
-              : 'phone-landscape:mt-8 tablet-landscape:mt-12 mt-6',
-          )}
-        >
+      <PageBackgroundProvider
+        fallbackConvergence={fallbackConvergence}
+        intensity={isHomePage ? 0.4 : 0.1}
+        motionMode="target"
+        waitForTarget={isHomePage}
+      >
+        <div className="relative z-10 flex min-h-dvh w-full flex-auto flex-col">
+          <SharedNav />
           {!isHomePage && (
-            // Sticky offset clears the sticky section switcher (68px tall) plus an
-            // 8px gap; max height subtracts that offset and the 8px bottom margin.
-            <Sidebar className="tablet-landscape:sticky tablet-landscape:top-[76px] tablet-landscape:flex tablet-landscape:max-h-[calc(100dvh-84px)] mx-4 hidden max-w-80" />
+            <>
+              <div
+                ref={workflowNavSentinelRef}
+                aria-hidden="true"
+                className="-mb-px h-px"
+              />
+              <WorkflowNav
+                variant="collapsed"
+                className={cx(
+                  'sticky top-0 z-40 w-full px-4 py-2',
+                  isWorkflowNavStuck && 'bg-background',
+                )}
+              />
+            </>
           )}
+          <main
+            className={cx(
+              'flex h-full w-full flex-auto justify-center',
+              // Space content away from the nav on content pages; the margin scales
+              // down on smaller viewports.
+              isHomePage
+                ? 'mt-4'
+                : 'phone-landscape:mt-8 tablet-landscape:mt-12 mt-6',
+            )}
+          >
+            {!isHomePage && (
+              // Sticky offset clears the sticky section switcher (68px tall) plus an
+              // 8px gap; max height subtracts that offset and the 8px bottom margin.
+              <Sidebar className="tablet-landscape:sticky tablet-landscape:top-[76px] tablet-landscape:flex tablet-landscape:max-h-[calc(100dvh-84px)] mx-4 hidden max-w-80" />
+            )}
 
-          {children}
-        </main>
-        <DocumentationFooter />
-      </div>
+            {children}
+          </main>
+          <DocumentationFooter />
+        </div>
+      </PageBackgroundProvider>
     </div>
   );
 }

--- a/apps/documentation/components/TableOfContents.tsx
+++ b/apps/documentation/components/TableOfContents.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useRef } from 'react';
+import { type RefObject, useEffect, useRef } from 'react';
 
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import { cx } from '@codaco/fresco-ui/utils/cva';
@@ -11,9 +11,11 @@ import type { HeadingNode } from '~/lib/tableOfContents';
 const TOCLink = ({
   node,
   sideBar,
+  sideBarRef,
 }: {
   node: HeadingNode;
   sideBar: boolean;
+  sideBarRef: RefObject<HTMLElement | null>;
 }) => {
   const ref = useRef<HTMLAnchorElement>(null);
   const [highlighted] = useHighlighted(node.id);
@@ -21,14 +23,23 @@ const TOCLink = ({
   useEffect(() => {
     if (!sideBar) return;
 
-    if (highlighted && ref.current) {
-      ref.current.scrollIntoView({
-        behavior: 'auto',
-        block: 'nearest',
-        inline: 'nearest',
-      });
+    const link = ref.current;
+    const container = sideBarRef.current;
+    if (!highlighted || !link || !container) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    const linkTop = linkRect.top - containerRect.top + container.scrollTop;
+    const linkBottom = linkTop + linkRect.height;
+    const visibleTop = container.scrollTop;
+    const visibleBottom = visibleTop + container.clientHeight;
+
+    if (linkTop < visibleTop) {
+      container.scrollTop = linkTop;
+    } else if (linkBottom > visibleBottom) {
+      container.scrollTop = linkBottom - container.clientHeight;
     }
-  }, [highlighted, sideBar]);
+  }, [highlighted, sideBar, sideBarRef]);
 
   return (
     <Link
@@ -53,8 +64,11 @@ const TableOfContents = ({
   headings: HeadingNode[];
   sideBar?: boolean;
 }) => {
+  const sideBarRef = useRef<HTMLElement>(null);
+
   return (
     <aside
+      ref={sideBarRef}
       className={cx(
         'hidden shrink-0',
         sideBar &&
@@ -62,7 +76,7 @@ const TableOfContents = ({
           // gap; max height subtracts that offset and the 8px bottom margin.
           'laptop:block sticky top-19 max-h-[calc(100vh-84px)] w-64 overflow-x-hidden overflow-y-auto',
         !sideBar &&
-          'border-outline bg-input laptop:hidden mb-5 block rounded-lg border px-6 py-4',
+          'border-outline bg-input laptop:hidden mb-5 block rounded border px-6 py-4',
       )}
     >
       <Heading
@@ -73,18 +87,23 @@ const TableOfContents = ({
       >
         Table of Contents
       </Heading>
-      {renderNodes(headings, sideBar)}
+      {renderNodes(headings, sideBar, sideBarRef)}
     </aside>
   );
 };
 
-function renderNodes(nodes: HeadingNode[], sideBar: boolean) {
+function renderNodes(
+  nodes: HeadingNode[],
+  sideBar: boolean,
+  sideBarRef: RefObject<HTMLElement | null>,
+) {
   return (
     <ol>
       {nodes.map((node) => (
         <li key={node.id} className={cx('list-none')}>
-          <TOCLink node={node} sideBar={sideBar} />
-          {node.children?.length > 0 && renderNodes(node.children, sideBar)}
+          <TOCLink node={node} sideBar={sideBar} sideBarRef={sideBarRef} />
+          {node.children?.length > 0 &&
+            renderNodes(node.children, sideBar, sideBarRef)}
         </li>
       ))}
     </ol>

--- a/apps/documentation/components/WorkflowNav.tsx
+++ b/apps/documentation/components/WorkflowNav.tsx
@@ -5,8 +5,9 @@ import { ChartNetwork, ChevronRight } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type ReactNode, useCallback, useRef } from 'react';
 
+import { usePageBackgroundTargetRef } from '@codaco/art';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { cx } from '@codaco/fresco-ui/utils/cva';
 import {
@@ -94,7 +95,7 @@ function CollapsedNav({ className }: { className?: string }) {
               <Tabs.Tab
                 value={section.key}
                 className={cx(
-                  'focusable relative flex shrink-0 cursor-pointer items-center gap-2 rounded-xl py-2 pr-5 pl-3 text-base font-semibold transition-colors duration-200',
+                  'focusable relative flex shrink-0 cursor-pointer items-center gap-2 rounded py-2 pr-5 pl-3 text-base font-semibold transition-colors duration-200',
                   isActive ? 'text-white' : 'hover:text-text text-current/70',
                 )}
               >
@@ -114,7 +115,7 @@ function CollapsedNav({ className }: { className?: string }) {
                   className={cx(
                     'relative z-10 flex h-9 shrink-0 items-center justify-center',
                     dualIcon ? 'w-auto px-1' : 'w-9',
-                    isActive && 'rounded-lg bg-white/20',
+                    isActive && 'rounded bg-white/20',
                   )}
                 >
                   <SectionIcon section={section} onColor={isActive} />
@@ -133,15 +134,31 @@ function CollapsedNav({ className }: { className?: string }) {
 
 function WorkflowCard({ section }: { section: SectionConfig }) {
   const t = useTranslations('SectionSwitcher');
+  const backgroundTargetRef = usePageBackgroundTargetRef();
+  const cardRef = useRef<HTMLAnchorElement>(null);
+  const setCardRef = useCallback(
+    (element: HTMLAnchorElement | null) => {
+      cardRef.current = element;
+      if (section.key === 'get-started') backgroundTargetRef?.(element);
+    },
+    [backgroundTargetRef, section.key],
+  );
+  const selectBackgroundTarget = useCallback(() => {
+    backgroundTargetRef?.(cardRef.current);
+  }, [backgroundTargetRef]);
+
   return (
     <Link
+      ref={setCardRef}
       href={`/${section.key}`}
+      onFocus={selectBackgroundTarget}
+      onPointerEnter={selectBackgroundTarget}
       className={cx(
-        'group focusable laptop:min-h-56 flex flex-1 flex-col gap-6 rounded-lg p-6 text-white shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl',
+        'group focusable laptop:min-h-56 flex flex-1 flex-col gap-6 rounded p-6 text-white shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl',
         sectionColorClasses[section.color],
       )}
     >
-      <span className="flex h-14 w-fit min-w-14 shrink-0 items-center justify-center gap-1.5 rounded-lg bg-white/15 px-2">
+      <span className="flex h-14 w-fit min-w-14 shrink-0 items-center justify-center gap-1.5 rounded bg-white/15 px-2">
         <SectionIcon section={section} onColor large />
       </span>
       <div className="mt-auto flex flex-col gap-2">

--- a/apps/documentation/components/customComponents/Pre.tsx
+++ b/apps/documentation/components/customComponents/Pre.tsx
@@ -7,7 +7,7 @@ type PreProps = React.HTMLAttributes<HTMLPreElement> & {
 
 const Pre = ({ raw, children, ...props }: PreProps) => {
   return (
-    <div className="group bg-rich-black relative my-5 overflow-hidden rounded-xl last:mb-0">
+    <div className="group bg-rich-black relative my-5 overflow-hidden rounded last:mb-0">
       <pre {...props} className="[&_code]:bg-transparent">
         {children}
       </pre>

--- a/apps/documentation/components/customComponents/SummaryCard.tsx
+++ b/apps/documentation/components/customComponents/SummaryCard.tsx
@@ -12,7 +12,7 @@ export const SummaryCard = ({
   duration: string;
 }) => {
   return (
-    <div className="border-outline bg-accent text-accent-contrast my-8 rounded-lg border p-6 text-base [--link:var(--accent-contrast)]">
+    <div className="border-outline bg-accent text-accent-contrast my-8 rounded border p-6 text-base [--link:var(--accent-contrast)]">
       {children}
       <Heading level="h4" variant="all-caps">
         Duration:

--- a/apps/documentation/components/customComponents/WorkflowsOverview.tsx
+++ b/apps/documentation/components/customComponents/WorkflowsOverview.tsx
@@ -121,7 +121,7 @@ const StepCell = ({ step }: { step: Step }) => (
 
 const WorkflowsOverview = () => (
   <div className="my-8">
-    <div className="border-outline overflow-x-auto rounded-lg border">
+    <div className="border-outline overflow-x-auto rounded border">
       <table className="w-full min-w-[44rem] border-collapse text-sm">
         <caption className="sr-only">
           The three ways to run a Network Canvas study, across the design,

--- a/apps/documentation/components/ui/typography/Details.tsx
+++ b/apps/documentation/components/ui/typography/Details.tsx
@@ -17,7 +17,7 @@ export const Details = forwardRef<
       ref={ref}
       className={cx(
         'mt-5',
-        'border-outline my-5 rounded-xl border-2 px-5 [&_svg]:open:rotate-90',
+        'border-outline my-5 rounded border-2 px-5 [&_svg]:open:rotate-90',
         className,
       )}
       {...props}

--- a/apps/documentation/lib/docs.tsx
+++ b/apps/documentation/lib/docs.tsx
@@ -367,8 +367,9 @@ const createMarkdownComponents = (docSlug?: string) => ({
   ),
   // Markdown tables render through fresco-ui's Table primitives so they match
   // the design system (surface-tinted header, row separators + hover, rounded
-  // bordered container). Cells override fresco's data-table `whitespace-nowrap`
-  // because docs tables carry prose (sentences, links) that must wrap.
+  // bordered container). Cells override fresco's data-table
+  // `whitespace-nowrap` because docs tables carry prose (sentences, links) that
+  // must wrap.
   // Spacing goes on the Surface via `surfaceProps`, not `className` — Table's
   // `className` targets the inner <table>, so `my-6` there would open a gap of
   // bare surface above/below the rows inside the bordered container.
@@ -381,7 +382,10 @@ const createMarkdownComponents = (docSlug?: string) => ({
   tbody: (props: ComponentProps<typeof TableBody>) => <TableBody {...props} />,
   tr: (props: ComponentProps<typeof TableRow>) => <TableRow {...props} />,
   th: (props: ComponentProps<typeof TableHead>) => (
-    <TableHead className="w-auto align-top whitespace-normal" {...props} />
+    <TableHead
+      {...props}
+      className={cx('w-auto whitespace-normal', props.className)}
+    />
   ),
   td: (props: ComponentProps<typeof TableCell>) => (
     <TableCell className="w-auto align-top whitespace-normal" {...props} />

--- a/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
+++ b/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
@@ -109,7 +109,7 @@ export function AppChoiceCard({ app }: { app: AppRecord }) {
   return (
     <article
       className={cn(
-        'tablet-portrait:p-9 flex h-full flex-col rounded-[2rem] p-7 transition-transform focus-within:-translate-y-1 hover:-translate-y-1 motion-reduce:transform-none',
+        'tablet-portrait:p-9 flex h-full flex-col rounded p-7 transition-transform focus-within:-translate-y-1 hover:-translate-y-1 motion-reduce:transform-none',
         treatmentClasses[app.treatment],
       )}
     >

--- a/apps/networkcanvas.com/components/get-started/GetStartedIntro.tsx
+++ b/apps/networkcanvas.com/components/get-started/GetStartedIntro.tsx
@@ -99,7 +99,7 @@ export function GetStartedIntro() {
                 variants={entrance.itemVariants}
                 whileHover={reduceMotion ? undefined : { y: -5 }}
                 whileFocus={reduceMotion ? undefined : { y: -5 }}
-                className="focusable elevation-medium group tablet-portrait:p-10 bg-surface/55 flex min-h-64 flex-col justify-between rounded-[2rem] p-8 backdrop-blur-md"
+                className="focusable elevation-medium group tablet-portrait:p-10 bg-surface/55 flex min-h-64 flex-col justify-between rounded p-8 backdrop-blur-md"
               >
                 <span className="font-heading text-text/65 text-xs font-bold tracking-[0.14em] uppercase">
                   {t(`intro.stages.${stage.id}.label`)}

--- a/apps/networkcanvas.com/components/sections/DesignPrinciples.tsx
+++ b/apps/networkcanvas.com/components/sections/DesignPrinciples.tsx
@@ -34,7 +34,7 @@ export function DesignPrinciples() {
             <Reveal
               key={principle.id}
               delay={i * 0.04}
-              className="bg-surface tablet-landscape:p-10 rounded-[1.75rem] p-8 shadow-lg"
+              className="bg-surface tablet-landscape:p-10 rounded p-8 shadow-lg"
             >
               <Heading
                 level="h3"

--- a/apps/networkcanvas.com/components/sections/Grants.tsx
+++ b/apps/networkcanvas.com/components/sections/Grants.tsx
@@ -49,7 +49,7 @@ export function Grants({ grants }: { grants: readonly Grant[] }) {
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: direction >= 0 ? -60 : 60 }}
                 transition={{ duration: 0.3, ease: 'easeInOut' }}
-                className="focusable bg-surface tablet-landscape:p-10 pointer-events-auto flex h-full flex-col rounded-[1.75rem] p-8 shadow-xl"
+                className="focusable bg-surface tablet-landscape:p-10 pointer-events-auto flex h-full flex-col rounded p-8 shadow-xl"
               >
                 <Heading
                   level="h3"

--- a/apps/networkcanvas.com/components/sections/Institutions.tsx
+++ b/apps/networkcanvas.com/components/sections/Institutions.tsx
@@ -57,7 +57,7 @@ export function Institutions() {
           // in light mode the plate is absent and the logos render as before.
           <div
             key={inst.name}
-            className="[[data-theme=dark]_&]:rounded-2xl [[data-theme=dark]_&]:bg-white/90 [[data-theme=dark]_&]:px-5 [[data-theme=dark]_&]:py-3"
+            className="[[data-theme=dark]_&]:rounded [[data-theme=dark]_&]:bg-white/90 [[data-theme=dark]_&]:px-5 [[data-theme=dark]_&]:py-3"
           >
             <img
               src={inst.logo}

--- a/apps/networkcanvas.com/components/sections/MailingListForm.tsx
+++ b/apps/networkcanvas.com/components/sections/MailingListForm.tsx
@@ -33,11 +33,11 @@ export function MailingListForm() {
         required
         placeholder={t('placeholder')}
         aria-label={t('emailLabel')}
-        className="focusable bg-surface-1 text-text placeholder:text-text/40 phone-landscape:max-w-xs w-full rounded-2xl px-4 py-3 text-base"
+        className="focusable bg-surface-1 text-text placeholder:text-text/40 phone-landscape:max-w-xs w-full rounded px-4 py-3 text-base"
       />
       <Button
         type="submit"
-        className="bg-cyber-grape shrink-0 rounded-2xl border-transparent px-6 py-3 text-sm text-white uppercase transition-transform hover:-translate-y-0.5"
+        className="bg-cyber-grape shrink-0 rounded border-transparent px-6 py-3 text-sm text-white uppercase transition-transform hover:-translate-y-0.5"
       >
         {t('submit')}
       </Button>

--- a/apps/networkcanvas.com/components/sections/Publications.tsx
+++ b/apps/networkcanvas.com/components/sections/Publications.tsx
@@ -61,7 +61,7 @@ export function Publications({
               href={pub.href}
               target="_blank"
               rel="noreferrer"
-              className="focusable bg-cyber-grape tablet-landscape:p-10 flex h-full flex-col rounded-[1.75rem] p-8 text-white shadow-lg transition-transform hover:-translate-y-1"
+              className="focusable bg-cyber-grape tablet-landscape:p-10 flex h-full flex-col rounded p-8 text-white shadow-lg transition-transform hover:-translate-y-1"
             >
               <Heading
                 level="h3"

--- a/apps/networkcanvas.com/components/sections/Tools.tsx
+++ b/apps/networkcanvas.com/components/sections/Tools.tsx
@@ -42,7 +42,7 @@ export function Tools() {
           return (
             <Reveal
               key={tool.id}
-              className="tablet-landscape:grid-cols-2 tablet-landscape:gap-16 tablet-landscape:p-10 bg-surface/55 grid items-center gap-8 rounded-[2rem] p-6 shadow-xl backdrop-blur-md"
+              className="tablet-landscape:grid-cols-2 tablet-landscape:gap-16 tablet-landscape:p-10 bg-surface/55 grid items-center gap-8 rounded p-6 shadow-xl backdrop-blur-md"
             >
               <div>
                 <Heading
@@ -84,7 +84,7 @@ export function Tools() {
                   href={tool.href}
                   target="_blank"
                   rel="noreferrer"
-                  className="focusable block rounded-[1.75rem]"
+                  className="focusable block rounded"
                 >
                   <DeviceMockup variant={tool.variant} />
                 </a>

--- a/apps/networkcanvas.com/components/sections/VideoSection.tsx
+++ b/apps/networkcanvas.com/components/sections/VideoSection.tsx
@@ -37,7 +37,7 @@ export function VideoSection() {
           target="_blank"
           rel="noreferrer"
           aria-label={t('watchLabel')}
-          className="focusable group relative flex aspect-video items-center justify-center overflow-hidden rounded-[1.75rem] shadow-xl"
+          className="focusable group relative flex aspect-video items-center justify-center overflow-hidden rounded shadow-xl"
         >
           <span className="animate-background-gradient from-neon-coral via-purple-pizazz to-cerulean-blue absolute inset-0 bg-linear-to-br bg-[length:200%_200%]" />
           <span className="relative flex flex-col items-center gap-5 text-white">

--- a/apps/networkcanvas.com/components/sections/WhatNext.tsx
+++ b/apps/networkcanvas.com/components/sections/WhatNext.tsx
@@ -75,7 +75,7 @@ export function WhatNext() {
         {cards.map((card) => (
           <Reveal
             key={card.id}
-            className="bg-surface tablet-landscape:gap-10 tablet-landscape:p-10 flex items-center gap-6 rounded-[1.75rem] p-8 shadow-lg"
+            className="bg-surface tablet-landscape:gap-10 tablet-landscape:p-10 flex items-center gap-6 rounded p-8 shadow-lg"
           >
             <div className="flex-1">
               <Heading

--- a/apps/networkcanvas.com/components/ui/DeviceMockup.tsx
+++ b/apps/networkcanvas.com/components/ui/DeviceMockup.tsx
@@ -30,7 +30,7 @@ export function DeviceMockup({
   return (
     <div
       className={cn(
-        'bg-cyber-grape tablet-landscape:p-4 w-full rounded-[1.75rem] p-3 shadow-2xl',
+        'bg-cyber-grape tablet-landscape:p-4 w-full rounded p-3 shadow-2xl',
         className,
       )}
     >

--- a/apps/networkcanvas.com/components/ui/HeroVideo.tsx
+++ b/apps/networkcanvas.com/components/ui/HeroVideo.tsx
@@ -21,7 +21,7 @@ export function HeroVideo() {
     <div
       ref={backgroundTargetRef}
       aria-hidden="true"
-      className="bg-cyber-grape relative aspect-4/3 w-full overflow-hidden rounded-[1.75rem] shadow-2xl"
+      className="bg-cyber-grape relative aspect-4/3 w-full overflow-hidden rounded shadow-2xl"
     >
       {hasMounted && shouldReduceMotion === false ? (
         <video

--- a/packages/art/src/PageBackground/PageBackground.tsx
+++ b/packages/art/src/PageBackground/PageBackground.tsx
@@ -19,7 +19,6 @@ import {
   type RefCallback,
   useCallback,
   useContext,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -43,7 +42,6 @@ const BASELINE_INTENSITY = 0.1;
 const DEFAULT_FLARE = 1.8;
 const DEFAULT_SPEED_FACTOR = 0.35;
 const INTENSITY_SCROLL_RANGE = [0, 0.18];
-const INTENSITY_VALUES = [INITIAL_INTENSITY, BASELINE_INTENSITY];
 const PARAMETER_SCROLL_RANGE = [0, 0.25, 0.5, 0.75, 1];
 // The initial flare is the floor; the scroll animation only ever flares further
 // out from it, peaking well into the doubled range.
@@ -60,13 +58,18 @@ const REVEAL_START_MARGIN = 1.06;
 const REVEAL_INITIAL_RADIUS = 100000;
 
 const PageBackgroundTargetContext =
-  createContext<RefCallback<HTMLDivElement> | null>(null);
+  createContext<RefCallback<HTMLElement> | null>(null);
 
 type DocumentLayoutBox = {
   left: number;
   top: number;
   width: number;
   height: number;
+};
+
+type TargetMeasurement = {
+  convergence: NetworkWeaveConvergence;
+  targetIsBeforeLayer: boolean;
 };
 
 type ScrollCurve = {
@@ -81,6 +84,34 @@ type WeaveSettings = {
   flare: number;
   speedFactor: number;
 };
+
+function convergencePointsAreEqual(
+  currentPoint: NetworkWeaveConvergence,
+  nextPoint: NetworkWeaveConvergence,
+) {
+  return (
+    Math.abs(currentPoint.x - nextPoint.x) < POSITION_TOLERANCE &&
+    Math.abs(currentPoint.y - nextPoint.y) < POSITION_TOLERANCE
+  );
+}
+
+function weaveSettingsAreEqual(
+  currentSettings: WeaveSettings,
+  nextSettings: WeaveSettings,
+) {
+  return (
+    convergencePointsAreEqual(
+      currentSettings.convergence,
+      nextSettings.convergence,
+    ) &&
+    Math.abs(currentSettings.intensity - nextSettings.intensity) <
+      PARAMETER_TOLERANCE &&
+    Math.abs(currentSettings.flare - nextSettings.flare) <
+      PARAMETER_TOLERANCE &&
+    Math.abs(currentSettings.speedFactor - nextSettings.speedFactor) <
+      PARAMETER_TOLERANCE
+  );
+}
 
 const randomBetween = (minimum: number, maximum: number) =>
   minimum + Math.random() * (maximum - minimum);
@@ -124,7 +155,7 @@ function pointOnScrollCurve(
   };
 }
 
-function getDocumentLayoutBox(element: HTMLDivElement): DocumentLayoutBox {
+function getDocumentLayoutBox(element: HTMLElement): DocumentLayoutBox {
   const rect = element.getBoundingClientRect();
   const isFixed = window.getComputedStyle(element).position === 'fixed';
 
@@ -164,9 +195,9 @@ function getDocumentLayoutBox(element: HTMLDivElement): DocumentLayoutBox {
 
 function measureConvergence(
   layer: HTMLDivElement,
-  target: HTMLDivElement,
-): NetworkWeaveConvergence | null {
-  // Layout boxes ignore the hero's entrance transform and share document space.
+  target: HTMLElement,
+): TargetMeasurement | null {
+  // Layout boxes ignore entrance transforms and share document space.
   const layerBox = getDocumentLayoutBox(layer);
   const targetBox = getDocumentLayoutBox(target);
 
@@ -178,7 +209,10 @@ function measureConvergence(
   };
 
   return Number.isFinite(convergence.x) && Number.isFinite(convergence.y)
-    ? convergence
+    ? {
+        convergence,
+        targetIsBeforeLayer: targetBox.top + targetBox.height <= layerBox.top,
+      }
     : null;
 }
 
@@ -186,31 +220,56 @@ export function usePageBackgroundTargetRef() {
   return useContext(PageBackgroundTargetContext);
 }
 
-export function PageBackgroundProvider({ children }: { children: ReactNode }) {
+export function PageBackgroundProvider({
+  children,
+  fallbackConvergence = DEFAULT_CONVERGENCE,
+  intensity = INITIAL_INTENSITY,
+  motionMode = 'scroll',
+  waitForTarget = true,
+}: {
+  children: ReactNode;
+  fallbackConvergence?: NetworkWeaveConvergence;
+  intensity?: number;
+  motionMode?: 'scroll' | 'target';
+  waitForTarget?: boolean;
+}) {
   const layerRef = useRef<HTMLDivElement>(null);
-  const [target, setTarget] = useState<HTMLDivElement | null>(null);
+  const [target, setTarget] = useState<HTMLElement | null>(null);
   const [resolved, setResolved] = useState(false);
   const [convergence, setConvergence] =
-    useState<NetworkWeaveConvergence>(DEFAULT_CONVERGENCE);
-  const targetRef = useCallback<RefCallback<HTMLDivElement>>((element) => {
+    useState<NetworkWeaveConvergence>(fallbackConvergence);
+  const hasTrackedTargetRef = useRef(false);
+  const targetRef = useCallback<RefCallback<HTMLElement>>((element) => {
     setTarget(element);
   }, []);
 
   useLayoutEffect(() => {
+    hasTrackedTargetRef.current = false;
     const layer = layerRef.current;
-    if (!layer || !target) return undefined;
+    if (!waitForTarget || !layer || !target) return undefined;
 
     const updateConvergence = () => {
-      const nextConvergence = measureConvergence(layer, target);
-      if (!nextConvergence) return;
+      const measurement = measureConvergence(layer, target);
+      if (!measurement) return;
 
+      if (
+        motionMode === 'scroll' &&
+        !hasTrackedTargetRef.current &&
+        measurement.targetIsBeforeLayer
+      ) {
+        setResolved(true);
+        return;
+      }
+
+      hasTrackedTargetRef.current = true;
       setResolved(true);
       setConvergence((currentConvergence) =>
-        Math.abs(currentConvergence.x - nextConvergence.x) <
+        Math.abs(currentConvergence.x - measurement.convergence.x) <
           POSITION_TOLERANCE &&
-        Math.abs(currentConvergence.y - nextConvergence.y) < POSITION_TOLERANCE
+        Math.abs(currentConvergence.y - measurement.convergence.y) <
+          POSITION_TOLERANCE
           ? currentConvergence
-          : nextConvergence,
+          : measurement.convergence,
       );
     };
 
@@ -220,6 +279,7 @@ export function PageBackgroundProvider({ children }: { children: ReactNode }) {
     observer.observe(layer);
     observer.observe(target);
     window.addEventListener('resize', updateConvergence);
+    window.addEventListener('scroll', updateConvergence, { passive: true });
     let isActive = true;
     void document.fonts?.ready.then(() => {
       if (isActive) updateConvergence();
@@ -230,15 +290,25 @@ export function PageBackgroundProvider({ children }: { children: ReactNode }) {
       isActive = false;
       observer.disconnect();
       window.removeEventListener('resize', updateConvergence);
+      window.removeEventListener('scroll', updateConvergence);
     };
-  }, [target]);
+  }, [motionMode, target, waitForTarget]);
+
+  useLayoutEffect(() => {
+    if (waitForTarget && target) return;
+
+    setResolved(false);
+    setConvergence(fallbackConvergence);
+  }, [fallbackConvergence, target, waitForTarget]);
 
   return (
     <>
       <PageBackground
         convergence={convergence}
-        resolved={resolved}
+        intensity={intensity}
         layerRef={layerRef}
+        motionMode={motionMode}
+        resolved={waitForTarget ? resolved : undefined}
       />
       <PageBackgroundTargetContext.Provider value={targetRef}>
         {children}
@@ -289,14 +359,28 @@ function useConvergenceReveal(
   const convergenceRef = useRef(convergence);
   convergenceRef.current = convergence;
 
-  useEffect(() => {
-    if (!resolved || reduceMotion === null || hasRevealedRef.current) return;
+  useLayoutEffect(() => {
+    if (resolved === undefined) {
+      hasRevealedRef.current = false;
+      radius.set(REVEAL_INITIAL_RADIUS);
+      setMasked(false);
+      return undefined;
+    }
+
+    if (!resolved) {
+      hasRevealedRef.current = false;
+      radius.set(REVEAL_INITIAL_RADIUS);
+      setMasked(true);
+      return undefined;
+    }
+
+    if (reduceMotion === null || hasRevealedRef.current) return undefined;
     hasRevealedRef.current = true;
 
     if (reduceMotion) {
       radius.set(0);
       setMasked(false);
-      return;
+      return undefined;
     }
 
     const cornerDistance = getFarthestCornerDistance(
@@ -339,40 +423,50 @@ function useResponsiveOrientation(): NetworkWeaveOrientation {
 
 export function PageBackground({
   convergence = DEFAULT_CONVERGENCE,
+  intensity = INITIAL_INTENSITY,
+  motionMode = 'scroll',
   resolved,
   layerRef,
 }: {
   convergence?: NetworkWeaveConvergence;
+  intensity?: number;
+  motionMode?: 'scroll' | 'target';
   resolved?: boolean;
   layerRef?: Ref<HTMLDivElement>;
 }) {
   const reduceMotion = useReducedMotion();
   const orientation = useResponsiveOrientation();
-  const { maskImage, masked } = useConvergenceReveal(
-    convergence,
-    resolved,
-    reduceMotion,
-  );
   const { scrollYProgress } = useScroll();
   const curveRef = useRef<ScrollCurve | null>(null);
   const [weaveSettings, setWeaveSettings] = useState<WeaveSettings>({
     convergence,
-    intensity: INITIAL_INTENSITY,
+    intensity,
     flare: DEFAULT_FLARE,
     speedFactor: DEFAULT_SPEED_FACTOR,
   });
+  const weaveSettingsRef = useRef(weaveSettings);
+  const [scrollBasis, setScrollBasis] =
+    useState<NetworkWeaveConvergence | null>(null);
+  const hasResolvedTargetRef = useRef(resolved === true);
+  const commitWeaveSettings = useCallback((settings: WeaveSettings) => {
+    if (weaveSettingsAreEqual(weaveSettingsRef.current, settings)) return;
+
+    weaveSettingsRef.current = settings;
+    setWeaveSettings(settings);
+  }, []);
   const updateWeaveSettings = useCallback(
     (progress: number) => {
+      if (motionMode !== 'scroll') return;
+
       const curve = curveRef.current;
       const nextSettings: WeaveSettings =
         reduceMotion === false && curve
           ? {
               convergence: pointOnScrollCurve(convergence, curve, progress),
-              intensity: transform(
-                progress,
-                INTENSITY_SCROLL_RANGE,
-                INTENSITY_VALUES,
-              ),
+              intensity: transform(progress, INTENSITY_SCROLL_RANGE, [
+                intensity,
+                BASELINE_INTENSITY,
+              ]),
               flare: transform(progress, PARAMETER_SCROLL_RANGE, FLARE_VALUES),
               speedFactor: transform(
                 progress,
@@ -382,35 +476,100 @@ export function PageBackground({
             }
           : {
               convergence,
-              intensity: INITIAL_INTENSITY,
+              intensity,
               flare: DEFAULT_FLARE,
               speedFactor: DEFAULT_SPEED_FACTOR,
             };
 
-      setWeaveSettings((currentSettings) =>
-        Math.abs(currentSettings.convergence.x - nextSettings.convergence.x) <
-          POSITION_TOLERANCE &&
-        Math.abs(currentSettings.convergence.y - nextSettings.convergence.y) <
-          POSITION_TOLERANCE &&
-        Math.abs(currentSettings.intensity - nextSettings.intensity) <
-          PARAMETER_TOLERANCE &&
-        Math.abs(currentSettings.flare - nextSettings.flare) <
-          PARAMETER_TOLERANCE &&
-        Math.abs(currentSettings.speedFactor - nextSettings.speedFactor) <
-          PARAMETER_TOLERANCE
-          ? currentSettings
-          : nextSettings,
+      commitWeaveSettings(nextSettings);
+      setScrollBasis((currentBasis) =>
+        currentBasis && convergencePointsAreEqual(currentBasis, convergence)
+          ? currentBasis
+          : convergence,
       );
     },
-    [convergence, reduceMotion],
+    [commitWeaveSettings, convergence, intensity, motionMode, reduceMotion],
   );
 
   useLayoutEffect(() => {
+    if (motionMode !== 'scroll') return;
+
     curveRef.current ??= createRandomScrollCurve();
     updateWeaveSettings(scrollYProgress.get());
-  }, [scrollYProgress, updateWeaveSettings]);
+  }, [motionMode, scrollYProgress, updateWeaveSettings]);
 
   useMotionValueEvent(scrollYProgress, 'change', updateWeaveSettings);
+
+  useLayoutEffect(() => {
+    if (motionMode !== 'target') return undefined;
+
+    const nextSettings: WeaveSettings = {
+      convergence,
+      intensity,
+      flare: DEFAULT_FLARE,
+      speedFactor: DEFAULT_SPEED_FACTOR,
+    };
+    const isFirstResolvedTarget =
+      resolved === true && !hasResolvedTargetRef.current;
+
+    if (resolved === false) hasResolvedTargetRef.current = false;
+    if (resolved === true) hasResolvedTargetRef.current = true;
+
+    if (reduceMotion !== false || resolved === false || isFirstResolvedTarget) {
+      commitWeaveSettings(nextSettings);
+      return undefined;
+    }
+
+    const startSettings = weaveSettingsRef.current;
+    if (weaveSettingsAreEqual(startSettings, nextSettings)) return undefined;
+
+    const controls = animate(0, 1, {
+      type: 'spring',
+      stiffness: 100,
+      damping: 20,
+      mass: 0.8,
+      onUpdate: (progress) => {
+        commitWeaveSettings({
+          convergence: {
+            x:
+              startSettings.convergence.x +
+              (nextSettings.convergence.x - startSettings.convergence.x) *
+                progress,
+            y:
+              startSettings.convergence.y +
+              (nextSettings.convergence.y - startSettings.convergence.y) *
+                progress,
+          },
+          intensity:
+            startSettings.intensity +
+            (nextSettings.intensity - startSettings.intensity) * progress,
+          flare: DEFAULT_FLARE,
+          speedFactor: DEFAULT_SPEED_FACTOR,
+        });
+      },
+    });
+
+    return () => controls.stop();
+  }, [
+    commitWeaveSettings,
+    convergence,
+    intensity,
+    motionMode,
+    reduceMotion,
+    resolved,
+  ]);
+
+  const scrollSettingsReady =
+    motionMode !== 'scroll' ||
+    (scrollBasis !== null &&
+      convergencePointsAreEqual(scrollBasis, convergence));
+  const revealResolved =
+    resolved === undefined ? undefined : resolved && scrollSettingsReady;
+  const { maskImage, masked } = useConvergenceReveal(
+    motionMode === 'scroll' ? weaveSettings.convergence : convergence,
+    revealResolved,
+    reduceMotion,
+  );
 
   return (
     <motion.div

--- a/packages/art/src/__tests__/PageBackground.component.test.tsx
+++ b/packages/art/src/__tests__/PageBackground.component.test.tsx
@@ -15,6 +15,18 @@ import {
 } from '../PageBackground/PageBackground';
 
 const networkWeaveProps = vi.hoisted(() => vi.fn());
+const animateMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      start: unknown,
+      _end: unknown,
+      options?: { onUpdate?: (progress: number) => void },
+    ) => {
+      if (typeof start === 'number') options?.onUpdate?.(1);
+      return { stop: () => {} };
+    },
+  ),
+);
 const motionState = vi.hoisted(() => {
   const state: {
     reduced: boolean;
@@ -58,7 +70,7 @@ vi.mock('motion/react', () => ({
   useMotionValue: (initial: number) => createMotionValue(initial),
   useTransform: () => createMotionValue(0),
   useMotionTemplate: () => 'none',
-  animate: () => ({ stop: () => {} }),
+  animate: animateMock,
   transform: (input: number, inputRange: number[], outputRange: number[]) => {
     if (input <= (inputRange[0] ?? 0)) return outputRange[0] ?? 0;
     const lastIndex = inputRange.length - 1;
@@ -144,6 +156,7 @@ function BackgroundTarget() {
 describe('PageBackground', () => {
   beforeEach(() => {
     networkWeaveProps.mockClear();
+    animateMock.mockClear();
     motionState.reduced = false;
     motionState.progress = 0;
     motionState.listener = null;
@@ -271,6 +284,65 @@ describe('PageBackground', () => {
     );
   });
 
+  it('animates between target positions and intensities', () => {
+    const { rerender } = render(
+      <PageBackground
+        convergence={{ x: 0.2, y: 0.4 }}
+        intensity={0.4}
+        motionMode="target"
+        resolved
+      />,
+    );
+
+    animateMock.mockClear();
+    rerender(
+      <PageBackground
+        convergence={{ x: 0.8, y: 0.7 }}
+        intensity={0.1}
+        motionMode="target"
+        resolved
+      />,
+    );
+
+    expect(animateMock).toHaveBeenCalledWith(
+      0,
+      1,
+      expect.objectContaining({
+        type: 'spring',
+        stiffness: 100,
+        damping: 20,
+      }),
+    );
+    const latestProps = networkWeaveProps.mock.lastCall?.[0] as {
+      convergence: { x: number; y: number };
+      intensity: number;
+    };
+    expect(latestProps.convergence).toEqual({ x: 0.8, y: 0.7 });
+    expect(latestProps.intensity).toBeCloseTo(0.1);
+  });
+
+  it('snaps to the first measured target before revealing the weave', () => {
+    const { rerender } = render(
+      <PageBackground motionMode="target" resolved={false} />,
+    );
+
+    animateMock.mockClear();
+    rerender(
+      <PageBackground
+        convergence={{ x: 0.25, y: 0.75 }}
+        motionMode="target"
+        resolved
+      />,
+    );
+
+    expect(
+      animateMock.mock.calls.some(([start, end]) => start === 0 && end === 1),
+    ).toBe(false);
+    expect(networkWeaveProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ convergence: { x: 0.25, y: 0.75 } }),
+    );
+  });
+
   it('measures the target center in the hero layer coordinate space', () => {
     const layerRect = createRect({ left: 0, top: 0, width: 1000, height: 800 });
     const targetRect = createRect({
@@ -320,7 +392,7 @@ describe('PageBackground', () => {
     );
   });
 
-  it('updates for viewport changes and cleans up its observers', () => {
+  it('updates for scroll and viewport changes and cleans up its observers', () => {
     let layerRect = createRect({ left: 0, top: 0, width: 1000, height: 800 });
     let targetRect = createRect({
       left: 100,
@@ -369,8 +441,61 @@ describe('PageBackground', () => {
     expect(latestProps.convergence.x).toBeCloseTo(0.625);
     expect(latestProps.convergence.y).toBeCloseTo(0.4167);
 
+    targetRect = createRect({
+      left: 300,
+      top: -50,
+      width: 400,
+      height: 300,
+    });
+    act(() => {
+      fireEvent.scroll(window);
+    });
+
+    const scrolledProps = networkWeaveProps.mock.lastCall?.[0] as {
+      convergence: { x: number; y: number };
+    };
+    expect(scrolledProps.convergence.x).toBeCloseTo(0.625);
+    expect(scrolledProps.convergence.y).toBeCloseTo(0.1667);
+
     unmount();
     expect(observer?.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('reveals at the scroll path when the initial target is above the viewport', () => {
+    motionState.progress = 0.5;
+    const layerRect = createRect({ left: 0, top: 0, width: 1000, height: 800 });
+    const targetRect = createRect({
+      left: 100,
+      top: -500,
+      width: 400,
+      height: 100,
+    });
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: Element) {
+        return (this as HTMLElement).dataset.testid === 'page-background-layer'
+          ? layerRect
+          : targetRect;
+      },
+    );
+
+    render(
+      <PageBackgroundProvider>
+        <BackgroundTarget />
+      </PageBackgroundProvider>,
+    );
+
+    const latestProps = networkWeaveProps.mock.lastCall?.[0] as {
+      convergence: { x: number; y: number };
+      intensity: number;
+    };
+    expect(latestProps.convergence.x).toBeCloseTo(0.5);
+    expect(latestProps.convergence.y).toBeCloseTo(0.5125);
+    expect(latestProps.intensity).toBeCloseTo(0.1);
+    expect(
+      animateMock.mock.calls.some(
+        ([start, end]) => typeof start === 'object' && end === 0,
+      ),
+    ).toBe(true);
   });
 
   it('keeps the last finite coordinates when the layer has no size', () => {

--- a/packages/fresco-ui/src/Table.tsx
+++ b/packages/fresco-ui/src/Table.tsx
@@ -107,7 +107,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cx(
-      'w-0 px-6 whitespace-nowrap',
+      'w-0 px-6 py-3 align-bottom whitespace-nowrap',
       'text-left font-medium last:w-auto',
       className,
     )}

--- a/tooling/tailwind/fresco/themes/default.css
+++ b/tooling/tailwind/fresco/themes/default.css
@@ -105,13 +105,13 @@
     --secondary: oklch(from var(--primary) calc(l + 0.2) calc(c + 0.05) h);
     --secondary-contrast: oklch(var(--white));
 
-    --surface: oklch(100% 0.01 var(--base-hue));
+    --surface: oklch(var(--white));
     --surface-contrast: var(--text);
-    --surface-1: oklch(97% 0.02 var(--base-hue));
+    --surface-1: var(--background);
     --surface-1-contrast: var(--text);
-    --surface-2: oklch(0.91 0.01 231.77);
+    --surface-2: oklch(from var(--background) calc(l - 0.03) c h);
     --surface-2-contrast: var(--text);
-    --surface-3: oklch(93% 0.03 var(--base-hue));
+    --surface-3: oklch(from var(--background) calc(l - 0.06) c h);
     --surface-3-contrast: var(--text);
 
     --surface-popover: oklch(var(--white));


### PR DESCRIPTION
## Summary
- animate the shared page background toward live element refs, keep focus aligned while scrolling, and use the path fallback when the marketing hero is already out of view
- update the documentation homepage cards to drive background focus and prevent table-of-contents tracking from snapping the page away from the footer
- derive website surface levels from the background, use Fresco table styling directly, and normalize oversized website radii

## Test plan
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @codaco/art test` (138 tests)
- [x] `pnpm --filter networkcanvas.com test` (94 tests)
- [x] visually verify documentation and marketing pages in light/dark and mobile/desktop layouts

## Notes
- The full Fresco unit run passed 808 tests but hit one async-dialog timing failure and three worker startup timeouts under load. All four affected files passed when rerun serially (92 tests).
