### PR TITLE
e2e: persist pnpm store in a named volume

### DIFF
--- a/apps/architect/e2e/scripts/run.sh
+++ b/apps/architect/e2e/scripts/run.sh
@@ -76,6 +76,7 @@ docker run --rm \
   -v "$(pwd)":/workspace \
   -v "${VOLUME}":/workspace/node_modules \
   -v "${TURBO_VOLUME}":/workspace/.turbo/cache \
+  -v architect-e2e-pnpm-store:/workspace/.pnpm-store \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \

--- a/apps/interviewer/e2e/scripts/run.sh
+++ b/apps/interviewer/e2e/scripts/run.sh
@@ -39,6 +39,7 @@ docker run --rm \
   -v "$(pwd)":/workspace \
   -v interviewer-e2e-node-modules:/workspace/node_modules \
   -v interviewer-e2e-turbo-cache:/workspace/.turbo/cache \
+  -v interviewer-e2e-pnpm-store:/workspace/.pnpm-store \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \

--- a/packages/interview/e2e/scripts/run.sh
+++ b/packages/interview/e2e/scripts/run.sh
@@ -28,6 +28,14 @@
 # with:
 #   docker volume rm interview-e2e-turbo-cache
 #
+# A third volume backs .pnpm-store: pnpm picks the project dir for its store
+# when the configured global store is on a different filesystem, which
+# otherwise dumps gigabytes of root-owned content-addressed store files into
+# the bind-mounted workspace on every install (observed breaking the next
+# `git clean` on the self-hosted runner). The volume keeps the store out of
+# the checkout AND on the same filesystem as the node_modules volume, so
+# pnpm can hardlink instead of copying.
+#
 # Build @codaco/interview and its workspace deps before launching the vite
 # host. Sibling workspace packages ship dist-only (their package.json `exports`
 # point at ./dist/*), so the dist trees must exist before the host can resolve
@@ -74,6 +82,7 @@ docker run --rm \
   -v "$(pwd)":/workspace \
   -v interview-e2e-node-modules:/workspace/node_modules \
   -v interview-e2e-turbo-cache:/workspace/.turbo/cache \
+  -v interview-e2e-pnpm-store:/workspace/.pnpm-store \
   -w /workspace \
   "${IMAGE}" \
   sh -c "set -e \


### PR DESCRIPTION
Follow-up to #987 (this commit was accidentally pushed to that branch minutes after it merged, so it never landed).

pnpm places its store inside the project when the global store dir is on a different filesystem, dumping gigabytes of root-owned `.pnpm-store` files into the bind-mounted workspace on every install — this is what broke `interview-e2e` checkouts on the self-hosted runner after #985 merged (`git clean`: Permission denied). #987's whole-checkout chown already stops the checkout failures; this change keeps the store out of the checkout entirely and puts it on the same filesystem as the `node_modules` volume, so pnpm can hardlink instead of copying. On GitHub-hosted runners the volume starts empty every run — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved end-to-end test setup by persisting the pnpm package store across Docker runs.
  * Reduced repeated package downloads and installation overhead during Playwright test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->