### PR TITLE
ci: install Playwright Chromium inside site-navigation-element test task

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -336,10 +336,6 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      # Same requirement as the test job below: site-navigation-element's
-      # test script runs vitest browser mode against real Chromium.
-      - name: Install Playwright Chromium (vitest browser mode)
-        run: pnpm --filter @codaco/site-navigation-element exec playwright install --with-deps chromium
       - run: pnpm exec turbo run test typecheck
 
   lint:
@@ -432,11 +428,6 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      # site-navigation-element's test script runs vitest browser mode
-      # (real Chromium via @vitest/browser-playwright); the runner image
-      # doesn't ship the pinned Playwright build's browsers.
-      - name: Install Playwright Chromium (vitest browser mode)
-        run: pnpm --filter @codaco/site-navigation-element exec playwright install --with-deps chromium
       - name: Run tests (PRs run only tasks affected by the PR diff)
         run: |
           # PR checkouts are a synthetic merge of the PR into its base, so

--- a/packages/site-navigation-element/package.json
+++ b/packages/site-navigation-element/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "build": "node ../../scripts/with-turbo.mjs node scripts/build.mjs",
     "dev": "node ../../scripts/with-turbo.mjs --watch-deps node scripts/build.mjs --dev",
-    "test": "node scripts/build.mjs --css-only && vitest run",
-    "test:watch": "node scripts/build.mjs --css-only && vitest",
+    "test": "playwright install --with-deps chromium && node scripts/build.mjs --css-only && vitest run",
+    "test:watch": "playwright install --with-deps chromium && node scripts/build.mjs --css-only && vitest",
     "typecheck": "tsc --build --noEmit && tsc -p tsconfig.node.json --noEmit",
     "prepublishOnly": "pnpm build",
     "clean": "rm -rf .turbo node_modules dist .generated public/fonts"

--- a/packages/site-navigation-element/vitest.config.ts
+++ b/packages/site-navigation-element/vitest.config.ts
@@ -1,6 +1,10 @@
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+// Tests run in real Chromium, which CI runner images don't ship for the
+// pinned Playwright build. The test scripts run `playwright install` first
+// (a fast no-op once installed) so the download happens inside the turbo
+// task — skipped entirely when the task is a cache hit.
 export default defineConfig({
   oxc: {
     jsx: { runtime: 'automatic' },


### PR DESCRIPTION
## Summary

The `test` and `seed-turbo-cache` jobs in `ci-and-release.yml` ran `playwright install --with-deps chromium` unconditionally on every run (~26s), even when `@codaco/site-navigation-element:test` — the only task in `turbo run test` that launches a real browser — was a turbo cache hit and Chromium was never used. (Interview, Fresco UI, and Interviewer all scope their `test` scripts to unit projects.)

This moves the install into the package's `test`/`test:watch` scripts, so it lives inside the turbo task:

- **Cache hit → no download at all.** The workflow steps are gone; nothing runs unless the task executes.
- **Cache miss → same install as before**, in CI or locally. Re-running it is a fast no-op once browsers are present (verified: no sudo prompt or error on macOS).
- A short comment in `vitest.config.ts` records why the scripts self-install, so it isn't mistaken for redundancy.

No changeset: test/CI-tooling only, no consumer-visible change to the published package.

## Test plan

- [x] `pnpm exec turbo run test --filter=@codaco/site-navigation-element --force` — 11 tests pass in real Chromium via the new chained script
- [x] `pnpm --filter @codaco/site-navigation-element typecheck`
- [x] `pnpm knip`
- [x] oxfmt/oxlint on modified files (also enforced by the pre-commit hook)
- [ ] CI `test` job green without the removed install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)