### PR TITLE
ci: scope PR test runs with --affected and fix turbo cache invalidation

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -176,11 +176,22 @@ jobs:
             echo "snapshot_branch=$(jq -r '.snapshotBranch' <<< "$policy")"
           } >> "$GITHUB_OUTPUT"
 
-  # Cache design: every Turbo-using job restores `.turbo` from the same
-  # `${{ runner.os }}-turbo-*` keyspace. Whichever job finishes its build first
-  # writes the SHA-specific slot; subsequent jobs read it via `restore-keys`
-  # fallback. Per-package env values (NEXT_PUBLIC_*, VITE_*) are part of each
-  # build task's `env:` list in turbo.json so they participate in the cache key.
+  # Cache design: turbo-ci-setup runs a runner-local server speaking turbo's
+  # remote-cache protocol, backed by the GitHub Actions Cache with per-task,
+  # hash-addressed entries. Per-package env values (NEXT_PUBLIC_*, VITE_*) are
+  # part of each build task's `env:` list in turbo.json so they participate in
+  # the cache key. The lockfile is deliberately NOT in turbo.json's
+  # `globalDependencies`: turbo hashes each package's resolved dependencies
+  # (including pnpm catalog entries) granularly, so a dependency bump only
+  # invalidates the packages that use it — listing pnpm-lock.yaml globally
+  # would invalidate every task on every bump.
+  #
+  # GitHub's cache is branch-scoped: PR and merge-queue runs can restore main's
+  # entries plus their own branch's, but entries written on ephemeral
+  # merge-queue refs die with the ref, and the quality jobs skip `push` — so
+  # without the `seed-turbo-cache` job below, main's tree would never have
+  # cache entries and every run after a merge would re-run everything that
+  # merge changed.
   #
   # `quality` used to be a single job running everything serially; it is now a
   # fan-out of independent sub-jobs behind the `quality` aggregator below, so
@@ -189,6 +200,31 @@ jobs:
   # (where `detect` is skipped). `typecheck`/`test` restore `build`'s output via
   # their own `^build` dependency; `lint` needs it too (below) because oxlint's
   # type-aware rules resolve workspace imports through built `.d.ts` files.
+  seed-turbo-cache:
+    if: github.event_name == 'push'
+    # Cache warming only — the merge queue already validated this identical
+    # tree, so a flake here must not fail the push run (which also carries the
+    # release jobs).
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/turbo-ci-setup
+      - name: Write protocol-validation .env (test fixture)
+        env:
+          PROTOCOL_ENCRYPTION_KEY: ${{ secrets.PROTOCOL_ENCRYPTION_KEY }}
+          PROTOCOL_ENCRYPTION_IV: ${{ secrets.PROTOCOL_ENCRYPTION_IV }}
+          TEST_PROTOCOL_TOKEN: ${{ secrets.TEST_PROTOCOL_TOKEN }}
+        run: |
+          {
+            echo "PROTOCOL_ENCRYPTION_KEY=$PROTOCOL_ENCRYPTION_KEY"
+            echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
+            echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
+          } > packages/protocol-validation/.env
+      - run: pnpm exec turbo run test typecheck
+
   lint:
     needs: build
     if: github.event_name != 'push'
@@ -264,6 +300,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           persist-credentials: false
+          # `--affected` diffs against the PR base; on a shallow clone turbo
+          # treats every package as changed.
+          fetch-depth: 0
       - uses: ./.github/actions/turbo-ci-setup
       - name: Write protocol-validation .env (test fixture)
         env:
@@ -276,7 +315,21 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      - run: pnpm exec turbo run test
+      - name: Run tests (PRs run only packages affected by the PR diff)
+        run: |
+          # PR checkouts are a synthetic merge of the PR into its base, so
+          # HEAD^1 is the base tip and --affected scopes the run to the
+          # packages the PR touches plus their dependents. Anything skipped
+          # here is still covered by the full merge-queue run before it can
+          # land. A change to this workflow can alter how this job itself
+          # behaves, so it falls back to the full suite (same rule as
+          # detect's WORKFLOW_CHANGED).
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] \
+            && git diff --quiet HEAD^1 HEAD -- .github/workflows/ci-and-release.yml; then
+            TURBO_SCM_BASE=$(git rev-parse HEAD^1) pnpm exec turbo run test --affected
+          else
+            pnpm exec turbo run test
+          fi
 
   quality:
     needs:

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -201,7 +201,7 @@ jobs:
   # their own `^build` dependency; `lint` needs it too (below) because oxlint's
   # type-aware rules resolve workspace imports through built `.d.ts` files.
   seed-turbo-cache:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     # Cache warming only — the merge queue already validated this identical
     # tree, so a flake here must not fail the push run (which also carries the
     # release jobs).
