### PR TITLE
Fix capitalization of generated stage names

### DIFF
--- a/.changeset/bright-stage-titles.md
+++ b/.changeset/bright-stage-titles.md
@@ -1,0 +1,5 @@
+---
+"@codaco/architect": patch
+---
+
+Ensure automatically generated stage names start with a capital letter when they begin with user-defined text.

--- a/apps/architect/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
+++ b/apps/architect/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
@@ -29,6 +29,15 @@ describe('composeStageName', () => {
       }),
     ).toBe('Ego Form');
   });
+  it('capitalises a lowercase user-defined subject without changing other casing', () => {
+    expect(
+      composeStageName({
+        subjectName: 'person',
+        typeName: 'Form Name Generator',
+        qualifier: null,
+      }),
+    ).toBe('Person Form Name Generator');
+  });
 });
 
 describe('dedupeStageLabel', () => {

--- a/apps/architect/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
+++ b/apps/architect/src/components/StageEditor/autoStageName/__tests__/generateStageLabel.test.ts
@@ -38,6 +38,15 @@ describe('composeStageName', () => {
       }),
     ).toBe('Person Form Name Generator');
   });
+  it('trims user-defined parts before capitalising the stage name', () => {
+    expect(
+      composeStageName({
+        subjectName: '  person ',
+        typeName: 'Form Name Generator',
+        qualifier: null,
+      }),
+    ).toBe('Person Form Name Generator');
+  });
 });
 
 describe('dedupeStageLabel', () => {

--- a/apps/architect/src/components/StageEditor/autoStageName/generateStageLabel.ts
+++ b/apps/architect/src/components/StageEditor/autoStageName/generateStageLabel.ts
@@ -32,7 +32,8 @@ export function composeStageName(parts: {
   qualifier?: string | null;
 }): string {
   const stageName = [parts.subjectName, parts.typeName, parts.qualifier]
-    .filter((part): part is string => Boolean(part && part.trim()))
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
     .join(' ');
 
   return stageName.charAt(0).toUpperCase() + stageName.slice(1);

--- a/apps/architect/src/components/StageEditor/autoStageName/generateStageLabel.ts
+++ b/apps/architect/src/components/StageEditor/autoStageName/generateStageLabel.ts
@@ -31,9 +31,11 @@ export function composeStageName(parts: {
   typeName: string;
   qualifier?: string | null;
 }): string {
-  return [parts.subjectName, parts.typeName, parts.qualifier]
+  const stageName = [parts.subjectName, parts.typeName, parts.qualifier]
     .filter((part): part is string => Boolean(part && part.trim()))
     .join(' ');
+
+  return stageName.charAt(0).toUpperCase() + stageName.slice(1);
 }
 
 export function dedupeStageLabel(


### PR DESCRIPTION
## Summary
- capitalize the first character of automatically composed stage names
- preserve the casing of the remaining user-defined and built-in title text
- add regression coverage and an Architect patch changeset

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] Architect unit suite (154 files, 889 passed)
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] Architect Playwright E2E suite (35 passed)
- [x] `pnpm check:changesets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically generated stage names now begin with a capital letter when based on user-defined text.
  * Existing capitalization within the rest of the stage name is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->