### PR TITLE
fix(ci): cancel superseded release PR runs

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -36,14 +36,12 @@ permissions:
 # safety net if a release run is dropped anyway.
 concurrency:
   group: ci-${{ github.ref }}${{ github.event_name == 'push' && format('-{0}', github.sha) || '' }}
-  # Cancel superseded feature-PR runs and explicitly dispatched release-branch
-  # runs. Keep pull_request runs for the changesets bot's release PRs alive:
-  # cancelling those leaves the required `quality` aggregate skipped and can
-  # strand the PR. A release-branch dispatch targets a concrete branch head, so
-  # a newer dispatch can safely replace an obsolete one.
+  # Cancel every superseded PR run, including generated release PRs. Only the
+  # current head's required `quality` aggregate matters, and its replacement run
+  # will report that check. A release-branch dispatch also targets a concrete
+  # branch head, so a newer dispatch can safely replace an obsolete one.
   cancel-in-progress: >-
-    ${{ (github.event_name == 'pull_request'
-    && !startsWith(github.head_ref, 'changeset-release/'))
+    ${{ github.event_name == 'pull_request'
     || (github.event_name == 'workflow_dispatch'
     && (startsWith(github.ref_name, 'changeset-release/')
     || github.ref_name == 'e2e-snapshots/main')) }}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync(
+  new URL('../.github/workflows/ci-and-release.yml', import.meta.url),
+  'utf8',
+);
+
+const topLevelConcurrency = workflow.match(
+  /^concurrency:\n(?<config>[\s\S]*?)\n\njobs:/m,
+)?.groups?.config;
+
+test('superseded CI runs are cancelled for every pull request', () => {
+  assert.ok(
+    topLevelConcurrency,
+    'top-level CI concurrency configuration exists',
+  );
+  assert.match(
+    topLevelConcurrency,
+    /cancel-in-progress: >-\n\s+\$\{\{ github\.event_name == 'pull_request'/,
+  );
+  assert.doesNotMatch(topLevelConcurrency, /github\.head_ref/);
+});


### PR DESCRIPTION
## Summary
- cancel superseded CI runs for every pull request, including generated release PRs
- keep the current-head `quality` check as the only relevant required result
- add a regression test that rejects future head-branch exceptions

## Test plan
- [x] Parse `.github/workflows/ci-and-release.yml` as YAML
- [x] `pnpm test:scripts` (49 tests)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm exec oxfmt --check .github/workflows/ci-and-release.yml scripts/ci-workflow.test.mjs`

No changeset: CI/tooling-only change.