@@ -324,17 +324,28 @@ jobs:
       # doesn't ship the pinned Playwright build's browsers.
       - name: Install Playwright Chromium (vitest browser mode)
         run: pnpm --filter @codaco/site-navigation-element exec playwright install --with-deps chromium
-      - name: Run tests (PRs run only packages affected by the PR diff)
+      - name: Run tests (PRs run only tasks affected by the PR diff)
         run: |
           # PR checkouts are a synthetic merge of the PR into its base, so
-          # HEAD^1 is the base tip and --affected scopes the run to the
-          # packages the PR touches plus their dependents. Anything skipped
-          # here is still covered by the full merge-queue run before it can
-          # land. A change to this workflow can alter how this job itself
-          # behaves, so it falls back to the full suite (same rule as
-          # detect's WORKFLOW_CHANGED).
+          # HEAD^1 is the base tip and --affected scopes the run to tasks
+          # whose declared inputs the PR touches, plus their dependents
+          # (turbo.json enables futureFlags.affectedUsingTaskInputs so
+          # selection matches what cache hashing considers an input).
+          # Anything skipped here is still covered by the full merge-queue
+          # run before it can land.
+          #
+          # Fail closed: a change outside the workspace package trees (this
+          # workflow, composite actions, .nvmrc, pnpm-workspace.yaml, root
+          # configs/scripts) can alter how tests run without being any turbo
+          # task's input, so any such change forces the full suite. The
+          # lockfile stays on the affected path because turbo hashes it
+          # granularly per package; docs, changesets, and markdown are inert
+          # to tests.
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] \
-            && git diff --quiet HEAD^1 HEAD -- .github/workflows/ci-and-release.yml; then
+            && git diff --quiet HEAD^1 HEAD -- . \
+              ':(exclude)packages' ':(exclude)apps' ':(exclude)workers' \
+              ':(exclude)tooling' ':(exclude)docs' ':(exclude).changeset' \
+              ':(exclude)pnpm-lock.yaml' ':(exclude)*.md'; then
             TURBO_SCM_BASE=$(git rev-parse HEAD^1) pnpm exec turbo run test --affected
           else
             pnpm exec turbo run test

--- a/turbo.json
+++ b/turbo.json
@@ -274,6 +274,8 @@
         "src/**",
         "__tests__/**",
         "vitest.config.*",
+        "vitest.setup.*",
+        "config/vitest/**",
         "package.json",
         ".env"
       ],
@@ -350,6 +352,24 @@
         "__tests__/**",
         "vitest.config.*",
         "vite.config.*",
