### PR TITLE
feat: package SiteNavigation as a web component for external hosts

### DIFF
--- a/.changeset/fresco-ui-external-site-portals.md
+++ b/.changeset/fresco-ui-external-site-portals.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': minor
+---
+
+SiteNavigation accepts `site="external"` for non-Network-Canvas hosts (every destination renders as an absolute URL) and portals its desktop menus into the `PortalContainerProvider` container when one is present, so embedders can keep popups inside their own DOM scope (e.g. a shadow root).

--- a/.changeset/site-navigation-element-initial.md
+++ b/.changeset/site-navigation-element-initial.md
@@ -1,0 +1,5 @@
+---
+'@codaco/site-navigation-element': major
+---
+
+Initial release: the canonical Network Canvas site header packaged as a self-contained `<nc-site-navigation>` web component for non-React hosts. Loads from a CDN with a single script tag; Shadow DOM isolation; `active-item`, `locale`, and `theme` (light/dark/auto) attributes. Bundle size: ~194 kB gzipped / ~161 kB brotli (JS + CSS inlined; jsDelivr serves brotli).

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -282,6 +282,11 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
+      # site-navigation-element's test script runs vitest browser mode
+      # (real Chromium via @vitest/browser-playwright); the runner image
+      # doesn't ship the pinned Playwright build's browsers.
+      - name: Install Playwright Chromium (vitest browser mode)
+        run: pnpm --filter @codaco/site-navigation-element exec playwright install --with-deps chromium
       - run: pnpm exec turbo run test
 
   quality:

