### PR TITLE
Fix Architect protocol exit browser history

### DIFF
--- a/.changeset/architect-browser-history.md
+++ b/.changeset/architect-browser-history.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Prevent the browser Back button from opening an empty, invalid protocol after returning to the start screen.

--- a/apps/architect/e2e/pageobjects/toolbar.ts
+++ b/apps/architect/e2e/pageobjects/toolbar.ts
@@ -19,7 +19,9 @@ export class Toolbar {
   button(id: string) {
     // ActionToolbar (SegmentedToolbar) renders items with aria-label = label
     // (icon-only) or visible text; target by accessible name either way.
-    return this.page.getByRole('button', { name: this.labelFor(id) });
+    return this.page
+      .getByRole('toolbar')
+      .getByRole('button', { name: this.labelFor(id) });
   }
 
   private labelFor(id: string): string {
@@ -60,7 +62,9 @@ export class Toolbar {
   // the at-rest label.
   async expectLabel(id: string, text: string) {
     await expect(
-      this.page.getByRole('button', { name: text, exact: true }),
+      this.page
+        .getByRole('toolbar')
+        .getByRole('button', { name: text, exact: true }),
       `expected toolbar item "${id}" to show label "${text}"`,
     ).toBeVisible();
   }

--- a/apps/architect/e2e/specs/app-functionality.spec.ts
+++ b/apps/architect/e2e/specs/app-functionality.spec.ts
@@ -83,6 +83,17 @@ test('does not leave a cleared protocol in browser history', async ({
     .click();
   await expect(architectPage).toHaveURL(/\/protocol$/);
 
+  await architectPage.getByRole('link', { name: 'Resources' }).click();
+  await expect(architectPage).toHaveURL(/\/protocol\/assets$/);
+  await architectPage.getByRole('link', { name: 'Codebook' }).click();
+  await expect(architectPage).toHaveURL(/\/protocol\/codebook$/);
+
+  // Protocol routes keep their normal Back/Forward behavior while editing.
+  await architectPage.goBack();
+  await expect(architectPage).toHaveURL(/\/protocol\/assets$/);
+  await architectPage.goForward();
+  await expect(architectPage).toHaveURL(/\/protocol\/codebook$/);
+
   const toolbar = new Toolbar(architectPage);
   await toolbar.returnToStart();
   await architectPage.getByTestId('dialog-primary').click();

--- a/apps/architect/e2e/specs/app-functionality.spec.ts
+++ b/apps/architect/e2e/specs/app-functionality.spec.ts
@@ -68,6 +68,36 @@ test('imports a .netcanvas via the home dropzone', async ({
   await expect(architectPage).toHaveURL(/\/protocol$/);
 });
 
+test('does not leave a cleared protocol in browser history', async ({
+  architectPage,
+  seed,
+}) => {
+  const { protocol } = loadAllInterfacesFixture();
+  await seed(protocol, { name: 'Browser History Seed' });
+  // The seed writes directly to IndexedDB after the start screen has already
+  // rendered. Reload so the Recent collection reads the new library row.
+  await architectPage.reload();
+
+  await architectPage
+    .getByText('Browser History Seed', { exact: true })
+    .click();
+  await expect(architectPage).toHaveURL(/\/protocol$/);
+
+  const toolbar = new Toolbar(architectPage);
+  await toolbar.returnToStart();
+  await architectPage.getByTestId('dialog-primary').click();
+  await expect(architectPage).toHaveURL(/\/$/);
+
+  await architectPage.goBack();
+  await expect(architectPage).toHaveURL(/\/$/);
+  await expect(
+    architectPage.getByText('Browser History Seed', { exact: true }),
+  ).toBeVisible();
+  await expect(
+    architectPage.getByRole('textbox', { name: 'Protocol name' }),
+  ).toHaveCount(0);
+});
+
 test('undoes and redoes a protocol-name edit', async ({
   architectPage,
   seed,

--- a/apps/architect/src/components/ProtocolGuardedRouter.tsx
+++ b/apps/architect/src/components/ProtocolGuardedRouter.tsx
@@ -6,6 +6,7 @@ import type { AroundNavHandler } from 'wouter';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useAppDispatch } from '~/ducks/hooks';
 import {
+  collapseProtocolHistory,
   guardState,
   isProtocolPath,
   promptLeaveEditor,
@@ -35,11 +36,8 @@ const ProtocolGuardedRouter = ({ children }: ProtocolGuardedRouterProps) => {
         return;
       }
 
-      // Leaving clears the active protocol, so the editor route must not stay
-      // directly behind the start screen in browser history. Otherwise Back
-      // would revisit /protocol without the protocol that route needs.
       void promptLeaveEditor(dispatch, openDialog, () =>
-        nav(to, { ...opts, replace: true }),
+        collapseProtocolHistory(to, () => nav(to, { ...opts, replace: true })),
       );
     },
     [dispatch, openDialog],

--- a/apps/architect/src/components/ProtocolGuardedRouter.tsx
+++ b/apps/architect/src/components/ProtocolGuardedRouter.tsx
@@ -35,7 +35,12 @@ const ProtocolGuardedRouter = ({ children }: ProtocolGuardedRouterProps) => {
         return;
       }
 
-      void promptLeaveEditor(dispatch, openDialog, () => nav(to, opts));
+      // Leaving clears the active protocol, so the editor route must not stay
+      // directly behind the start screen in browser history. Otherwise Back
+      // would revisit /protocol without the protocol that route needs.
+      void promptLeaveEditor(dispatch, openDialog, () =>
+        nav(to, { ...opts, replace: true }),
+      );
     },
     [dispatch, openDialog],
   );

--- a/apps/architect/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect/src/hooks/useProtocolNavGuard.ts
@@ -210,7 +210,7 @@ export const useProtocolNavGuard = () => {
         void promptLeaveEditor(
           dispatch,
           openDialog,
-          () => setLocation('/'),
+          () => setLocation('/', { replace: true }),
           draftDirty,
         );
         return;

--- a/apps/architect/src/hooks/useProtocolNavGuard.ts
+++ b/apps/architect/src/hooks/useProtocolNavGuard.ts
@@ -25,15 +25,121 @@ import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
 const getFullPath = () =>
   window.location.pathname + window.location.search + window.location.hash;
 
-export const guardState = {
-  bypass: false,
-  prompting: false,
-  prevPath: getFullPath(),
-};
-
 // path may include a search/hash suffix; pathname always comes first, so a
 // prefix check still correctly identifies protocol routes.
 export const isProtocolPath = (path: string) => path.startsWith('/protocol');
+
+const PROTOCOL_HISTORY_KEY = '__architectProtocolHistory';
+
+type ProtocolHistoryMarker = {
+  depth: number;
+  hasAppEntryBeforeProtocol: boolean;
+};
+
+const readProtocolHistoryMarker = (): ProtocolHistoryMarker | null => {
+  const state: unknown = history.state;
+  if (typeof state !== 'object' || state === null || Array.isArray(state)) {
+    return null;
+  }
+
+  const marker = (state as Record<string, unknown>)[PROTOCOL_HISTORY_KEY];
+  if (typeof marker !== 'object' || marker === null) return null;
+
+  const depth = (marker as Record<string, unknown>).depth;
+  const hasAppEntryBeforeProtocol = (marker as Record<string, unknown>)
+    .hasAppEntryBeforeProtocol;
+  if (
+    typeof depth !== 'number' ||
+    !Number.isInteger(depth) ||
+    depth < 1 ||
+    typeof hasAppEntryBeforeProtocol !== 'boolean'
+  ) {
+    return null;
+  }
+
+  return { depth, hasAppEntryBeforeProtocol };
+};
+
+const initialPath = getFullPath();
+const initialHistoryMarker = isProtocolPath(initialPath)
+  ? readProtocolHistoryMarker()
+  : null;
+
+export const guardState = {
+  bypass: false,
+  prompting: false,
+  prevPath: initialPath,
+  protocolHistoryDepth: isProtocolPath(initialPath)
+    ? (initialHistoryMarker?.depth ?? 1)
+    : 0,
+  hasAppEntryBeforeProtocol:
+    initialHistoryMarker?.hasAppEntryBeforeProtocol ?? false,
+  taggingHistory: false,
+  restoringProtocolHistory: null as ProtocolHistoryMarker | null,
+};
+
+const tagCurrentProtocolHistoryEntry = (marker: ProtocolHistoryMarker) => {
+  const state: unknown = history.state;
+  const stateRecord =
+    typeof state === 'object' && state !== null && !Array.isArray(state)
+      ? (state as Record<string, unknown>)
+      : {};
+
+  guardState.taggingHistory = true;
+  try {
+    history.replaceState(
+      { ...stateRecord, [PROTOCOL_HISTORY_KEY]: marker },
+      '',
+      getFullPath(),
+    );
+  } finally {
+    guardState.taggingHistory = false;
+  }
+};
+
+const syncProtocolHistoryMarker = (
+  path: string,
+  marker: ProtocolHistoryMarker | null,
+) => {
+  guardState.prevPath = path;
+  guardState.protocolHistoryDepth = marker?.depth ?? 0;
+  guardState.hasAppEntryBeforeProtocol =
+    marker?.hasAppEntryBeforeProtocol ?? false;
+};
+
+// Keep normal browser history while editing, then remove the entire protocol
+// session only after the user confirms the exit. Rewinding to the entry before
+// the protocol and pushing the target path truncates all protocol entries from
+// the forward stack. A direct-load session has no in-app entry before it, so
+// its first protocol entry is replaced before the final push instead.
+export const collapseProtocolHistory = (
+  targetPath: string,
+  replaceCurrentEntry: () => void,
+): void | Promise<void> => {
+  const depth = guardState.protocolHistoryDepth;
+  const hasAppEntryBeforeProtocol = guardState.hasAppEntryBeforeProtocol;
+  const stepsBack = hasAppEntryBeforeProtocol ? depth : depth - 1;
+
+  if (stepsBack <= 0) {
+    replaceCurrentEntry();
+    return;
+  }
+
+  return new Promise<void>((resolve) => {
+    window.addEventListener(
+      'popstate',
+      () => {
+        if (!hasAppEntryBeforeProtocol) {
+          history.replaceState(null, '', targetPath);
+        }
+        history.pushState(null, '', targetPath);
+        resolve();
+      },
+      { once: true },
+    );
+    history.go(-stepsBack);
+  });
+};
 
 // The stage editor lives under /protocol/stage/, so leaving it can be intra-
 // /protocol nav (e.g. Back to the overview) that isProtocolPath() alone misses.
@@ -51,7 +157,7 @@ const isStageEditorPath = (path: string) => path.startsWith('/protocol/stage/');
 export const promptLeaveEditor = async (
   dispatch: AppDispatch,
   openDialog: DialogContextType['openDialog'],
-  performLeave: () => void,
+  performLeave: () => void | Promise<void>,
   draftDirty = false,
 ) => {
   if (guardState.prompting) return;
@@ -99,7 +205,7 @@ export const promptLeaveEditor = async (
         dispatch(resetDraft(null));
       }
       dispatch(clearActiveProtocol());
-      performLeave();
+      await performLeave();
     } finally {
       guardState.bypass = false;
     }
@@ -163,16 +269,60 @@ export const useProtocolNavGuard = () => {
     // wouter/use-browser-location used by Redux thunks) fires the synthetic
     // event wouter dispatches from its monkey-patch. Use it to keep prevPath
     // in sync with the URL at all times.
-    const updatePrevPath = () => {
-      guardState.prevPath = getFullPath();
+    const onPushState = () => {
+      if (guardState.taggingHistory) return;
+
+      const newPath = getFullPath();
+      if (!isProtocolPath(newPath)) {
+        guardState.restoringProtocolHistory = null;
+        syncProtocolHistoryMarker(newPath, null);
+        return;
+      }
+
+      const marker =
+        guardState.restoringProtocolHistory ??
+        (isProtocolPath(guardState.prevPath)
+          ? {
+              depth: guardState.protocolHistoryDepth + 1,
+              hasAppEntryBeforeProtocol: guardState.hasAppEntryBeforeProtocol,
+            }
+          : { depth: 1, hasAppEntryBeforeProtocol: true });
+      guardState.restoringProtocolHistory = null;
+      tagCurrentProtocolHistoryEntry(marker);
+      syncProtocolHistoryMarker(newPath, marker);
+    };
+
+    const onReplaceState = () => {
+      if (guardState.taggingHistory) return;
+
+      const newPath = getFullPath();
+      if (!isProtocolPath(newPath)) {
+        syncProtocolHistoryMarker(newPath, null);
+        return;
+      }
+
+      const marker = isProtocolPath(guardState.prevPath)
+        ? {
+            depth: Math.max(guardState.protocolHistoryDepth, 1),
+            hasAppEntryBeforeProtocol: guardState.hasAppEntryBeforeProtocol,
+          }
+        : { depth: 1, hasAppEntryBeforeProtocol: false };
+      tagCurrentProtocolHistoryEntry(marker);
+      syncProtocolHistoryMarker(newPath, marker);
     };
 
     const onPop = () => {
       const newPath = getFullPath();
       const oldPath = guardState.prevPath;
+      const destinationMarker = isProtocolPath(newPath)
+        ? (readProtocolHistoryMarker() ?? {
+            depth: 1,
+            hasAppEntryBeforeProtocol: false,
+          })
+        : null;
 
       if (guardState.bypass) {
-        guardState.prevPath = newPath;
+        syncProtocolHistoryMarker(newPath, destinationMarker);
         return;
       }
 
@@ -192,13 +342,20 @@ export const useProtocolNavGuard = () => {
         getStageDraftDirty(store.getState());
 
       if (!leavingProtocol && !leavingDirtyStageEditor) {
-        guardState.prevPath = newPath;
+        syncProtocolHistoryMarker(newPath, destinationMarker);
         return;
       }
 
       // Push the user back to where they were. pushState does not fire popstate,
       // so we don't re-enter this handler. (Our pushState listener will update
       // prevPath to oldPath, which is correct.)
+      guardState.restoringProtocolHistory = destinationMarker
+        ? {
+            depth: destinationMarker.depth + 1,
+            hasAppEntryBeforeProtocol:
+              destinationMarker.hasAppEntryBeforeProtocol,
+          }
+        : { depth: 1, hasAppEntryBeforeProtocol: true };
       history.pushState(null, '', oldPath);
 
       if (leavingProtocol) {
@@ -210,7 +367,10 @@ export const useProtocolNavGuard = () => {
         void promptLeaveEditor(
           dispatch,
           openDialog,
-          () => setLocation('/', { replace: true }),
+          () =>
+            collapseProtocolHistory('/', () =>
+              setLocation('/', { replace: true }),
+            ),
           draftDirty,
         );
         return;
@@ -220,12 +380,26 @@ export const useProtocolNavGuard = () => {
     };
 
     window.addEventListener('popstate', onPop);
-    window.addEventListener('pushState', updatePrevPath);
-    window.addEventListener('replaceState', updatePrevPath);
+    const currentPath = getFullPath();
+    if (isProtocolPath(currentPath)) {
+      const marker = readProtocolHistoryMarker() ?? {
+        depth: 1,
+        hasAppEntryBeforeProtocol: false,
+      };
+      if (!readProtocolHistoryMarker()) {
+        tagCurrentProtocolHistoryEntry(marker);
+      }
+      syncProtocolHistoryMarker(currentPath, marker);
+    } else {
+      syncProtocolHistoryMarker(currentPath, null);
+    }
+
+    window.addEventListener('pushState', onPushState);
+    window.addEventListener('replaceState', onReplaceState);
     return () => {
       window.removeEventListener('popstate', onPop);
-      window.removeEventListener('pushState', updatePrevPath);
-      window.removeEventListener('replaceState', updatePrevPath);
+      window.removeEventListener('pushState', onPushState);
+      window.removeEventListener('replaceState', onReplaceState);
     };
   }, [dispatch, openDialog, setLocation]);
 };


### PR DESCRIPTION
## Summary
- replace the protocol editor history entry when a confirmed exit clears the active protocol
- apply the same replacement behavior when browser Back triggers the exit confirmation
- add Playwright coverage for opening a recent protocol, returning home, and pressing Back
- scope the reusable toolbar page object to its accessible toolbar container

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/architect test`
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts` (37 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser Back navigation so cleared protocols no longer reopen or leave invalid protocol pages in history.
  * Improved navigation when leaving the protocol editor, including correct handling of browser Back and Forward actions.
  * Ensured exiting a protocol removes intermediate protocol pages from browser history.

* **Tests**
  * Added end-to-end coverage for clearing protocols and verifying browser history behavior.
  * Improved toolbar label test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->