### PR TITLE
feat(fresco-ui): add Classic apps to shared navigation

### DIFF
--- a/.changeset/shared-navigation-classic-apps.md
+++ b/.changeset/shared-navigation-classic-apps.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': minor
+---
+
+Add Architect Classic and Interviewer Classic to the shared site navigation and arrange the software destinations in a two-column grid.

--- a/.changeset/shared-navigation-classic-apps.md
+++ b/.changeset/shared-navigation-classic-apps.md
@@ -2,4 +2,4 @@
 '@codaco/fresco-ui': minor
 ---
 
-Add Architect Classic and Interviewer Classic to the shared site navigation and arrange the software destinations in a two-column grid.
+Add Architect Classic and Interviewer Classic to the shared site navigation and arrange the software destinations in a two-row grid that distinguishes Classic apps.

--- a/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
+++ b/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
@@ -66,7 +66,7 @@ function PlatformActions({ app }: { app: (typeof classicApps)[number] }) {
   const t = useTranslations('GetStarted');
 
   return (
-    <div className="mt-8">
+    <div id={`${app.id}-downloads`} className="mt-8 scroll-mt-8">
       <Paragraph
         margin="none"
         className="font-heading text-xs font-bold tracking-[0.12em] uppercase"

--- a/apps/networkcanvas.com/components/get-started/__tests__/AppChoiceCard.test.tsx
+++ b/apps/networkcanvas.com/components/get-started/__tests__/AppChoiceCard.test.tsx
@@ -91,11 +91,15 @@ describe('AppChoiceCard', () => {
   it('gives each Classic platform link an app-specific accessible name', () => {
     renderWithIntl(<AppChoiceCard app={architectClassic} />);
 
-    expect(
-      screen.getByRole('link', {
-        name: 'Apple Silicon for Architect Classic',
-      }),
-    ).toHaveAttribute('target', '_blank');
+    const appleSiliconLink = screen.getByRole('link', {
+      name: 'Apple Silicon for Architect Classic',
+    });
+
+    expect(appleSiliconLink).toHaveAttribute('target', '_blank');
+    expect(appleSiliconLink.closest('[id]')).toHaveAttribute(
+      'id',
+      'architect-classic-downloads',
+    );
     expect(
       screen.getByRole('link', { name: 'Apple Intel for Architect Classic' }),
     ).toBeInTheDocument();

--- a/packages/fresco-ui/src/navigation/SiteNavigation.messages.ts
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.messages.ts
@@ -18,7 +18,11 @@ export type SiteNavigationMessages = {
   openMenu: string;
   closeMenu: string;
   softwareLinks: Record<
-    'architect' | 'interviewer' | 'fresco',
+    | 'architect'
+    | 'architectClassic'
+    | 'interviewer'
+    | 'interviewerClassic'
+    | 'fresco',
     SoftwareMessage
   >;
 };
@@ -41,11 +45,23 @@ const englishMessages = {
       description:
         'Design polished Network Canvas interview protocols in your browser with a visual workflow built for researchers.',
     },
+    architectClassic: {
+      name: 'Architect Classic',
+      action: 'Get Architect Classic',
+      description:
+        'Use only when your study must remain compatible with Interviewer Classic and schema 7.',
+    },
     interviewer: {
       name: 'Interviewer',
       action: 'Open Interviewer',
       description:
         'Run engaging, interviewer-led network interviews in the field from any supported browser.',
+    },
+    interviewerClassic: {
+      name: 'Interviewer Classic',
+      action: 'Get Interviewer Classic',
+      description:
+        'For established schema 7 studies and offline desktop or tablet workflows. Maintained for compatibility and bug fixes.',
     },
     fresco: {
       name: 'Fresco',
@@ -77,11 +93,23 @@ export const siteNavigationMessages = {
         description:
           'Diseñe protocolos de entrevista de Network Canvas en su navegador con un flujo de trabajo visual creado para equipos de investigación.',
       },
+      architectClassic: {
+        name: 'Architect Classic',
+        action: 'Obtener Architect Classic',
+        description:
+          'Utilícelo únicamente cuando su estudio deba seguir siendo compatible con Interviewer Classic y el esquema 7.',
+      },
       interviewer: {
         name: 'Interviewer',
         action: 'Abrir Interviewer',
         description:
           'Realice entrevistas de redes atractivas y guiadas por una persona entrevistadora desde cualquier navegador compatible.',
+      },
+      interviewerClassic: {
+        name: 'Interviewer Classic',
+        action: 'Obtener Interviewer Classic',
+        description:
+          'Para estudios consolidados con esquema 7 y flujos de trabajo sin conexión en computadoras de escritorio o tabletas. Se mantiene para ofrecer compatibilidad y corregir errores.',
       },
       fresco: {
         name: 'Fresco',

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -50,7 +50,12 @@ export type SiteNavigationUtilityRenderProps = {
   view: 'desktop' | 'mobile';
 };
 
-type SoftwareId = 'architect' | 'interviewer' | 'fresco';
+type SoftwareId =
+  | 'architect'
+  | 'architectClassic'
+  | 'interviewer'
+  | 'interviewerClassic'
+  | 'fresco';
 
 type ResourceLink = {
   id: 'community' | 'documentation' | 'protocolGallery';
@@ -95,7 +100,9 @@ const destinations = {
   documentation: 'https://documentation.networkcanvas.com/',
   protocolGallery: 'https://protocolgallery.networkcanvas.com/',
   architect: 'https://architect.networkcanvas.com/',
+  architectClassic: 'https://networkcanvas.com/get-started#design',
   interviewer: 'https://interviewer.networkcanvas.com/',
+  interviewerClassic: 'https://networkcanvas.com/get-started#collect',
   fresco: 'https://fresco-sandbox.networkcanvas.com/',
   networkCanvas: 'https://networkcanvas.com/',
 } as const;
@@ -112,13 +119,17 @@ const breakpointClasses = {
 
 const accentClasses: Record<SoftwareId, string> = {
   architect: 'text-sea-green',
+  architectClassic: 'text-sea-green',
   interviewer: 'text-neon-coral',
+  interviewerClassic: 'text-neon-coral',
   fresco: 'text-slate-blue',
 };
 
 const hoverAccentClasses: Record<SoftwareId, string> = {
   architect: 'hover:bg-sea-green/10 focus-visible:bg-sea-green/10',
+  architectClassic: 'hover:bg-sea-green/10 focus-visible:bg-sea-green/10',
   interviewer: 'hover:bg-neon-coral/10 focus-visible:bg-neon-coral/10',
+  interviewerClassic: 'hover:bg-neon-coral/10 focus-visible:bg-neon-coral/10',
   fresco: 'hover:bg-slate-blue/10 focus-visible:bg-slate-blue/10',
 };
 
@@ -273,7 +284,7 @@ function SoftwareCard({
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
   const className = cx(
-    'focusable tablet-landscape:w-[clamp(19rem,29vw,22rem)] block h-full w-[min(42rem,calc(100vw-4rem))] rounded p-4 transition-colors',
+    'focusable block h-full w-80 rounded p-4 transition-colors',
     hoverAccentClasses[link.id],
   );
   const content = (
@@ -365,18 +376,9 @@ function SoftwareMenu({
             />
           </NavigationMenu.Trigger>
           <NavigationMenu.Content className="transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
-            <ul className="tablet-landscape:flex-row flex flex-col p-1">
-              {links.map((link, index) => (
-                <li
-                  key={link.id}
-                  className={cx(
-                    'tablet-landscape:flex tablet-landscape:px-2',
-                    index > 0 &&
-                      'border-outline tablet-landscape:mt-0 tablet-landscape:border-t-0 tablet-landscape:border-l tablet-landscape:pt-0 mt-2 border-t pt-2',
-                    index === 0 && 'tablet-landscape:pl-0',
-                    index === links.length - 1 && 'tablet-landscape:pr-0',
-                  )}
-                >
+            <ul className="grid grid-cols-2 gap-1 p-1">
+              {links.map((link) => (
+                <li key={link.id} className="flex">
                   <SoftwareCard link={link} renderLink={renderLink} />
                 </li>
               ))}
@@ -519,7 +521,13 @@ export default function SiteNavigation({
     },
   ];
   const softwareLinks: SoftwareLink[] = (
-    ['architect', 'interviewer', 'fresco'] as const
+    [
+      'architect',
+      'architectClassic',
+      'interviewer',
+      'interviewerClassic',
+      'fresco',
+    ] as const
   ).map((id) => ({
     id,
     ...labels.softwareLinks[id],

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -100,9 +100,11 @@ const destinations = {
   documentation: 'https://documentation.networkcanvas.com/',
   protocolGallery: 'https://protocolgallery.networkcanvas.com/',
   architect: 'https://architect.networkcanvas.com/',
-  architectClassic: 'https://networkcanvas.com/get-started#design',
+  architectClassic:
+    'https://networkcanvas.com/get-started#architect-classic-downloads',
   interviewer: 'https://interviewer.networkcanvas.com/',
-  interviewerClassic: 'https://networkcanvas.com/get-started#collect',
+  interviewerClassic:
+    'https://networkcanvas.com/get-started#interviewer-classic-downloads',
   fresco: 'https://fresco-sandbox.networkcanvas.com/',
   networkCanvas: 'https://networkcanvas.com/',
 } as const;

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -121,17 +121,20 @@ const breakpointClasses = {
 
 const accentClasses: Record<SoftwareId, string> = {
   architect: 'text-sea-green',
-  architectClassic: 'text-mustard',
+  architectClassic: 'text-cyber-grape [[data-theme=dark]_&]:text-platinum-dark',
   interviewer: 'text-neon-coral',
-  interviewerClassic: 'text-mustard',
+  interviewerClassic:
+    'text-cyber-grape [[data-theme=dark]_&]:text-platinum-dark',
   fresco: 'text-slate-blue',
 };
 
 const hoverAccentClasses: Record<SoftwareId, string> = {
   architect: 'hover:bg-sea-green/10 focus-visible:bg-sea-green/10',
-  architectClassic: 'hover:bg-mustard/10 focus-visible:bg-mustard/10',
+  architectClassic:
+    'hover:bg-cyber-grape/10 focus-visible:bg-cyber-grape/10 [[data-theme=dark]_&]:hover:bg-platinum-dark/10 [[data-theme=dark]_&]:focus-visible:bg-platinum-dark/10',
   interviewer: 'hover:bg-neon-coral/10 focus-visible:bg-neon-coral/10',
-  interviewerClassic: 'hover:bg-mustard/10 focus-visible:bg-mustard/10',
+  interviewerClassic:
+    'hover:bg-cyber-grape/10 focus-visible:bg-cyber-grape/10 [[data-theme=dark]_&]:hover:bg-platinum-dark/10 [[data-theme=dark]_&]:focus-visible:bg-platinum-dark/10',
   fresco: 'hover:bg-slate-blue/10 focus-visible:bg-slate-blue/10',
 };
 
@@ -286,7 +289,7 @@ function SoftwareCard({
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
   const className = cx(
-    'focusable block h-full w-[19rem] rounded p-5 transition-colors',
+    'focusable flex h-full w-[19rem] flex-col rounded p-5 transition-colors',
     hoverAccentClasses[link.id],
   );
   const content = (
@@ -312,7 +315,7 @@ function SoftwareCard({
       </Paragraph>
       <span
         className={cx(
-          'font-heading mt-2.5 inline-flex items-center gap-1.5 text-xs font-bold tracking-[0.12em] uppercase',
+          'font-heading mt-auto inline-flex items-center gap-1.5 pt-2.5 text-xs font-bold tracking-[0.12em] uppercase',
           accentClasses[link.id],
         )}
       >

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -119,17 +119,17 @@ const breakpointClasses = {
 
 const accentClasses: Record<SoftwareId, string> = {
   architect: 'text-sea-green',
-  architectClassic: 'text-sea-green',
+  architectClassic: 'text-mustard',
   interviewer: 'text-neon-coral',
-  interviewerClassic: 'text-neon-coral',
+  interviewerClassic: 'text-mustard',
   fresco: 'text-slate-blue',
 };
 
 const hoverAccentClasses: Record<SoftwareId, string> = {
   architect: 'hover:bg-sea-green/10 focus-visible:bg-sea-green/10',
-  architectClassic: 'hover:bg-sea-green/10 focus-visible:bg-sea-green/10',
+  architectClassic: 'hover:bg-mustard/10 focus-visible:bg-mustard/10',
   interviewer: 'hover:bg-neon-coral/10 focus-visible:bg-neon-coral/10',
-  interviewerClassic: 'hover:bg-neon-coral/10 focus-visible:bg-neon-coral/10',
+  interviewerClassic: 'hover:bg-mustard/10 focus-visible:bg-mustard/10',
   fresco: 'hover:bg-slate-blue/10 focus-visible:bg-slate-blue/10',
 };
 
@@ -284,7 +284,7 @@ function SoftwareCard({
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
   const className = cx(
-    'focusable block h-full w-80 rounded p-4 transition-colors',
+    'focusable block h-full w-[19rem] rounded p-5 transition-colors',
     hoverAccentClasses[link.id],
   );
   const content = (
@@ -376,7 +376,7 @@ function SoftwareMenu({
             />
           </NavigationMenu.Trigger>
           <NavigationMenu.Content className="transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
-            <ul className="grid grid-cols-2 gap-1 p-1">
+            <ul className="grid grid-cols-3 gap-1 p-1">
               {links.map((link) => (
                 <li key={link.id} className="flex">
                   <SoftwareCard link={link} renderLink={renderLink} />
@@ -523,10 +523,10 @@ export default function SiteNavigation({
   const softwareLinks: SoftwareLink[] = (
     [
       'architect',
-      'architectClassic',
       'interviewer',
-      'interviewerClassic',
       'fresco',
+      'architectClassic',
+      'interviewerClassic',
     ] as const
   ).map((id) => ({
     id,

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -163,10 +163,21 @@ describe('SiteNavigation', () => {
       'Architect Classic',
       'Interviewer Classic',
     ]);
-    expect(architectClassicLink).toHaveClass('p-5', 'hover:bg-mustard/10');
+    expect(architectClassicLink).toHaveClass(
+      'flex-col',
+      'p-5',
+      'hover:bg-cyber-grape/10',
+      '[[data-theme=dark]_&]:hover:bg-platinum-dark/10',
+    );
     expect(
       within(architectClassicLink).getByText('Architect Classic'),
-    ).toHaveClass('text-mustard');
+    ).toHaveClass(
+      'text-cyber-grape',
+      '[[data-theme=dark]_&]:text-platinum-dark',
+    );
+    expect(
+      within(architectClassicLink).getByText('Get Architect Classic'),
+    ).toHaveClass('mt-auto');
   });
 
   it('exposes an active compact navigation group semantically', () => {

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -105,7 +105,10 @@ describe('SiteNavigation', () => {
       within(compactNavigation).getByRole('link', {
         name: 'Get Architect Classic',
       }),
-    ).toHaveAttribute('href', 'https://networkcanvas.com/get-started#design');
+    ).toHaveAttribute(
+      'href',
+      'https://networkcanvas.com/get-started#architect-classic-downloads',
+    );
     expect(
       within(compactNavigation).getByRole('link', { name: 'Open Interviewer' }),
     ).toHaveAttribute('href', 'https://interviewer.networkcanvas.com/');
@@ -113,7 +116,10 @@ describe('SiteNavigation', () => {
       within(compactNavigation).getByRole('link', {
         name: 'Get Interviewer Classic',
       }),
-    ).toHaveAttribute('href', 'https://networkcanvas.com/get-started#collect');
+    ).toHaveAttribute(
+      'href',
+      'https://networkcanvas.com/get-started#interviewer-classic-downloads',
+    );
     expect(
       within(compactNavigation).getByRole('link', {
         name: 'Try the Fresco Sandbox',

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -134,7 +134,7 @@ describe('SiteNavigation', () => {
     expect(resourcesButton).toHaveAttribute('aria-current', 'page');
   });
 
-  it('lays out the five software destinations in a two-column grid', () => {
+  it('lays out modern apps above their Classic counterparts', () => {
     render(<SiteNavigation locale="en-US" site="website" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Software' }));
@@ -144,8 +144,23 @@ describe('SiteNavigation', () => {
     const softwareGrid = architectClassicLink.closest('ul');
     if (!softwareGrid) throw new Error('Expected the software grid.');
 
-    expect(softwareGrid).toHaveClass('grid', 'grid-cols-2');
+    expect(softwareGrid).toHaveClass('grid', 'grid-cols-3');
     expect(within(softwareGrid).getAllByRole('listitem')).toHaveLength(5);
+    expect(
+      within(softwareGrid)
+        .getAllByRole('link')
+        .map((link) => link.getAttribute('aria-label')),
+    ).toEqual([
+      'Architect',
+      'Interviewer',
+      'Fresco',
+      'Architect Classic',
+      'Interviewer Classic',
+    ]);
+    expect(architectClassicLink).toHaveClass('p-5', 'hover:bg-mustard/10');
+    expect(
+      within(architectClassicLink).getByText('Architect Classic'),
+    ).toHaveClass('text-mustard');
   });
 
   it('exposes an active compact navigation group semantically', () => {

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -102,8 +102,18 @@ describe('SiteNavigation', () => {
       within(compactNavigation).getByRole('link', { name: 'Open Architect' }),
     ).toHaveAttribute('href', 'https://architect.networkcanvas.com/');
     expect(
+      within(compactNavigation).getByRole('link', {
+        name: 'Get Architect Classic',
+      }),
+    ).toHaveAttribute('href', 'https://networkcanvas.com/get-started#design');
+    expect(
       within(compactNavigation).getByRole('link', { name: 'Open Interviewer' }),
     ).toHaveAttribute('href', 'https://interviewer.networkcanvas.com/');
+    expect(
+      within(compactNavigation).getByRole('link', {
+        name: 'Get Interviewer Classic',
+      }),
+    ).toHaveAttribute('href', 'https://networkcanvas.com/get-started#collect');
     expect(
       within(compactNavigation).getByRole('link', {
         name: 'Try the Fresco Sandbox',
@@ -122,6 +132,20 @@ describe('SiteNavigation', () => {
 
     const resourcesButton = screen.getByRole('button', { name: 'Resources' });
     expect(resourcesButton).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('lays out the five software destinations in a two-column grid', () => {
+    render(<SiteNavigation locale="en-US" site="website" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Software' }));
+    const architectClassicLink = screen.getByRole('link', {
+      name: 'Architect Classic',
+    });
+    const softwareGrid = architectClassicLink.closest('ul');
+    if (!softwareGrid) throw new Error('Expected the software grid.');
+
+    expect(softwareGrid).toHaveClass('grid', 'grid-cols-2');
+    expect(within(softwareGrid).getAllByRole('listitem')).toHaveLength(5);
   });
 
   it('exposes an active compact navigation group semantically', () => {


### PR DESCRIPTION
## Summary
- add Architect Classic and Interviewer Classic to the canonical shared software navigation
- deep-link each Classic app to its platform download section on the Get Started page
- provide English and Spanish copy for both Classic destinations
- arrange current apps across the first row, with Architect Classic and Interviewer Classic beneath their modern counterparts
- distinguish Classic cards with cyber-grape in light mode and platinum-dark in dark mode
- increase card padding and align every card action along the bottom edge
- add focused navigation and Get Started anchor coverage plus a Fresco UI changeset

## Test plan
- [x] Fresco UI typecheck
- [x] SiteNavigation unit tests (9 passing)
- [x] networkcanvas.com typecheck
- [x] networkcanvas.com unit tests (94 passing)
- [x] Fresco UI production build
- [x] Targeted lint and formatting auto-fix
- [x] `knip`
- [x] changeset lane validation
