### PR TITLE
fix(ci): unblock library release + fix seed-turbo-cache flake on main pushes

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -851,6 +851,12 @@ jobs:
         # publishes to npm. Apps (./apps/*) are private:true and don't need to
         # build successfully here; their deploy pipeline is per-app deploy jobs.
         run: pnpm exec turbo run build --filter='./packages/*'
+      - name: Hide gated-product changesets from the library release
+        # Product changesets persist until their release PR consumes them, but
+        # changesets/action counts them as pending: it would push an empty
+        # Version Packages branch (PR creation 422s) and never reach its
+        # publish path. Working-tree-only deletion; see the script header.
+        run: node scripts/prune-ignored-changesets.mjs
       - id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:

--- a/apps/interviewer-classic/src/containers/CategoricalList/__tests__/CategoricalList.test.jsx
+++ b/apps/interviewer-classic/src/containers/CategoricalList/__tests__/CategoricalList.test.jsx
@@ -6,7 +6,7 @@ import { CategoricalListItem } from '../CategoricalListItem';
 
 const mockStore = {
   getState: () => ({}),
-  subscribe: () => ({}),
+  subscribe: () => () => {},
 };
 
 const mockProps = {
@@ -36,5 +36,10 @@ describe('CategoricalList component', () => {
     );
 
     expect(component.find(CategoricalListItem)).toHaveLength(2);
+
+    // The mounted tree contains DropTarget behaviours whose setTimeout->rAF
+    // polling loop only stops on unmount; left mounted, a pending timeout can
+    // fire after jsdom teardown, where requestAnimationFrame no longer exists.
+    component.unmount();
   });
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -22,3 +22,21 @@ test('superseded CI runs are cancelled for every pull request', () => {
   );
   assert.doesNotMatch(topLevelConcurrency, /github\.head_ref/);
 });
+
+test('release job prunes ignored-lane changesets before changesets/action', () => {
+  const releaseJob = workflow.match(
+    /^ {2}release:\n(?<body>[\s\S]*?)(?=^ {2}\S)/m,
+  )?.groups?.body;
+  assert.ok(releaseJob, 'release job exists');
+
+  const pruneIndex = releaseJob.indexOf(
+    'run: node scripts/prune-ignored-changesets.mjs',
+  );
+  const actionIndex = releaseJob.indexOf('uses: changesets/action@');
+  assert.ok(pruneIndex !== -1, 'release job runs prune-ignored-changesets.mjs');
+  assert.ok(actionIndex !== -1, 'release job uses changesets/action');
+  assert.ok(
+    pruneIndex < actionIndex,
+    'prune step must run before changesets/action reads changeset state',
+  );
+});

--- a/scripts/prune-ignored-changesets.mjs
+++ b/scripts/prune-ignored-changesets.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// The library release (changesets/action) picks between its two paths by
+// whether any changeset files exist: some pending -> push a Version Packages
+// branch and open a PR; none pending -> publish unpublished packages to npm.
+// Gated-product changesets deliberately persist in .changeset/ until their
+// product release PR consumes them, but `changeset version` never touches
+// them (their packages are in the config `ignore` list) — so when only
+// product changesets are pending, the action pushes a branch identical to
+// main (PR creation then fails with "No commits between...") and the publish
+// path never runs, silently skipping npm publishes after a Version Packages
+// merge.
+//
+// Deleting ignored-lane changesets from the working tree before the action
+// reads state scopes its decision to the library lane. Nothing is committed:
+// the publish path never commits, and the version path starts with the
+// action's own `git reset --hard`, which restores the deleted files.
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { readChangesets } from './changeset-app-utils.mjs';
+
+const changesetDir = join(process.cwd(), '.changeset');
+const config = JSON.parse(
+  readFileSync(join(changesetDir, 'config.json'), 'utf8'),
+);
+const ignored = new Set(config.ignore ?? []);
+
+let pruned = 0;
+for (const cs of readChangesets(changesetDir)) {
+  if (cs.releases.length === 0) continue;
+  if (!cs.releases.every((release) => ignored.has(release.name))) continue;
+  rmSync(join(changesetDir, `${cs.id}.md`));
+  pruned += 1;
+  console.log(
+    `pruned .changeset/${cs.id}.md (${cs.releases.map((r) => r.name).join(', ')})`,
+  );
+}
+
+console.log(
+  pruned === 0
+    ? 'no ignored-lane changesets to prune'
+    : `pruned ${pruned} ignored-lane changeset(s) from the working tree`,
+);

