### PR TITLE
e2e: persist Turbo cache across Dockerized runs

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -697,12 +697,15 @@ jobs:
       - name: Merge sharded blob reports
         if: ${{ env.PW_BLOB == '1' }}
         run: pnpm --filter @codaco/interview exec playwright merge-reports --reporter html ./blob-report
-      - name: Reclaim artifact ownership
+      - name: Reclaim workspace ownership
+        # The Dockerized run executes as container root, so everything it
+        # writes into the bind-mounted workspace (dist trees, reports, volume
+        # mountpoints) lands root-owned. Reclaim the WHOLE checkout, not just
+        # the report dirs: on a self-hosted runner the workspace persists
+        # between runs, and the next checkout's `git clean` cannot remove
+        # root-owned files. (Ephemeral GitHub-hosted VMs never noticed.)
         if: always()
-        run: |
-          sudo chown -R "$(id -u):$(id -g)" \
-            packages/interview/e2e/playwright-report \
-            packages/interview/e2e/test-results 2>/dev/null || true
+        run: sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
       - name: Flag flaky tests
         # Reporting only — never gate the job on it (belt-and-suspenders with the
         # script's own guards).
@@ -741,12 +744,10 @@ jobs:
           detected=$(node scripts/playwright-snapshot-failure.mjs apps/interviewer/e2e/test-results/results.json)
           echo "snapshot-only failure: $detected"
           echo "detected=$detected" >> "$GITHUB_OUTPUT"
-      - name: Reclaim artifact ownership
+      - name: Reclaim workspace ownership
+        # See interview-e2e: reclaim the whole checkout for self-hosted runs.
         if: always()
-        run: |
-          sudo chown -R "$(id -u):$(id -g)" \
-            apps/interviewer/e2e/playwright-report \
-            apps/interviewer/e2e/test-results 2>/dev/null || true
+        run: sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -779,12 +780,10 @@ jobs:
           detected=$(node scripts/playwright-snapshot-failure.mjs apps/architect/e2e/test-results/results.json)
           echo "snapshot-only failure: $detected"
           echo "detected=$detected" >> "$GITHUB_OUTPUT"
-      - name: Reclaim artifact ownership
+      - name: Reclaim workspace ownership
+        # See interview-e2e: reclaim the whole checkout for self-hosted runs.
         if: always()
-        run: |
-          sudo chown -R "$(id -u):$(id -g)" \
-            apps/architect/e2e/playwright-report \
-            apps/architect/e2e/test-results 2>/dev/null || true
+        run: sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/architect/e2e/scripts/run.sh
+++ b/apps/architect/e2e/scripts/run.sh
@@ -53,9 +53,11 @@ fi
 # so native binaries never mix.
 PLATFORM_FLAG=""
 VOLUME="architect-e2e-node-modules"
+TURBO_VOLUME="architect-e2e-turbo-cache"
 if [[ " $* " == *"--update-snapshots"* ]]; then
   PLATFORM_FLAG="--platform linux/amd64"
   VOLUME="architect-e2e-node-modules-amd64"
+  TURBO_VOLUME="architect-e2e-turbo-cache-amd64"
 fi
 # Forwarded args are spliced into the container's `sh -c` string, so each one
 # must be shell-quoted or characters like the `|` in `--grep "A|B"` are
@@ -73,6 +75,7 @@ docker run --rm \
   -e VITE_DISABLE_ANALYTICS=true \
   -v "$(pwd)":/workspace \
   -v "${VOLUME}":/workspace/node_modules \
+  -v "${TURBO_VOLUME}":/workspace/.turbo/cache \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \

--- a/apps/interviewer/e2e/scripts/run.sh
+++ b/apps/interviewer/e2e/scripts/run.sh
@@ -38,6 +38,7 @@ docker run --rm \
   -e VITE_DISABLE_ANALYTICS=true \
   -v "$(pwd)":/workspace \
   -v interviewer-e2e-node-modules:/workspace/node_modules \
+  -v interviewer-e2e-turbo-cache:/workspace/.turbo/cache \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \

--- a/packages/interview/e2e/scripts/run.sh
+++ b/packages/interview/e2e/scripts/run.sh
@@ -20,6 +20,14 @@
 # runs so subsequent installs are no-ops; wipe with:
 #   docker volume rm interview-e2e-node-modules
 #
+# A second named volume backs Turbo's local cache (.turbo/cache) so the
+# `turbo build` of unchanged workspace deps restores instead of rebuilding.
+# This matters on hosts where the checkout is cleaned between runs (the
+# self-hosted CI runner) or the repo dir is fresh; Turbo's cache is
+# content-addressed, so persisting it across branches/commits is safe. Wipe
+# with:
+#   docker volume rm interview-e2e-turbo-cache
+#
 # Build @codaco/interview and its workspace deps before launching the vite
 # host. Sibling workspace packages ship dist-only (their package.json `exports`
 # point at ./dist/*), so the dist trees must exist before the host can resolve
@@ -65,6 +73,7 @@ docker run --rm \
   -e PW_WORKERS \
   -v "$(pwd)":/workspace \
   -v interview-e2e-node-modules:/workspace/node_modules \
+  -v interview-e2e-turbo-cache:/workspace/.turbo/cache \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \


### PR DESCRIPTION
## Summary

Persist Turbo's local cache (`.turbo/cache`) across Dockerized e2e runs via a named Docker volume, mirroring the existing `*-e2e-node-modules` volume pattern in all three `run.sh` scripts. On hosts where the workspace doesn't survive between runs as-built (fresh clones, and the self-hosted CI runner where `actions/checkout` cleans the tree), the `turbo build` of unchanged workspace dependencies restores from cache instead of rebuilding.

- Turbo's cache is content-addressed, so persisting it across branches and commits is safe.
- On GitHub-hosted runners the volume simply starts empty every run — behavior is unchanged there.
- The architect script's amd64-pinned baseline runs get their own `-amd64` cache volume, mirroring the existing platform split for `node_modules`.

Measured on the self-hosted runner (interview suite, build-only via `--list`): cold cache **2m18s** turbo build (3m04 wall), warm cache **259ms — FULL TURBO** (25s wall). ~2.5 min saved per run.

## Workspace ownership fix (self-hosted correctness)

The Dockerized suites run as container root, so everything they write into the bind-mounted workspace (dist trees, reports, volume mountpoints) lands root-owned. The "Reclaim artifact ownership" steps only chowned the two report directories — enough on ephemeral GitHub-hosted VMs, but on a self-hosted runner the `_work` checkout persists and the **next** run's `git clean` cannot remove root-owned files, failing the job at checkout. The step now reclaims the whole checkout (`chown -R … .`).

## Relation to #985

Complements #985 (which routes `interview-e2e` to the self-hosted runner): the cache volume is what makes the second-and-later routed runs fast, and the ownership fix is what makes them work at all. No file overlap conflicts — #985 touches the jobs' scheduling; this touches the run scripts and the chown steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
