### PR TITLE
chore: update fuse.js to 7.5.0

### DIFF
--- a/apps/architect-classic/package.json
+++ b/apps/architect-classic/package.json
@@ -64,7 +64,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.8",
     "framer-motion": "^5.5.6",
-    "fuse.js": "^7.4.0",
+    "fuse.js": "catalog:",
     "icon-gen": "^1.2.3",
     "jsdom": "catalog:",
     "lodash": "^4.18.1",

--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -35,7 +35,7 @@
     "cva": "1.0.0-beta.4",
     "dexie": "^4.4.4",
     "es-toolkit": "catalog:",
-    "fuse.js": "^7.4.0",
+    "fuse.js": "catalog:",
     "jszip": "catalog:",
     "lucide-react": "catalog:",
     "luxon": "^3.7.2",

--- a/apps/interviewer-classic/package.json
+++ b/apps/interviewer-classic/package.json
@@ -87,7 +87,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.8",
     "framer-motion": "^2.9.1",
-    "fuse.js": "~7.4.0",
+    "fuse.js": "catalog:",
     "fuse.js-legacy": "npm:fuse.js@3.4.6",
     "history": "^4.7.2",
     "is-hotkey": "^0.2.0",

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -600,7 +600,7 @@
     "comlink": "^4.4.2",
     "cva": "1.0.0-beta.4",
     "es-toolkit": "catalog:",
-    "fuse.js": "^7.4.0",
+    "fuse.js": "catalog:",
     "immer": "^11.1.8",
     "lucide-react": "catalog:",
     "nanoid": "^5.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ catalogs:
     es-toolkit:
       specifier: ^1.47.0
       version: 1.47.0
+    fuse.js:
+      specifier: ^7.5.0
+      version: 7.5.0
     jsdom:
       specifier: ^29.1.1
       version: 29.1.1
@@ -339,8 +342,8 @@ importers:
         specifier: 'catalog:'
         version: 1.47.0
       fuse.js:
-        specifier: ^7.4.0
-        version: 7.4.0
+        specifier: 'catalog:'
+        version: 7.5.0
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -566,8 +569,8 @@ importers:
         specifier: ^5.5.6
         version: 5.6.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       fuse.js:
-        specifier: ^7.4.0
-        version: 7.4.0
+        specifier: 'catalog:'
+        version: 7.5.0
       icon-gen:
         specifier: ^1.2.3
         version: 1.2.3
@@ -1157,8 +1160,8 @@ importers:
         specifier: ^2.9.1
         version: 2.9.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       fuse.js:
-        specifier: ~7.4.0
-        version: 7.4.0
+        specifier: 'catalog:'
+        version: 7.5.0
       fuse.js-legacy:
         specifier: npm:fuse.js@3.4.6
         version: fuse.js@3.4.6
@@ -1482,8 +1485,8 @@ importers:
         specifier: 'catalog:'
         version: 1.47.0
       fuse.js:
-        specifier: ^7.4.0
-        version: 7.4.0
+        specifier: 'catalog:'
+        version: 7.5.0
       immer:
         specifier: ^11.1.8
         version: 11.1.8
@@ -9230,8 +9233,8 @@ packages:
     resolution: {integrity: sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==}
     engines: {node: '>=6'}
 
-  fuse.js@7.4.0:
-    resolution: {integrity: sha512-3UqmoSFwzX1sNB1YSk+Co0EdH29XCW2p9g48OAiy93cjKqzuABsqw2VIgSN3CmsT/wo6pIJ3F0Jxeiiby8rhIQ==}
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
     engines: {node: '>=10'}
 
   gemoji@8.1.0:
@@ -21494,7 +21497,7 @@ snapshots:
 
   fuse.js@3.4.6: {}
 
-  fuse.js@7.4.0: {}
+  fuse.js@7.5.0: {}
 
   gemoji@8.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,6 +73,7 @@ catalog:
   electron-builder: ^26.15.2
   electron-vite: ^6.0.0-beta.1
   es-toolkit: ^1.47.0
+  fuse.js: ^7.5.0
   jsdom: ^29.1.1
   jszip: ^3.10.1
   lucide-react: ^1.17.0


### PR DESCRIPTION
## Summary
- add Fuse.js 7.5.0 to the workspace catalog
- align all Fuse.js 7 consumers with the catalog
- retain the intentional Fuse.js 3 legacy alias

## Test plan
- [x] pnpm lint:fix
- [x] pnpm knip
- [x] pnpm test
- [ ] pnpm typecheck (blocked by existing unrelated errors in Fresco UI, Interview, Documentation, and networkcanvas.com)