### PR TITLE
fix(architect): remove printable codebook table tint

### DIFF
--- a/.changeset/architect-printable-codebook-tables.md
+++ b/.changeset/architect-printable-codebook-tables.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Remove the unintended green tint from tables in printable protocol codebooks while preserving the intended row and column striping.

--- a/apps/architect/src/lib/ProtocolSummary/components/MiniTable.tsx
+++ b/apps/architect/src/lib/ProtocolSummary/components/MiniTable.tsx
@@ -11,7 +11,7 @@ type MiniTableProps = {
 
 const tableVariants = cva({
   base: [
-    'bg-table-row-tint my-5 break-inside-avoid overflow-hidden rounded',
+    'my-5 break-inside-avoid overflow-hidden rounded',
     '[&>thead>tr>th]:text-xs [&>thead>tr>th]:font-semibold [&>thead>tr>th]:tracking-widest [&>thead>tr>th]:break-keep [&>thead>tr>th]:uppercase',
     '[&_:is(td,th)]:px-5 [&_:is(td,th)]:py-2.5',
     '[&_:is(td,th)_:is(ul,ol)]:p-[inherit]',


### PR DESCRIPTION
## Summary

- Remove the table-level background tint from printable protocol summary tables.
- Preserve the intended row and column striping on table cells.
- Add an Architect patch changeset.

### Root cause

`MiniTable` applied `bg-table-row-tint` to the table element itself while also applying the same translucent tint selectively to striped cells. In the printable codebook, that made the entire table green and compounded the tint on striped cells. Removing the table-level utility leaves the table transparent and confines the tint to the intended cells.

## Test plan

- [x] Verified the printable codebook in the browser and confirmed table backgrounds are transparent while intended striped cells remain tinted.
- [x] `CI=true pnpm --filter @codaco/architect test`
- [x] `CI=true pnpm --filter @codaco/architect typecheck`
- [x] `CI=true pnpm --filter @codaco/architect build`
- [x] `CI=true pnpm lint:fix`
- [x] `CI=true pnpm knip`
- [x] `CI=true pnpm check:changesets`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed an unintended green tint from tables in printable protocol codebooks.
  - Preserved the intended alternating row and column striping.
  - Maintained existing table layout, spacing, and print behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->