--- a/docs/superpowers/plans/2026-07-15-site-navigation-element.md
+++ b/docs/superpowers/plans/2026-07-15-site-navigation-element.md
@@ -1,0 +1,1376 @@
+# Site Navigation Web Component Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Package the canonical `SiteNavigation` React header as a self-contained `<nc-site-navigation>` custom element (`@codaco/site-navigation-element`) that non-React hosts (the Discourse forum) load from a CDN, per `docs/superpowers/specs/2026-07-15-site-navigation-element-design.md`.
+
+**Architecture:** Two small upstream fresco-ui changes (`site: 'external'`, portal containment via the existing `PortalContainerProvider`), then a new library package that compiles a scoped Tailwind CSS payload, splits it into shadow-root and document-level parts at build time, and bundles React + motion + Base UI + fresco-ui into a single minified ESM file with Shadow DOM isolation.
+
+**Tech Stack:** React 19, Vite 8 (rolldown lib mode), Tailwind v4 (`@tailwindcss/cli` for the CSS pass, postcss for the split), vitest 4 browser mode (`@vitest/browser-playwright`, chromium), pnpm catalog + changesets.
+
+## Global Constraints
+
+- NO `any` types; no type assertions (`as`) to silence errors; no barrel files; never re-export "for convenience".
+- Shared deps use `catalog:`; internal deps use `workspace:*`; single-consumer deps use regular semver (`@tailwindcss/cli: ^4.3.2`, `postcss: ^8.5.6`).
+- Formatter runs via the lint-staged pre-commit hook — do not run root `lint:fix` (it rewrites the whole repo).
+- Custom element tag: `nc-site-navigation`. Package: `@codaco/site-navigation-element`, initial `version: "0.0.0"` + a `major` changeset (changesets bumps it to 1.0.0 on release).
+- Never mix an app and a library in one changeset; both changesets here are library-lane.
+- Node scripts are ESM `.mjs`. Package `build` scripts are wrapped with `scripts/with-turbo.mjs`.
+- Size budget for `dist/element.js` + inlined CSS: ~120–150 kB gzipped (soft budget; report the number, flag if > 160 kB).
+- Verification economy: run each task's own focused test cycle, but defer repo-wide `typecheck`/`knip`/`lint` to the single final task.
+- All commits: no Co-Authored-By/self-attribution; user's git credentials.
+- Worktree: run everything from the current worktree root (`/Users/jmh629/Projects/network-canvas/.claude/worktrees/interview-interface-e2e-tests-e307d9`). Never use paths into the main repo checkout.
+
+---
+
+### Task 1: fresco-ui `site="external"`
+
+**Files:**
+
+- Modify: `packages/fresco-ui/src/navigation/SiteNavigation.tsx:92` (the `site` prop type)
+- Modify: `packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx`
+- Test: `packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx`
+
+**Interfaces:**
+
+- Consumes: existing `SiteNavigationProps`.
+- Produces: `SiteNavigationProps['site']` = `'documentation' | 'external' | 'website'`. With `site="external"` every destination is absolute: brand → `https://networkcanvas.com/`, Docs → `https://documentation.networkcanvas.com/` (with `target="_blank"`), Get Started → `https://networkcanvas.com/download`. Task 5 relies on this.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `describe('SiteNavigation', ...)` block in `packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx`:
+
+```tsx
+  it('renders every destination absolutely for external hosts', () => {
+    render(
+      <SiteNavigation activeItemId="community" locale="en-US" site="external" />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Network Canvas home' }),
+    ).toHaveAttribute('href', 'https://networkcanvas.com/');
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'href',
+      'https://documentation.networkcanvas.com/',
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+    expect(screen.getByRole('link', { name: 'Community' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Get Started' })).toHaveAttribute(
+      'href',
+      'https://networkcanvas.com/download',
+    );
+  });
+```
+
+- [ ] **Step 2: Verify it fails (at typecheck — the runtime logic already falls through correctly)**
+
+Run: `pnpm --filter @codaco/fresco-ui typecheck`
+Expected: FAIL — TS2322: `"external"` is not assignable to `'documentation' | 'website'`.
+
+(`pnpm --filter @codaco/fresco-ui test` will PASS at runtime even before the fix — the existing href logic treats any non-`website`/non-`documentation` value as absolute. The type union is the actual gate; that's expected.)
+
+- [ ] **Step 3: Widen the union**
+
+In `packages/fresco-ui/src/navigation/SiteNavigation.tsx`, change the `site` prop type inside `SiteNavigationProps` (line 92):
+
+```tsx
+  site: 'documentation' | 'external' | 'website';
+```
+
+No logic changes are needed: `networkCanvasRootHref` (`site === 'website' ? '/' : destinations.networkCanvas`), `documentationRootHref` (`site === 'documentation' ? '/' : destinations.documentation`), and `getStartedHref` all already resolve `external` to absolute URLs.
+
+- [ ] **Step 4: Verify test and typecheck pass**
+
+Run: `pnpm --filter @codaco/fresco-ui test` then `pnpm --filter @codaco/fresco-ui typecheck`
+Expected: both PASS.
+
+- [ ] **Step 5: Update the story (repo convention: new prop variant → story same change)**
+
+In `packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx`:
+
+1. Change the `StoryArgs` site union:
+
+```tsx
+  site: 'documentation' | 'external' | 'website';
+```
+
+2. Change the `site` argType options:
+
+```tsx
+    site: {
+      control: 'radio',
+      options: ['website', 'documentation', 'external'],
+    },
+```
+
+3. Add after the `Spanish` story:
+
+```tsx
+export const ExternalHost: Story = {
+  args: {
+    activeItemId: 'community',
+    site: 'external',
+  },
+};
+```
+
+4. Extend the docs description list item for **`site`** to mention the new value — replace the existing bullet with:
+
+```
+- **\`site\`** selects routing context only; menu items and destinations are
+  not configurable. \`external\` is for non-Network-Canvas hosts (e.g. the
+  community forum): every destination renders as an absolute URL.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/fresco-ui/src/navigation
+git commit -m "feat(fresco-ui): support site=\"external\" in SiteNavigation"
+```
+
+---
+
+### Task 2: fresco-ui portal containment
+
+**Files:**
+
+- Modify: `packages/fresco-ui/src/navigation/SiteNavigation.tsx` (imports; `ResourcesMenu`; `SoftwareMenu`)
+- Test: `packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `usePortalContainer` / `PortalContainerProvider` from `packages/fresco-ui/src/PortalContainer.tsx` (context returns `HTMLElement | null`; the provider renders a `fixed inset-0 z-3000` layer).
+- Produces: when a `PortalContainerProvider` ancestor exists, both `NavigationMenu.Portal`s render into its container; with no provider, behavior is unchanged (portals to `document.body`). Task 5 relies on this to keep dropdowns inside the shadow root.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx`. Add this import at the top of the file with the other imports:
+
+```tsx
+import { PortalContainerProvider } from '../../PortalContainer';
+```
+
+Append tests:
+
+```tsx
+  it('portals desktop menus into the app portal container when provided', () => {
+    const { baseElement } = render(
+      <PortalContainerProvider>
+        <SiteNavigation locale="en-US" site="website" />
+      </PortalContainerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Software' }));
+    const architectLink = screen.getByRole('link', { name: 'Architect' });
+    const portalLayer = baseElement.querySelector('.z-3000');
+    if (!portalLayer) throw new Error('Expected the portal container layer.');
+
+    expect(portalLayer).toContainElement(architectLink);
+  });
+
+  it('keeps portaling to the document body without a provider', () => {
+    render(<SiteNavigation locale="en-US" site="website" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Software' }));
+
+    expect(screen.getByRole('link', { name: 'Architect' })).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Verify the first test fails**
+
+Run: `pnpm --filter @codaco/fresco-ui test`
+Expected: FAIL — `portalLayer` does not contain the Architect link (the popup portals to `document.body`, not the provider layer). The second test passes already.
+
+- [ ] **Step 3: Implement**
+
+In `packages/fresco-ui/src/navigation/SiteNavigation.tsx`:
+
+1. Add to the fresco-ui-internal imports (after the `Spinner` import):
+
+```tsx
+import { usePortalContainer } from '../PortalContainer';
+```
+
+2. In `ResourcesMenu`, read the context at the top of the component body:
+
+```tsx
+  const portalContainer = usePortalContainer();
+```
+
+and change its portal opening tag to:
+
+```tsx
+      <NavigationMenu.Portal container={portalContainer ?? undefined}>
+```
+
+3. Make the identical two-line change in `SoftwareMenu`.
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `pnpm --filter @codaco/fresco-ui test` then `pnpm --filter @codaco/fresco-ui typecheck`
+Expected: both PASS (all pre-existing SiteNavigation tests included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/fresco-ui/src/navigation
+git commit -m "feat(fresco-ui): contain SiteNavigation menus in the portal container context"
+```
+
+---
+
+### Task 3: Scaffold `packages/site-navigation-element` + CSS pipeline
+
+**Files:**
+
+- Create: `packages/site-navigation-element/package.json`
+- Create: `packages/site-navigation-element/tsconfig.json`
+- Create: `packages/site-navigation-element/tsconfig.node.json`
+- Create: `packages/site-navigation-element/.gitignore`
+- Create: `packages/site-navigation-element/src/styles/shadow.css`
+- Create: `packages/site-navigation-element/scripts/build.mjs`
+- Modify: `turbo.json` (two package-scoped task overrides)
+- Modify: `knip.json` (workspace entry)
+
+**Interfaces:**
+
+- Consumes: `@codaco/fresco-ui` dist (built by turbo `^build`), `@codaco/tailwind-config/fresco.css`, `@fontsource-variable/*` font files.
+- Produces (relied on by Tasks 4–7): `node scripts/build.mjs --css-only` emits three gitignored files under `.generated/`: `shadow.css` (full compiled Tailwind payload, `:root` selectors rewritten to `:is(:root, :host)`, `@property` rules stripped), `document-properties.css` (the stripped `@property` rules), `document-fonts.css` (normal-style `@font-face` blocks whose `src` URLs use the placeholder `__NC_FONT_BASE__/<file>.woff2`). The same script copies the referenced woff2 files (`copyFonts`) into `public/fonts` (dev) or `dist/fonts` (build).
+
+- [ ] **Step 1: Create `packages/site-navigation-element/package.json`**
+
+```json
+{
+  "name": "@codaco/site-navigation-element",
+  "version": "0.0.0",
+  "description": "The canonical Network Canvas site header as a self-contained <nc-site-navigation> web component for non-React hosts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/complexdatacollective/network-canvas-monorepo.git",
+    "directory": "packages/site-navigation-element"
+  },
+  "type": "module",
+  "files": ["dist"],
+  "exports": {
+    ".": "./dist/element.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
+    "dev": "node ../../scripts/with-turbo.mjs --watch-deps node scripts/build.mjs --dev",
+    "test": "node scripts/build.mjs --css-only && vitest run",
+    "test:watch": "node scripts/build.mjs --css-only && vitest",
+    "typecheck": "tsc --build --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "prepublishOnly": "pnpm build",
+    "clean": "rm -rf .turbo node_modules dist .generated public/fonts"
+  },
+  "devDependencies": {
+    "@base-ui/react": "catalog:",
+    "@codaco/fresco-ui": "workspace:*",
+    "@codaco/tailwind-config": "workspace:*",
+    "@codaco/tsconfig": "workspace:*",
+    "@fontsource-variable/inclusive-sans": "catalog:",
+    "@fontsource-variable/nunito": "catalog:",
+    "@tailwindcss/cli": "^4.3.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
+    "motion": "catalog:",
+    "playwright": "catalog:",
+    "postcss": "^8.5.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}
+```
+
+Notes: no `dependencies` on purpose — everything is inlined into the bundle, so nothing is needed at consumer install time. fresco-ui's remaining peers (`zod`, `zustand`, `@tanstack/react-table`, `@codaco/shared-consts`) are satisfied by the workspace's `autoInstallPeers: true` and are never imported by the nav's module graph, so they don't enter the bundle. `playwright` is declared to keep the repo's three playwright pins in lock-step (catalog).
+
+- [ ] **Step 2: Create `packages/site-navigation-element/tsconfig.json`**
+
+```json
+{
+  "extends": "@codaco/tsconfig/web.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "src/__tests__"]
+}
+```
+
+- [ ] **Step 3: Create `packages/site-navigation-element/tsconfig.node.json`**
+
+```json
+{
+  "extends": "@codaco/tsconfig/dev.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/__tests__/**/*.ts",
+    "src/__tests__/**/*.tsx",
+    "src/*.d.ts"
+  ]
+}
+```
+
+- [ ] **Step 4: Create `packages/site-navigation-element/.gitignore`**
+
+```
+.generated/
+public/fonts/
+```
+
+- [ ] **Step 5: Create `packages/site-navigation-element/src/styles/shadow.css`**
+
+This is the Tailwind entry. It pulls the full design-system foundation, then points the class scanner at exactly the fresco-ui dist modules `SiteNavigation` imports (scoping keeps the payload lean — do NOT import `@codaco/fresco-ui/styles.css`, which scans every component):
+
+```css
+/*
+ * Tailwind entry for the <nc-site-navigation> shadow stylesheet.
+ * Compiled by scripts/build.mjs via @tailwindcss/cli, then post-processed:
+ * `:root` is rewritten to `:is(:root, :host)` and `@property` rules are
+ * hoisted to a document-level stylesheet (neither applies inside a shadow
+ * root as-authored).
+ */
+@import '@codaco/tailwind-config/fresco.css';
+
+@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.messages.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/Button.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/Spinner.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/PortalContainer.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/typography/Heading.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/typography/Paragraph.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/utils/cva.js';
+@source '../*.tsx';
+```
+
+- [ ] **Step 6: Create `packages/site-navigation-element/scripts/build.mjs`**
+
+```js
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import postcss from 'postcss';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const generated = join(pkgRoot, '.generated');
+const require = createRequire(import.meta.url);
+
+const mode = process.argv.includes('--css-only')
+  ? 'css-only'
+  : process.argv.includes('--dev')
+    ? 'dev'
+    : 'build';
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: pkgRoot, stdio: 'inherit' });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+// The Tailwind @source directives scan fresco-ui's dist; fail early with a
+// clear message instead of silently emitting a stylesheet with no utilities.
+const frescoDist = dirname(
+  require.resolve('@codaco/fresco-ui/navigation/SiteNavigation'),
+);
+if (!existsSync(join(frescoDist, 'SiteNavigation.js'))) {
+  console.error(
+    '@codaco/fresco-ui dist is missing. Build it first (turbo does this ' +
+      'automatically: `pnpm build`/`pnpm test` from the repo root, or ' +
+      '`pnpm --filter @codaco/fresco-ui build`).',
+  );
+  process.exit(1);
+}
+
+mkdirSync(generated, { recursive: true });
+
+// 1) Compile the Tailwind entry.
+run('pnpm', [
+  'exec',
+  'tailwindcss',
+  '-i',
+  'src/styles/shadow.css',
+  '-o',
+  join(generated, 'tailwind.css'),
+]);
+
+// 2) Split the compiled CSS for shadow-DOM use. `:root` and `@property`
+// don't apply inside shadow roots as-authored: token blocks must also match
+// `:host`, and `@property` registrations move to a document-level style tag.
+const compiled = postcss.parse(
+  readFileSync(join(generated, 'tailwind.css'), 'utf8'),
+);
+const documentProperties = [];
+compiled.walkAtRules('property', (atRule) => {
+  documentProperties.push(atRule.toString());
+  atRule.remove();
+});
+compiled.walkRules((rule) => {
+  if (rule.selector.includes(':root')) {
+    rule.selectors = rule.selectors.map((selector) =>
+      selector.replaceAll(':root', ':is(:root, :host)'),
+    );
+  }
+});
+writeFileSync(join(generated, 'shadow.css'), compiled.toString());
+writeFileSync(
+  join(generated, 'document-properties.css'),
+  documentProperties.join('\n\n'),
+);
+
+// 3) Derive @font-face CSS from the canonical tailwind-config font files
+// (single source of truth), keeping only normal-style faces (the nav sets
+// no italic text) and rewriting fontsource URLs to a runtime placeholder.
+const fontSources = [
+  require.resolve('@codaco/tailwind-config/fonts/nunito.css'),
+  require.resolve('@codaco/tailwind-config/fonts/inclusive-sans.css'),
+];
+const fontFiles = new Set();
+const fontFaces = [];
+for (const source of fontSources) {
+  postcss.parse(readFileSync(source, 'utf8')).walkAtRules('font-face', (face) => {
+    let style = 'normal';
+    let file = null;
+    face.walkDecls('font-style', (decl) => {
+      style = decl.value;
+    });
+    face.walkDecls('src', (decl) => {
+      const match = decl.value.match(
+        /url\('@fontsource-variable\/[^/]+\/files\/([^']+)'\)/,
+      );
+      if (!match) return;
+      file = match[1];
+      decl.value = decl.value.replace(
+        /url\('[^']+'\)/,
+        `url('__NC_FONT_BASE__/${match[1]}')`,
+      );
+    });
+    if (style !== 'normal' || !file) return;
+    fontFiles.add(file);
+    fontFaces.push(face.toString());
+  });
+}
+writeFileSync(join(generated, 'document-fonts.css'), fontFaces.join('\n\n'));
+
+function copyFonts(targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  for (const file of fontFiles) {
+    const pkg = file.startsWith('nunito')
+      ? '@fontsource-variable/nunito'
+      : '@fontsource-variable/inclusive-sans';
+    cpSync(require.resolve(`${pkg}/files/${file}`), join(targetDir, file));
+  }
+}
+
+if (mode === 'css-only') process.exit(0);
+
+if (mode === 'dev') {
+  copyFonts(join(pkgRoot, 'public', 'fonts'));
+  run('pnpm', ['exec', 'vite', '--open']);
+} else {
+  run('pnpm', ['exec', 'vite', 'build']);
+  copyFonts(join(pkgRoot, 'dist', 'fonts'));
+}
+```
+
+- [ ] **Step 7: Add package-scoped turbo overrides**
+
+In root `turbo.json`, alongside the other `<pkg>#task` overrides, add (the generic `build`/`test` inputs don't include `scripts/**`, which would make caching stale):
+
+```json
+"@codaco/site-navigation-element#build": {
+  "dependsOn": ["^build"],
+  "inputs": [
+    "src/**",
+    "scripts/**",
+    "tsconfig*.json",
+    "vite.config.*",
+    "package.json"
+  ],
+  "env": ["NODE_ENV"],
+  "outputs": ["dist/**", ".generated/**"]
+},
+"@codaco/site-navigation-element#test": {
+  "dependsOn": ["^build"],
+  "inputs": [
+    "src/**",
+    "scripts/**",
+    "vitest.config.*",
+    "vite.config.*",
+    "tsconfig*.json",
+    "package.json"
+  ],
+  "outputs": []
+}
+```
+
+- [ ] **Step 8: Add the knip workspace entry**
+
+In root `knip.json`, add to `"workspaces"` (fonts are consumed via `require.resolve` file paths, the Tailwind CLI via a spawned binary, playwright via the vitest provider — knip can't see any of them):
+
+```json
+"packages/site-navigation-element": {
+  "entry": ["src/element.tsx", "scripts/build.mjs"],
+  "ignoreDependencies": [
+    "@fontsource-variable/inclusive-sans",
+    "@fontsource-variable/nunito",
+    "@tailwindcss/cli",
+    "playwright"
+  ]
+}
+```
+
+- [ ] **Step 9: Install and verify the CSS pipeline end-to-end**
+
+```bash
+pnpm install
+pnpm --filter @codaco/fresco-ui build
+pnpm --filter @codaco/site-navigation-element exec node scripts/build.mjs --css-only
+```
+
+Expected: exit 0; `.generated/` contains `tailwind.css`, `shadow.css`, `document-properties.css`, `document-fonts.css`.
+
+Verify the transforms:
+
+```bash
+grep -c ':is(:root, :host)' packages/site-navigation-element/.generated/shadow.css   # >= 1
+grep -c '@property' packages/site-navigation-element/.generated/shadow.css            # 0
+grep -c '@property' packages/site-navigation-element/.generated/document-properties.css  # >= 1
+grep -c '__NC_FONT_BASE__' packages/site-navigation-element/.generated/document-fonts.css # >= 1
+grep -c 'neon-coral' packages/site-navigation-element/.generated/shadow.css           # >= 1 (utilities were scanned)
+grep -c 'data-theme' packages/site-navigation-element/.generated/shadow.css           # >= 1 (dark token block present; quoting may be normalized)
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/site-navigation-element turbo.json knip.json pnpm-lock.yaml
+git commit -m "feat(site-navigation-element): scaffold package and shadow-DOM CSS pipeline"
+```
+
+---
+
+### Task 4: Document-level style injection + vitest browser harness
+
+**Files:**
+
+- Create: `packages/site-navigation-element/src/css-modules.d.ts`
+- Create: `packages/site-navigation-element/src/documentStyles.ts`
+- Create: `packages/site-navigation-element/vitest.config.ts`
+- Create: `packages/site-navigation-element/vite.config.ts` (minimal now; Task 7 extends it)
+- Test: `packages/site-navigation-element/src/__tests__/documentStyles.test.ts`
+
+**Interfaces:**
+
+- Consumes: `.generated/document-fonts.css`, `.generated/document-properties.css` (Task 3).
+- Produces: `ensureDocumentStyles(): void` — idempotently appends one `<style data-nc-site-navigation>` tag to `document.head` containing the `@font-face` rules (font URLs resolved at runtime) and the `@property` rules. Task 5 calls this from `connectedCallback`.
+
+- [ ] **Step 1: Create `packages/site-navigation-element/src/css-modules.d.ts`**
+
+```ts
+declare module '*.css?inline' {
+  const css: string;
+  export default css;
+}
+```
+
+- [ ] **Step 2: Create `packages/site-navigation-element/vite.config.ts`** (shared by vitest and the Task 7 build)
+
+```ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+});
+```
+
+- [ ] **Step 3: Create `packages/site-navigation-element/vitest.config.ts`**
+
+First plain (non-Storybook) browser-mode vitest project in the repo — modeled on fresco-ui's storybook project minus the storybook plugin:
+
+```ts
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+  test: {
+    name: 'browser',
+    include: ['src/__tests__/**/*.test.{ts,tsx}'],
+    testTimeout: 20_000,
+    browser: {
+      provider: playwright(),
+      enabled: true,
+      instances: [{ browser: 'chromium' }],
+      headless: true,
+    },
+  },
+});
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `packages/site-navigation-element/src/__tests__/documentStyles.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureDocumentStyles } from '../documentStyles';
+
+describe('ensureDocumentStyles', () => {
+  beforeEach(() => {
+    document
+      .querySelectorAll('style[data-nc-site-navigation]')
+      .forEach((tag) => tag.remove());
+  });
+
+  it('appends a single document-level style tag, idempotently', () => {
+    ensureDocumentStyles();
+    ensureDocumentStyles();
+
+    const tags = document.querySelectorAll('style[data-nc-site-navigation]');
+    expect(tags).toHaveLength(1);
+  });
+
+  it('registers the fonts and property rules at document level', () => {
+    ensureDocumentStyles();
+
+    const css =
+      document.querySelector('style[data-nc-site-navigation]')?.textContent ??
+      '';
+    expect(css).toContain("font-family: 'Nunito Variable'");
+    expect(css).toContain("font-family: 'Inclusive Sans Variable'");
+    expect(css).toContain('@property');
+    expect(css).not.toContain('__NC_FONT_BASE__');
+    expect(css).toContain('/fonts/nunito-latin-wght-normal.woff2');
+  });
+});
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `pnpm --filter @codaco/site-navigation-element test`
+Expected: FAIL — cannot resolve `../documentStyles`. (The script's `--css-only` step runs first and must succeed; if it errors about fresco-ui dist, run `pnpm --filter @codaco/fresco-ui build`.)
+
+- [ ] **Step 6: Create `packages/site-navigation-element/src/documentStyles.ts`**
+
+```ts
+import documentFontsCss from '../.generated/document-fonts.css?inline';
+import documentPropertiesCss from '../.generated/document-properties.css?inline';
+
+const MARKER_ATTRIBUTE = 'data-nc-site-navigation';
+
+/**
+ * `@font-face` and `@property` rules only take effect at document level, so
+ * they can't ship inside the element's shadow stylesheet. In production the
+ * woff2 files sit next to the bundle (dist/fonts/) and resolve via
+ * import.meta.url; the Vite dev server and vitest serve them from
+ * public/fonts instead, where import.meta.url would point into /src.
+ */
+const fontBase = import.meta.env.DEV
+  ? '/fonts'
+  : new URL('./fonts', import.meta.url).href;
+
+export function ensureDocumentStyles(): void {
+  if (document.head.querySelector(`style[${MARKER_ATTRIBUTE}]`)) return;
+
+  const style = document.createElement('style');
+  style.setAttribute(MARKER_ATTRIBUTE, '');
+  style.textContent = `${documentFontsCss.replaceAll(
+    '__NC_FONT_BASE__',
+    fontBase,
+  )}\n\n${documentPropertiesCss}`;
+  document.head.append(style);
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `pnpm --filter @codaco/site-navigation-element test`
+Expected: PASS (2 tests). This also proves the browser harness works — chromium may download on first run.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/site-navigation-element
+git commit -m "feat(site-navigation-element): document-level style injection and browser test harness"
+```
+
+---
+
+### Task 5: The `<nc-site-navigation>` element
+
+**Files:**
+
+- Create: `packages/site-navigation-element/src/element.tsx`
+- Test: `packages/site-navigation-element/src/__tests__/element.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `SiteNavigation` (`site="external"` from Task 1), `PortalContainerProvider` (Task 2 makes it effective), `ensureDocumentStyles` (Task 4), `.generated/shadow.css` (Task 3).
+- Produces: side-effect module registering `nc-site-navigation` with attributes `active-item` (`SiteNavigationItemId`), `locale` (`'en-US' | 'en-GB' | 'es'`, default `'en-US'`), `theme` (`'light' | 'dark' | 'auto'`, default `'auto'`). Shadow root contains a `div.nc-root[data-theme]` wrapper. Tasks 6–7 rely on the tag and this DOM shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/site-navigation-element/src/__tests__/element.test.tsx`:
+
+```tsx
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../element';
+
+function mount(attributes: Record<string, string> = {}, width = 1280) {
+  const frame = document.createElement('div');
+  frame.style.width = `${width}px`;
+  const host = document.createElement('nc-site-navigation');
+  for (const [name, value] of Object.entries(attributes)) {
+    host.setAttribute(name, value);
+  }
+  frame.append(host);
+  document.body.append(frame);
+  return host;
+}
+
+function shadowLink(host: HTMLElement, href: string) {
+  return host.shadowRoot?.querySelector(`a[href="${href}"]`) ?? null;
+}
+
+function themeWrapper(host: HTMLElement) {
+  const wrapper = host.shadowRoot?.querySelector<HTMLElement>('.nc-root');
+  if (!wrapper) throw new Error('Expected the nc-root wrapper.');
+  return wrapper;
+}
+
+async function rendered(host: HTMLElement) {
+  await expect
+    .poll(() => host.shadowRoot?.querySelectorAll('a').length ?? 0)
+    .toBeGreaterThan(0);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('<nc-site-navigation>', () => {
+  it('registers and renders the canonical link set inside its shadow root', async () => {
+    const host = mount();
+    await rendered(host);
+
+    expect(customElements.get('nc-site-navigation')).toBeDefined();
+    expect(shadowLink(host, 'https://networkcanvas.com/')).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://community.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://documentation.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://protocolgallery.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://networkcanvas.com/download'),
+    ).not.toBeNull();
+    // Nothing rendered into the light DOM.
+    expect(host.querySelector('a')).toBeNull();
+  });
+
+  it('marks the active item with aria-current', async () => {
+    const host = mount({ 'active-item': 'community' });
+    await rendered(host);
+
+    expect(
+      shadowLink(host, 'https://community.networkcanvas.com/')?.getAttribute(
+        'aria-current',
+      ),
+    ).toBe('page');
+  });
+
+  it('selects translated copy from the locale attribute', async () => {
+    const host = mount({ locale: 'es' });
+    await rendered(host);
+
+    expect(
+      host.shadowRoot?.querySelector('nav[aria-label="Navegación principal"]'),
+    ).not.toBeNull();
+  });
+
+  it('resolves explicit themes and re-renders on attribute change', async () => {
+    const host = mount({ theme: 'dark' });
+    await rendered(host);
+
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe('dark');
+    const darkBackground = getComputedStyle(
+      themeWrapper(host),
+    ).backgroundColor;
+
+    host.setAttribute('theme', 'light');
+    await expect
+      .poll(() => themeWrapper(host).getAttribute('data-theme'))
+      .toBe('light');
+    expect(getComputedStyle(themeWrapper(host)).backgroundColor).not.toBe(
+      darkBackground,
+    );
+  });
+
+  it('follows prefers-color-scheme when theme is auto', async () => {
+    const host = mount();
+    await rendered(host);
+
+    const expected = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe(expected);
+  });
+
+  it('warns and falls back on invalid attribute values', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const host = mount({ 'theme': 'banana', 'active-item': 'nonsense' });
+    await rendered(host);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('banana'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('nonsense'));
+    const expected = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe(expected);
+    warn.mockRestore();
+  });
+
+  it('injects the document-level styles exactly once across instances', async () => {
+    const first = mount();
+    const second = mount();
+    await rendered(first);
+    await rendered(second);
+
+    expect(
+      document.querySelectorAll('style[data-nc-site-navigation]'),
+    ).toHaveLength(1);
+  });
+});
+```
+
+Note: `@testing-library/jest-dom` matchers are deliberately not used — this package has no jsdom setup file, so assertions stay on plain DOM APIs (`getAttribute`).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @codaco/site-navigation-element test`
+Expected: FAIL — cannot resolve `../element`.
+
+- [ ] **Step 3: Create `packages/site-navigation-element/src/element.tsx`**
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { PortalContainerProvider } from '@codaco/fresco-ui/PortalContainer';
+import SiteNavigation, {
+  type SiteNavigationItemId,
+  type SiteNavigationLocale,
+} from '@codaco/fresco-ui/navigation/SiteNavigation';
+
+import shadowCss from '../.generated/shadow.css?inline';
+import { ensureDocumentStyles } from './documentStyles';
+
+const TAG_NAME = 'nc-site-navigation';
+
+const ACTIVE_ITEMS: readonly SiteNavigationItemId[] = [
+  'home',
+  'community',
+  'documentation',
+  'protocolGallery',
+  'resources',
+  'software',
+  'getStarted',
+];
+const LOCALES: readonly SiteNavigationLocale[] = ['en-US', 'en-GB', 'es'];
+const THEMES = ['light', 'dark', 'auto'] as const;
+type Theme = (typeof THEMES)[number];
+
+// Preflight's html/body rules can't reach into the shadow tree, so the
+// wrapper re-establishes the base typography itself.
+const HOST_CSS = `
+:host { display: block; }
+.nc-root { font-family: var(--body-font); }
+`;
+
+let sharedSheet: CSSStyleSheet | null = null;
+function shadowStyles(): CSSStyleSheet {
+  if (!sharedSheet) {
+    sharedSheet = new CSSStyleSheet();
+    sharedSheet.replaceSync(`${shadowCss}\n${HOST_CSS}`);
+  }
+  return sharedSheet;
+}
+
+function parseAttribute<T extends string>(
+  host: HTMLElement,
+  name: string,
+  allowed: readonly T[],
+  fallback: T | undefined,
+): T | undefined {
+  const value = host.getAttribute(name);
+  if (value === null) return fallback;
+  const match = allowed.find((candidate) => candidate === value);
+  if (match !== undefined) return match;
+  console.warn(
+    `<${TAG_NAME}>: ignoring invalid ${name}="${value}" (expected one of: ${allowed.join(', ')})`,
+  );
+  return fallback;
+}
+
+class NcSiteNavigation extends HTMLElement {
+  static observedAttributes = ['active-item', 'locale', 'theme'];
+
+  #reactRoot: Root | null = null;
+  #colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+  #handleSchemeChange = () => {
+    if (parseAttribute(this, 'theme', THEMES, 'auto') === 'auto') {
+      this.#render();
+    }
+  };
+
+  connectedCallback() {
+    ensureDocumentStyles();
+    const shadow = this.shadowRoot ?? this.attachShadow({ mode: 'open' });
+    shadow.adoptedStyleSheets = [shadowStyles()];
+    this.#reactRoot ??= createRoot(shadow);
+    this.#colorScheme.addEventListener('change', this.#handleSchemeChange);
+    this.#render();
+  }
+
+  disconnectedCallback() {
+    this.#colorScheme.removeEventListener('change', this.#handleSchemeChange);
+    this.#reactRoot?.unmount();
+    this.#reactRoot = null;
+  }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.#render();
+  }
+
+  #render() {
+    if (!this.#reactRoot) return;
+    const activeItemId = parseAttribute(
+      this,
+      'active-item',
+      ACTIVE_ITEMS,
+      undefined,
+    );
+    const locale = parseAttribute(this, 'locale', LOCALES, 'en-US') ?? 'en-US';
+    const theme: Theme = parseAttribute(this, 'theme', THEMES, 'auto') ?? 'auto';
+    const resolvedTheme =
+      theme === 'auto'
+        ? this.#colorScheme.matches
+          ? 'dark'
+          : 'light'
+        : theme;
+
+    this.#reactRoot.render(
+      <StrictMode>
+        <div
+          className="nc-root bg-background text-text"
+          data-theme={resolvedTheme}
+        >
+          <PortalContainerProvider>
+            <SiteNavigation
+              activeItemId={activeItemId}
+              locale={locale}
+              site="external"
+            />
+          </PortalContainerProvider>
+        </div>
+      </StrictMode>,
+    );
+  }
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, NcSiteNavigation);
+}
+```
+
+Implementation notes:
+
+- `createRoot(shadow)` is valid — a `ShadowRoot` is a `DocumentFragment`, which React 19 accepts as a container.
+- `adoptedStyleSheets` needs no fallback: every browser Discourse supports (and chromium in tests) implements constructable stylesheets.
+- The `PortalContainerProvider` sits **inside** the `data-theme` wrapper so portaled popups inherit the theme tokens and stay inside the shadow root (Task 2).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @codaco/site-navigation-element test`
+Expected: PASS (Task 4's 2 tests + this task's 7).
+
+- [ ] **Step 5: Typecheck the package**
+
+Run: `pnpm --filter @codaco/site-navigation-element typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/site-navigation-element/src
+git commit -m "feat(site-navigation-element): implement the nc-site-navigation custom element"
+```
+
+---
+
+### Task 6: Interaction tests (dropdowns in shadow, mobile drawer)
+
+**Files:**
+
+- Test: `packages/site-navigation-element/src/__tests__/interactions.test.tsx`
+
+**Interfaces:**
+
+- Consumes: the element from Task 5 (its `mount` DOM shape) and the portal containment from Task 2.
+- Produces: regression coverage only; no exports.
+
+- [ ] **Step 1: Write the tests**
+
+Create `packages/site-navigation-element/src/__tests__/interactions.test.tsx`:
+
+```tsx
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import '../element';
+
+function mount(width: number) {
+  const frame = document.createElement('div');
+  frame.style.width = `${width}px`;
+  const host = document.createElement('nc-site-navigation');
+  frame.append(host);
+  document.body.append(frame);
+  return host;
+}
+
+function shadowButton(host: HTMLElement, label: string) {
+  const buttons = host.shadowRoot?.querySelectorAll('button') ?? [];
+  for (const button of buttons) {
+    if (
+      button.textContent?.includes(label) ||
+      button.getAttribute('aria-label') === label
+    ) {
+      return button;
+    }
+  }
+  return null;
+}
+
+async function rendered(host: HTMLElement) {
+  await expect
+    .poll(() => host.shadowRoot?.querySelectorAll('a').length ?? 0)
+    .toBeGreaterThan(0);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('<nc-site-navigation> interactions', () => {
+  it('opens the Software menu with its popup inside the shadow root', async () => {
+    const host = mount(1280);
+    await rendered(host);
+
+    const trigger = shadowButton(host, 'Software');
+    expect(trigger).not.toBeNull();
+    trigger?.click();
+
+    await expect
+      .poll(() =>
+        host.shadowRoot?.querySelector('a[aria-label="Architect"]'),
+      )
+      .not.toBeNull();
+    const architect = host.shadowRoot?.querySelector(
+      'a[aria-label="Architect"]',
+    );
+    expect(architect?.getRootNode()).toBe(host.shadowRoot);
+  });
+
+  it('opens and closes the compact drawer, restoring trigger focus on Escape', async () => {
+    const host = mount(400);
+    await rendered(host);
+
+    const menuButton = shadowButton(host, 'Open site navigation');
+    expect(menuButton).not.toBeNull();
+    menuButton?.click();
+
+    await expect
+      .poll(() => menuButton?.getAttribute('aria-expanded'))
+      .toBe('true');
+
+    // The drawer is the second <nav>; the desktop menu's <nav> renders first
+    // (hidden below the container breakpoint but still in the DOM).
+    const navs = host.shadowRoot?.querySelectorAll('nav') ?? [];
+    const drawer = navs[1];
+    if (!drawer) throw new Error('Expected the compact drawer navigation.');
+    const firstLink = drawer.querySelector<HTMLElement>('a');
+    if (!firstLink) throw new Error('Expected a drawer link.');
+    firstLink.focus();
+    firstLink.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    await expect
+      .poll(() => menuButton?.getAttribute('aria-expanded'))
+      .toBe('false');
+    expect(host.shadowRoot?.activeElement).toBe(menuButton);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm --filter @codaco/site-navigation-element test`
+Expected: PASS. If the Software-menu test flakes on popup timing, raise the poll via `await expect.poll(..., { timeout: 5000 })` rather than adding sleeps. If Escape handling genuinely fails (shadow retargeting), that is a real bug to fix in the element (e.g. event listener placement), not in the test — investigate before touching assertions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/site-navigation-element/src/__tests__
+git commit -m "test(site-navigation-element): cover dropdown containment and compact drawer interactions"
+```
+
+---
+
+### Task 7: Production bundle + demo page
+
+**Files:**
+
+- Modify: `packages/site-navigation-element/vite.config.ts`
+- Create: `packages/site-navigation-element/index.html` (demo; excluded from npm by `files: ["dist"]`)
+
+**Interfaces:**
+
+- Consumes: element module (Task 5), `scripts/build.mjs` orchestration (Task 3).
+- Produces: `dist/element.js` — single minified self-contained ESM file — plus `dist/fonts/*.woff2` and `dist/element.js.map`. The npm entry the CDN serves.
+
+- [ ] **Step 1: Extend `packages/site-navigation-element/vite.config.ts`**
+
+Replace the file contents with:
+
+```ts
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ command }) => ({
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+  define:
+    command === 'build'
+      ? { 'process.env.NODE_ENV': JSON.stringify('production') }
+      : undefined,
+  build: {
+    lib: {
+      entry: resolve(import.meta.dirname, 'src/element.tsx'),
+      formats: ['es'],
+      fileName: () => 'element.js',
+    },
+    minify: true,
+    sourcemap: true,
+    emptyOutDir: true,
+  },
+}));
+```
+
+(The `define` guarantees React's production build is selected when everything is inlined; ESM output keeps `import.meta.url` — which `documentStyles.ts` uses for font URLs — valid when served from the CDN.)
+
+- [ ] **Step 2: Create the demo page `packages/site-navigation-element/index.html`**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>nc-site-navigation demo</title>
+    <style>
+      /* Deliberately hostile host styles — the shadow root must ignore them. */
+      body {
+        margin: 0;
+        font-family: 'Comic Sans MS', cursive;
+        background: #e8e4da;
+      }
+      a {
+        color: red !important;
+        text-decoration: underline wavy !important;
+      }
+      .controls {
+        padding: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+    </style>
+    <script type="module" src="/src/element.tsx"></script>
+  </head>
+  <body>
+    <nc-site-navigation
+      active-item="community"
+      theme="auto"
+    ></nc-site-navigation>
+    <div class="controls">
+      <button data-theme-value="light">Light</button>
+      <button data-theme-value="dark">Dark</button>
+      <button data-theme-value="auto">Auto</button>
+    </div>
+    <p style="padding: 1rem">
+      Host-page content. The header above is rendered by
+      <code>&lt;nc-site-navigation&gt;</code> inside a shadow root.
+    </p>
+    <script type="module">
+      const nav = document.querySelector('nc-site-navigation');
+      for (const button of document.querySelectorAll('[data-theme-value]')) {
+        button.addEventListener('click', () => {
+          nav.setAttribute('theme', button.dataset.themeValue);
+        });
+      }
+    </script>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: Build and inspect the artifact**
+
+```bash
+pnpm --filter @codaco/site-navigation-element build
+ls packages/site-navigation-element/dist
+```
+
+Expected: `element.js`, `element.js.map`, `fonts/` with 8 woff2 files (5 nunito + 3 inclusive-sans normal-style subsets).
+
+Verify self-containment and size:
+
+```bash
+head -c 1000 packages/site-navigation-element/dist/element.js | grep -o 'import[^;]*from[^;]*;' || echo "self-contained (no import statements)"
+gzip -c packages/site-navigation-element/dist/element.js | wc -c
+```
+
+Expected: `self-contained (no import statements)` — ESM static imports are hoisted to the top of the chunk, so their absence in the first kilobyte means everything was inlined. Gzipped size printed — record it, expect roughly 120,000–160,000 bytes. If over 160 kB, check the CSS payload first (`@source` scope creep) before blaming JS.
+
+- [ ] **Step 4: Verify the demo in a real browser**
+
+Run: `pnpm --filter @codaco/site-navigation-element dev` (starts the Vite dev server after regenerating CSS and copying fonts to `public/fonts`).
+
+Then verify in the app's browser pane (per the repo's visual-verification convention: confirm against the rendered page, not just tests):
+
+- Header renders with correct branding, fonts (Nunito headings — not Comic Sans), and colors on light and dark.
+- Resources/Software dropdowns open styled and positioned under their triggers.
+- Host page links are red/wavy; nav links are not (isolation works).
+- Narrow the window below ~1024 px of element width: hamburger + drawer work.
+- Take screenshots of light + dark and share them with the user for visual sign-off.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/site-navigation-element
+git commit -m "feat(site-navigation-element): production single-file bundle and demo page"
+```
+
+---
+
+### Task 8: Release wiring + full-repo verification
+
+**Files:**
+
+- Create: `.changeset/site-navigation-element-initial.md`
+- Create: `.changeset/fresco-ui-external-site-portals.md`
+- Modify: `docs/superpowers/specs/2026-07-15-site-navigation-element-design.md` (locale default correction)
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: release-ready branch; both packages queued for the library changeset lane.
+
+- [ ] **Step 1: Write the changesets (two files — never mix packages with different lanes; these are both libraries but keep one concern per file)**
+
+Create `.changeset/fresco-ui-external-site-portals.md`:
+
+```md
+---
+'@codaco/fresco-ui': minor
+---
+
+SiteNavigation accepts `site="external"` for non-Network-Canvas hosts (every destination renders as an absolute URL) and portals its desktop menus into the `PortalContainerProvider` container when one is present, so embedders can keep popups inside their own DOM scope (e.g. a shadow root).
+```
+
+Create `.changeset/site-navigation-element-initial.md`:
+
+```md
+---
+'@codaco/site-navigation-element': major
+---
+
+Initial release: the canonical Network Canvas site header packaged as a self-contained `<nc-site-navigation>` web component for non-React hosts. Loads from a CDN with a single script tag; Shadow DOM isolation; `active-item`, `locale`, and `theme` (light/dark/auto) attributes.
+```
+
+- [ ] **Step 2: Correct the spec's locale default**
+
+In `docs/superpowers/specs/2026-07-15-site-navigation-element-design.md`, the element-contract table lists the `locale` default as `en`; the real `SiteLocale` union is `en-US | en-GB | es`. Change that table row's default from `` `en` `` to `` `en-US` ``.
+
+- [ ] **Step 3: Full-repo verification (single pass, per repo convention)**
+
+```bash
+pnpm typecheck
+pnpm knip
+pnpm lint
+pnpm --filter @codaco/fresco-ui test
+pnpm --filter @codaco/site-navigation-element test
+```
+
+Expected: all PASS. Known traps if they fail:
+
+- `typecheck` cache can mask cross-package breakage — if suspicious, rerun with `--force`.
+- `knip` failures about the new package usually mean the `knip.json` entry from Task 3 needs adjusting (entry files or `ignoreDependencies`).
+- Do NOT run root `lint:fix`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset docs/superpowers/specs/2026-07-15-site-navigation-element-design.md
+git commit -m "chore: changesets for fresco-ui external site + site-navigation-element initial release"
+```
+
+- [ ] **Step 5: Ship**
+
+Invoke the repo's `shipping-a-pull-request` skill to open the PR from this branch against `main` and watch CI. PR summary should link the spec and note: two fresco-ui behavior changes (type widening + opt-in portal containment), new published package, first plain browser-mode vitest project in the repo, and the recorded bundle size from Task 7.

--- a/docs/superpowers/specs/2026-07-15-site-navigation-element-design.md
+++ b/docs/superpowers/specs/2026-07-15-site-navigation-element-design.md
@@ -1,0 +1,164 @@
+# Site Navigation Web Component (`@codaco/site-navigation-element`)
+
+**Date:** 2026-07-15
+**Status:** Approved
+
+## Motivation
+
+The Network Canvas community forum (<https://community.networkcanvas.com>, a
+self-hosted Discourse instance) should carry the same global site header as the
+other Network Canvas web properties. Discourse is an Ember application with
+server-compiled SCSS, so the canonical React header
+(`@codaco/fresco-ui/navigation/SiteNavigation`) cannot be imported there
+directly. Re-implementing the header as a Discourse theme component was
+rejected because it creates a second implementation that drifts.
+
+Instead, this design packages the existing `SiteNavigation` React component as
+a self-contained custom element that any non-React host page can load with a
+script tag, achieving a true 1:1 header.
+
+### Decisions already made
+
+- **Distribution: CDN auto-tracking.** The bundle is published to npm and
+  loaded from jsDelivr pinned to a major-version range (`@1`). Hosts pick up
+  nav changes automatically with zero touch. (Vendored/PR-sync and
+  exact-version pinning were considered and rejected in favour of zero-touch
+  updates.)
+- **Packaging: new monorepo package.** A second build target inside fresco-ui
+  and a standalone repo were rejected; fresco-ui's externals-only ESM build
+  stays untouched, and the element builds against `workspace:*` sources so nav
+  changes and element releases ship together from one PR.
+- **The Discourse theme component is out of scope for now.** This deliverable
+  is the element plus its consumption contract. The forum-side loader (theme
+  component, plugin outlet, CSP `csp_extensions` modifier, colour-scheme sync)
+  will be designed separately.
+
+## Scope
+
+**In scope**
+
+- New library package `packages/site-navigation-element`, published to npm as
+  `@codaco/site-navigation-element` (public, normal changesets library lane).
+- A custom element `<nc-site-navigation>` rendering `SiteNavigation` inside a
+  shadow root, fully self-contained (React, motion, Base UI, icons, compiled
+  CSS, fonts).
+- Small upstream changes to `@codaco/fresco-ui` (see below).
+
+**Out of scope (deliberately deferred)**
+
+- The Discourse theme component that loads the element on the forum.
+- `SiteFooter` as a web component (architecture leaves room for it).
+- Theming the forum itself with the shared design tokens.
+
+## Element contract
+
+Tag name: **`<nc-site-navigation>`**.
+
+| Attribute     | Values                         | Default | Maps to                                               |
+| ------------- | ------------------------------ | ------- | ----------------------------------------------------- |
+| `active-item` | `SiteNavigationItemId` strings | unset   | `activeItemId` (forum will use `community`)           |
+| `locale`      | `SiteLocale` strings           | `en`    | `locale`                                              |
+| `theme`       | `light` \| `dark` \| `auto`    | `auto`  | resolved theme; `auto` follows `prefers-color-scheme` |
+
+- Links render as plain anchors via the component's default `renderLink`.
+- No utility slot in v1 — the ThemeSwitcher remains app-side; a host such as
+  Discourse sets `theme` explicitly to mirror its own colour scheme.
+- Attribute changes re-render via `attributeChangedCallback`.
+- The element always passes `site="external"` to `SiteNavigation`.
+
+Consumption (any host):
+
+```html
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@codaco/site-navigation-element@1/dist/element.js"
+></script>
+<nc-site-navigation active-item="community" theme="dark"></nc-site-navigation>
+```
+
+## Upstream fresco-ui changes
+
+1. **`site: 'external'`** added to `SiteNavigationProps`. Today `site` is
+   `'documentation' | 'website'`, and each value makes one destination
+   root-relative. `external` makes both the brand link
+   (networkcanvas.com) and the Docs link absolute.
+2. **Portal containment.** `SiteNavigation` currently renders its two
+   `NavigationMenu.Portal`s with no `container`, so popups mount in
+   `document.body` — outside a shadow root and therefore unstyled.
+   `SiteNavigation` will consume the existing `usePortalContainer()` context
+   and pass it as `container` (undefined → unchanged default for existing
+   apps). The element wraps its React tree in `PortalContainerProvider`
+   _inside_ the shadow root so dropdowns stay styled and isolated.
+3. **Storybook**: the SiteNavigation story gains the `external` site variant,
+   per repo convention.
+
+## Style strategy — Shadow DOM
+
+`connectedCallback` attaches an open shadow root, mounts a React root inside
+it, and applies one compiled stylesheet via `adoptedStyleSheets`.
+
+- **CSS payload.** Compiled in this package by Tailwind v4 from an entry that
+  imports `@codaco/tailwind-config/fresco.css`, with `@source` scoped to only
+  the fresco-ui modules the nav uses (`navigation/`, `Button`, `Spinner`,
+  `typography/`, `PortalContainer`) to keep the payload lean.
+- **Shadow-boundary transforms (build-time).**
+  - `:root`-scoped token blocks are rewritten to also match `:host`.
+  - `@font-face` and `@property` rules do not take effect inside shadow
+    roots; they are hoisted into a document-level `<style>` the element
+    injects once (idempotent, guarded against double-injection).
+- **Dark mode.** The resolved theme is reflected onto a wrapper
+  `div[data-theme]` inside the shadow root — exactly the ancestor selector the
+  component's existing dark styles key off (`[data-theme='dark']` token block
+  and `[[data-theme=dark]_&]` utilities).
+- **Fonts.** Nunito Variable and Inclusive Sans Variable woff2 files are
+  copied into `dist/` at build time and referenced via
+  `new URL(..., import.meta.url)`, so they resolve from the CDN (or any
+  self-hosted copy) with no host setup.
+
+## Build & distribution
+
+- Vite lib build: a single minified ESM file with everything inlined — React,
+  react-dom, motion, Base UI, lucide icons, and the compiled CSS imported as a
+  string. This is intentionally the opposite of fresco-ui's externals-only
+  build.
+- Output: `dist/element.js` plus `dist/fonts/*.woff2`.
+- Size budget: **~120–150 kB gzipped** (JS + CSS); fonts load separately on
+  first visit.
+- **Supply-chain trade-off (accepted).** Subresource Integrity cannot be used
+  with a semver-range CDN URL: an `integrity` hash pins exact bytes and would
+  break on every release. Auto-tracking therefore extends trust to the npm +
+  jsDelivr supply chain for this bundle. Two properties bound the risk: npm
+  publishing for `@codaco` happens only through the repo's release CI, and the
+  element renders additive chrome (a compromised bundle still cannot read the
+  host page's DOM outside its own subtree without further action, though any
+  third-party script ultimately runs with page privileges). If harder
+  guarantees are wanted later, the host switches to an exact-version URL with
+  an `integrity` hash — a one-line change, at the cost of manual updates.
+- `demo/index.html` served by `pnpm dev` for local verification.
+- Standard turbo wiring (`build` via `with-turbo.mjs`, depends on `^build` so
+  fresco-ui dist exists for `@source` scanning).
+- Release: normal library changesets. fresco-ui gets a minor for the upstream
+  changes; the element publishes from 1.0.0.
+
+## Testing
+
+- **Browser tests (primary).** vitest browser mode (Chromium via the
+  catalog's `@vitest/browser-playwright`, as fresco-ui already uses):
+  - element registers and renders the full link set inside its shadow root;
+  - `active-item` produces `aria-current="page"` on the matching link;
+  - `theme="dark"` changes computed colours; `auto` follows
+    `prefers-color-scheme`;
+  - the Resources dropdown opens and its popup mounts **inside** the shadow
+    root;
+  - Escape/keyboard interactions survive shadow-DOM event retargeting.
+- **Unit tests.** fresco-ui's existing SiteNavigation tests extended for
+  `site="external"` and the portal-container plumbing.
+- Standard `typecheck`, `lint`, and `knip` gates.
+
+## Failure modes
+
+- Double registration guarded with `customElements.get()` before `define`.
+- Invalid attribute values fall back to defaults with a `console.warn`.
+- If the CDN script is blocked or fails, nothing renders — benign by design:
+  the element is additive chrome above the host's own header, so the host
+  page degrades to exactly what it is today.

--- a/docs/superpowers/specs/2026-07-15-site-navigation-element-design.md
+++ b/docs/superpowers/specs/2026-07-15-site-navigation-element-design.md
@@ -57,7 +57,7 @@ Tag name: **`<nc-site-navigation>`**.
 | Attribute     | Values                         | Default | Maps to                                               |
 | ------------- | ------------------------------ | ------- | ----------------------------------------------------- |
 | `active-item` | `SiteNavigationItemId` strings | unset   | `activeItemId` (forum will use `community`)           |
-| `locale`      | `SiteLocale` strings           | `en`    | `locale`                                              |
+| `locale`      | `SiteLocale` strings           | `en-US` | `locale`                                              |
 | `theme`       | `light` \| `dark` \| `auto`    | `auto`  | resolved theme; `auto` follows `prefers-color-scheme` |
 
 - Links render as plain anchors via the component's default `renderLink`.
@@ -122,8 +122,10 @@ it, and applies one compiled stylesheet via `adoptedStyleSheets`.
   string. This is intentionally the opposite of fresco-ui's externals-only
   build.
 - Output: `dist/element.js` plus `dist/fonts/*.woff2`.
-- Size budget: **~120–150 kB gzipped** (JS + CSS); fonts load separately on
-  first visit.
+- Size (measured at release): **~194 kB gzipped / ~161 kB brotli** (JS + CSS
+  inlined; jsDelivr serves brotli); fonts load separately on first visit. The
+  original ~120–150 kB estimate was revised after measurement; composition and
+  accepted trade-offs are documented in the implementation history.
 - **Supply-chain trade-off (accepted).** Subresource Integrity cannot be used
   with a semver-range CDN URL: an `integrity` hash pins exact bytes and would
   break on every release. Auto-tracking therefore extends trust to the npm +

--- a/knip.json
+++ b/knip.json
@@ -40,12 +40,11 @@
     "packages/network-exporters": {},
     "packages/interface-images": {},
     "packages/site-navigation-element": {
-      "entry": ["src/element.tsx", "scripts/build.mjs"],
+      "entry": ["src/styles/shadow.css"],
       "ignoreDependencies": [
         "@fontsource-variable/inclusive-sans",
         "@fontsource-variable/nunito",
-        "@tailwindcss/cli",
-        "playwright"
+        "@tailwindcss/cli"
       ]
     },
     "tooling/tailwind": {

--- a/knip.json
+++ b/knip.json
@@ -39,6 +39,15 @@
     "packages/protocol-validation": {},
     "packages/network-exporters": {},
     "packages/interface-images": {},
+    "packages/site-navigation-element": {
+      "entry": ["src/element.tsx", "scripts/build.mjs"],
+      "ignoreDependencies": [
+        "@fontsource-variable/inclusive-sans",
+        "@fontsource-variable/nunito",
+        "@tailwindcss/cli",
+        "playwright"
+      ]
+    },
     "tooling/tailwind": {
       "entry": [
         "shared/plugins/elevation/index.ts",

--- a/packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx
@@ -7,12 +7,17 @@ import SiteNavigation from './SiteNavigation';
 import type { SiteNavigationLocale } from './SiteNavigation';
 
 type StoryArgs = {
-  activeItemId: 'home' | 'documentation' | 'resources' | 'getStarted';
+  activeItemId:
+    | 'home'
+    | 'community'
+    | 'documentation'
+    | 'resources'
+    | 'getStarted';
   containerWidth: number;
   locale: SiteNavigationLocale;
   showMobileAccessory: boolean;
   showUtility: boolean;
-  site: 'documentation' | 'website';
+  site: 'documentation' | 'external' | 'website';
 };
 
 const widths = [320, 480, 768, 1024, 1280, 1536];
@@ -39,7 +44,8 @@ import SiteNavigation from '@codaco/fresco-ui/navigation/SiteNavigation';
   table is checked against that same union, so adding a supported locale also
   requires navigation copy at compile time.
 - **\`site\`** selects routing context only; menu items and destinations are
-  not configurable.
+  not configurable. \`external\` is for non-Network-Canvas hosts (e.g. the
+  community forum): every destination renders as an absolute URL.
 - **\`activeItemId\`** applies the current-page state to a canonical
   destination.
 - **\`mobileAccessory\`** injects compact-only UI beside the menu trigger,
@@ -70,7 +76,13 @@ const meta = {
   argTypes: {
     activeItemId: {
       control: 'select',
-      options: ['home', 'documentation', 'resources', 'getStarted'],
+      options: [
+        'home',
+        'community',
+        'documentation',
+        'resources',
+        'getStarted',
+      ],
     },
     containerWidth: {
       control: 'select',
@@ -82,7 +94,7 @@ const meta = {
     },
     site: {
       control: 'radio',
-      options: ['website', 'documentation'],
+      options: ['website', 'documentation', 'external'],
     },
   },
   args: {
@@ -135,6 +147,13 @@ export const Website: Story = {};
 export const Spanish: Story = {
   args: {
     locale: 'es',
+  },
+};
+
+export const ExternalHost: Story = {
+  args: {
+    activeItemId: 'community',
+    site: 'external',
   },
 };
 

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -89,7 +89,7 @@ export type SiteNavigationProps = {
   mobileAccessory?: ReactNode;
   renderLink?: (props: SiteNavigationLinkRenderProps) => ReactElement;
   renderUtility?: (props: SiteNavigationUtilityRenderProps) => ReactNode;
-  site: 'documentation' | 'website';
+  site: 'documentation' | 'external' | 'website';
   className?: string;
   containerClassName?: string;
   style?: CSSProperties;

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -17,6 +17,7 @@ import {
 import type { SiteLocale } from '@codaco/shared-consts';
 
 import { buttonVariants, IconButton } from '../Button';
+import { usePortalContainer } from '../PortalContainer';
 import Spinner from '../Spinner';
 import { headingVariants } from '../typography/Heading';
 import Paragraph from '../typography/Paragraph';
@@ -205,6 +206,8 @@ function ResourcesMenu({
   links: ResourceLink[];
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
+  const portalContainer = usePortalContainer();
+
   return (
     <NavigationMenu.Root
       delay={100}
@@ -265,7 +268,7 @@ function ResourcesMenu({
         </NavigationMenu.Item>
       </NavigationMenu.List>
 
-      <NavigationMenu.Portal>
+      <NavigationMenu.Portal container={portalContainer ?? undefined}>
         <NavigationMenu.Positioner
           sideOffset={14}
           align="center"
@@ -358,6 +361,8 @@ function SoftwareMenu({
   links: SoftwareLink[];
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
+  const portalContainer = usePortalContainer();
+
   return (
     <NavigationMenu.Root
       delay={100}
@@ -392,7 +397,7 @@ function SoftwareMenu({
         </NavigationMenu.Item>
       </NavigationMenu.List>
 
-      <NavigationMenu.Portal>
+      <NavigationMenu.Portal container={portalContainer ?? undefined}>
         <NavigationMenu.Positioner
           sideOffset={14}
           align="center"

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { PortalContainerProvider } from '../../PortalContainer';
 import SiteNavigation from '../SiteNavigation';
 
 describe('SiteNavigation', () => {
@@ -285,5 +286,28 @@ describe('SiteNavigation', () => {
       'href',
       'https://networkcanvas.com/download',
     );
+  });
+
+  it('portals desktop menus into the app portal container when provided', () => {
+    const { baseElement } = render(
+      <PortalContainerProvider>
+        <SiteNavigation locale="en-US" site="website" />
+      </PortalContainerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Software' }));
+    const architectLink = screen.getByRole('link', { name: 'Architect' });
+    const portalLayer = baseElement.querySelector('.z-3000');
+    if (!portalLayer) throw new Error('Expected the portal container layer.');
+
+    expect(portalLayer).toContainElement(architectLink);
+  });
+
+  it('keeps portaling to the document body without a provider', () => {
+    render(<SiteNavigation locale="en-US" site="website" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Software' }));
+
+    expect(screen.getByRole('link', { name: 'Architect' })).toBeInTheDocument();
   });
 });

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -256,4 +256,34 @@ describe('SiteNavigation', () => {
     ).toHaveAttribute('aria-expanded', 'false');
     expect(menuButton).toHaveFocus();
   });
+
+  it('renders every destination absolutely for external hosts', () => {
+    render(
+      <SiteNavigation
+        activeItemId="community"
+        locale="en-US"
+        site="external"
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Network Canvas home' }),
+    ).toHaveAttribute('href', 'https://networkcanvas.com/');
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'href',
+      'https://documentation.networkcanvas.com/',
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+    expect(screen.getByRole('link', { name: 'Community' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Get Started' })).toHaveAttribute(
+      'href',
+      'https://networkcanvas.com/download',
+    );
+  });
 });

--- a/packages/site-navigation-element/.gitignore
+++ b/packages/site-navigation-element/.gitignore
@@ -1,0 +1,2 @@
+.generated/
+public/fonts/

--- a/packages/site-navigation-element/README.md
+++ b/packages/site-navigation-element/README.md
@@ -1,0 +1,64 @@
+# @codaco/site-navigation-element
+
+The canonical Network Canvas site header, packaged as a self-contained
+`<nc-site-navigation>` web component for pages that aren't React apps (a
+Discourse forum, a static site, a CMS template, ...). It renders the same
+React `SiteNavigation` component the Network Canvas sites use, mounted inside
+a shadow root.
+
+## Usage
+
+```html
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@codaco/site-navigation-element@1/dist/element.js"
+></script>
+<nc-site-navigation active-item="community" theme="dark"></nc-site-navigation>
+```
+
+The `@1` pins to the major-version range, so hosts pick up nav changes
+automatically with no further action. A version range is incompatible with
+Subresource Integrity (a hash pins exact bytes and would break on every
+release); a host that wants that guarantee instead can point at an exact
+version and add its own `integrity` hash, trading auto-updates for a manual
+bump on every release.
+
+You can also install it as a regular dependency and import the same bundle
+through your own bundler (`import '@codaco/site-navigation-element'`) instead
+of loading it from a CDN.
+
+## Attributes
+
+| Attribute     | Values                                                                                                     | Default | Notes                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------- |
+| `active-item` | `home` \| `community` \| `documentation` \| `protocolGallery` \| `resources` \| `software` \| `getStarted` | unset   | Highlights the matching link (`aria-current="page"`). |
+| `locale`      | `en-US` \| `en-GB` \| `es`                                                                                 | `en-US` | Selects the nav's translated copy.                    |
+| `theme`       | `light` \| `dark` \| `auto`                                                                                | `auto`  | `auto` follows the page's `prefers-color-scheme`.     |
+
+Attribute changes re-render the element live — updating `theme` or
+`active-item` after the element has connected takes effect immediately.
+
+There's no utility slot (a place to render the account/theme switcher) in
+this version — hosts that want their own colour scheme reflected should set
+`theme` explicitly rather than relying on `auto`.
+
+## How it works / footprint
+
+- The whole thing ships as one self-contained ESM file — React, the compiled
+  CSS, and everything else needed to render the header are inlined into
+  `dist/element.js` (~194 kB gzipped / ~161 kB brotli over the wire).
+- Styles are isolated in a shadow root, so the header can't leak into or be
+  affected by the host page's CSS.
+- Fonts and the `@font-face`/`@property` rules that can't apply inside a
+  shadow root are injected once as a single document-level `<style>` tag. The
+  woff2 font files themselves load from `dist/fonts/`, next to the bundle.
+- **CSP caveat:** a host with a strict `style-src` may block that injected
+  document-level style tag. If it does, the header falls back to system fonts
+  but stays otherwise styled — the shadow root's own styles are unaffected.
+  The bundle URL also needs to be allowed by `script-src`.
+
+## Failure mode
+
+If the script fails to load (network error, blocked by CSP, etc.), nothing
+renders. The element is purely additive chrome above the host's own page, so
+the rest of the page is unaffected either way.

--- a/packages/site-navigation-element/index.html
+++ b/packages/site-navigation-element/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>nc-site-navigation demo</title>
+    <style>
+      /* Deliberately hostile host styles — the shadow root must ignore them. */
+      body {
+        margin: 0;
+        font-family: 'Comic Sans MS', cursive;
+        background: #e8e4da;
+      }
+      a {
+        color: red !important;
+        text-decoration: underline wavy !important;
+      }
+      .controls {
+        padding: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+    </style>
+    <script type="module" src="/src/element.tsx"></script>
+  </head>
+  <body>
+    <nc-site-navigation
+      active-item="community"
+      theme="auto"
+    ></nc-site-navigation>
+    <div class="controls">
+      <button data-theme-value="light">Light</button>
+      <button data-theme-value="dark">Dark</button>
+      <button data-theme-value="auto">Auto</button>
+    </div>
+    <p style="padding: 1rem">
+      Host-page content. The header above is rendered by
+      <code>&lt;nc-site-navigation&gt;</code> inside a shadow root.
+    </p>
+    <script type="module">
+      const nav = document.querySelector('nc-site-navigation');
+      for (const button of document.querySelectorAll('[data-theme-value]')) {
+        button.addEventListener('click', () => {
+          nav.setAttribute('theme', button.dataset.themeValue);
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/packages/site-navigation-element/package.json
+++ b/packages/site-navigation-element/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@codaco/site-navigation-element",
+  "version": "0.0.0",
+  "description": "The canonical Network Canvas site header as a self-contained <nc-site-navigation> web component for non-React hosts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/complexdatacollective/network-canvas-monorepo.git",
+    "directory": "packages/site-navigation-element"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./dist/element.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
+    "dev": "node ../../scripts/with-turbo.mjs --watch-deps node scripts/build.mjs --dev",
+    "test": "node scripts/build.mjs --css-only && vitest run",
+    "test:watch": "node scripts/build.mjs --css-only && vitest",
+    "typecheck": "tsc --build --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "prepublishOnly": "pnpm build",
+    "clean": "rm -rf .turbo node_modules dist .generated public/fonts"
+  },
+  "devDependencies": {
+    "@base-ui/react": "catalog:",
+    "@codaco/fresco-ui": "workspace:*",
+    "@codaco/tailwind-config": "workspace:*",
+    "@codaco/tsconfig": "workspace:*",
+    "@fontsource-variable/inclusive-sans": "catalog:",
+    "@fontsource-variable/nunito": "catalog:",
+    "@tailwindcss/cli": "^4.3.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
+    "motion": "catalog:",
+    "playwright": "catalog:",
+    "postcss": "^8.5.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/site-navigation-element/package.json
+++ b/packages/site-navigation-element/package.json
@@ -13,7 +13,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./dist/element.js"
+    ".": {
+      "types": "./dist/element.d.ts",
+      "default": "./dist/element.js"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/site-navigation-element/scripts/build.mjs
+++ b/packages/site-navigation-element/scripts/build.mjs
@@ -1,0 +1,134 @@
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import postcss from 'postcss';
+
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const generated = join(pkgRoot, '.generated');
+const require = createRequire(import.meta.url);
+
+const mode = process.argv.includes('--css-only')
+  ? 'css-only'
+  : process.argv.includes('--dev')
+    ? 'dev'
+    : 'build';
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: pkgRoot, stdio: 'inherit' });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+// The Tailwind @source directives scan fresco-ui's dist; fail early with a
+// clear message instead of silently emitting a stylesheet with no utilities.
+const frescoDist = dirname(
+  require.resolve('@codaco/fresco-ui/navigation/SiteNavigation'),
+);
+if (!existsSync(join(frescoDist, 'SiteNavigation.js'))) {
+  console.error(
+    '@codaco/fresco-ui dist is missing. Build it first (turbo does this ' +
+      'automatically: `pnpm build`/`pnpm test` from the repo root, or ' +
+      '`pnpm --filter @codaco/fresco-ui build`).',
+  );
+  process.exit(1);
+}
+
+mkdirSync(generated, { recursive: true });
+
+// 1) Compile the Tailwind entry.
+run('pnpm', [
+  'exec',
+  'tailwindcss',
+  '-i',
+  'src/styles/shadow.css',
+  '-o',
+  join(generated, 'tailwind.css'),
+]);
+
+// 2) Split the compiled CSS for shadow-DOM use. `:root` and `@property`
+// don't apply inside shadow roots as-authored: token blocks must also match
+// `:host`, and `@property` registrations move to a document-level style tag.
+const compiled = postcss.parse(
+  readFileSync(join(generated, 'tailwind.css'), 'utf8'),
+);
+const documentProperties = [];
+compiled.walkAtRules('property', (atRule) => {
+  documentProperties.push(atRule.toString());
+  atRule.remove();
+});
+compiled.walkRules((rule) => {
+  if (rule.selector.includes(':root')) {
+    rule.selectors = rule.selectors.map((selector) =>
+      selector.replaceAll(':root', ':is(:root, :host)'),
+    );
+  }
+});
+writeFileSync(join(generated, 'shadow.css'), compiled.toString());
+writeFileSync(
+  join(generated, 'document-properties.css'),
+  documentProperties.join('\n\n'),
+);
+
+// 3) Derive @font-face CSS from the canonical tailwind-config font files
+// (single source of truth), keeping only normal-style faces (the nav sets
+// no italic text) and rewriting fontsource URLs to a runtime placeholder.
+const fontSources = [
+  require.resolve('@codaco/tailwind-config/fonts/nunito.css'),
+  require.resolve('@codaco/tailwind-config/fonts/inclusive-sans.css'),
+];
+const fontFiles = new Set();
+const fontFaces = [];
+for (const source of fontSources) {
+  postcss
+    .parse(readFileSync(source, 'utf8'))
+    .walkAtRules('font-face', (face) => {
+      let style = 'normal';
+      let file = null;
+      face.walkDecls('font-style', (decl) => {
+        style = decl.value;
+      });
+      face.walkDecls('src', (decl) => {
+        const match = decl.value.match(
+          /url\('@fontsource-variable\/[^/]+\/files\/([^']+)'\)/,
+        );
+        if (!match) return;
+        file = match[1];
+        decl.value = decl.value.replace(
+          /url\('[^']+'\)/,
+          `url('__NC_FONT_BASE__/${match[1]}')`,
+        );
+      });
+      if (style !== 'normal' || !file) return;
+      fontFiles.add(file);
+      fontFaces.push(face.toString());
+    });
+}
+writeFileSync(join(generated, 'document-fonts.css'), fontFaces.join('\n\n'));
+
+function copyFonts(targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  for (const file of fontFiles) {
+    const pkg = file.startsWith('nunito')
+      ? '@fontsource-variable/nunito'
+      : '@fontsource-variable/inclusive-sans';
+    cpSync(require.resolve(`${pkg}/files/${file}`), join(targetDir, file));
+  }
+}
+
+if (mode === 'css-only') process.exit(0);
+
+if (mode === 'dev') {
+  copyFonts(join(pkgRoot, 'public', 'fonts'));
+  run('pnpm', ['exec', 'vite', '--open']);
+} else {
+  run('pnpm', ['exec', 'vite', 'build']);
+  copyFonts(join(pkgRoot, 'dist', 'fonts'));
+}

--- a/packages/site-navigation-element/scripts/build.mjs
+++ b/packages/site-navigation-element/scripts/build.mjs
@@ -23,7 +23,17 @@ const mode = process.argv.includes('--css-only')
     : 'build';
 
 function run(command, args) {
-  const result = spawnSync(command, args, { cwd: pkgRoot, stdio: 'inherit' });
+  const result = spawnSync(command, args, {
+    cwd: pkgRoot,
+    stdio: 'inherit',
+    // pnpm resolves to a .cmd shim on Windows, which Node can't exec without
+    // a shell (mirrors scripts/with-turbo.mjs).
+    shell: process.platform === 'win32',
+  });
+  if (result.error) {
+    console.error(`Failed to spawn ${command}: ${result.error.message}`);
+    process.exit(1);
+  }
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
@@ -131,4 +141,9 @@ if (mode === 'dev') {
 } else {
   run('pnpm', ['exec', 'vite', 'build']);
   copyFonts(join(pkgRoot, 'dist', 'fonts'));
+  // The bundle is a side-effect module; its public types are hand-authored.
+  cpSync(
+    join(pkgRoot, 'src', 'public-types.d.ts'),
+    join(pkgRoot, 'dist', 'element.d.ts'),
+  );
 }

--- a/packages/site-navigation-element/src/__tests__/documentStyles.test.ts
+++ b/packages/site-navigation-element/src/__tests__/documentStyles.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureDocumentStyles } from '../documentStyles';
+
+describe('ensureDocumentStyles', () => {
+  beforeEach(() => {
+    document
+      .querySelectorAll('style[data-nc-site-navigation]')
+      .forEach((tag) => tag.remove());
+  });
+
+  it('appends a single document-level style tag, idempotently', () => {
+    ensureDocumentStyles();
+    ensureDocumentStyles();
+
+    const tags = document.querySelectorAll('style[data-nc-site-navigation]');
+    expect(tags).toHaveLength(1);
+  });
+
+  it('registers the fonts and property rules at document level', () => {
+    ensureDocumentStyles();
+
+    const css =
+      document.querySelector('style[data-nc-site-navigation]')?.textContent ??
+      '';
+    expect(css).toContain("font-family: 'Nunito Variable'");
+    expect(css).toContain("font-family: 'Inclusive Sans Variable'");
+    expect(css).toContain('@property');
+    expect(css).not.toContain('__NC_FONT_BASE__');
+    expect(css).toContain('/fonts/nunito-latin-wght-normal.woff2');
+  });
+});

--- a/packages/site-navigation-element/src/__tests__/element.test.tsx
+++ b/packages/site-navigation-element/src/__tests__/element.test.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import '../element';
+
+function mount(attributes: Record<string, string> = {}, width = 1280) {
+  const frame = document.createElement('div');
+  frame.style.width = `${width}px`;
+  const host = document.createElement('nc-site-navigation');
+  for (const [name, value] of Object.entries(attributes)) {
+    host.setAttribute(name, value);
+  }
+  frame.append(host);
+  document.body.append(frame);
+  return host;
+}
+
+function shadowLink(host: HTMLElement, href: string) {
+  return host.shadowRoot?.querySelector(`a[href="${href}"]`) ?? null;
+}
+
+function themeWrapper(host: HTMLElement) {
+  const wrapper = host.shadowRoot?.querySelector<HTMLElement>('.nc-root');
+  if (!wrapper) throw new Error('Expected the nc-root wrapper.');
+  return wrapper;
+}
+
+async function rendered(host: HTMLElement) {
+  await expect
+    .poll(() => host.shadowRoot?.querySelectorAll('a').length ?? 0)
+    .toBeGreaterThan(0);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('<nc-site-navigation>', () => {
+  it('registers and renders the canonical link set inside its shadow root', async () => {
+    const host = mount();
+    await rendered(host);
+
+    expect(customElements.get('nc-site-navigation')).toBeDefined();
+    expect(shadowLink(host, 'https://networkcanvas.com/')).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://community.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://documentation.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://protocolgallery.networkcanvas.com/'),
+    ).not.toBeNull();
+    expect(
+      shadowLink(host, 'https://networkcanvas.com/download'),
+    ).not.toBeNull();
+    // Nothing rendered into the light DOM.
+    expect(host.querySelector('a')).toBeNull();
+  });
+
+  it('marks the active item with aria-current', async () => {
+    const host = mount({ 'active-item': 'community' });
+    await rendered(host);
+
+    expect(
+      shadowLink(host, 'https://community.networkcanvas.com/')?.getAttribute(
+        'aria-current',
+      ),
+    ).toBe('page');
+  });
+
+  it('selects translated copy from the locale attribute', async () => {
+    const host = mount({ locale: 'es' });
+    await rendered(host);
+
+    expect(
+      host.shadowRoot?.querySelector('nav[aria-label="Navegación principal"]'),
+    ).not.toBeNull();
+  });
+
+  it('resolves explicit themes and re-renders on attribute change', async () => {
+    const host = mount({ theme: 'dark' });
+    await rendered(host);
+
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe('dark');
+    const darkBackground = getComputedStyle(themeWrapper(host)).backgroundColor;
+
+    host.setAttribute('theme', 'light');
+    await expect
+      .poll(() => themeWrapper(host).getAttribute('data-theme'))
+      .toBe('light');
+    expect(getComputedStyle(themeWrapper(host)).backgroundColor).not.toBe(
+      darkBackground,
+    );
+  });
+
+  it('follows prefers-color-scheme when theme is auto', async () => {
+    const host = mount();
+    await rendered(host);
+
+    const expected = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe(expected);
+  });
+
+  it('warns and falls back on invalid attribute values', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const host = mount({ 'theme': 'banana', 'active-item': 'nonsense' });
+    await rendered(host);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('banana'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('nonsense'));
+    const expected = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    expect(themeWrapper(host).getAttribute('data-theme')).toBe(expected);
+    warn.mockRestore();
+  });
+
+  it('injects the document-level styles exactly once across instances', async () => {
+    const first = mount();
+    const second = mount();
+    await rendered(first);
+    await rendered(second);
+
+    expect(
+      document.querySelectorAll('style[data-nc-site-navigation]'),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/site-navigation-element/src/__tests__/interactions.test.tsx
+++ b/packages/site-navigation-element/src/__tests__/interactions.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import '../element';
+
+function mount(width: number) {
+  const frame = document.createElement('div');
+  frame.style.width = `${width}px`;
+  const host = document.createElement('nc-site-navigation');
+  frame.append(host);
+  document.body.append(frame);
+  return host;
+}
+
+function shadowButton(host: HTMLElement, label: string) {
+  const buttons = host.shadowRoot?.querySelectorAll('button') ?? [];
+  for (const button of buttons) {
+    if (
+      button.textContent?.includes(label) ||
+      button.getAttribute('aria-label') === label
+    ) {
+      return button;
+    }
+  }
+  return null;
+}
+
+async function rendered(host: HTMLElement) {
+  await expect
+    .poll(() => host.shadowRoot?.querySelectorAll('a').length ?? 0)
+    .toBeGreaterThan(0);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('<nc-site-navigation> interactions', () => {
+  it('opens the Software menu with its popup inside the shadow root', async () => {
+    const host = mount(1280);
+    await rendered(host);
+
+    const trigger = shadowButton(host, 'Software');
+    expect(trigger).not.toBeNull();
+    trigger?.click();
+
+    await expect
+      .poll(() => host.shadowRoot?.querySelector('a[aria-label="Architect"]'))
+      .not.toBeNull();
+    const architect = host.shadowRoot?.querySelector(
+      'a[aria-label="Architect"]',
+    );
+    expect(architect?.getRootNode()).toBe(host.shadowRoot);
+  });
+
+  it('opens and closes the compact drawer, restoring trigger focus on Escape', async () => {
+    const host = mount(400);
+    await rendered(host);
+
+    const menuButton = shadowButton(host, 'Open site navigation');
+    expect(menuButton).not.toBeNull();
+    menuButton?.click();
+
+    await expect
+      .poll(() => menuButton?.getAttribute('aria-expanded'))
+      .toBe('true');
+
+    // The drawer is the second <nav>; the desktop menu's <nav> renders first
+    // (hidden below the container breakpoint but still in the DOM).
+    const navs = host.shadowRoot?.querySelectorAll('nav') ?? [];
+    const drawer = navs[1];
+    if (!drawer) throw new Error('Expected the compact drawer navigation.');
+    const firstLink = drawer.querySelector<HTMLElement>('a');
+    if (!firstLink) throw new Error('Expected a drawer link.');
+    firstLink.focus();
+    firstLink.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    await expect
+      .poll(() => menuButton?.getAttribute('aria-expanded'))
+      .toBe('false');
+    expect(host.shadowRoot?.activeElement).toBe(menuButton);
+  });
+});

--- a/packages/site-navigation-element/src/css-modules.d.ts
+++ b/packages/site-navigation-element/src/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?inline' {
+  const css: string;
+  export default css;
+}

--- a/packages/site-navigation-element/src/documentStyles.ts
+++ b/packages/site-navigation-element/src/documentStyles.ts
@@ -1,0 +1,27 @@
+import documentFontsCss from '../.generated/document-fonts.css?inline';
+import documentPropertiesCss from '../.generated/document-properties.css?inline';
+
+const MARKER_ATTRIBUTE = 'data-nc-site-navigation';
+
+/**
+ * `@font-face` and `@property` rules only take effect at document level, so
+ * they can't ship inside the element's shadow stylesheet. In production the
+ * woff2 files sit next to the bundle (dist/fonts/) and resolve via
+ * import.meta.url; the Vite dev server and vitest serve them from
+ * public/fonts instead, where import.meta.url would point into /src.
+ */
+const fontBase = import.meta.env.DEV
+  ? '/fonts'
+  : new URL('./fonts', import.meta.url).href;
+
+export function ensureDocumentStyles(): void {
+  if (document.head.querySelector(`style[${MARKER_ATTRIBUTE}]`)) return;
+
+  const style = document.createElement('style');
+  style.setAttribute(MARKER_ATTRIBUTE, '');
+  style.textContent = `${documentFontsCss.replaceAll(
+    '__NC_FONT_BASE__',
+    fontBase,
+  )}\n\n${documentPropertiesCss}`;
+  document.head.append(style);
+}

--- a/packages/site-navigation-element/src/element.tsx
+++ b/packages/site-navigation-element/src/element.tsx
@@ -1,0 +1,126 @@
+import { StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import SiteNavigation, {
+  type SiteNavigationItemId,
+  type SiteNavigationLocale,
+} from '@codaco/fresco-ui/navigation/SiteNavigation';
+import { PortalContainerProvider } from '@codaco/fresco-ui/PortalContainer';
+
+import { ensureDocumentStyles } from './documentStyles';
+
+import shadowCss from '../.generated/shadow.css?inline';
+
+const TAG_NAME = 'nc-site-navigation';
+
+const ACTIVE_ITEMS: readonly SiteNavigationItemId[] = [
+  'home',
+  'community',
+  'documentation',
+  'protocolGallery',
+  'resources',
+  'software',
+  'getStarted',
+];
+const LOCALES: readonly SiteNavigationLocale[] = ['en-US', 'en-GB', 'es'];
+const THEMES = ['light', 'dark', 'auto'] as const;
+type Theme = (typeof THEMES)[number];
+
+// Preflight's html/body rules can't reach into the shadow tree, so the
+// wrapper re-establishes the base typography itself.
+const HOST_CSS = `
+:host { display: block; }
+.nc-root { font-family: var(--body-font); }
+`;
+
+let sharedSheet: CSSStyleSheet | null = null;
+function shadowStyles(): CSSStyleSheet {
+  if (!sharedSheet) {
+    sharedSheet = new CSSStyleSheet();
+    sharedSheet.replaceSync(`${shadowCss}\n${HOST_CSS}`);
+  }
+  return sharedSheet;
+}
+
+function parseAttribute<T extends string>(
+  host: HTMLElement,
+  name: string,
+  allowed: readonly T[],
+  fallback: T | undefined,
+): T | undefined {
+  const value = host.getAttribute(name);
+  if (value === null) return fallback;
+  const match = allowed.find((candidate) => candidate === value);
+  if (match !== undefined) return match;
+  console.warn(
+    `<${TAG_NAME}>: ignoring invalid ${name}="${value}" (expected one of: ${allowed.join(', ')})`,
+  );
+  return fallback;
+}
+
+class NcSiteNavigation extends HTMLElement {
+  static observedAttributes = ['active-item', 'locale', 'theme'];
+
+  #reactRoot: Root | null = null;
+  #colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+  #handleSchemeChange = () => {
+    if (parseAttribute(this, 'theme', THEMES, 'auto') === 'auto') {
+      this.#render();
+    }
+  };
+
+  connectedCallback() {
+    ensureDocumentStyles();
+    const shadow = this.shadowRoot ?? this.attachShadow({ mode: 'open' });
+    shadow.adoptedStyleSheets = [shadowStyles()];
+    this.#reactRoot ??= createRoot(shadow);
+    this.#colorScheme.addEventListener('change', this.#handleSchemeChange);
+    this.#render();
+  }
+
+  disconnectedCallback() {
+    this.#colorScheme.removeEventListener('change', this.#handleSchemeChange);
+    this.#reactRoot?.unmount();
+    this.#reactRoot = null;
+  }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.#render();
+  }
+
+  #render() {
+    if (!this.#reactRoot) return;
+    const activeItemId = parseAttribute(
+      this,
+      'active-item',
+      ACTIVE_ITEMS,
+      undefined,
+    );
+    const locale = parseAttribute(this, 'locale', LOCALES, 'en-US') ?? 'en-US';
+    const theme: Theme =
+      parseAttribute(this, 'theme', THEMES, 'auto') ?? 'auto';
+    const resolvedTheme =
+      theme === 'auto' ? (this.#colorScheme.matches ? 'dark' : 'light') : theme;
+
+    this.#reactRoot.render(
+      <StrictMode>
+        <div
+          className="nc-root bg-background text-text"
+          data-theme={resolvedTheme}
+        >
+          <PortalContainerProvider>
+            <SiteNavigation
+              activeItemId={activeItemId}
+              locale={locale}
+              site="external"
+            />
+          </PortalContainerProvider>
+        </div>
+      </StrictMode>,
+    );
+  }
+}
+
+if (!customElements.get(TAG_NAME)) {
+  customElements.define(TAG_NAME, NcSiteNavigation);
+}

--- a/packages/site-navigation-element/src/public-types.d.ts
+++ b/packages/site-navigation-element/src/public-types.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Public type surface for the published bundle. `dist/element.js` is a
+ * side-effect module (importing it registers the custom element), so the
+ * only thing a TypeScript consumer needs is the tag-name registration.
+ * Copied to `dist/element.d.ts` by scripts/build.mjs.
+ */
+declare global {
+  interface HTMLElementTagNameMap {
+    'nc-site-navigation': HTMLElement;
+  }
+}

--- a/packages/site-navigation-element/src/public-types.d.ts
+++ b/packages/site-navigation-element/src/public-types.d.ts
@@ -9,3 +9,8 @@ declare global {
     'nc-site-navigation': HTMLElement;
   }
 }
+
+// Load-bearing, not useless: without an export this file is a script, and
+// `declare global` is illegal outside a module (TS2669 for every consumer).
+// oxlint-disable-next-line unicorn/require-module-specifiers
+export {};

--- a/packages/site-navigation-element/src/styles/shadow.css
+++ b/packages/site-navigation-element/src/styles/shadow.css
@@ -4,15 +4,22 @@
  * `:root` is rewritten to `:is(:root, :host)` and `@property` rules are
  * hoisted to a document-level stylesheet (neither applies inside a shadow
  * root as-authored).
+ *
+ * `source(none)` disables Tailwind v4's automatic content detection, which
+ * otherwise roots at the monorepo `.git` and scans the *entire* workspace —
+ * baking in every utility class used by any package (interview, architect,
+ * other fresco-ui components), not just the ones this nav renders. The
+ * `@source` globs below scope detection back down to the nav's actual render
+ * closure. They use directory/brace globs rather than single-file paths:
+ * multiple explicit single-file `@source` directives into the
+ * symlinked+gitignored `node_modules/@codaco/fresco-ui/dist/*.js` scan
+ * unreliably and order-dependently under Tailwind v4, while glob forms scan
+ * reliably.
  */
-@import '@codaco/tailwind-config/fresco.css';
+@import '@codaco/tailwind-config/fresco.css' source(none);
 
-@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.messages.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/Button.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/Spinner.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/PortalContainer.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/typography/Heading.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/typography/Paragraph.js';
-@source '../../node_modules/@codaco/fresco-ui/dist/utils/cva.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/{Button,Spinner,PortalContainer}.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/navigation/*.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/typography/*.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/styles/controlVariants.js';
 @source '../*.tsx';

--- a/packages/site-navigation-element/src/styles/shadow.css
+++ b/packages/site-navigation-element/src/styles/shadow.css
@@ -15,6 +15,11 @@
  * symlinked+gitignored `node_modules/@codaco/fresco-ui/dist/*.js` scan
  * unreliably and order-dependently under Tailwind v4, while glob forms scan
  * reliably.
+ *
+ * Whenever SiteNavigation (or its fresco-ui imports) gains a new
+ * component/module, or starts using another class-bearing file, the
+ * `@source` list below must be extended to match — a missed file fails
+ * SILENTLY (its classes simply don't render, with no build error).
  */
 @import '@codaco/tailwind-config/fresco.css' source(none);
 

--- a/packages/site-navigation-element/src/styles/shadow.css
+++ b/packages/site-navigation-element/src/styles/shadow.css
@@ -1,0 +1,18 @@
+/*
+ * Tailwind entry for the <nc-site-navigation> shadow stylesheet.
+ * Compiled by scripts/build.mjs via @tailwindcss/cli, then post-processed:
+ * `:root` is rewritten to `:is(:root, :host)` and `@property` rules are
+ * hoisted to a document-level stylesheet (neither applies inside a shadow
+ * root as-authored).
+ */
+@import '@codaco/tailwind-config/fresco.css';
+
+@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/navigation/SiteNavigation.messages.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/Button.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/Spinner.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/PortalContainer.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/typography/Heading.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/typography/Paragraph.js';
+@source '../../node_modules/@codaco/fresco-ui/dist/utils/cva.js';
+@source '../*.tsx';

--- a/packages/site-navigation-element/tsconfig.json
+++ b/packages/site-navigation-element/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@codaco/tsconfig/web.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "src/__tests__"]
+}

--- a/packages/site-navigation-element/tsconfig.node.json
+++ b/packages/site-navigation-element/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@codaco/tsconfig/dev.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/__tests__/**/*.ts",
+    "src/__tests__/**/*.tsx",
+    "src/*.d.ts"
+  ]
+}

--- a/packages/site-navigation-element/vite.config.ts
+++ b/packages/site-navigation-element/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+});

--- a/packages/site-navigation-element/vite.config.ts
+++ b/packages/site-navigation-element/vite.config.ts
@@ -1,7 +1,23 @@
+import { resolve } from 'node:path';
+
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   oxc: {
     jsx: { runtime: 'automatic' },
   },
-});
+  define:
+    command === 'build'
+      ? { 'process.env.NODE_ENV': JSON.stringify('production') }
+      : undefined,
+  build: {
+    lib: {
+      entry: resolve(import.meta.dirname, 'src/element.tsx'),
+      formats: ['es'],
+      fileName: () => 'element.js',
+    },
+    minify: true,
+    sourcemap: true,
+    emptyOutDir: true,
+  },
+}));

--- a/packages/site-navigation-element/vite.config.ts
+++ b/packages/site-navigation-element/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ command }) => ({
       formats: ['es'],
       fileName: () => 'element.js',
     },
+    target: 'esnext',
     minify: true,
     sourcemap: true,
     emptyOutDir: true,

--- a/packages/site-navigation-element/vitest.config.ts
+++ b/packages/site-navigation-element/vitest.config.ts
@@ -1,0 +1,19 @@
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  oxc: {
+    jsx: { runtime: 'automatic' },
+  },
+  test: {
+    name: 'browser',
+    include: ['src/__tests__/**/*.test.{ts,tsx}'],
+    testTimeout: 20_000,
+    browser: {
+      provider: playwright(),
+      enabled: true,
+      instances: [{ browser: 'chromium' }],
+      headless: true,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,6 @@ catalogs:
     '@testing-library/react':
       specifier: ^16.3.2
       version: 16.3.2
-    '@types/react':
-      specifier: ^19.2.17
-      version: 19.2.17
-    '@types/react-dom':
-      specifier: ^19.2.3
-      version: 19.2.3
     '@vitejs/plugin-react':
       specifier: ^6.0.3
       version: 6.0.3
@@ -231,6 +225,8 @@ overrides:
   cheerio: 1.0.0-rc.12
   immer: ^11.1.8
   '@types/node': ^24.13.3
+  '@types/react': ^19.2.17
+  '@types/react-dom': ^19.2.3
   '@microsoft/api-extractor>typescript': npm:@typescript/typescript6@^6.0.2
   slate>immer: ^5.3.0
   slate-history>immer: ^5.3.0
@@ -418,10 +414,10 @@ importers:
         specifier: ^3.7.1
         version: 3.7.1
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@types/recompose':
         specifier: ^0.30.15
@@ -510,7 +506,7 @@ importers:
         version: 5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@material-ui/icons':
         specifier: ^4.11.3
-        version: 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -765,10 +761,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@types/unist':
         specifier: ^3.0.3
@@ -952,10 +948,10 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vite-pwa/assets-generator':
         specifier: ^1.0.2
@@ -1095,13 +1091,13 @@ importers:
         version: 0.0.2
       '@codaco/ui':
         specifier: ~5.8.6
-        version: 5.8.6(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@faker-js/faker':
         specifier: ~6.0.0
         version: 6.0.0
       '@material-ui/icons':
         specifier: ^4.11.3
-        version: 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1332,10 +1328,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
@@ -1399,10 +1395,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
@@ -1585,10 +1581,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
@@ -1643,7 +1639,7 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       jsdom:
         specifier: 'catalog:'
@@ -1803,10 +1799,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@types/redux-logger':
         specifier: ^3.0.13
@@ -2085,10 +2081,10 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       '@types/react':
-        specifier: 'catalog:'
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
@@ -2851,7 +2847,7 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
-      '@types/react': ^17 || ^18 || ^19
+      '@types/react': ^19.2.17
       date-fns: ^4.0.0
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
@@ -2866,7 +2862,7 @@ packages:
   '@base-ui/utils@0.2.9':
     resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
-      '@types/react': ^17 || ^18 || ^19
+      '@types/react': ^19.2.17
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
@@ -3355,7 +3351,7 @@ packages:
   '@docsearch/core@4.6.3':
     resolution: {integrity: sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 20.0.0'
+      '@types/react': ^19.2.17
       react: '>= 16.8.0 < 20.0.0'
       react-dom: '>= 16.8.0 < 20.0.0'
     peerDependenciesMeta:
@@ -3372,7 +3368,7 @@ packages:
   '@docsearch/react@4.6.3':
     resolution: {integrity: sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 20.0.0'
+      '@types/react': ^19.2.17
       react: '>= 16.8.0 < 20.0.0'
       react-dom: '>= 16.8.0 < 20.0.0'
       search-insights: '>= 1 < 3'
@@ -4440,7 +4436,7 @@ packages:
     engines: {node: '>=8.0.0'}
     deprecated: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
     peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
+      '@types/react': ^19.2.17
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
@@ -4452,7 +4448,7 @@ packages:
     engines: {node: '>=8.0.0'}
     peerDependencies:
       '@material-ui/core': ^4.0.0
-      '@types/react': ^16.8.6 || ^17.0.0
+      '@types/react': ^19.2.17
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
@@ -4464,7 +4460,7 @@ packages:
     engines: {node: '>=8.0.0'}
     deprecated: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
     peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
+      '@types/react': ^19.2.17
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
@@ -4475,7 +4471,7 @@ packages:
     resolution: {integrity: sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
-      '@types/react': ^16.8.6 || ^17.0.0
+      '@types/react': ^19.2.17
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
@@ -4485,7 +4481,7 @@ packages:
   '@material-ui/types@5.1.0':
     resolution: {integrity: sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4500,7 +4496,7 @@ packages:
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
-      '@types/react': '>=16'
+      '@types/react': ^19.2.17
       react: '>=16'
 
   '@microflash/rehype-figure@2.1.4':
@@ -5564,7 +5560,7 @@ packages:
   '@posthog/react@1.9.1':
     resolution: {integrity: sha512-tIGjs8WzKPrHQmSyM/2a3GoedQkttkxgmCsdn0kgy+6mIiSNk36FAFGKbWFJ7/Kln5bHwcM/MQhiGYbwQG8bQQ==}
     peerDependencies:
-      '@types/react': '>=16.8.0'
+      '@types/react': ^19.2.17
       posthog-js: '>=1.257.2'
       react: '>=16.8.0'
     peerDependenciesMeta:
@@ -5622,8 +5618,8 @@ packages:
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5635,7 +5631,7 @@ packages:
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5644,7 +5640,7 @@ packages:
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5653,7 +5649,7 @@ packages:
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5662,8 +5658,8 @@ packages:
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5675,8 +5671,8 @@ packages:
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -5688,7 +5684,7 @@ packages:
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5697,7 +5693,7 @@ packages:
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5706,7 +5702,7 @@ packages:
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5715,7 +5711,7 @@ packages:
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -5724,7 +5720,7 @@ packages:
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -6089,7 +6085,7 @@ packages:
   '@storybook/addon-docs@10.5.0':
     resolution: {integrity: sha512-kbZGdX+mysiY4xezhpcFEwzQ1zSXcMhSS3u09Qt8+w5XetCAMMSv/yAxzpi6z+YoH+EdQ53e1q3MFtPUkzkfUA==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
       storybook: ^10.5.0
     peerDependenciesMeta:
       '@types/react':
@@ -6152,8 +6148,8 @@ packages:
   '@storybook/react-dom-shim@10.5.0':
     resolution: {integrity: sha512-GwGA6zDj4Cfw6vGsdfPKfF39L0W6solNbbnjdjGa57m2ooASkidLhrXo2wgC9wh3o/jcfonmYPDRGY6sEhGDtg==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.5.0
@@ -6178,8 +6174,8 @@ packages:
   '@storybook/react@10.5.0':
     resolution: {integrity: sha512-2IhddiREy7NqAqnFsEOfW6HBG7azIcLxhRQYploSsaemOncR29xhzvAZsG+xlWgrtvxv4h3fYQTTR4TNn8CgPQ==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.5.0
@@ -6465,8 +6461,8 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -6639,8 +6635,8 @@ packages:
     peerDependencies:
       '@tiptap/core': 3.27.3
       '@tiptap/pm': 3.27.3
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
+      '@types/react-dom': ^19.2.3
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -6780,7 +6776,7 @@ packages:
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.17
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -6833,7 +6829,7 @@ packages:
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': ^19.2.17
 
   '@types/react-redux@7.1.34':
     resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
@@ -6841,10 +6837,7 @@ packages:
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
-      '@types/react': '*'
-
-  '@types/react@17.0.93':
-    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+      '@types/react': ^19.2.17
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -6866,9 +6859,6 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/slice-ansi@4.0.0':
     resolution: {integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==}
@@ -12139,13 +12129,13 @@ packages:
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
-      '@types/react': '>=18'
+      '@types/react': ^19.2.17
       react: '>=18'
 
   react-markdown@6.0.3:
     resolution: {integrity: sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==}
     peerDependencies:
-      '@types/react': '>=16'
+      '@types/react': ^19.2.17
       react: '>=16'
 
   react-merge-refs@1.1.0:
@@ -12171,7 +12161,7 @@ packages:
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
     peerDependencies:
-      '@types/react': ^18.2.25 || ^19
+      '@types/react': ^19.2.17
       react: ^18.0 || ^19
       redux: ^5.0.0
     peerDependenciesMeta:
@@ -13051,7 +13041,7 @@ packages:
     resolution: {integrity: sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig==}
     hasBin: true
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.17
       prettier: ^2 || ^3
       vite-plus: ^0.1.15 || ^0.2.0
     peerDependenciesMeta:
@@ -14407,7 +14397,7 @@ packages:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@types/react': '>=18.0.0'
+      '@types/react': ^19.2.17
       immer: ^11.1.8
       react: '>=18.0.0'
       use-sync-external-store: '>=1.2.0'
@@ -15632,46 +15622,10 @@ snapshots:
 
   '@codaco/shared-consts@0.0.2': {}
 
-  '@codaco/ui@5.8.6(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
-    dependencies:
-      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@productboard/slate-edit-list': 0.21.5(slate-react@0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3))(slate@0.57.3)
-      '@storybook/theming': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      animejs: 2.2.0
-      classnames: 2.5.1
-      emoji-dictionary: 1.0.12
-      framer-motion: 2.9.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      lodash: 4.18.1
-      luxon: 1.28.1
-      prop-types: 15.8.1
-      react: 16.14.0
-      react-compound-slider: 2.5.0(react@16.14.0)
-      react-dom: 16.14.0(react@16.14.0)
-      react-markdown: 6.0.3(@types/react@17.0.93)(react@16.14.0)
-      react-resize-aware: 3.1.3(react@16.14.0)
-      react-transition-group: 4.4.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      recompose: 0.30.0(react@16.14.0)
-      rehype-raw: 5.1.0
-      rehype-sanitize: 4.0.0
-      remark: 13.0.0
-      remark-parse: 9.0.0
-      remark-slate: 1.8.6
-      scrollparent: 2.1.0
-      slate: 0.57.3
-      slate-history: 0.59.0(slate@0.57.3)
-      slate-react: 0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3)
-      strip-markdown: 4.2.0
-      unified: 9.2.2
-      uuid: 3.4.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-
   '@codaco/ui@5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
-      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/core': 4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@productboard/slate-edit-list': 0.21.5(slate-react@0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3))(slate@0.57.3)
       '@storybook/theming': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       animejs: 2.2.0
@@ -16888,14 +16842,14 @@ snapshots:
 
   '@mapbox/sphericalmercator@1.2.0': {}
 
-  '@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@material-ui/styles': 4.11.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/system': 4.12.2(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/types': 5.1.0(@types/react@17.0.93)
+      '@material-ui/styles': 4.11.5(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/system': 4.12.2(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/types': 5.1.0(@types/react@19.2.17)
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@types/react-transition-group': 4.4.12(@types/react@17.0.93)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
       clsx: 1.2.1
       hoist-non-react-statics: 3.3.2
       popper.js: 1.16.1-lts
@@ -16905,22 +16859,22 @@ snapshots:
       react-is: 17.0.2
       react-transition-group: 4.4.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
     optionalDependencies:
-      '@types/react': 17.0.93
+      '@types/react': 19.2.17
 
-  '@material-ui/icons@4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/icons@4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/core': 4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 17.0.93
+      '@types/react': 19.2.17
 
-  '@material-ui/styles@4.11.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/styles@4.11.5(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.8.0
-      '@material-ui/types': 5.1.0(@types/react@17.0.93)
+      '@material-ui/types': 5.1.0(@types/react@19.2.17)
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       clsx: 1.2.1
       csstype: 2.6.21
@@ -16937,9 +16891,9 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 17.0.93
+      '@types/react': 19.2.17
 
-  '@material-ui/system@4.12.2(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/system@4.12.2(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -16948,11 +16902,11 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 17.0.93
+      '@types/react': 19.2.17
 
-  '@material-ui/types@5.1.0(@types/react@17.0.93)':
+  '@material-ui/types@5.1.0(@types/react@19.2.17)':
     optionalDependencies:
-      '@types/react': 17.0.93
+      '@types/react': 19.2.17
 
   '@material-ui/utils@4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
@@ -18822,15 +18776,9 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
-  '@types/react-transition-group@4.4.12(@types/react@17.0.93)':
+  '@types/react-transition-group@4.4.12(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 17.0.93
-
-  '@types/react@17.0.93':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      '@types/scheduler': 0.16.8
-      csstype: 3.2.3
+      '@types/react': 19.2.17
 
   '@types/react@19.2.17':
     dependencies:
@@ -18857,8 +18805,6 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.13.3
-
-  '@types/scheduler@0.16.8': {}
 
   '@types/slice-ansi@4.0.0': {}
 
@@ -25204,26 +25150,6 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  react-markdown@6.0.3(@types/react@17.0.93)(react@16.14.0):
-    dependencies:
-      '@types/hast': 2.3.10
-      '@types/react': 17.0.93
-      '@types/unist': 2.0.11
-      comma-separated-tokens: 1.0.8
-      prop-types: 15.8.1
-      property-information: 5.6.0
-      react: 16.14.0
-      react-is: 17.0.2
-      remark-parse: 9.0.0
-      remark-rehype: 8.1.0
-      space-separated-tokens: 1.1.5
-      style-to-object: 0.3.0
-      unified: 9.2.2
-      unist-util-visit: 2.0.3
-      vfile: 4.2.1
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,7 +510,7 @@ importers:
         version: 5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@material-ui/icons':
         specifier: ^4.11.3
-        version: 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1095,13 +1095,13 @@ importers:
         version: 0.0.2
       '@codaco/ui':
         specifier: ~5.8.6
-        version: 5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 5.8.6(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@faker-js/faker':
         specifier: ~6.0.0
         version: 6.0.0
       '@material-ui/icons':
         specifier: ^4.11.3
-        version: 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        version: 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -2054,6 +2054,69 @@ importers:
       vite-plugin-dts:
         specifier: 'catalog:'
         version: 5.0.3(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(@typescript/typescript6@6.0.2)(esbuild@0.28.0)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.0))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+
+  packages/site-navigation-element:
+    devDependencies:
+      '@base-ui/react':
+        specifier: 'catalog:'
+        version: 1.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@codaco/fresco-ui':
+        specifier: workspace:*
+        version: link:../fresco-ui
+      '@codaco/tailwind-config':
+        specifier: workspace:*
+        version: link:../../tooling/tailwind
+      '@codaco/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      '@fontsource-variable/inclusive-sans':
+        specifier: 'catalog:'
+        version: 5.2.8
+      '@fontsource-variable/nunito':
+        specifier: 'catalog:'
+        version: 5.2.7
+      '@tailwindcss/cli':
+        specifier: ^4.3.2
+        version: 4.3.2
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.10(playwright@1.61.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
+      motion:
+        specifier: 'catalog:'
+        version: 12.40.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      playwright:
+        specifier: 'catalog:'
+        version: 1.61.1
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.17
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.2
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -5281,16 +5344,34 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@parcel/watcher-android-arm64@2.5.1':
+    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
+  '@parcel/watcher-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@parcel/watcher-darwin-arm64@2.5.6':
     resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   '@parcel/watcher-darwin-x64@2.5.6':
@@ -5299,11 +5380,24 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@parcel/watcher-freebsd-x64@2.5.1':
+    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@parcel/watcher-freebsd-x64@2.5.6':
     resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-glibc@2.5.6':
     resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
@@ -5312,12 +5406,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@parcel/watcher-linux-arm-musl@2.5.1':
+    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
@@ -5326,12 +5434,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
@@ -5340,6 +5462,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@parcel/watcher-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
@@ -5347,10 +5476,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@parcel/watcher-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.1':
+    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
     os: [win32]
 
   '@parcel/watcher-win32-ia32@2.5.6':
@@ -5359,11 +5500,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@parcel/watcher-win32-x64@2.5.1':
+    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@parcel/watcher-win32-x64@2.5.6':
     resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
+
+  '@parcel/watcher@2.5.1':
+    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+    engines: {node: '>= 10.0.0'}
 
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
@@ -6184,6 +6335,10 @@ packages:
       zod:
         optional: true
 
+  '@tailwindcss/cli@4.3.2':
+    resolution: {integrity: sha512-Fzt+HrIZHDlkRYKdLMBeufaroaPvwCBG70sMLdmurdeadNMO/LxbmT8Sbb+P83ep0iAlAImettb7Y+rO+37rXw==}
+    hasBin: true
+
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
@@ -6688,6 +6843,9 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
+  '@types/react@17.0.93':
+    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
+
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
@@ -6708,6 +6866,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/slice-ansi@4.0.0':
     resolution: {integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==}
@@ -8379,6 +8540,11 @@ packages:
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -15466,10 +15632,46 @@ snapshots:
 
   '@codaco/shared-consts@0.0.2': {}
 
+  '@codaco/ui@5.8.6(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+    dependencies:
+      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@productboard/slate-edit-list': 0.21.5(slate-react@0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3))(slate@0.57.3)
+      '@storybook/theming': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      animejs: 2.2.0
+      classnames: 2.5.1
+      emoji-dictionary: 1.0.12
+      framer-motion: 2.9.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      lodash: 4.18.1
+      luxon: 1.28.1
+      prop-types: 15.8.1
+      react: 16.14.0
+      react-compound-slider: 2.5.0(react@16.14.0)
+      react-dom: 16.14.0(react@16.14.0)
+      react-markdown: 6.0.3(@types/react@17.0.93)(react@16.14.0)
+      react-resize-aware: 3.1.3(react@16.14.0)
+      react-transition-group: 4.4.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      recompose: 0.30.0(react@16.14.0)
+      rehype-raw: 5.1.0
+      rehype-sanitize: 4.0.0
+      remark: 13.0.0
+      remark-parse: 9.0.0
+      remark-slate: 1.8.6
+      scrollparent: 2.1.0
+      slate: 0.57.3
+      slate-history: 0.59.0(slate@0.57.3)
+      slate-react: 0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3)
+      strip-markdown: 4.2.0
+      unified: 9.2.2
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   '@codaco/ui@5.8.6(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
-      '@material-ui/core': 4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@productboard/slate-edit-list': 0.21.5(slate-react@0.57.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(slate@0.57.3))(slate@0.57.3)
       '@storybook/theming': 6.5.16(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       animejs: 2.2.0
@@ -16686,14 +16888,14 @@ snapshots:
 
   '@mapbox/sphericalmercator@1.2.0': {}
 
-  '@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@material-ui/styles': 4.11.5(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/system': 4.12.2(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@material-ui/types': 5.1.0(@types/react@19.2.17)
+      '@material-ui/styles': 4.11.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/system': 4.12.2(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/types': 5.1.0(@types/react@17.0.93)
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      '@types/react-transition-group': 4.4.12(@types/react@17.0.93)
       clsx: 1.2.1
       hoist-non-react-statics: 3.3.2
       popper.js: 1.16.1-lts
@@ -16703,22 +16905,22 @@ snapshots:
       react-is: 17.0.2
       react-transition-group: 4.4.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
 
-  '@material-ui/icons@4.11.3(@material-ui/core@4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/icons@4.11.3(@material-ui/core@4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@material-ui/core': 4.12.4(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@material-ui/core': 4.12.4(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
 
-  '@material-ui/styles@4.11.5(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/styles@4.11.5(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/hash': 0.8.0
-      '@material-ui/types': 5.1.0(@types/react@19.2.17)
+      '@material-ui/types': 5.1.0(@types/react@17.0.93)
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       clsx: 1.2.1
       csstype: 2.6.21
@@ -16735,9 +16937,9 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
 
-  '@material-ui/system@4.12.2(@types/react@19.2.17)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+  '@material-ui/system@4.12.2(@types/react@17.0.93)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@material-ui/utils': 4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -16746,11 +16948,11 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
 
-  '@material-ui/types@5.1.0(@types/react@19.2.17)':
+  '@material-ui/types@5.1.0(@types/react@17.0.93)':
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
 
   '@material-ui/utils@4.11.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
     dependencies:
@@ -17305,44 +17507,104 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.73.0':
     optional: true
 
+  '@parcel/watcher-android-arm64@2.5.1':
+    optional: true
+
   '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.1':
     optional: true
 
   '@parcel/watcher-darwin-arm64@2.5.6':
     optional: true
 
+  '@parcel/watcher-darwin-x64@2.5.1':
+    optional: true
+
   '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.1':
     optional: true
 
   '@parcel/watcher-freebsd-x64@2.5.6':
     optional: true
 
+  '@parcel/watcher-linux-arm-glibc@2.5.1':
+    optional: true
+
   '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.1':
     optional: true
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     optional: true
 
+  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+    optional: true
+
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.1':
     optional: true
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     optional: true
 
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    optional: true
+
   '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.1':
     optional: true
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     optional: true
 
+  '@parcel/watcher-win32-arm64@2.5.1':
+    optional: true
+
   '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.1':
     optional: true
 
   '@parcel/watcher-win32-ia32@2.5.6':
     optional: true
 
+  '@parcel/watcher-win32-x64@2.5.1':
+    optional: true
+
   '@parcel/watcher-win32-x64@2.5.6':
     optional: true
+
+  '@parcel/watcher@2.5.1':
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.8
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.1
+      '@parcel/watcher-darwin-arm64': 2.5.1
+      '@parcel/watcher-darwin-x64': 2.5.1
+      '@parcel/watcher-freebsd-x64': 2.5.1
+      '@parcel/watcher-linux-arm-glibc': 2.5.1
+      '@parcel/watcher-linux-arm-musl': 2.5.1
+      '@parcel/watcher-linux-arm64-glibc': 2.5.1
+      '@parcel/watcher-linux-arm64-musl': 2.5.1
+      '@parcel/watcher-linux-x64-glibc': 2.5.1
+      '@parcel/watcher-linux-x64-musl': 2.5.1
+      '@parcel/watcher-win32-arm64': 2.5.1
+      '@parcel/watcher-win32-ia32': 2.5.1
+      '@parcel/watcher-win32-x64': 2.5.1
 
   '@parcel/watcher@2.5.6':
     dependencies:
@@ -18017,6 +18279,16 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
       zod: 4.4.3
 
+  '@tailwindcss/cli@4.3.2':
+    dependencies:
+      '@parcel/watcher': 2.5.1
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      enhanced-resolve: 5.21.6
+      mri: 1.2.0
+      picocolors: 1.1.1
+      tailwindcss: 4.3.2
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -18550,9 +18822,15 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       redux: 4.2.1
 
-  '@types/react-transition-group@4.4.12(@types/react@19.2.17)':
+  '@types/react-transition-group@4.4.12(@types/react@17.0.93)':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 17.0.93
+
+  '@types/react@17.0.93':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
 
   '@types/react@19.2.17':
     dependencies:
@@ -18579,6 +18857,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.13.3
+
+  '@types/scheduler@0.16.8': {}
 
   '@types/slice-ansi@4.0.0': {}
 
@@ -20367,6 +20647,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -24922,6 +25204,26 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react-markdown@6.0.3(@types/react@17.0.93)(react@16.14.0):
+    dependencies:
+      '@types/hast': 2.3.10
+      '@types/react': 17.0.93
+      '@types/unist': 2.0.11
+      comma-separated-tokens: 1.0.8
+      prop-types: 15.8.1
+      property-information: 5.6.0
+      react: 16.14.0
+      react-is: 17.0.2
+      remark-parse: 9.0.0
+      remark-rehype: 8.1.0
+      space-separated-tokens: 1.1.5
+      style-to-object: 0.3.0
+      unified: 9.2.2
+      unist-util-visit: 2.0.3
+      vfile: 4.2.1
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -106,6 +106,12 @@ overrides:
   cheerio: 1.0.0-rc.12
   immer: ^11.1.8
   '@types/node': 'catalog:'
+  # A single workspace-wide @types/react instance: without this, the classic
+  # apps' @material-ui auto-installed peers pull in a second @types/react@17,
+  # and fresco-ui's declaration emit (vite-plugin-dts) can bind inferred types
+  # to the wrong instance (TS2883) depending on hoisting (broke Netlify).
+  '@types/react': 'catalog:'
+  '@types/react-dom': 'catalog:'
   '@microsoft/api-extractor>typescript': npm:@typescript/typescript6@^6.0.2
   'slate>immer': '^5.3.0'
   'slate-history>immer': '^5.3.0'

--- a/turbo.json
+++ b/turbo.json
@@ -186,6 +186,30 @@
       ],
       "outputs": ["out/**", "dist/**"]
     },
+    "@codaco/site-navigation-element#build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "scripts/**",
+        "tsconfig*.json",
+        "vite.config.*",
+        "package.json"
+      ],
+      "env": ["NODE_ENV"],
+      "outputs": ["dist/**", ".generated/**"]
+    },
+    "@codaco/site-navigation-element#test": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "scripts/**",
+        "vitest.config.*",
+        "vite.config.*",
+        "tsconfig*.json",
+        "package.json"
+      ],
+      "outputs": []
+    },
     "build-storybook": {
       "dependsOn": ["^build"],
       "inputs": [

--- a/turbo.json
+++ b/turbo.json
@@ -193,7 +193,8 @@
         "scripts/**",
         "tsconfig*.json",
         "vite.config.*",
-        "package.json"
+        "package.json",
+        "$TURBO_ROOT$/tooling/tailwind/**"
       ],
       "env": ["NODE_ENV"],
       "outputs": ["dist/**", ".generated/**"]
@@ -206,7 +207,8 @@
         "vitest.config.*",
         "vite.config.*",
         "tsconfig*.json",
-        "package.json"
+        "package.json",
+        "$TURBO_ROOT$/tooling/tailwind/**"
       ],
       "outputs": []
     },


### PR DESCRIPTION
## Summary

Packages the canonical `SiteNavigation` header as a self-contained `<nc-site-navigation>` custom element (new published package `@codaco/site-navigation-element`) so non-React hosts — first target: the self-hosted Discourse forum at community.networkcanvas.com — can carry a 1:1 site header from a single CDN script tag.

Design spec: `docs/superpowers/specs/2026-07-15-site-navigation-element-design.md` (implementation plan alongside in `docs/superpowers/plans/`).

- **New package `@codaco/site-navigation-element`** (major, publishes 1.0.0): Shadow-DOM-isolated element with `active-item` / `locale` / `theme` (light|dark|auto) attributes; single self-contained ESM bundle, **~194 kB gzipped / ~161 kB brotli** over the wire; fonts + `@property` rules injected at document level; consumed via jsDelivr `@1` (README documents the contract and the SRI trade-off).
- **fresco-ui (minor), two behavior changes:** `SiteNavigation` accepts `site="external"` (all destinations absolute), and its desktop menus portal into the `PortalContainerProvider` container when one is present (unchanged default without a provider) so embedders can keep popups inside their own DOM scope.
- **CSS pipeline:** Tailwind v4 compile scoped with `source(none)` + explicit `@source` globs (workspace auto-detection was baking in other packages' classes), then a postcss split rewrites `:root` → `:is(:root, :host)` and hoists shadow-incompatible rules.
- **First plain (non-Storybook) vitest browser-mode project in the repo** — 11 real-Chromium tests covering the element contract, computed dark/light colors, portal containment inside the shadow root, and the compact drawer's keyboard behavior.

## Test plan

- [x] `pnpm typecheck` (23/23, also with `--force`), `pnpm knip`, `pnpm lint`
- [x] fresco-ui unit tests (889) incl. new `site="external"` + portal-containment coverage
- [x] element browser tests (11, Chromium via `@vitest/browser-playwright`)
- [x] Production `dist/element.js` smoke-tested in a real browser (two instances, dark+light, fonts fetched via `import.meta.url`, zero console errors)
- [x] Visual verification of the dev demo: light/dark themes, Software mega-menu, mobile drawer, style isolation against hostile host CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the standalone `<nc-site-navigation>` web component for non-React sites, available through CDN or package installation.
  * Supports `active-item`, `locale`, and light, dark, or automatic theme settings.
  * Added Shadow DOM style isolation and responsive navigation interactions.
  * Added external-host navigation with absolute URLs.
  * Desktop menus remain contained within embedded contexts when supported.

* **Bug Fixes**
  * Improved menu rendering for embedded environments, including shadow roots.

* **Tests**
  * Added browser and interaction coverage for navigation, themes, accessibility, and menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->