### PR TITLE
test(e2e): unshadow streets-v8 TileJSON mock and declare style glyphs

### DIFF
--- a/apps/architect/e2e/fixtures/mapbox-mocks.ts
+++ b/apps/architect/e2e/fixtures/mapbox-mocks.ts
@@ -9,10 +9,17 @@ const corsHeaders = { 'access-control-allow-origin': '*' };
  * basemap renders as a flat background. The app's own layers (GeoJSON
  * outline/selection from the local asset server, transit from the
  * mocked TileJSON below) render on top as normal.
+ *
+ * The glyphs template is required for the app's transit-labels layer to
+ * pass style validation (a text-field layer without style glyphs is
+ * rejected with a console error). Glyph URLs resolve to the 204
+ * interceptor below, and with all transit tiles empty no glyph is ever
+ * actually requested.
  */
 const MINIMAL_STYLE = {
   version: 8,
   name: 'e2e-minimal',
+  glyphs: 'https://api.mapbox.com/fonts/v1/mapbox/{fontstack}/{range}.pbf',
   sources: {},
   layers: [
     {
@@ -71,19 +78,24 @@ export async function installMapboxMocks(page: Page): Promise<void> {
     route.fulfill({ headers: corsHeaders, json: MINIMAL_STYLE }),
   );
 
-  await page.route(
-    /https:\/\/api\.mapbox\.com\/v4\/mapbox\.mapbox-streets-v8\.json/,
-    (route) => route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON }),
-  );
-
   // Vector tiles, sprites, glyphs: 204 = "resource is empty", which
-  // mapbox-gl handles gracefully without erroring the source.
+  // mapbox-gl handles gracefully without erroring the source. The .json
+  // check reads the URL pathname because real requests carry an
+  // access_token query string.
   await page.route(
     /https:\/\/api\.mapbox\.com\/(v4|fonts|tiles)\//,
     (route, request) =>
-      request.url().endsWith('.json')
+      new URL(request.url()).pathname.endsWith('.json')
         ? route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON })
         : route.fulfill({ status: 204, headers: corsHeaders }),
+  );
+
+  // Registered after the (v4|fonts|tiles) catch-all: Playwright checks
+  // routes in reverse registration order, so the specific TileJSON mock
+  // must come later to win for this URL.
+  await page.route(
+    /https:\/\/api\.mapbox\.com\/v4\/mapbox\.mapbox-streets-v8\.json/,
+    (route) => route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON }),
   );
 
   await page.route(/https:\/\/events\.mapbox\.com\//, (route) =>

--- a/packages/interview/e2e/fixtures/mapbox-mocks.ts
+++ b/packages/interview/e2e/fixtures/mapbox-mocks.ts
@@ -9,10 +9,17 @@ const corsHeaders = { 'access-control-allow-origin': '*' };
  * basemap renders as a flat background. The app's own layers (GeoJSON
  * outline/selection from the local asset server, transit from the
  * mocked TileJSON below) render on top as normal.
+ *
+ * The glyphs template is required for the app's transit-labels layer to
+ * pass style validation (a text-field layer without style glyphs is
+ * rejected with a console error). Glyph URLs resolve to the 204
+ * interceptor below, and with all transit tiles empty no glyph is ever
+ * actually requested.
  */
 const MINIMAL_STYLE = {
   version: 8,
   name: 'e2e-minimal',
+  glyphs: 'https://api.mapbox.com/fonts/v1/mapbox/{fontstack}/{range}.pbf',
   sources: {},
   layers: [
     {
@@ -71,19 +78,24 @@ export async function installMapboxMocks(page: Page): Promise<void> {
     route.fulfill({ headers: corsHeaders, json: MINIMAL_STYLE }),
   );
 
-  await page.route(
-    /https:\/\/api\.mapbox\.com\/v4\/mapbox\.mapbox-streets-v8\.json/,
-    (route) => route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON }),
-  );
-
   // Vector tiles, sprites, glyphs: 204 = "resource is empty", which
-  // mapbox-gl handles gracefully without erroring the source.
+  // mapbox-gl handles gracefully without erroring the source. The .json
+  // check reads the URL pathname because real requests carry an
+  // access_token query string.
   await page.route(
     /https:\/\/api\.mapbox\.com\/(v4|fonts|tiles)\//,
     (route, request) =>
-      request.url().endsWith('.json')
+      new URL(request.url()).pathname.endsWith('.json')
         ? route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON })
         : route.fulfill({ status: 204, headers: corsHeaders }),
+  );
+
+  // Registered after the (v4|fonts|tiles) catch-all: Playwright checks
+  // routes in reverse registration order, so the specific TileJSON mock
+  // must come later to win for this URL.
+  await page.route(
+    /https:\/\/api\.mapbox\.com\/v4\/mapbox\.mapbox-streets-v8\.json/,
+    (route) => route.fulfill({ headers: corsHeaders, json: STREETS_TILEJSON }),
   );
 
   await page.route(/https:\/\/events\.mapbox\.com\//, (route) =>


### PR DESCRIPTION
## Summary

Follow-up to #969 (stacked on it). Two deterministic-but-wrong behaviors in the shared `installMapboxMocks` fixture (both copies: `packages/interview/e2e`, `apps/architect/e2e`):

- The dedicated `mapbox.mapbox-streets-v8.json` TileJSON route never fired. Playwright checks routes in **reverse registration order**, so the later-registered `(v4|fonts|tiles)` catch-all won, and its `endsWith('.json')` check failed against the real request's `?access_token=…` query string — the transit source always got a 204 and mapbox-gl logged `Unexpected end of JSON input` (confirmed via CI traces from run 29406368033). The catch-all is now registered first (so the specific route wins) and matches `.json` on the URL pathname.
- The minimal style had no `glyphs` template, so the app's transit-labels `text-field` layer failed style validation with a console error. A glyphs template pointing at the 204 interceptor is now declared; no glyph is ever requested because transit tiles are empty.

## Verification (pinned Playwright Docker)

- `--project=chromium-visual -g Geospatial`: 3 passed against **unchanged** committed baselines.
- Traced transit-scenario run: zero console errors (previously four categories), `map-sessions` 200 (mock), TileJSON 200 (mock, now actually served), six vector-tile requests cleanly 204'd, events 204.
- `tsc -p e2e/tsconfig.json --noEmit` clean for both packages; lint/format via hooks.

Test-only change — no changeset (per repo changeset policy).