### PR TITLE
Fix website load and scrolling regressions

### DIFF
--- a/.changeset/neat-chairs-serve.md
+++ b/.changeset/neat-chairs-serve.md
@@ -1,0 +1,5 @@
+---
+"@codaco/art": patch
+---
+
+Keep the page background visible after its initial reveal instead of restarting the fade during scrolling.

--- a/apps/networkcanvas.com/app/[locale]/layout.tsx
+++ b/apps/networkcanvas.com/app/[locale]/layout.tsx
@@ -24,6 +24,8 @@ type LocaleMetadataProps = {
   params: Promise<{ locale: string }>;
 };
 
+const entranceMotionScript = `document.documentElement.dataset.entranceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduced' : 'enabled';`;
+
 export const generateStaticParams = getStaticLocaleParams;
 export const dynamicParams = false;
 
@@ -76,6 +78,9 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale} data-scroll-behavior="smooth" suppressHydrationWarning>
+      <head>
+        <script id="entrance-motion">{entranceMotionScript}</script>
+      </head>
       <body className="root overflow-x-hidden">
         <ThemeProvider
           enableSystem

--- a/apps/networkcanvas.com/app/globals.css
+++ b/apps/networkcanvas.com/app/globals.css
@@ -22,6 +22,13 @@
   html {
     scroll-behavior: smooth;
   }
+
+  html[data-entrance-motion='enabled']
+    [data-entrance-pending]
+    .entrance-motion-item {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
 }
 
 /* Continuous horizontal marquee used by the desktop news ticker. */

