### PR TITLE
fix(interview): resolve unencrypted node labels synchronously

### DIFF
--- a/.changeset/spotty-lemons-tell.md
+++ b/.changeset/spotty-lemons-tell.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Node labels now resolve synchronously on first render whenever the label attribute is not encrypted. Previously every label — encrypted or not — was resolved through an asynchronous effect, which briefly exposed the node type's fallback name to assistive technology (and to name-based queries) each time a node mounted. The asynchronous path is now used only when an anonymisation-encrypted label genuinely needs decryption.

--- a/packages/interview/src/interfaces/Anonymisation/useNodeLabel.tsx
+++ b/packages/interview/src/interfaces/Anonymisation/useNodeLabel.tsx
@@ -6,6 +6,7 @@ import usePrevious from '@codaco/fresco-ui/hooks/usePrevious';
 import {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
+  entitySecureAttributesMeta,
   type NcNode,
 } from '@codaco/shared-consts';
 import { makeGetCodebookForNodeType } from '~/selectors/protocol';
@@ -21,7 +22,7 @@ const labelCache = new Map<string, string>();
 export function useNodeLabel(node: NcNode | undefined) {
   const getCodebookForNodeType = useSelector(makeGetCodebookForNodeType);
   const codebook = node ? getCodebookForNodeType(node.type) : undefined;
-  const { passphrase } = usePassphrase();
+  const { passphrase, isEnabled } = usePassphrase();
   const prevPassphrase = usePrevious(passphrase);
   const prevNode = usePrevious(node);
 
@@ -32,13 +33,43 @@ export function useNodeLabel(node: NcNode | undefined) {
     node?.[entityAttributesProperty] ?? {},
   );
 
+  // Decryption is the ONLY genuinely asynchronous label source: it applies
+  // when anonymisation is enabled, the label attribute is marked encrypted,
+  // AND the node carries secure-attribute metadata for it (mirrors the gate
+  // in useNodeAttributes.getById — nodes without the metadata still hold
+  // plaintext).
+  const needsAsyncDecrypt = Boolean(
+    node &&
+    labelAttributeId &&
+    isEnabled &&
+    codebook?.variables?.[labelAttributeId]?.encrypted &&
+    node[entitySecureAttributesMeta]?.[labelAttributeId],
+  );
+
+  // Synchronous label for every non-decrypt case, available on the FIRST
+  // committed render. Resolving plain labels through the async effect below
+  // left a window where a node's accessible name was still the type fallback;
+  // under a starved event loop (loaded CI) that window stretched long enough
+  // for name-based queries and assistive tech to see the wrong name.
+  const syncLabel = useMemo(() => {
+    if (!node) return undefined;
+    if (needsAsyncDecrypt) return undefined;
+    const fallback = codebook?.name ?? node[entityPrimaryKeyProperty];
+    if (!labelAttributeId) return fallback;
+    const value = node[entityAttributesProperty]?.[labelAttributeId];
+    // getNodeLabelAttribute only nominates text/number-valued attributes;
+    // anything else (stale codebook, ciphertext arrays) falls back.
+    return typeof value === 'string' || typeof value === 'number'
+      ? String(value)
+      : fallback;
+  }, [node, needsAsyncDecrypt, codebook, labelAttributeId]);
+
   const getById = useNodeAttributes(node);
   const [label, setLabel] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (!node) return;
-
-    const fallback = codebook?.name ?? node[entityPrimaryKeyProperty];
+    if (!needsAsyncDecrypt || !labelAttributeId) return;
 
     // Only check the cache if the passphrase is the same, to allow revalidating
     // Also skip the cache if the node attributes changed
@@ -49,10 +80,7 @@ export function useNodeLabel(node: NcNode | undefined) {
       }
     }
 
-    if (!labelAttributeId) {
-      setLabel(fallback);
-      return;
-    }
+    const fallback = codebook?.name ?? node[entityPrimaryKeyProperty];
 
     void (async () => {
       try {
@@ -68,6 +96,7 @@ export function useNodeLabel(node: NcNode | undefined) {
       }
     })();
   }, [
+    needsAsyncDecrypt,
     labelAttributeId,
     codebook,
     node,
@@ -78,5 +107,5 @@ export function useNodeLabel(node: NcNode | undefined) {
     prevNode,
   ]);
 
-  return label;
+  return syncLabel ?? label;
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the flaky `NetworkComposer.lasso.test.tsx` unit test that dequeued #971 from the merge queue (merge-group run 29412845324, `failed_checks`).

**The race:** `useNodeLabel` resolved every node label through an async effect — a promise hop plus an out-of-act React flush — so each node mounted with its accessible name still set to the type fallback until the hop completed. Node *positions* sync synchronously, so the button exists immediately; only its **name** lags. Under CI event-loop starvation that window stretched past `findByRole`'s 1s budget: `Unable to find role="button" and name /alice/i`.

**Proof:** injecting a 1.3s delay into the label hop reproduces the exact CI failure signature on all five lasso tests. Stress runs (22 rounds, 8–10 CPU hogs) never reproduced it on Apple Silicon — the window is normally sub-millisecond, which is why the test looked healthy locally and in most CI runs.

**Fix:** derive the label synchronously at render for every case that needs no decryption. The async path remains only for anonymisation-encrypted attributes; its gate mirrors `useNodeAttributes.getById` exactly (plaintext fallbacks for missing secure metadata or disabled anonymisation, 🔒 on missing passphrase). This also removes a real accessibility flash: assistive tech briefly saw the wrong node name on every mount.

## Verification

- Lasso tests: 5/5 pass; **mutation test** — with the 1.3s delay re-injected into the now-decrypt-only path (which previously failed all 5), all 5 still pass, proving the race is eliminated rather than narrowed.
- Full interview units suite: 136 files / 1172 tests pass.
- Anonymisation e2e (pinned Playwright Docker, chromium-matrix): 8/8 pass, covering encrypted-downstream-write, encrypted-off-not-decrypted, and missing/wrong-passphrase flows.
- `turbo typecheck --force`, oxlint, oxfmt, knip all clean.

Changeset: patch for `@codaco/interview`.