--- a/scripts/prune-ignored-changesets.test.mjs
+++ b/scripts/prune-ignored-changesets.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(scriptDir, 'prune-ignored-changesets.mjs');
+
+const CONFIG = JSON.stringify({
+  ignore: ['@codaco/architect', '@codaco/documentation'],
+});
+
+function fixture(files) {
+  const cwd = mkdtempSync(join(tmpdir(), 'prune-'));
+  mkdirSync(join(cwd, '.changeset'));
+  writeFileSync(join(cwd, '.changeset', 'config.json'), CONFIG);
+  writeFileSync(join(cwd, '.changeset', 'README.md'), 'readme');
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(cwd, '.changeset', name), body);
+  }
+  return cwd;
+}
+
+function run(cwd) {
+  return spawnSync(process.execPath, [SCRIPT], { cwd, encoding: 'utf8' });
+}
+
+test('removes changesets that only release ignored packages', () => {
+  const cwd = fixture({
+    'docs.md': `---\n"@codaco/documentation": minor\n---\n\ndocs change`,
+    'app.md': `---\n'@codaco/architect': patch\n---\n\napp change`,
+  });
+  const res = run(cwd);
+  assert.equal(res.status, 0);
+  assert.ok(!existsSync(join(cwd, '.changeset', 'docs.md')));
+  assert.ok(!existsSync(join(cwd, '.changeset', 'app.md')));
+  assert.match(res.stdout, /pruned \.changeset\/docs\.md/);
+  assert.match(res.stdout, /pruned \.changeset\/app\.md/);
+});
+
+test('keeps changesets that release a library package', () => {
+  const cwd = fixture({
+    'lib.md': `---\n"@codaco/interview": minor\n---\n\nlib change`,
+    'mixed.md': `---\n"@codaco/architect": minor\n"@codaco/interview": patch\n---\n\nmixed`,
+  });
+  const res = run(cwd);
+  assert.equal(res.status, 0);
+  assert.ok(existsSync(join(cwd, '.changeset', 'lib.md')));
+  assert.ok(existsSync(join(cwd, '.changeset', 'mixed.md')));
+  assert.match(res.stdout, /no ignored-lane changesets to prune/);
+});
+
+test('leaves README.md and empty changesets alone', () => {
+  const cwd = fixture({
+    'empty.md': `---\n---\n\nnote without releases`,
+  });
+  const res = run(cwd);
+  assert.equal(res.status, 0);
+  assert.ok(existsSync(join(cwd, '.changeset', 'README.md')));
+  assert.ok(existsSync(join(cwd, '.changeset', 'empty.md')));
+});


### PR DESCRIPTION
## Summary

Every push to `main` since the Architect/Interviewer/docs release lanes started carrying pending product changesets has failed the **CI and Release** run twice over:

### 1. `release` job — library publish silently broken

All pending changesets on `main` target `@codaco/documentation`, which is in the changeset `ignore` list. `changesets/action` counts them as pending, so it:

- takes the **version-PR path**, pushes a `changeset-release/main` branch identical to `main`, and fails with `No commits between main and changeset-release/main` (422) on every push; and
- **never reaches its publish path** — the npm publish for the merged Version Packages PR (#855) never ran: `main` has `@codaco/protocol-validation@11.9.0` / `@codaco/shared-consts@5.5.0`, npm has `11.8.1` / `5.4.0`.

**Fix:** a new `scripts/prune-ignored-changesets.mjs` step in the `release` job deletes ignored-lane changesets from the working tree before the action reads state, so its version/publish decision is scoped to the library lane. Nothing is committed: the publish path never commits, and the version path begins with the action's own `git reset --hard`, which restores the files (verified in the failing run's log). Once merged, the next push to `main` takes the publish path and catches up the missed 11.9.0/5.5.0 publishes.

### 2. `seed-turbo-cache` job — interviewer-classic teardown race

All 443 interviewer-classic tests passed, but the job failed on 2 unhandled `ReferenceError: requestAnimationFrame is not defined` errors: `CategoricalList.test.jsx` `mount`s a tree containing `DropTarget` behaviours whose `setTimeout` → `requestAnimationFrame` polling loop only stops on unmount, and the test never unmounted. A pending timeout firing after jsdom teardown hits a missing `requestAnimationFrame` global. (Same tree passed in the merge queue minutes earlier — pure timing race.)

**Fix:** unmount after the assertion (mirroring `DropTarget.test.jsx`'s own `afterEach`), and fix the mock store's `subscribe` to return an unsubscribe function so react-redux's `Provider` survives unmount.

The earlier `release` / `Release PR (Interviewer)` failures on the 15:38–15:49 UTC pushes were a separate transient race (the target branches were locked in the merge queue) and self-resolved.

## Test plan

- [x] `pnpm test:scripts` — 53 pass, including new prune-script tests and a workflow-wiring assertion (prune step must precede `changesets/action`)
- [x] Prune script run against a copy of `main`'s real `.changeset/` — removes exactly the 4 docs changesets, leaves `README.md`/`config.json`
- [x] `pnpm --filter @codaco/interviewer-classic exec vitest run src/containers/CategoricalList/__tests__/CategoricalList.test.jsx` — passes with unmount
- [x] `pnpm knip` — no new issues; targeted `oxlint`/`oxfmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)