--- a/apps/networkcanvas.com/components/get-started/GetStartedIntro.tsx
+++ b/apps/networkcanvas.com/components/get-started/GetStartedIntro.tsx
@@ -36,6 +36,7 @@ export function GetStartedIntro() {
   const entrance = createHeroEntrance(reduceMotion ?? true);
   const controls = useAnimationControls();
   const entranceStarted = useRef(false);
+  const introRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (reduceMotion !== false || entranceStarted.current) {
@@ -44,11 +45,16 @@ export function GetStartedIntro() {
 
     entranceStarted.current = true;
     controls.set('hidden');
+    introRef.current?.removeAttribute('data-entrance-pending');
     void controls.start('visible');
   }, [controls, reduceMotion]);
 
   return (
-    <div className="relative isolate overflow-hidden">
+    <div
+      ref={introRef}
+      data-entrance-pending
+      className="relative isolate overflow-hidden"
+    >
       <motion.div
         className="relative z-10"
         variants={entrance.pageVariants}
@@ -66,7 +72,7 @@ export function GetStartedIntro() {
         >
           <motion.div
             variants={entrance.itemVariants}
-            className="mx-auto max-w-4xl px-6 text-center"
+            className="entrance-motion-item mx-auto max-w-4xl px-6 text-center"
           >
             <Paragraph
               margin="none"
@@ -99,7 +105,7 @@ export function GetStartedIntro() {
                 variants={entrance.itemVariants}
                 whileHover={reduceMotion ? undefined : { y: -5 }}
                 whileFocus={reduceMotion ? undefined : { y: -5 }}
-                className="focusable elevation-medium group tablet-portrait:p-10 bg-surface/55 flex min-h-64 flex-col justify-between rounded p-8 backdrop-blur-md"
+                className="entrance-motion-item focusable elevation-medium group tablet-portrait:p-10 bg-surface/55 flex min-h-64 flex-col justify-between rounded p-8 backdrop-blur-md"
               >
                 <span className="font-heading text-text/65 text-xs font-bold tracking-[0.14em] uppercase">
                   {t(`intro.stages.${stage.id}.label`)}

--- a/apps/networkcanvas.com/components/get-started/__tests__/GetStartedIntro.test.tsx
+++ b/apps/networkcanvas.com/components/get-started/__tests__/GetStartedIntro.test.tsx
@@ -107,6 +107,9 @@ describe('GetStartedIntro', () => {
     motionPreference.reduced = true;
     const { container } = renderWithIntl(<GetStartedIntro />);
 
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-entrance-pending',
+    );
     expect(container.firstElementChild?.firstElementChild).toHaveAttribute(
       'data-initial',
       'false',
@@ -124,6 +127,19 @@ describe('GetStartedIntro', () => {
     expect(animationControls.set).toHaveBeenCalledBefore(
       animationControls.start,
     );
+    expect(screen.getByRole('heading', { level: 1 }).parentElement).toHaveClass(
+      'entrance-motion-item',
+    );
+    expect(
+      screen.getByRole('link', {
+        name: 'Design or create an interview protocol',
+      }),
+    ).toHaveClass('entrance-motion-item');
+    expect(
+      screen
+        .getByRole('heading', { level: 1 })
+        .closest('[data-entrance-pending]'),
+    ).toBeNull();
   });
 
   it('localizes the stage choices', () => {

--- a/apps/networkcanvas.com/components/layout/Header.tsx
+++ b/apps/networkcanvas.com/components/layout/Header.tsx
@@ -31,6 +31,7 @@ export function Header({
   return (
     <SiteNavigation
       activeItemId={activeItemId}
+      className={entranceVariants ? 'entrance-motion-item' : undefined}
       entranceVariants={entranceVariants}
       locale={locale}
       renderLink={renderNavigationLink}

--- a/apps/networkcanvas.com/components/layout/__tests__/Header.test.tsx
+++ b/apps/networkcanvas.com/components/layout/__tests__/Header.test.tsx
@@ -60,6 +60,16 @@ describe('localized layout navigation', () => {
     ).toHaveAttribute('aria-expanded', 'true');
   });
 
+  it('marks animated navigation for its pre-hydration entrance state', () => {
+    const { container } = renderWithIntl(
+      <Header entranceVariants={{ hidden: {}, visible: {} }} />,
+    );
+
+    expect(container.querySelector('header')).toHaveClass(
+      'entrance-motion-item',
+    );
+  });
+
   it('renders translated footer links and language selection', () => {
     renderWithIntl(<Footer />, 'es');
 

--- a/apps/networkcanvas.com/components/sections/Hero.tsx
+++ b/apps/networkcanvas.com/components/sections/Hero.tsx
@@ -46,7 +46,7 @@ export function Hero({
           level="h1"
           margin="none"
           variants={itemVariants}
-          className="font-heading text-text tablet-portrait:row-start-1 tablet-portrait:self-center tablet-portrait:text-[4rem] tablet-portrait:leading-[1.04] tablet-landscape:text-[4.5rem] tablet-landscape:leading-[1.02] desktop:text-[5rem] mx-auto max-w-5xl text-center text-4xl font-black"
+          className="entrance-motion-item font-heading text-text tablet-portrait:row-start-1 tablet-portrait:self-center tablet-portrait:text-[4rem] tablet-portrait:leading-[1.04] tablet-landscape:text-[4.5rem] tablet-landscape:leading-[1.02] desktop:text-[5rem] mx-auto max-w-5xl text-center text-4xl font-black"
         >
           {t('headline')}
         </MotionHeading>
@@ -54,7 +54,7 @@ export function Hero({
         <motion.div
           variants={itemVariants}
           data-testid="hero-media-row"
-          className="tablet-portrait:row-start-2 tablet-portrait:mt-0 tablet-portrait:grid-cols-[1.1fr_0.9fr] tablet-portrait:gap-10 tablet-landscape:gap-16 mt-12 grid items-center gap-10"
+          className="entrance-motion-item tablet-portrait:row-start-2 tablet-portrait:mt-0 tablet-portrait:grid-cols-[1.1fr_0.9fr] tablet-portrait:gap-10 tablet-landscape:gap-16 mt-12 grid items-center gap-10"
         >
           <div
             data-testid="hero-media-sizer"
@@ -73,7 +73,7 @@ export function Hero({
         <motion.div
           variants={itemVariants}
           data-testid="hero-news-wrapper"
-          className="tablet-portrait:col-start-1 tablet-portrait:row-start-3 tablet-portrait:mt-0 tablet-portrait:min-w-0 mt-12"
+          className="entrance-motion-item tablet-portrait:col-start-1 tablet-portrait:row-start-3 tablet-portrait:mt-0 tablet-portrait:min-w-0 mt-12"
         >
           <NewsTicker newsItems={newsItems} />
         </motion.div>
@@ -81,7 +81,7 @@ export function Hero({
         <motion.div
           variants={itemVariants}
           data-testid="hero-cta-wrapper"
-          className="tablet-portrait:col-start-1 tablet-portrait:row-start-4 tablet-portrait:mt-0 mt-12 flex flex-col items-center gap-3"
+          className="entrance-motion-item tablet-portrait:col-start-1 tablet-portrait:row-start-4 tablet-portrait:mt-0 mt-12 flex flex-col items-center gap-3"
         >
           <ButtonLink
             href={GET_STARTED_PATH}

--- a/apps/networkcanvas.com/components/sections/HeroIntro.tsx
+++ b/apps/networkcanvas.com/components/sections/HeroIntro.tsx
@@ -13,6 +13,7 @@ export function HeroIntro({ newsItems }: { newsItems: readonly NewsItem[] }) {
   const entrance = createHeroEntrance(reduceMotion ?? true);
   const controls = useAnimationControls();
   const entranceStarted = useRef(false);
+  const introRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (reduceMotion !== false || entranceStarted.current) {
@@ -21,11 +22,16 @@ export function HeroIntro({ newsItems }: { newsItems: readonly NewsItem[] }) {
 
     entranceStarted.current = true;
     controls.set('hidden');
+    introRef.current?.removeAttribute('data-entrance-pending');
     void controls.start('visible');
   }, [controls, reduceMotion]);
 
   return (
-    <div className="tablet-portrait:min-h-svh relative isolate overflow-hidden">
+    <div
+      ref={introRef}
+      data-entrance-pending
+      className="tablet-portrait:min-h-svh relative isolate overflow-hidden"
+    >
       <motion.div
         className="tablet-portrait:flex tablet-portrait:min-h-svh tablet-portrait:flex-col relative z-10"
         variants={entrance.pageVariants}

--- a/apps/networkcanvas.com/components/sections/__tests__/Hero.test.tsx
+++ b/apps/networkcanvas.com/components/sections/__tests__/Hero.test.tsx
@@ -73,10 +73,12 @@ describe('Hero', () => {
       'tablet-portrait:content-center',
     );
     expect(heading).toHaveClass(
+      'entrance-motion-item',
       'tablet-portrait:row-start-1',
       'tablet-portrait:self-center',
     );
     expect(mediaRow).toHaveClass(
+      'entrance-motion-item',
       'tablet-portrait:row-start-2',
       'tablet-portrait:grid-cols-[1.1fr_0.9fr]',
       'tablet-portrait:mt-0',
@@ -87,11 +89,13 @@ describe('Hero', () => {
       'tablet-portrait:justify-self-center',
     );
     expect(newsWrapper).toHaveClass(
+      'entrance-motion-item',
       'tablet-portrait:col-start-1',
       'tablet-portrait:row-start-3',
       'tablet-portrait:mt-0',
     );
     expect(ctaWrapper).toHaveClass(
+      'entrance-motion-item',
       'tablet-portrait:col-start-1',
       'tablet-portrait:row-start-4',
       'tablet-portrait:mt-0',

--- a/apps/networkcanvas.com/components/sections/__tests__/HeroIntro.test.tsx
+++ b/apps/networkcanvas.com/components/sections/__tests__/HeroIntro.test.tsx
@@ -133,6 +133,9 @@ describe('HeroIntro', () => {
     const container = document.createElement('div');
     container.innerHTML = serverMarkup;
 
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-entrance-pending',
+    );
     expect(container.querySelector('[data-motion-root]')).toHaveAttribute(
       'data-initial',
       'false',
@@ -194,6 +197,9 @@ describe('HeroIntro', () => {
     ).toHaveAttribute('data-hero-item-variants', 'active');
     expect(animationControls.set).not.toHaveBeenCalled();
     expect(animationControls.start).not.toHaveBeenCalled();
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-entrance-pending',
+    );
 
     await act(async () => root.unmount());
     container.remove();
@@ -240,6 +246,9 @@ describe('HeroIntro', () => {
     expect(animationControls.start).toHaveBeenCalledWith('visible');
     expect(animationControls.set).toHaveBeenCalledBefore(
       animationControls.start,
+    );
+    expect(container.firstElementChild).not.toHaveAttribute(
+      'data-entrance-pending',
     );
 
     await act(async () => root.unmount());

--- a/apps/networkcanvas.com/lib/i18n/__tests__/clientLocale.test.ts
+++ b/apps/networkcanvas.com/lib/i18n/__tests__/clientLocale.test.ts
@@ -8,6 +8,18 @@ describe('client locale selection', () => {
     expect(getLocalizedPathname('es', '/get-started')).toBe('/es/get-started/');
   });
 
+  it.each([
+    ['/es', 'en-GB', '/en-GB/'],
+    ['/en-US/', 'es', '/es/'],
+    ['/en-GB/get-started/', 'en-US', '/en-US/get-started/'],
+    ['/en-gb/get-started', 'es', '/es/get-started/'],
+  ] as const)(
+    'replaces the locale prefix in %s with %s',
+    (pathname, locale, expected) => {
+      expect(getLocalizedPathname(locale, pathname)).toBe(expected);
+    },
+  );
+
   it('persists an explicit locale for one year', () => {
     expect(getLocaleCookie('en-US')).toBe(
       'NEXT_LOCALE=en-US; Path=/; Max-Age=31536000; SameSite=Lax',

--- a/apps/networkcanvas.com/lib/i18n/clientLocale.ts
+++ b/apps/networkcanvas.com/lib/i18n/clientLocale.ts
@@ -19,5 +19,7 @@ export function getLocaleCookie(locale: Locale) {
 
 export function switchLocale(locale: Locale, pathname: string) {
   document.cookie = getLocaleCookie(locale);
-  window.location.assign(getLocalizedPathname(locale, pathname));
+  window.location.assign(
+    `${getLocalizedPathname(locale, pathname)}${window.location.search}${window.location.hash}`,
+  );
 }

--- a/apps/networkcanvas.com/lib/i18n/clientLocale.ts
+++ b/apps/networkcanvas.com/lib/i18n/clientLocale.ts
@@ -1,7 +1,14 @@
-import { localeCookie, type Locale } from './locales';
+import { localeCookie, locales, type Locale } from './locales';
 
 export function getLocalizedPathname(locale: Locale, pathname: string) {
-  const unlocalizedPath = pathname.replace(/^\/+|\/+$/g, '');
+  const segments = pathname.split('/').filter(Boolean);
+  const unlocalizedSegments = locales.some(
+    (supportedLocale) =>
+      supportedLocale.toLowerCase() === segments[0]?.toLowerCase(),
+  )
+    ? segments.slice(1)
+    : segments;
+  const unlocalizedPath = unlocalizedSegments.join('/');
 
   return unlocalizedPath ? `/${locale}/${unlocalizedPath}/` : `/${locale}/`;
 }

--- a/packages/art/src/PageBackground/PageBackground.tsx
+++ b/packages/art/src/PageBackground/PageBackground.tsx
@@ -447,6 +447,8 @@ export function PageBackground({
   const weaveSettingsRef = useRef(weaveSettings);
   const [scrollBasis, setScrollBasis] =
     useState<NetworkWeaveConvergence | null>(null);
+  const [hasPreparedScrollSettings, setHasPreparedScrollSettings] =
+    useState(false);
   const hasResolvedTargetRef = useRef(resolved === true);
   const commitWeaveSettings = useCallback((settings: WeaveSettings) => {
     if (weaveSettingsAreEqual(weaveSettingsRef.current, settings)) return;
@@ -563,8 +565,18 @@ export function PageBackground({
     motionMode !== 'scroll' ||
     (scrollBasis !== null &&
       convergencePointsAreEqual(scrollBasis, convergence));
+  useLayoutEffect(() => {
+    if (motionMode !== 'scroll' || resolved === false) {
+      setHasPreparedScrollSettings(false);
+      return;
+    }
+
+    if (scrollSettingsReady) setHasPreparedScrollSettings(true);
+  }, [motionMode, resolved, scrollSettingsReady]);
   const revealResolved =
-    resolved === undefined ? undefined : resolved && scrollSettingsReady;
+    resolved === undefined
+      ? undefined
+      : resolved && (motionMode !== 'scroll' || hasPreparedScrollSettings);
   const { maskImage, masked } = useConvergenceReveal(
     motionMode === 'scroll' ? weaveSettings.convergence : convergence,
     revealResolved,

--- a/packages/art/src/__tests__/PageBackground.component.test.tsx
+++ b/packages/art/src/__tests__/PageBackground.component.test.tsx
@@ -456,6 +456,11 @@ describe('PageBackground', () => {
     };
     expect(scrolledProps.convergence.x).toBeCloseTo(0.625);
     expect(scrolledProps.convergence.y).toBeCloseTo(0.1667);
+    expect(
+      animateMock.mock.calls.filter(
+        ([start, end]) => typeof start === 'object' && end === 0,
+      ),
+    ).toHaveLength(1);
 
     unmount();
     expect(observer?.disconnect).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary
- prevent server-rendered hero content from flashing before its entrance animation
- keep the page background reveal latched after its first completion during scrolling
- replace existing locale prefixes when switching languages

## Test plan
- [x] pnpm lint:fix
- [x] pnpm typecheck
- [x] pnpm knip
- [x] pnpm check:changesets
- [x] pnpm --filter @codaco/art test
- [x] pnpm --filter networkcanvas.com test
- [x] pnpm --filter networkcanvas.com build
- [x] verify normal and reduced-motion first loads, scrolling, and locale switching in the production export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated entrance animations across homepage heroes, navigation, calls to action, and introductory content.
  - Respects reduced-motion preferences for a more accessible experience.
  - Improved locale switching and handling of existing locale prefixes.

- **Bug Fixes**
  - Page backgrounds now remain visible after their initial reveal instead of restarting during scrolling.
  - Improved animation behavior during page hydration and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->