+        "package.json",
+        ".env"
+      ],
+      "env": [
+        "PROTOCOL_ENCRYPTION_KEY",
+        "PROTOCOL_ENCRYPTION_IV",
+        "GITHUB_TOKEN"
+      ],
+      "outputs": []
+    },
+    "@codaco/interview#test": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "__tests__/**",
+        "e2e/**",
+        "vitest.config.*",
+        "vitest.setup.*",
         "package.json",
         ".env"
       ],

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalDependencies": [
-    "pnpm-lock.yaml",
-    "pnpm-workspace.yaml",
-    "packages/protocols/e2e/all-interfaces/**"
-  ],
   "globalPassThroughEnv": [
     "NC_PREVIEW_HOST",
     "NEXT_PUBLIC_ALGOLIA_APPLICATION_ID",
@@ -329,6 +324,23 @@
         "__tests__/**",
         "vitest.config.*",
         "vite.config.*",
+        "package.json",
+        ".env"
+      ],
+      "env": [
+        "PROTOCOL_ENCRYPTION_KEY",
+        "PROTOCOL_ENCRYPTION_IV",
+        "GITHUB_TOKEN"
+      ],
+      "outputs": []
+    },
+    "@codaco/protocol-validation#test": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_ROOT$/packages/protocols/e2e/all-interfaces/**",
+        "src/**",
+        "__tests__/**",
+        "vitest.config.*",
         "package.json",
         ".env"
       ],

--- a/turbo.json
+++ b/turbo.json
@@ -402,5 +402,8 @@
       "env": ["NODE_ENV"],
       "outputs": []
     }
+  },
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
   }
 }


### PR DESCRIPTION
## Summary

The `test` job is the long pole of the quality gate: ~9–10 min on most PR runs (and every merge-queue run), vs ~1 min when the turbo cache actually hits. The cache exists and works — it was being invalidated wholesale. This PR makes PR test runs scale with the PR's blast radius instead of the whole repo.

### 1. Stop whole-repo cache invalidation (`turbo.json`)

- **Drop `pnpm-lock.yaml` / `pnpm-workspace.yaml` from `globalDependencies`.** Turbo hashes each package's resolved dependencies (including pnpm `catalog:` entries) granularly, so a dependency bump now invalidates only the packages that use it. Previously every dependabot bump, catalog bump, or added package re-ran all ~23 test suites. Verified empirically: a simulated `fuse.js` bump in the lockfile invalidates only its dependency closure (13 tasks), leaving shared-consts, protocol-validation, network-query, analytics, etc. untouched.
- **Scope `packages/protocols/e2e/all-interfaces/**` to `@codaco/protocol-validation#test`.** Its only cached consumer is protocol-validation's fixture test — architect's tasks already declare `$TURBO_ROOT$/packages/protocols/**`, and the e2e tasks are `cache: false`. Verified: touching the fixture invalidates exactly `protocol-validation#test` + `architect#test`.

### 2. Seed the cache from main (`seed-turbo-cache` job)

GitHub's cache is branch-scoped: PR/merge-queue runs can restore main's entries, but quality jobs skip `push` and merge-queue caches die with their ephemeral refs — so main's tree never had cache entries, and every run after a merge re-ran everything that merge touched. A new job on push to main (explicitly gated to `refs/heads/main`) runs `turbo run test typecheck` purely to write cache entries. It's `continue-on-error` because the merge queue already validated the identical tree — a flake must not fail the release-carrying push run.

### 3. PR test runs use `--affected`, selection derived from task inputs

`turbo run test --affected` with `TURBO_SCM_BASE=HEAD^1` (the base tip of the synthetic merge commit) runs only tasks whose declared inputs the PR touches **plus their dependents**. `turbo.json` enables `futureFlags.affectedUsingTaskInputs` so `--affected` selection uses the same facts as cache hashing — a fixture-only edit selects exactly `protocol-validation#test` + `architect#test` (package-graph mode missed protocol-validation, caught in review by Codex).

Safety properties:

- The **merge queue still runs the full suite** before anything lands — a wrongly-skipped suite surfaces there, not on main.
- **Fail closed on non-package changes**: any diff outside `packages`/`apps`/`workers`/`tooling` (this workflow, composite actions, `.nvmrc`, `pnpm-workspace.yaml`, root configs/scripts) forces the full suite. Only the granularly-hashed lockfile, `docs/`, `.changeset/`, and markdown stay on the affected path (also a Codex review catch — previously only this workflow file was special-cased).
- A `turbo.json` change marks **all** packages affected (verified); a changeset-only diff runs zero suites and exits 0 (verified).
- `merge_group` and `workflow_dispatch` runs are unchanged (full suite).

## Test plan

- [x] `actionlint` passes on the workflow
- [x] `pnpm knip`, changeset lane check pass; no changeset needed (CI/tooling-only)
- [x] Turbo dry-run experiments (lockfile granularity, fixture scoping, --affected selection under `affectedUsingTaskInputs` for root/package/fixture/no-op diffs, dependent inclusion)
- [x] Fail-closed pathspec verified against .nvmrc / pnpm-workspace.yaml / composite-action / changeset-only / lockfile-only diffs
- [ ] Observe the `test` job on this PR: it changes the workflow file, so it should itself take the full-suite fallback path
- [ ] After merge: confirm `seed-turbo-cache` runs on main and a follow-up PR's `test` job replays unchanged packages from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)