### PR TITLE
Add download option when leaving Architect

### DIFF
--- a/.changeset/quick-otters-return.md
+++ b/.changeset/quick-otters-return.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Add a “Return and download now” option when leaving the protocol editor, so researchers can download the active protocol and return to the start screen in one step.

--- a/apps/architect/e2e/pageobjects/toolbar.ts
+++ b/apps/architect/e2e/pageobjects/toolbar.ts
@@ -19,7 +19,9 @@ export class Toolbar {
   button(id: string) {
     // ActionToolbar (SegmentedToolbar) renders items with aria-label = label
     // (icon-only) or visible text; target by accessible name either way.
-    return this.page.getByRole('button', { name: this.labelFor(id) });
+    return this.page
+      .getByRole('toolbar')
+      .getByRole('button', { name: this.labelFor(id) });
   }
 
   private labelFor(id: string): string {

--- a/apps/architect/e2e/specs/app-functionality.spec.ts
+++ b/apps/architect/e2e/specs/app-functionality.spec.ts
@@ -31,6 +31,29 @@ test('downloads the active protocol as a .netcanvas', async ({
   await toolbar.expectLabel('download', 'Downloaded');
 });
 
+test('downloads the active protocol while returning to the start screen', async ({
+  architectPage,
+  seed,
+}) => {
+  const { protocol, assets } = loadAllInterfacesFixture();
+  await seed(protocol, { name: 'Download On Exit', assets });
+  await gotoProtocol(architectPage);
+
+  const toolbar = new Toolbar(architectPage);
+  await toolbar.returnToStart();
+
+  const [download] = await Promise.all([
+    architectPage.waitForEvent('download'),
+    architectPage.getByTestId('dialog-secondary').click(),
+  ]);
+
+  expect(download.suggestedFilename()).toMatch(
+    /^Download_On_Exit-\d{4}-\d{2}-\d{2}_\d{2}-\d{2}\.netcanvas$/,
+  );
+  await expect(architectPage).toHaveURL(/\/$/);
+  await expect(architectPage.getByText('Download On Exit')).toBeVisible();
+});
+
 test('clears all stored protocols', async ({ architectPage, seed }) => {
   const { protocol } = loadAllInterfacesFixture();
   await seed(protocol, { name: 'To Be Cleared' });

--- a/apps/architect/e2e/specs/app-functionality.spec.ts
+++ b/apps/architect/e2e/specs/app-functionality.spec.ts
@@ -1,6 +1,9 @@
+import { validateProtocol } from '@codaco/protocol-validation';
+
 import { expect, gotoProtocol, test } from '../fixtures/architect-test.js';
 import { loadAllInterfacesFixture } from '../helpers/load-fixture.js';
 import { readProtocolJson } from '../helpers/read-store.js';
+import { Timeline } from '../pageobjects/timeline.js';
 import { Toolbar } from '../pageobjects/toolbar.js';
 
 test('downloads the active protocol as a .netcanvas', async ({
@@ -52,6 +55,53 @@ test('downloads the active protocol while returning to the start screen', async 
   );
   await expect(architectPage).toHaveURL(/\/$/);
   await expect(architectPage.getByText('Download On Exit')).toBeVisible();
+});
+
+test('discards an invalid stage draft before returning to the start screen', async ({
+  architectPage,
+  seed,
+}) => {
+  const { protocol, assets } = loadAllInterfacesFixture();
+  const informationStage = protocol.stages.find(
+    (stage) => stage.type === 'Information',
+  );
+  if (!informationStage) throw new Error('fixture has no Information stage');
+
+  await seed(protocol, { name: 'Discard Invalid Draft', assets });
+  await gotoProtocol(architectPage);
+  await new Timeline(architectPage).openStage(informationStage.label);
+
+  // Clearing Information's required page heading makes the in-progress stage
+  // invalid. The stage editor keeps this in its separate draft until the user
+  // chooses "Finished Editing", so it must never replace the durable protocol
+  // shown on the start screen.
+  await architectPage.getByRole('textbox', { name: 'Page heading' }).fill('');
+
+  // The stage editor replaces ProjectActions with StageEditorNav, so leaving
+  // the protocol from here uses Brand's app-header button rather than the
+  // overview toolbar action.
+  await architectPage
+    .getByRole('button', { name: 'Return to start screen', exact: true })
+    .click();
+  const dialog = architectPage.getByRole('dialog', {
+    name: 'Discard unsaved stage changes?',
+  });
+  await expect(dialog).toBeVisible();
+  await expect(
+    dialog.getByRole('button', { name: 'Return and download now' }),
+  ).toHaveCount(0);
+  await dialog
+    .getByRole('button', { name: 'Discard Changes and Return' })
+    .click();
+
+  await expect(architectPage).toHaveURL(/\/$/);
+  await expect(architectPage.getByText('Discard Invalid Draft')).toBeVisible();
+
+  const persistedProtocol = await readProtocolJson(architectPage);
+  expect(
+    persistedProtocol.stages.find((stage) => stage.id === informationStage.id),
+  ).toEqual(informationStage);
+  expect((await validateProtocol(persistedProtocol)).success).toBe(true);
 });
 
 test('clears all stored protocols', async ({ architectPage, seed }) => {

--- a/apps/architect/src/components/ProjectNav/ProjectActions.tsx
+++ b/apps/architect/src/components/ProjectNav/ProjectActions.tsx
@@ -13,7 +13,6 @@ import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import type { ToolbarSegment } from '@codaco/fresco-ui/SegmentedToolbar';
 import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
 import { getActiveProtocolId } from '~/ducks/modules/app';
-import { exportNetcanvas } from '~/ducks/modules/userActions/userActions';
 import { useScopedUndoRedo } from '~/hooks/useScopedUndoRedo';
 import { getProtocol } from '~/selectors/protocol';
 import type { ProtocolSourceRef } from '~/templates';
@@ -21,6 +20,7 @@ import {
   isProtocolSourceAuthoringEnabled,
   saveProtocolSource,
 } from '~/templates/source-authoring';
+import { downloadActiveProtocol } from '~/utils/downloadActiveProtocol';
 import { getStoredProtocol } from '~/utils/protocolLibrary';
 import { reportError } from '~/utils/reportError';
 
@@ -61,31 +61,11 @@ const ProjectActions = ({
   const handleRedo = useCallback(() => scopedRedo(), [scopedRedo]);
 
   const handleDownload = useCallback(async () => {
+    setIsExporting(true);
     try {
-      setIsExporting(true);
-      const { skippedAssets } = await dispatch(exportNetcanvas()).unwrap();
-      if (skippedAssets.length > 0) {
-        const assetList = skippedAssets.map((asset) => asset.name).join(', ');
-        void openDialog({
-          type: 'acknowledge',
-          intent: 'warning',
-          title: 'Some assets could not be exported',
-          description:
-            'Your protocol was downloaded, but these assets could not be ' +
-            `included and are missing from the file: ${assetList}.`,
-          actions: { primary: { label: 'OK', value: true } },
-        });
-      }
+      const downloaded = await downloadActiveProtocol(dispatch, openDialog);
+      if (!downloaded) return;
       setDownloadSuccess(true);
-    } catch (error) {
-      const { message } = reportError(error);
-      void openDialog({
-        type: 'acknowledge',
-        intent: 'destructive',
-        title: 'Failed to export protocol',
-        description: message,
-        actions: { primary: { label: 'OK', value: true } },
-      });
     } finally {
       setIsExporting(false);
     }

--- a/apps/architect/src/components/ProtocolGuardedRouter.tsx
+++ b/apps/architect/src/components/ProtocolGuardedRouter.tsx
@@ -5,12 +5,14 @@ import type { AroundNavHandler } from 'wouter';
 
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useAppDispatch } from '~/ducks/hooks';
+import { store } from '~/ducks/store';
 import {
   guardState,
   isProtocolPath,
   promptLeaveEditor,
   useProtocolNavGuard,
 } from '~/hooks/useProtocolNavGuard';
+import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
 
 const NavGuardListener = () => {
   useProtocolNavGuard();
@@ -35,7 +37,12 @@ const ProtocolGuardedRouter = ({ children }: ProtocolGuardedRouterProps) => {
         return;
       }
 
-      void promptLeaveEditor(dispatch, openDialog, () => nav(to, opts));
+      void promptLeaveEditor(
+        dispatch,
+        openDialog,
+        () => nav(to, opts),
+        getStageDraftDirty(store.getState()),
+      );
     },
     [dispatch, openDialog],
   );

--- a/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
+++ b/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
@@ -12,17 +12,30 @@ import { guardState, promptLeaveEditor } from '../useProtocolNavGuard';
 // Intercepts the fresco dialog request so the test can read the config shown to
 // the user and auto-confirm it. Records every dispatched action (resetDraft is a
 // thunk, i.e. a function, so we can detect it by type).
-const setup = () => {
+const setup = (
+  dialogAction: 'leave' | 'download-and-leave' | null = 'leave',
+  downloadResult: 'success' | 'failure' = 'success',
+) => {
   const dispatched: unknown[] = [];
-  let captured: AnyDialog | undefined;
+  const captured: AnyDialog[] = [];
 
   const openDialog = (async (config: AnyDialog) => {
-    captured = config;
-    return true;
+    captured.push(config);
+    return dialogAction;
   }) as DialogContextType['openDialog'];
 
   const dispatch = ((action: unknown) => {
     dispatched.push(action);
+    if (typeof action === 'function') {
+      return {
+        unwrap: async () => {
+          if (downloadResult === 'failure') {
+            throw new Error('Export failed');
+          }
+          return { skippedAssets: [] };
+        },
+      };
+    }
     return action;
   }) as unknown as AppDispatch;
 
@@ -30,7 +43,8 @@ const setup = () => {
     dispatch,
     dispatched,
     openDialog,
-    getCaptured: () => captured,
+    getCaptured: () => captured[0],
+    getCapturedDialogs: () => captured,
   };
 };
 
@@ -55,6 +69,10 @@ describe('promptLeaveEditor', () => {
     expect(captured.size).toBe('readable');
     expect(captured.description).not.toMatch(/saved automatically/i);
     expect(captured.description).toMatch(/unsaved changes/i);
+    expect(captured.actions.secondary).toEqual({
+      label: 'Return and download now',
+      value: 'download-and-leave',
+    });
 
     // resetDraft is a thunk, so a function is dispatched to clear the draft.
     expect(dispatched.some((action) => typeof action === 'function')).toBe(
@@ -83,5 +101,46 @@ describe('promptLeaveEditor', () => {
     );
     expect(dispatched).toContainEqual(clearActiveProtocol());
     expect(performLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads the protocol before returning to the start screen', async () => {
+    const { dispatch, dispatched, openDialog, getCaptured } =
+      setup('download-and-leave');
+    const performLeave = vi.fn();
+
+    await promptLeaveEditor(dispatch, openDialog, performLeave, false);
+
+    const captured = getCaptured();
+    expect(captured?.type).toBe('choice');
+    if (captured?.type !== 'choice') throw new Error('Expected choice dialog');
+    expect(captured.actions.secondary).toEqual({
+      label: 'Return and download now',
+      value: 'download-and-leave',
+    });
+    expect(
+      dispatched.filter((action) => typeof action === 'function'),
+    ).toHaveLength(1);
+    expect(dispatched).toContainEqual(clearActiveProtocol());
+    expect(performLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays in the editor and reports an export failure', async () => {
+    const { dispatch, dispatched, openDialog, getCapturedDialogs } = setup(
+      'download-and-leave',
+      'failure',
+    );
+    const performLeave = vi.fn();
+
+    await promptLeaveEditor(dispatch, openDialog, performLeave, false);
+
+    expect(dispatched).not.toContainEqual(clearActiveProtocol());
+    expect(performLeave).not.toHaveBeenCalled();
+    expect(getCapturedDialogs()).toHaveLength(2);
+    expect(getCapturedDialogs()[1]).toMatchObject({
+      type: 'acknowledge',
+      intent: 'destructive',
+      title: 'Failed to export protocol',
+      description: 'Export failed',
+    });
   });
 });

--- a/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
+++ b/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
@@ -13,7 +13,11 @@ import { guardState, promptLeaveEditor } from '../useProtocolNavGuard';
 // the user and auto-confirm it. Records every dispatched action (resetDraft is a
 // thunk, i.e. a function, so we can detect it by type).
 const setup = (
-  dialogAction: 'leave' | 'download-and-leave' | null = 'leave',
+  dialogAction:
+    | 'leave'
+    | 'download-and-leave'
+    | 'discard-and-leave'
+    | null = 'leave',
   downloadResult: 'success' | 'failure' = 'success',
 ) => {
   const dispatched: unknown[] = [];
@@ -55,8 +59,9 @@ describe('promptLeaveEditor', () => {
     vi.restoreAllMocks();
   });
 
-  it('warns about data loss and resets the dirty stage draft when leaving to the start screen', async () => {
-    const { dispatch, dispatched, openDialog, getCaptured } = setup();
+  it('uses a separate discard dialog and resets a dirty stage draft when returning to the start screen', async () => {
+    const { dispatch, dispatched, openDialog, getCaptured } =
+      setup('discard-and-leave');
     const performLeave = vi.fn();
 
     await promptLeaveEditor(dispatch, openDialog, performLeave, true);
@@ -67,8 +72,16 @@ describe('promptLeaveEditor', () => {
     if (captured?.type !== 'choice') throw new Error('Expected choice dialog');
     expect(captured.intent).toBe('warning');
     expect(captured.size).toBe('readable');
+    expect(captured.title).toBe('Discard unsaved stage changes?');
     expect(captured.description).not.toMatch(/saved automatically/i);
-    expect(captured.description).toMatch(/unsaved changes/i);
+    expect(captured.description).toMatch(
+      /have not been saved to the protocol/i,
+    );
+    expect(captured.description).toMatch(/last saved version/i);
+    expect(captured.actions.primary).toEqual({
+      label: 'Discard Changes and Return',
+      value: 'discard-and-leave',
+    });
     expect(captured.actions.secondary).toBeUndefined();
 
     // resetDraft is a thunk, so a function is dispatched to clear the draft.

--- a/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
+++ b/apps/architect/src/hooks/__tests__/useProtocolNavGuard.test.tsx
@@ -69,10 +69,7 @@ describe('promptLeaveEditor', () => {
     expect(captured.size).toBe('readable');
     expect(captured.description).not.toMatch(/saved automatically/i);
     expect(captured.description).toMatch(/unsaved changes/i);
-    expect(captured.actions.secondary).toEqual({
-      label: 'Return and download now',
-      value: 'download-and-leave',
-    });
+    expect(captured.actions.secondary).toBeUndefined();
 
     // resetDraft is a thunk, so a function is dispatched to clear the draft.
     expect(dispatched.some((action) => typeof action === 'function')).toBe(

--- a/apps/architect/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect/src/hooks/useProtocolNavGuard.ts
@@ -47,8 +47,9 @@ const isStageEditorPath = (path: string) => path.startsWith('/protocol/stage/');
 //
 // `draftDirty` reflects whether the stage editor holds uncommitted edits. The
 // stage draft is not persisted (see rememberedKeys in store.ts), so leaving with
-// a dirty draft loses those edits: warn accordingly and reset the draft on
-// confirm. A pristine editor keeps the reassuring "saved automatically" copy.
+// a dirty draft uses a separate discard dialog and resets the draft on confirm.
+// A pristine editor keeps the reassuring "saved automatically" copy and offers
+// the download-and-leave action.
 export const promptLeaveEditor = async (
   dispatch: AppDispatch,
   openDialog: DialogContextType['openDialog'],
@@ -58,47 +59,54 @@ export const promptLeaveEditor = async (
   if (guardState.prompting) return;
   guardState.prompting = true;
   try {
-    const dialogConfig = draftDirty
-      ? {
-          intent: 'warning' as const,
-          title: 'Return to start screen?',
+    const action = draftDirty
+      ? await openDialog({
+          type: 'choice',
+          title: 'Discard unsaved stage changes?',
           description:
-            'You have unsaved changes in the stage editor that will be lost if you leave now. Are you sure you want to return to the start screen?',
-          confirmLabel: 'Discard Changes and Leave',
-        }
-      : {
-          intent: 'default' as const,
+            'Changes made in this stage have not been saved to the protocol. If you return to the start screen now, those changes will be discarded and the last saved version of the protocol will remain available.',
+          intent: 'warning',
+          size: 'readable',
+          actions: {
+            primary: {
+              label: 'Discard Changes and Return',
+              value: 'discard-and-leave' as const,
+            },
+            cancel: {
+              label: 'Cancel',
+              value: null,
+            },
+          },
+        })
+      : await openDialog({
+          type: 'choice',
           title: 'Return to start screen?',
           description:
             "Your work is saved automatically in your browser, so you can return to the editor at any time. Don't forget to download your protocol when you are ready to collect data.",
-          confirmLabel: 'Return to Start Screen',
-        };
-
-    const action = await openDialog({
-      type: 'choice',
-      title: dialogConfig.title,
-      description: dialogConfig.description,
-      intent: dialogConfig.intent,
-      size: 'readable',
-      actions: {
-        primary: {
-          label: dialogConfig.confirmLabel,
-          value: 'leave' as const,
-        },
-        ...(!draftDirty && {
-          secondary: {
-            label: 'Return and download now',
-            value: 'download-and-leave' as const,
+          intent: 'default',
+          size: 'readable',
+          actions: {
+            primary: {
+              label: 'Return to Start Screen',
+              value: 'leave' as const,
+            },
+            secondary: {
+              label: 'Return and download now',
+              value: 'download-and-leave' as const,
+            },
+            cancel: {
+              label: 'Cancel',
+              value: null,
+            },
           },
-        }),
-        cancel: {
-          label: 'Cancel',
-          value: null,
-        },
-      },
-    });
+        });
 
-    if (action !== 'leave' && action !== 'download-and-leave') return;
+    if (draftDirty && action !== 'discard-and-leave') {
+      return;
+    }
+    if (!draftDirty && action !== 'leave' && action !== 'download-and-leave') {
+      return;
+    }
 
     if (action === 'download-and-leave') {
       const downloaded = await downloadActiveProtocol(dispatch, openDialog);

--- a/apps/architect/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect/src/hooks/useProtocolNavGuard.ts
@@ -9,6 +9,7 @@ import { resetDraft } from '~/ducks/modules/stageEditorDraft';
 import type { AppDispatch } from '~/ducks/store';
 import { store } from '~/ducks/store';
 import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
+import { downloadActiveProtocol } from '~/utils/downloadActiveProtocol';
 
 // Shared mutable state read by this hook and the Router's aroundNav.
 // - bypass: flipped on while we're performing the confirmed navigation so the
@@ -73,7 +74,7 @@ export const promptLeaveEditor = async (
           confirmLabel: 'Return to Start Screen',
         };
 
-    const confirmed = await openDialog({
+    const action = await openDialog({
       type: 'choice',
       title: dialogConfig.title,
       description: dialogConfig.description,
@@ -82,16 +83,25 @@ export const promptLeaveEditor = async (
       actions: {
         primary: {
           label: dialogConfig.confirmLabel,
-          value: true,
+          value: 'leave' as const,
+        },
+        secondary: {
+          label: 'Return and download now',
+          value: 'download-and-leave' as const,
         },
         cancel: {
           label: 'Cancel',
-          value: false,
+          value: null,
         },
       },
     });
 
-    if (confirmed !== true) return;
+    if (action !== 'leave' && action !== 'download-and-leave') return;
+
+    if (action === 'download-and-leave') {
+      const downloaded = await downloadActiveProtocol(dispatch, openDialog);
+      if (!downloaded) return;
+    }
 
     guardState.bypass = true;
     try {

--- a/apps/architect/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect/src/hooks/useProtocolNavGuard.ts
@@ -85,10 +85,12 @@ export const promptLeaveEditor = async (
           label: dialogConfig.confirmLabel,
           value: 'leave' as const,
         },
-        secondary: {
-          label: 'Return and download now',
-          value: 'download-and-leave' as const,
-        },
+        ...(!draftDirty && {
+          secondary: {
+            label: 'Return and download now',
+            value: 'download-and-leave' as const,
+          },
+        }),
         cancel: {
           label: 'Cancel',
           value: null,

--- a/apps/architect/src/utils/downloadActiveProtocol.ts
+++ b/apps/architect/src/utils/downloadActiveProtocol.ts
@@ -1,0 +1,37 @@
+import type { DialogContextType } from '@codaco/fresco-ui/dialogs/DialogProvider';
+import { exportNetcanvas } from '~/ducks/modules/userActions/userActions';
+import type { AppDispatch } from '~/ducks/store';
+
+import { reportError } from './reportError';
+
+export const downloadActiveProtocol = async (
+  dispatch: AppDispatch,
+  openDialog: DialogContextType['openDialog'],
+): Promise<boolean> => {
+  try {
+    const { skippedAssets } = await dispatch(exportNetcanvas()).unwrap();
+    if (skippedAssets.length > 0) {
+      const assetList = skippedAssets.map((asset) => asset.name).join(', ');
+      void openDialog({
+        type: 'acknowledge',
+        intent: 'warning',
+        title: 'Some assets could not be exported',
+        description:
+          'Your protocol was downloaded, but these assets could not be ' +
+          `included and are missing from the file: ${assetList}.`,
+        actions: { primary: { label: 'OK', value: true } },
+      });
+    }
+    return true;
+  } catch (error) {
+    const { message } = reportError(error);
+    void openDialog({
+      type: 'acknowledge',
+      intent: 'destructive',
+      title: 'Failed to export protocol',
+      description: message,
+      actions: { primary: { label: 'OK', value: true } },
+    });
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- add a "Return and download now" secondary action to Architect's exit confirmation
- reuse the active-protocol export flow for toolbar and exit downloads, preserving skipped-asset and failure feedback
- keep the editor open if export fails
- show a separate discard warning for unsaved stage drafts and never offer to download a draft that has not been committed
- verify an invalid stage draft is discarded and only the last saved, schema-valid protocol reaches the start screen
- add an Architect patch changeset

## Test plan
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] focused Architect unit tests (14 passed)
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] full Architect Playwright E2E suite (38 passed)
