### PR TITLE
Update corepack to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
       "oxfmt"
     ]
   },
-  "packageManager": "pnpm@11.10.0"
+  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a"
 }


### PR DESCRIPTION
This pull request updates the `packageManager` field in `package.json` to specify a newer version of `pnpm`, including a specific SHA hash for the release.

Dependency management:

* Updated the `packageManager` field to use `pnpm@11.13.0` with a specific SHA hash for improved version tracking and reproducibility.