### PR TITLE
fix(e2e): deterministic geospatial maps + durable Pages reports

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -714,7 +714,8 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write is for the gh-pages state branch below, not the source.
+      contents: write
       pages: write
       id-token: write
       pull-requests: write
@@ -751,6 +752,25 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: merged/
+      - name: Persist merged site to gh-pages branch
+        # deploy-pages replaces the ENTIRE Pages site with this run's artifact
+        # and maintains no branch, so the only prior content the merge step can
+        # fetch is what this step saves. Without it, the two release lanes
+        # erase each other's report subdirectory on every deploy (the report
+        # link 404s a minute after it is posted). The branch is pure derived
+        # state, so force-push a fresh single commit; the job concurrency
+        # group serialises writers.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git init -q -b gh-pages "$RUNNER_TEMP/pages-state"
+          git --git-dir="$RUNNER_TEMP/pages-state/.git" --work-tree=merged add -A
+          git --git-dir="$RUNNER_TEMP/pages-state/.git" --work-tree=merged \
+            -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -q -m "interview-e2e report site (run ${{ github.run_id }})"
+          git --git-dir="$RUNNER_TEMP/pages-state/.git" push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" gh-pages
       - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
       - name: Comment on PR
         # always(): still post the E2E result even if the Pages publish above

--- a/apps/architect/e2e/fixtures/mapbox-mocks.ts
+++ b/apps/architect/e2e/fixtures/mapbox-mocks.ts
@@ -57,6 +57,16 @@ const STREETS_TILEJSON = {
  * Stub-mode browsers (firefox/webkit) never request these URLs.
  */
 export async function installMapboxMocks(page: Page): Promise<void> {
+  // Billing/session probe (mapbox-gl v3 `map-sessions/v1`). Left unmocked it
+  // reaches the real API, whose 401 for the fake e2e token makes mapbox-gl
+  // revoke auth: the painter permanently stops drawing and the canvas is
+  // cleared, while load/idle events (and data-map-idle) have already fired.
+  // Whether the 401 lands before or after a capture is a network race, so
+  // screenshots flip between a rendered map and a blank panel per attempt.
+  await page.route(/https:\/\/api\.mapbox\.com\/map-sessions\//, (route) =>
+    route.fulfill({ headers: corsHeaders, json: {} }),
+  );
+
   await page.route(/https:\/\/api\.mapbox\.com\/styles\/v1\//, (route) =>
     route.fulfill({ headers: corsHeaders, json: MINIMAL_STYLE }),
   );

--- a/packages/interview/e2e/fixtures/mapbox-mocks.ts
+++ b/packages/interview/e2e/fixtures/mapbox-mocks.ts
@@ -57,6 +57,16 @@ const STREETS_TILEJSON = {
  * Stub-mode browsers (firefox/webkit) never request these URLs.
  */
 export async function installMapboxMocks(page: Page): Promise<void> {
+  // Billing/session probe (mapbox-gl v3 `map-sessions/v1`). Left unmocked it
+  // reaches the real API, whose 401 for the fake e2e token makes mapbox-gl
+  // revoke auth: the painter permanently stops drawing and the canvas is
+  // cleared, while load/idle events (and data-map-idle) have already fired.
+  // Whether the 401 lands before or after a capture is a network race, so
+  // screenshots flip between a rendered map and a blank panel per attempt.
+  await page.route(/https:\/\/api\.mapbox\.com\/map-sessions\//, (route) =>
+    route.fulfill({ headers: corsHeaders, json: {} }),
+  );
+
   await page.route(/https:\/\/api\.mapbox\.com\/styles\/v1\//, (route) =>
     route.fulfill({ headers: corsHeaders, json: MINIMAL_STYLE }),
   );


### PR DESCRIPTION
## Summary

Fixes the two failures blocking the `changeset-release/main` release PR (#855):

### 1. Geospatial e2e visual snapshots render a blank map (interview-e2e red)

mapbox-gl v3 sends a billing/session probe to `https://api.mapbox.com/map-sessions/v1` on every map init. This endpoint was the **only** Mapbox request not covered by `installMapboxMocks`, so it reached the real API with the fake e2e token and got a 401. On a 401, mapbox-gl calls `_revokeAuth()`: it removes the GL context from its authenticated-contexts set (the painter then skips **all** drawing every frame) and clears the canvas — while `load`/`idle` events have already fired, so `data-map-idle` stays `true` and every functional wait passes. The screenshot then captures a blank panel.

Whether the 401 lands before or after the capture is a network race:

- Locally (before this fix) all 3 Geospatial `chromium-visual` tests are **flaky** — blank on first attempt, rendered on retry.
- On CI runners the race resolves consistently per VM, which is why the release runs failed with identical 683k/604k-pixel diffs across all retries on some runs, while the 07:44 run and the 08:21 regeneration job (different VMs) rendered fine.

The regeneration lane hit the same race, which is why child PR #965 proposes **blank-map PNGs** as new baselines. It must not be merged (see below).

Fix: mock `map-sessions/v1` with a 200 so the probe deterministically succeeds and revocation can never occur. Applied to both copies of the fixture (`packages/interview/e2e`, `apps/architect/e2e`).

Verification (pinned Playwright Docker, `--project=chromium-visual -g Geospatial`):

| Run | Result |
| --- | --- |
| Before fix | 3 flaky (blank-map failures on first attempts) |
| After fix, run 1 | 3 passed |
| After fix, run 2 | 3 passed |

Existing committed baselines still match — no baseline regeneration needed.

### 2. E2E report links 404 (Pages deploys clobber each other)

`interview-e2e-report` merges "existing pages content" from a `gh-pages` branch that **does not exist** (the checkout fails on every run and is swallowed by `continue-on-error`), and `actions/deploy-pages` replaces the entire Pages site with the run's artifact without maintaining any branch. Every deploy therefore wipes every other slug's report. Yesterday's sequence: the `changeset-release/main` report deployed at 10:14:09 and the `changeset-release/apps` lane deployed at 10:15:09, 404ing the main-lane link one minute after it was posted.

Fix: after merging, force-push the merged site as a fresh single-commit `gh-pages` branch (pure derived state; the job's concurrency group serialises writers), so the next deploy from any lane has real prior content to merge. The job gets `contents: write` for this push. The first run bootstraps the branch.

## Follow-ups (not in this PR)

- The `mapbox.mapbox-streets-v8.json` TileJSON mock is shadowed by the later-registered `/v4|fonts|tiles/` catch-all (`endsWith('.json')` fails on query strings), so the transit source TileJSON always 204s. Deterministic, and current baselines were generated in this state, so left untouched here.
- The minimal mock style has no `glyphs` property, so the transit-labels layer logs a style validation error (cosmetic, deterministic).
- App-side: a revoked/errored map currently leaves a silently blank panel for real users; surfacing the existing map-error overlay on `error` events would make this state visible (and loudly fail e2e instead of capturing blank pixels).

## Release flow

Merging this refreshes `changeset-release/main` via changesets, which re-dispatches the full e2e run with the fix. Child PR #965 (blank-baseline PNGs) should be **closed, not merged**.
