### PR TITLE
feat(fresco-ui): share public-site theme switcher

### DIFF
--- a/.changeset/fresco-theme-switcher.md
+++ b/.changeset/fresco-theme-switcher.md
@@ -1,0 +1,7 @@
+---
+"@codaco/fresco-ui": minor
+---
+
+Add a reusable, accessible colour-theme switcher for public-site navigation.
+Hosts can provide their own theme persistence and translated labels while using
+the same light, dark, and system-mode picker.

--- a/apps/documentation/components/ThemeSwitcher.tsx
+++ b/apps/documentation/components/ThemeSwitcher.tsx
@@ -1,105 +1,31 @@
 'use client';
 
-import { Moon, Sun, SunMoon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
 
-import { Button, IconButton } from '@codaco/fresco-ui/Button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@codaco/fresco-ui/DropdownMenu';
-
-const themeOptions = [
-  { id: 'light', icon: Sun },
-  { id: 'dark', icon: Moon },
-  { id: 'system', icon: SunMoon },
-] as const;
-const THEME_ICON_STROKE_CLASS = '[&>.lucide]:[stroke-width:3.5]';
-
-type ThemeOption = (typeof themeOptions)[number]['id'];
-
-function isThemeOption(theme: string | undefined): theme is ThemeOption {
-  return themeOptions.some((option) => option.id === theme);
-}
+import SharedThemeSwitcher from '@codaco/fresco-ui/navigation/ThemeSwitcher';
 
 type ThemeSwitcherProps = {
   view: 'desktop' | 'mobile';
 };
 
 export default function ThemeSwitcher({ view }: ThemeSwitcherProps) {
-  const [mounted, setMounted] = useState(false);
   const { setTheme, theme } = useTheme();
   const t = useTranslations('ThemeTranslations');
 
-  useEffect(() => setMounted(true), []);
-
-  // Keep the server and first client render identical. next-themes restores the
-  // persisted preference after hydration, at which point the control can show
-  // the actual configured mode.
-  const selectedTheme = mounted && isThemeOption(theme) ? theme : 'system';
-  const SelectedIcon =
-    themeOptions.find((option) => option.id === selectedTheme)?.icon ?? SunMoon;
-  const triggerLabel = t('triggerLabel', {
-    theme: t(selectedTheme),
-  });
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          view === 'desktop' ? (
-            <IconButton
-              aria-label={triggerLabel}
-              icon={<SelectedIcon aria-hidden />}
-              size="sm"
-              variant="text"
-              color="dynamic"
-              className={`text-text border-transparent ${THEME_ICON_STROKE_CLASS}`}
-            />
-          ) : (
-            <Button
-              aria-label={triggerLabel}
-              icon={<SelectedIcon aria-hidden />}
-              size="sm"
-              variant="text"
-              color="dynamic"
-              className={`text-text justify-start border-transparent ${THEME_ICON_STROKE_CLASS}`}
-            />
-          )
-        }
-      >
-        {view === 'mobile' ? triggerLabel : undefined}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align={view === 'desktop' ? 'end' : 'start'}
-        className="min-w-48"
-      >
-        <DropdownMenuRadioGroup
-          aria-label={t('label')}
-          value={selectedTheme}
-          onValueChange={(value) => {
-            if (isThemeOption(value)) setTheme(value);
-          }}
-          className="flex flex-col gap-1"
-        >
-          {themeOptions.map(({ id, icon: OptionIcon }) => (
-            <DropdownMenuRadioItem
-              key={id}
-              value={id}
-              closeOnClick
-              icon={<OptionIcon aria-hidden />}
-              className={THEME_ICON_STROKE_CLASS}
-            >
-              {t(id)}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <SharedThemeSwitcher
+      labels={{
+        label: t('label'),
+        triggerLabel: (selectedTheme) =>
+          t('triggerLabel', { theme: t(selectedTheme) }),
+        light: t('light'),
+        dark: t('dark'),
+        system: t('system'),
+      }}
+      onThemeChange={setTheme}
+      theme={theme}
+      view={view}
+    />
   );
 }

--- a/apps/networkcanvas.com/components/layout/ThemeSwitcher.tsx
+++ b/apps/networkcanvas.com/components/layout/ThemeSwitcher.tsx
@@ -1,105 +1,31 @@
 'use client';
 
-import { Moon, Sun, SunMoon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
 
-import { Button, IconButton } from '@codaco/fresco-ui/Button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@codaco/fresco-ui/DropdownMenu';
-
-const themeOptions = [
-  { id: 'light', icon: Sun },
-  { id: 'dark', icon: Moon },
-  { id: 'system', icon: SunMoon },
-] as const;
-const THEME_ICON_STROKE_CLASS = '[&>.lucide]:[stroke-width:3.5]';
-
-type ThemeOption = (typeof themeOptions)[number]['id'];
-
-function isThemeOption(theme: string | undefined): theme is ThemeOption {
-  return themeOptions.some((option) => option.id === theme);
-}
+import SharedThemeSwitcher from '@codaco/fresco-ui/navigation/ThemeSwitcher';
 
 type ThemeSwitcherProps = {
   view: 'desktop' | 'mobile';
 };
 
 export default function ThemeSwitcher({ view }: ThemeSwitcherProps) {
-  const [mounted, setMounted] = useState(false);
   const { setTheme, theme } = useTheme();
   const t = useTranslations('ThemeTranslations');
 
-  useEffect(() => setMounted(true), []);
-
-  // Keep the server and first client render identical. next-themes restores the
-  // persisted preference after hydration, at which point the control can show
-  // the actual configured mode.
-  const selectedTheme = mounted && isThemeOption(theme) ? theme : 'system';
-  const SelectedIcon =
-    themeOptions.find((option) => option.id === selectedTheme)?.icon ?? SunMoon;
-  const triggerLabel = t('triggerLabel', {
-    theme: t(selectedTheme),
-  });
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          view === 'desktop' ? (
-            <IconButton
-              aria-label={triggerLabel}
-              icon={<SelectedIcon aria-hidden />}
-              size="lg"
-              variant="text"
-              color="dynamic"
-              className={`text-text border-transparent ${THEME_ICON_STROKE_CLASS}`}
-            />
-          ) : (
-            <Button
-              aria-label={triggerLabel}
-              icon={<SelectedIcon aria-hidden />}
-              size="sm"
-              variant="text"
-              color="dynamic"
-              className={`text-text justify-start border-transparent ${THEME_ICON_STROKE_CLASS}`}
-            />
-          )
-        }
-      >
-        {view === 'mobile' ? triggerLabel : undefined}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align={view === 'desktop' ? 'end' : 'start'}
-        className="min-w-48"
-      >
-        <DropdownMenuRadioGroup
-          aria-label={t('label')}
-          value={selectedTheme}
-          onValueChange={(value) => {
-            if (isThemeOption(value)) setTheme(value);
-          }}
-          className="flex flex-col gap-1"
-        >
-          {themeOptions.map(({ id, icon: OptionIcon }) => (
-            <DropdownMenuRadioItem
-              key={id}
-              value={id}
-              closeOnClick
-              icon={<OptionIcon aria-hidden />}
-              className={THEME_ICON_STROKE_CLASS}
-            >
-              {t(id)}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <SharedThemeSwitcher
+      labels={{
+        label: t('label'),
+        triggerLabel: (selectedTheme) =>
+          t('triggerLabel', { theme: t(selectedTheme) }),
+        light: t('light'),
+        dark: t('dark'),
+        system: t('system'),
+      }}
+      onThemeChange={setTheme}
+      theme={theme}
+      view={view}
+    />
   );
 }

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -156,6 +156,10 @@
       "types": "./dist/navigation/SiteNavigation.d.ts",
       "default": "./dist/navigation/SiteNavigation.js"
     },
+    "./navigation/ThemeSwitcher": {
+      "types": "./dist/navigation/ThemeSwitcher.d.ts",
+      "default": "./dist/navigation/ThemeSwitcher.js"
+    },
     "./navigation/SiteFooter": {
       "types": "./dist/navigation/SiteFooter.d.ts",
       "default": "./dist/navigation/SiteFooter.js"

--- a/packages/fresco-ui/src/navigation/ThemeSwitcher.stories.tsx
+++ b/packages/fresco-ui/src/navigation/ThemeSwitcher.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import ThemeSwitcher from './ThemeSwitcher';
+import type { ThemeSwitcherTheme } from './ThemeSwitcher';
+
+const labels = {
+  label: 'Color theme',
+  triggerLabel: (theme: ThemeSwitcherTheme) => `Color theme: ${theme}`,
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+};
+
+const documentation = `
+A controlled colour-theme picker for the utility slot in \`SiteNavigation\`.
+The host owns persistence and localisation, so the component can be shared
+without requiring a particular theme provider or i18n framework.
+
+\`\`\`tsx
+<ThemeSwitcher
+  labels={themeLabels}
+  theme={theme}
+  onThemeChange={setTheme}
+  view="desktop"
+/>
+\`\`\`
+
+- **\`theme\`** accepts \`light\`, \`dark\`, or \`system\`; unexpected values
+  safely fall back to \`system\` until the host restores its preference.
+- **\`labels\`** provides the visible and accessible copy for localisation.
+- **\`view\`** matches the desktop or compact navigation context.
+`;
+
+const meta = {
+  title: 'Navigation/ThemeSwitcher',
+  component: ThemeSwitcher,
+  tags: ['autodocs'],
+  parameters: {
+    docs: { description: { component: documentation } },
+  },
+  argTypes: {
+    theme: {
+      control: 'radio',
+      options: ['light', 'dark', 'system'],
+    },
+    view: {
+      control: 'radio',
+      options: ['desktop', 'mobile'],
+    },
+  },
+  args: {
+    labels,
+    onThemeChange: () => {},
+    theme: 'system',
+    view: 'desktop',
+  },
+  render: ({ theme: initialTheme, ...args }) => {
+    const [theme, setTheme] = useState(initialTheme);
+    return <ThemeSwitcher {...args} theme={theme} onThemeChange={setTheme} />;
+  },
+} satisfies Meta<typeof ThemeSwitcher>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CompactNavigation: Story = {
+  args: { view: 'mobile' },
+};

--- a/packages/fresco-ui/src/navigation/ThemeSwitcher.test.tsx
+++ b/packages/fresco-ui/src/navigation/ThemeSwitcher.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ThemeSwitcher from './ThemeSwitcher';
+
+const labels = {
+  label: 'Color theme',
+  triggerLabel: (theme: 'light' | 'dark' | 'system') => `Color theme: ${theme}`,
+  light: 'Light',
+  dark: 'Dark',
+  system: 'System',
+};
+
+describe('ThemeSwitcher', () => {
+  it('uses the selected theme for its accessible trigger label', () => {
+    render(
+      <ThemeSwitcher
+        labels={labels}
+        onThemeChange={vi.fn()}
+        theme="dark"
+        view="desktop"
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: 'Color theme: dark',
+    });
+    expect(trigger).toHaveClass('h-16');
+    expect(trigger.querySelector('.lucide-moon')).toBeInTheDocument();
+  });
+
+  it('renders labelled theme options and reports the selected option', () => {
+    const onThemeChange = vi.fn();
+    render(
+      <ThemeSwitcher
+        labels={labels}
+        onThemeChange={onThemeChange}
+        theme="system"
+        view="desktop"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Color theme: system' }),
+    );
+
+    const lightOption = screen.getByRole('menuitemradio', { name: 'Light' });
+    const darkOption = screen.getByRole('menuitemradio', { name: 'Dark' });
+    const systemOption = screen.getByRole('menuitemradio', {
+      name: 'System',
+    });
+
+    expect(lightOption.querySelector('.lucide-sun')).toBeInTheDocument();
+    expect(darkOption.querySelector('.lucide-moon')).toBeInTheDocument();
+    expect(systemOption.querySelector('.lucide-sun-moon')).toBeInTheDocument();
+    expect(document.querySelector('.lucide-check')).not.toBeInTheDocument();
+
+    fireEvent.click(darkOption);
+    expect(onThemeChange).toHaveBeenCalledWith('dark');
+  });
+});

--- a/packages/fresco-ui/src/navigation/ThemeSwitcher.tsx
+++ b/packages/fresco-ui/src/navigation/ThemeSwitcher.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { Moon, Sun, SunMoon } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Button, IconButton } from '../Button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '../DropdownMenu';
+
+const themeOptions = [
+  { id: 'light', icon: Sun },
+  { id: 'dark', icon: Moon },
+  { id: 'system', icon: SunMoon },
+] as const;
+
+const THEME_ICON_STROKE_CLASS = '[&>.lucide]:[stroke-width:3.5]';
+
+export type ThemeSwitcherTheme = (typeof themeOptions)[number]['id'];
+
+export type ThemeSwitcherLabels = Record<ThemeSwitcherTheme, string> & {
+  label: string;
+  triggerLabel: (theme: ThemeSwitcherTheme) => string;
+};
+
+export type ThemeSwitcherProps = {
+  labels: ThemeSwitcherLabels;
+  onThemeChange: (theme: ThemeSwitcherTheme) => void;
+  theme?: string;
+  view: 'desktop' | 'mobile';
+};
+
+function isThemeSwitcherTheme(
+  theme: string | undefined,
+): theme is ThemeSwitcherTheme {
+  return themeOptions.some((option) => option.id === theme);
+}
+
+/**
+ * A controlled colour-theme picker for use in the shared site navigation.
+ * Hosts provide their theme-provider state and translated labels so this
+ * component stays independent of framework-specific theme and i18n libraries.
+ */
+export default function ThemeSwitcher({
+  labels,
+  onThemeChange,
+  theme,
+  view,
+}: ThemeSwitcherProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  // Keep the server and first client render identical. The host's theme
+  // provider can restore a persisted preference after hydration, at which
+  // point the control shows the configured mode.
+  const selectedTheme =
+    mounted && isThemeSwitcherTheme(theme) ? theme : 'system';
+  const SelectedIcon =
+    themeOptions.find((option) => option.id === selectedTheme)?.icon ?? SunMoon;
+  const triggerLabel = labels.triggerLabel(selectedTheme);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          view === 'desktop' ? (
+            <IconButton
+              aria-label={triggerLabel}
+              icon={<SelectedIcon aria-hidden />}
+              size="lg"
+              variant="text"
+              color="dynamic"
+              className={`text-text border-transparent ${THEME_ICON_STROKE_CLASS}`}
+            />
+          ) : (
+            <Button
+              aria-label={triggerLabel}
+              icon={<SelectedIcon aria-hidden />}
+              size="sm"
+              variant="text"
+              color="dynamic"
+              className={`text-text justify-start border-transparent ${THEME_ICON_STROKE_CLASS}`}
+            />
+          )
+        }
+      >
+        {view === 'mobile' ? triggerLabel : undefined}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={view === 'desktop' ? 'end' : 'start'}
+        className="min-w-48"
+      >
+        <DropdownMenuRadioGroup
+          aria-label={labels.label}
+          value={selectedTheme}
+          onValueChange={(value) => {
+            if (isThemeSwitcherTheme(value)) onThemeChange(value);
+          }}
+          className="flex flex-col gap-1"
+        >
+          {themeOptions.map(({ id, icon: OptionIcon }) => (
+            <DropdownMenuRadioItem
+              key={id}
+              value={id}
+              closeOnClick
+              icon={<OptionIcon aria-hidden />}
+              className={THEME_ICON_STROKE_CLASS}
+            >
+              {labels[id]}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- add a controlled Fresco UI theme switcher for public-site navigation
- use it in networkcanvas.com and documentation while preserving each site's theme persistence and translations
- document, test, and add release metadata for the shared component

## Test plan
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @codaco/fresco-ui test`
- [x] `pnpm --filter networkcanvas.com test`
- [x] `pnpm --filter @codaco/fresco-ui build-storybook`