### PR TITLE
ci: scope release E2E to shipped suites, skip re-validated merge queues

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -47,8 +47,10 @@ concurrency:
     || github.ref_name == 'e2e-snapshots/main')) }}
 
 jobs:
+  # Skipped on push: its only consumers (docs-preview-checks, the quality
+  # aggregate, carry-forward-statuses) never run on push-to-main.
   detect:
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && github.event_name != 'push'
     runs-on: ubuntu-latest
     outputs:
       docs: ${{ steps.flags.outputs.docs }}
@@ -142,11 +144,17 @@ jobs:
           docs=$(flag @codaco/documentation)
           echo "docs=$docs" >> "$GITHUB_OUTPUT"
 
+  # Decides per suite whether release E2E must run for this ref: each release
+  # lane requires only the suites whose subject package ships in its deploy,
+  # and a merge-group run skips suites already validated by the dispatched run
+  # on an identical tree (see scripts/release-e2e-policy.mjs).
   e2e-policy:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
     outputs:
-      required: ${{ steps.policy.outputs.required }}
+      interview: ${{ steps.policy.outputs.interview }}
+      interviewer: ${{ steps.policy.outputs.interviewer }}
+      architect: ${{ steps.policy.outputs.architect }}
       release_ref: ${{ steps.policy.outputs.release_ref }}
       snapshot_branch: ${{ steps.policy.outputs.snapshot_branch }}
     steps:
@@ -157,7 +165,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version-file: '.nvmrc'
-      - name: Determine whether this ref triggers a release
+      - name: Determine which release E2E suites this ref requires
         id: policy
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -165,11 +173,15 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           BASE_SHA: ${{ github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          # Read-only, for the merge-queue already-validated lookup.
+          GH_TOKEN: ${{ github.token }}
         run: |
           policy=$(node scripts/release-e2e-policy.mjs)
           echo "release E2E policy: $policy"
           {
-            echo "required=$(jq -r '.required' <<< "$policy")"
+            echo "interview=$(jq -r '.interview' <<< "$policy")"
+            echo "interviewer=$(jq -r '.interviewer' <<< "$policy")"
+            echo "architect=$(jq -r '.architect' <<< "$policy")"
             echo "release_ref=$(jq -r '.releaseRef' <<< "$policy")"
             echo "snapshot_branch=$(jq -r '.snapshotBranch' <<< "$policy")"
           } >> "$GITHUB_OUTPUT"
@@ -189,7 +201,7 @@ jobs:
   # GitHub-hosted runners and never execute on the self-hosted machine.
   pick-e2e-runner:
     needs: e2e-policy
-    if: ${{ !cancelled() && needs.e2e-policy.outputs.required == 'true' }}
+    if: ${{ !cancelled() && needs.e2e-policy.outputs.interview == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       runs_on: ${{ steps.pick.outputs.runs_on }}
@@ -235,7 +247,7 @@ jobs:
   e2e-queue-watchdog:
     needs: [e2e-policy, pick-e2e-runner]
     if: >-
-      ${{ !cancelled() && needs.e2e-policy.outputs.required == 'true'
+      ${{ !cancelled() && needs.e2e-policy.outputs.interview == 'true'
       && needs.pick-e2e-runner.result == 'success'
       && contains(needs.pick-e2e-runner.outputs.runs_on, 'self-hosted') }}
     runs-on: ubuntu-latest
@@ -477,7 +489,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DETECT_RESULT: ${{ needs.detect.result }}
           E2E_POLICY_RESULT: ${{ needs.e2e-policy.result }}
-          E2E_REQUIRED: ${{ needs.e2e-policy.outputs.required }}
+          E2E_INTERVIEW_REQUIRED: ${{ needs.e2e-policy.outputs.interview }}
+          E2E_INTERVIEWER_REQUIRED: ${{ needs.e2e-policy.outputs.interviewer }}
+          E2E_ARCHITECT_REQUIRED: ${{ needs.e2e-policy.outputs.architect }}
           LINT_RESULT: ${{ needs.lint.result }}
           KNIP_RESULT: ${{ needs.knip.result }}
           CHANGESETS_RESULT: ${{ needs.check-changesets.result }}
@@ -520,14 +534,22 @@ jobs:
             exit 1
           fi
 
-          if [[ "$E2E_REQUIRED" == "true" ]]; then
-            verify_successes "release E2E gate" \
-              "$INTERVIEW_E2E_RESULT" \
-              "$INTERVIEWER_E2E_RESULT" \
-              "$ARCHITECT_E2E_RESULT"
-          else
-            echo "E2E gate is not required for this event"
-          fi
+          verify_required_e2e() {
+            local suite=$1 required=$2 result=$3
+            if [[ "$required" != "true" ]]; then
+              echo "$suite is not required for this event (result: $result)"
+              return
+            fi
+            if [[ "$result" != "success" ]]; then
+              echo "::error::release E2E gate failed — $suite concluded '$result'"
+              exit 1
+            fi
+            echo "$suite passed"
+          }
+
+          verify_required_e2e interview-e2e "$E2E_INTERVIEW_REQUIRED" "$INTERVIEW_E2E_RESULT"
+          verify_required_e2e interviewer-e2e "$E2E_INTERVIEWER_REQUIRED" "$INTERVIEWER_E2E_RESULT"
+          verify_required_e2e architect-e2e "$E2E_ARCHITECT_REQUIRED" "$ARCHITECT_E2E_RESULT"
           echo "quality gate passed"
 
   docs-preview-checks:
@@ -633,12 +655,13 @@ jobs:
         run: pnpm run test-redirects
 
   interview-e2e:
-    # Generated package/app release PRs run every E2E suite. The Dockerized
-    # suite builds its own dependency graph and cannot consume the host runner's
-    # Turbo cache, so start it as soon as the release policy completes.
+    # Runs when the release policy requires the interview suite (the lane
+    # ships @codaco/interview). The Dockerized suite builds its own dependency
+    # graph and cannot consume the host runner's Turbo cache, so start it as
+    # soon as the release policy completes.
     needs: [e2e-policy, pick-e2e-runner]
     if: >-
-      ${{ !cancelled() && needs.e2e-policy.outputs.required == 'true'
+      ${{ !cancelled() && needs.e2e-policy.outputs.interview == 'true'
       && needs.pick-e2e-runner.result == 'success' }}
     runs-on: ${{ fromJSON(needs.pick-e2e-runner.outputs.runs_on) }}
     timeout-minutes: 45
@@ -715,7 +738,7 @@ jobs:
   interviewer-e2e:
     # See interview-e2e: this Dockerized suite owns its build too.
     needs: e2e-policy
-    if: ${{ !cancelled() && needs.e2e-policy.outputs.required == 'true' }}
+    if: ${{ !cancelled() && needs.e2e-policy.outputs.interviewer == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -751,7 +774,7 @@ jobs:
   architect-e2e:
     # See interview-e2e: this Dockerized suite owns its build too.
     needs: e2e-policy
-    if: ${{ !cancelled() && needs.e2e-policy.outputs.required == 'true' }}
+    if: ${{ !cancelled() && needs.e2e-policy.outputs.architect == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
@@ -1051,49 +1074,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_REF: changeset-release/${{ matrix.slug }}
         run: gh workflow run ci-and-release.yml --ref "$RELEASE_REF"
-
-  # The combined product branch predates the independent gates. Once this change
-  # reaches main, close its parent release PR and any snapshot child that still
-  # targets it so the retired gate cannot release several products together.
-  # Branches are deliberately left intact; this is a reversible PR-state change.
-  retire-combined-release-pr:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Close PRs attached to the retired combined release branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const retiredRef = 'changeset-release/apps';
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-            const retired = pulls.filter(
-              (pull) =>
-                pull.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` &&
-                (pull.head.ref === retiredRef || pull.base.ref === retiredRef),
-            );
-
-            for (const pull of retired) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pull.number,
-                body:
-                  'This PR was closed because the combined product release gate has been replaced by independent Architect, Interviewer, Documentation, and Website release PRs. Pending changesets will be proposed again in the matching product PR.',
-              });
-              await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pull.number,
-                state: 'closed',
-              });
-            }
 
   # On a push to main that changes a gated product version (i.e. one product's
   # release PR just merged), detect which product moved. Idempotency is a local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,14 +265,25 @@ stories.
 
 #### Release-only E2E checks
 
-CI runs the complete Architect, Interview, and Interviewer E2E suites only for
-the generated library branch `changeset-release/main`, the generated product
-branches `changeset-release/architect`, `changeset-release/interviewer`,
-`changeset-release/documentation`, and `changeset-release/website`, or merge
-groups whose package or product version changes will trigger a release. The
-required `quality` check
-conditionally requires all three E2E jobs in those cases. Ordinary PRs skip E2E,
-and E2E results are never carried forward from an earlier commit.
+CI runs the Architect, Interview, and Interviewer E2E suites only for
+generated release branches (`changeset-release/*`) and merge groups whose
+package or product version changes will trigger a release — and only the
+suites whose subject ships in that release lane: the library lane
+(`changeset-release/main`) runs all three; the Architect and Interviewer lanes
+run their own suite plus Interview (both apps bundle the interview runtime);
+the Documentation and Website lanes run none. The mapping lives in
+`scripts/release-e2e-policy.mjs`, and its test derives the expected lanes from
+the real package.json dependency graph so the table cannot silently drift.
+The required `quality` check requires exactly the suites the policy selects.
+Ordinary PRs skip E2E, and E2E verdicts are never carried forward from an
+earlier commit.
+
+A merge-queue run skips a suite only in one narrow case: the queued merge
+commit's tree is byte-identical to the tip of a generated release branch, and
+a dispatched run of this workflow already ran that suite successfully at that
+exact SHA. Every guard fails closed (tree mismatch, non-release tip, or any
+Actions-API doubt reruns the suite), so batched merge groups and moved `main`
+always re-run E2E.
 
 The release jobs explicitly dispatch `ci-and-release.yml` after creating or
 updating a generated branch. Normal release PRs therefore do not need a

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -11,6 +11,15 @@ const topLevelConcurrency = workflow.match(
   /^concurrency:\n(?<config>[\s\S]*?)\n\njobs:/m,
 )?.groups?.config;
 
+function job(name) {
+  return workflow.match(
+    new RegExp(
+      `^ {2}${name}:\\n(?<body>[\\s\\S]*?)(?=^ {2}\\S|$(?![\\s\\S]))`,
+      'm',
+    ),
+  )?.groups?.body;
+}
+
 test('superseded CI runs are cancelled for every pull request', () => {
   assert.ok(
     topLevelConcurrency,
@@ -23,10 +32,58 @@ test('superseded CI runs are cancelled for every pull request', () => {
   assert.doesNotMatch(topLevelConcurrency, /github\.head_ref/);
 });
 
+test('detect never runs on push-to-main (its consumers are PR/dispatch only)', () => {
+  const detectJob = job('detect');
+  assert.ok(detectJob, 'detect job exists');
+  assert.match(
+    detectJob,
+    /if: github\.event_name != 'merge_group' && github\.event_name != 'push'/,
+  );
+});
+
+test('each release E2E suite gates on its own policy flag', () => {
+  for (const [jobName, flag] of [
+    ['interview-e2e', 'interview'],
+    ['interviewer-e2e', 'interviewer'],
+    ['architect-e2e', 'architect'],
+    ['pick-e2e-runner', 'interview'],
+    ['e2e-queue-watchdog', 'interview'],
+  ]) {
+    const body = job(jobName);
+    assert.ok(body, `${jobName} job exists`);
+    assert.match(
+      body,
+      new RegExp(`needs\\.e2e-policy\\.outputs\\.${flag} == 'true'`),
+      `${jobName} is gated on the ${flag} suite flag`,
+    );
+  }
+});
+
+test('the quality gate verifies each required E2E suite individually', () => {
+  const qualityJob = job('quality');
+  assert.ok(qualityJob, 'quality job exists');
+  for (const suite of ['interview', 'interviewer', 'architect']) {
+    assert.match(
+      qualityJob,
+      new RegExp(
+        `E2E_${suite.toUpperCase()}_REQUIRED: \\$\\{\\{ needs\\.e2e-policy\\.outputs\\.${suite} \\}\\}`,
+      ),
+      `quality receives the ${suite} requirement flag`,
+    );
+  }
+  assert.match(qualityJob, /verify_required_e2e interview-e2e/);
+  assert.match(qualityJob, /verify_required_e2e interviewer-e2e/);
+  assert.match(qualityJob, /verify_required_e2e architect-e2e/);
+});
+
+test('e2e-policy can query the Actions API for the merge-queue fast path', () => {
+  const policyJob = job('e2e-policy');
+  assert.ok(policyJob, 'e2e-policy job exists');
+  assert.match(policyJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+});
+
 test('release job prunes ignored-lane changesets before changesets/action', () => {
-  const releaseJob = workflow.match(
-    /^ {2}release:\n(?<body>[\s\S]*?)(?=^ {2}\S)/m,
-  )?.groups?.body;
+  const releaseJob = job('release');
   assert.ok(releaseJob, 'release job exists');
 
   const pruneIndex = releaseJob.indexOf(

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -1,13 +1,66 @@
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
-const RELEASE_REFS = new Set([
-  'changeset-release/architect',
-  'changeset-release/documentation',
-  'changeset-release/interviewer',
-  'changeset-release/main',
-  'changeset-release/website',
-]);
+export const SUITE_KEYS = ['interview', 'interviewer', 'architect'];
+
+// Workspace package each E2E suite exercises. A suite gates a release lane
+// only when this package ships in that lane's deploy (it is the released
+// product or one of its transitive workspace `dependencies`).
+export const E2E_SUITE_SUBJECTS = {
+  interview: '@codaco/interview',
+  interviewer: '@codaco/interviewer',
+  architect: '@codaco/architect',
+};
+
+const E2E_JOB_NAMES = {
+  interview: 'interview-e2e',
+  interviewer: 'interviewer-e2e',
+  architect: 'architect-e2e',
+};
+
+function suites(...keys) {
+  return Object.fromEntries(SUITE_KEYS.map((key) => [key, keys.includes(key)]));
+}
+
+// Which suites gate each release lane. Architect and Interviewer both bundle
+// the @codaco/interview runtime, so their lanes keep interview-e2e; the
+// library lane publishes packages consumed by every app and keeps all three;
+// Documentation and Website ship none of the suite subjects and need no E2E.
+// Hand-maintained for a simple CI hot path — release-e2e-policy.test.mjs
+// derives the expected mapping from the real package.json dependency graph
+// and fails when this table drifts.
+export const SUITES_BY_RELEASE_REF = {
+  'changeset-release/architect': suites('architect', 'interview'),
+  'changeset-release/documentation': suites(),
+  'changeset-release/interviewer': suites('interviewer', 'interview'),
+  'changeset-release/main': suites('interview', 'interviewer', 'architect'),
+  'changeset-release/website': suites(),
+};
+
+// Manifests whose version field moving in a merge group means that group is
+// about to trigger the mapped lane's release when it lands on main.
+const MANIFEST_LANES = [
+  {
+    pattern: /^packages\/[^/]+\/package\.json$/,
+    ref: 'changeset-release/main',
+  },
+  {
+    pattern: /^apps\/architect\/package\.json$/,
+    ref: 'changeset-release/architect',
+  },
+  {
+    pattern: /^apps\/interviewer\/package\.json$/,
+    ref: 'changeset-release/interviewer',
+  },
+  {
+    pattern: /^apps\/documentation\/package\.json$/,
+    ref: 'changeset-release/documentation',
+  },
+  {
+    pattern: /^apps\/networkcanvas\.com\/package\.json$/,
+    ref: 'changeset-release/website',
+  },
+];
 
 const VERSIONED_MANIFESTS = [
   'packages/*/package.json',
@@ -24,16 +77,29 @@ export function releaseRefForEvent({ eventName, headRef, refName }) {
       : eventName === 'workflow_dispatch'
         ? refName
         : '';
-  return RELEASE_REFS.has(candidate) ? candidate : '';
+  return candidate in SUITES_BY_RELEASE_REF ? candidate : '';
+}
+
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function tryGit(args, cwd) {
+  try {
+    return git(args, cwd);
+  } catch {
+    return null;
+  }
 }
 
 function readVersionAt(revision, manifest, cwd) {
+  const contents = tryGit(['show', `${revision}:${manifest}`], cwd);
+  if (contents === null) return null;
   try {
-    const contents = execFileSync('git', ['show', `${revision}:${manifest}`], {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
     const parsed = JSON.parse(contents);
     return typeof parsed.version === 'string' ? parsed.version : null;
   } catch {
@@ -41,7 +107,10 @@ function readVersionAt(revision, manifest, cwd) {
   }
 }
 
-export function mergeGroupChangesReleaseVersion(baseSha, headSha, cwd) {
+// Union of the suites required by every versioned manifest whose version
+// field changes between the merge group's base and head — i.e. by every
+// release the group will trigger when it lands.
+export function mergeGroupRequiredSuites(baseSha, headSha, cwd) {
   if (!baseSha || !headSha) {
     throw new Error(
       'merge_group release detection requires base and head SHAs',
@@ -56,21 +125,31 @@ export function mergeGroupChangesReleaseVersion(baseSha, headSha, cwd) {
     .split('\n')
     .filter(Boolean);
 
-  return changedManifests.some(
-    (manifest) =>
-      readVersionAt(baseSha, manifest, cwd) !==
-      readVersionAt(headSha, manifest, cwd),
-  );
+  const required = suites();
+  for (const manifest of changedManifests) {
+    if (
+      readVersionAt(baseSha, manifest, cwd) ===
+      readVersionAt(headSha, manifest, cwd)
+    ) {
+      continue;
+    }
+    const lane = MANIFEST_LANES.find(({ pattern }) => pattern.test(manifest));
+    if (!lane) continue;
+    for (const key of SUITE_KEYS) {
+      required[key] ||= SUITES_BY_RELEASE_REF[lane.ref][key];
+    }
+  }
+  return required;
 }
 
 export function releaseE2EPolicy(
   { eventName, headRef = '', refName = '', baseSha = '', headSha = '' },
-  mergeGroupDetector = mergeGroupChangesReleaseVersion,
+  mergeGroupDetector = mergeGroupRequiredSuites,
 ) {
   const releaseRef = releaseRefForEvent({ eventName, headRef, refName });
   if (releaseRef) {
     return {
-      required: true,
+      ...SUITES_BY_RELEASE_REF[releaseRef],
       releaseRef,
       snapshotBranch: 'e2e-snapshots/main',
     };
@@ -78,23 +157,112 @@ export function releaseE2EPolicy(
 
   if (eventName === 'merge_group') {
     return {
-      required: mergeGroupDetector(baseSha, headSha),
+      ...mergeGroupDetector(baseSha, headSha),
       releaseRef: '',
       snapshotBranch: '',
     };
   }
 
-  return { required: false, releaseRef: '', snapshotBranch: '' };
+  return { ...suites(), releaseRef: '', snapshotBranch: '' };
 }
 
-function main() {
+// Merge-queue fast path: a release PR's branch head was already fully
+// E2E-validated by the workflow_dispatch run fired when the branch was
+// created/updated (the required `quality` check means the PR could not have
+// been enqueued otherwise). When the queue's merge commit has the SAME TREE
+// as that branch tip — main did not move and nothing else was batched — the
+// queue would re-run the suites against byte-identical code, so each suite
+// whose dispatched job succeeded on that exact SHA can be skipped.
+//
+// Every guard fails closed (the suite runs):
+//  * the merge commit's tree must equal its second parent's (the PR tip's);
+//  * the PR tip must be the current head of a generated changeset-release/*
+//    branch, so only trusted generated branches — never an arbitrary PR that
+//    happens to bump a version — can satisfy the fast path;
+//  * the succeeded job must belong to a workflow_dispatch run of THIS
+//    workflow at that SHA, looked up via the Actions API; any API error
+//    counts as not validated.
+export async function alreadyValidatedSuites({
+  cwd,
+  repository,
+  token,
+  fetcher = fetch,
+}) {
+  const validated = suites();
+
+  const headTree = tryGit(['rev-parse', 'HEAD^{tree}'], cwd);
+  const prTip = tryGit(['rev-parse', 'HEAD^2'], cwd);
+  const prTree = tryGit(['rev-parse', 'HEAD^2^{tree}'], cwd);
+  if (!headTree || !prTip || !prTree || headTree !== prTree) {
+    return validated;
+  }
+
+  const isReleaseBranchTip = Object.keys(SUITES_BY_RELEASE_REF).some(
+    (ref) => tryGit(['rev-parse', `origin/${ref}`], cwd) === prTip,
+  );
+  if (!isReleaseBranchTip) return validated;
+  if (!repository || !token) return validated;
+
+  const apiOptions = {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+    },
+  };
+  try {
+    const runsResponse = await fetcher(
+      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=workflow_dispatch&head_sha=${prTip}&per_page=100`,
+      apiOptions,
+    );
+    if (!runsResponse.ok) return validated;
+    const { workflow_runs: runs = [] } = await runsResponse.json();
+
+    for (const run of runs) {
+      const jobsResponse = await fetcher(
+        `${run.jobs_url}?per_page=100`,
+        apiOptions,
+      );
+      if (!jobsResponse.ok) continue;
+      const { jobs = [] } = await jobsResponse.json();
+      for (const job of jobs) {
+        if (job.conclusion !== 'success') continue;
+        for (const key of SUITE_KEYS) {
+          if (job.name === E2E_JOB_NAMES[key]) validated[key] = true;
+        }
+      }
+    }
+  } catch {
+    return suites();
+  }
+  return validated;
+}
+
+async function main() {
+  const eventName = process.env.EVENT_NAME ?? '';
   const policy = releaseE2EPolicy({
-    eventName: process.env.EVENT_NAME ?? '',
+    eventName,
     headRef: process.env.HEAD_REF ?? '',
     refName: process.env.REF_NAME ?? '',
     baseSha: process.env.BASE_SHA ?? '',
     headSha: process.env.HEAD_SHA ?? '',
   });
+
+  if (eventName === 'merge_group' && SUITE_KEYS.some((key) => policy[key])) {
+    const validated = await alreadyValidatedSuites({
+      cwd: process.cwd(),
+      repository: process.env.GITHUB_REPOSITORY ?? '',
+      token: process.env.GH_TOKEN ?? '',
+    });
+    for (const key of SUITE_KEYS) {
+      if (policy[key] && validated[key]) {
+        policy[key] = false;
+        console.error(
+          `${E2E_JOB_NAMES[key]}: skipping — this merge group's tree is identical to a release branch tip it already passed on.`,
+        );
+      }
+    }
+  }
+
   process.stdout.write(`${JSON.stringify(policy)}\n`);
 }
 
@@ -102,5 +270,5 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  main();
+  await main();
 }

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -1,28 +1,56 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
-  mergeGroupChangesReleaseVersion,
+  alreadyValidatedSuites,
+  E2E_SUITE_SUBJECTS,
+  mergeGroupRequiredSuites,
   releaseE2EPolicy,
   releaseRefForEvent,
+  SUITE_KEYS,
+  SUITES_BY_RELEASE_REF,
 } from './release-e2e-policy.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 function git(cwd, ...args) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+function initRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-'));
+  git(cwd, 'init', '-q');
+  git(cwd, 'config', 'user.email', 'ci@example.com');
+  git(cwd, 'config', 'user.name', 'ci');
+  return cwd;
+}
+
+function commitManifest(cwd, manifest, contents, message) {
+  const dir = join(cwd, manifest, '..');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(cwd, manifest), contents);
+  git(cwd, 'add', '.');
+  git(cwd, 'commit', '-qm', message);
+  return git(cwd, 'rev-parse', 'HEAD');
+}
+
+function suiteFlags(policy) {
+  return Object.fromEntries(SUITE_KEYS.map((key) => [key, policy[key]]));
+}
+
 test('recognises only the generated release PR refs', () => {
-  for (const releaseRef of [
-    'changeset-release/architect',
-    'changeset-release/documentation',
-    'changeset-release/interviewer',
-    'changeset-release/main',
-    'changeset-release/website',
-  ]) {
+  for (const releaseRef of Object.keys(SUITES_BY_RELEASE_REF)) {
     assert.equal(
       releaseRefForEvent({
         eventName: 'pull_request',
@@ -40,30 +68,84 @@ test('recognises only the generated release PR refs', () => {
       releaseRef,
     );
   }
-  assert.equal(
-    releaseRefForEvent({
-      eventName: 'pull_request',
-      headRef: 'changeset-release/not-a-release',
-      refName: '',
-    }),
-    '',
-  );
-  assert.equal(
-    releaseRefForEvent({
-      eventName: 'pull_request',
-      headRef: 'changeset-release/apps',
-      refName: '',
-    }),
-    '',
-  );
-  assert.equal(
-    releaseRefForEvent({
-      eventName: 'pull_request',
-      headRef: 'feature/add-changeset',
-      refName: '',
-    }),
-    '',
-  );
+  for (const headRef of [
+    'changeset-release/not-a-release',
+    'changeset-release/apps',
+    'feature/add-changeset',
+  ]) {
+    assert.equal(
+      releaseRefForEvent({ eventName: 'pull_request', headRef, refName: '' }),
+      '',
+    );
+  }
+});
+
+test('release lane suites match the workspace dependency graph', () => {
+  // A suite gates a product lane when its subject package ships in that
+  // product's deploy: it IS the product, or one of the product's transitive
+  // workspace `dependencies` (devDependencies do not ship). Derive that from
+  // the real package.json files so SUITES_BY_RELEASE_REF cannot silently
+  // drift when an app gains or drops a suite subject as a dependency.
+  const dependenciesByName = new Map();
+  for (const group of ['packages', 'apps', 'tooling', 'workers']) {
+    for (const entry of readdirSync(join(REPO_ROOT, group), {
+      withFileTypes: true,
+    })) {
+      if (!entry.isDirectory()) continue;
+      let manifest;
+      try {
+        manifest = JSON.parse(
+          readFileSync(join(REPO_ROOT, group, entry.name, 'package.json')),
+        );
+      } catch {
+        continue;
+      }
+      dependenciesByName.set(
+        manifest.name,
+        Object.keys(manifest.dependencies ?? {}),
+      );
+    }
+  }
+
+  const transitiveDependencies = (name) => {
+    const seen = new Set();
+    const queue = [...(dependenciesByName.get(name) ?? [])];
+    while (queue.length > 0) {
+      const dependency = queue.pop();
+      if (seen.has(dependency)) continue;
+      seen.add(dependency);
+      queue.push(...(dependenciesByName.get(dependency) ?? []));
+    }
+    return seen;
+  };
+
+  const productLanes = {
+    'changeset-release/architect': '@codaco/architect',
+    'changeset-release/documentation': '@codaco/documentation',
+    'changeset-release/interviewer': '@codaco/interviewer',
+    'changeset-release/website': 'networkcanvas.com',
+  };
+  for (const [releaseRef, product] of Object.entries(productLanes)) {
+    assert.ok(
+      dependenciesByName.has(product),
+      `workspace package ${product} exists`,
+    );
+    const shipped = transitiveDependencies(product);
+    for (const key of SUITE_KEYS) {
+      const subject = E2E_SUITE_SUBJECTS[key];
+      assert.equal(
+        SUITES_BY_RELEASE_REF[releaseRef][key],
+        subject === product || shipped.has(subject),
+        `${releaseRef} requires the ${key} suite exactly when ${subject} ships in ${product}`,
+      );
+    }
+  }
+
+  // The library lane publishes packages consumed by every app, so it always
+  // requires every suite.
+  for (const key of SUITE_KEYS) {
+    assert.equal(SUITES_BY_RELEASE_REF['changeset-release/main'][key], true);
+  }
 });
 
 test('all release policies share the central snapshot PR target', () => {
@@ -81,7 +163,7 @@ test('all release policies share the central snapshot PR target', () => {
         refName: eventName === 'workflow_dispatch' ? releaseRef : '',
       }),
       {
-        required: true,
+        ...SUITES_BY_RELEASE_REF[releaseRef],
         releaseRef,
         snapshotBranch: 'e2e-snapshots/main',
       },
@@ -89,55 +171,254 @@ test('all release policies share the central snapshot PR target', () => {
   }
 });
 
-test('merge groups require E2E only when a release version changed', () => {
-  assert.equal(
+test('merge groups require the suites the detector reports', () => {
+  const detected = {
+    interview: true,
+    interviewer: false,
+    architect: true,
+  };
+  assert.deepEqual(
     releaseE2EPolicy(
       { eventName: 'merge_group', baseSha: 'base', headSha: 'head' },
-      () => true,
-    ).required,
-    true,
-  );
-  assert.equal(
-    releaseE2EPolicy(
-      { eventName: 'merge_group', baseSha: 'base', headSha: 'head' },
-      () => false,
-    ).required,
-    false,
+      () => detected,
+    ),
+    { ...detected, releaseRef: '', snapshotBranch: '' },
   );
 });
 
-test('a website version bump makes merge-group release E2E required', () => {
-  const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-'));
-  const manifestDir = join(cwd, 'apps/networkcanvas.com');
-  const manifest = join(manifestDir, 'package.json');
-  mkdirSync(manifestDir, { recursive: true });
-  git(cwd, 'init', '-q');
-  git(cwd, 'config', 'user.email', 'ci@example.com');
-  git(cwd, 'config', 'user.name', 'ci');
+test('merge-group version bumps require only the affected lanes', () => {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'apps/networkcanvas.com/package.json',
+    '{"name":"networkcanvas.com","version":"0.1.1"}\n',
+    'add website',
+  );
+  const baseSha = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0"}\n',
+    'base',
+  );
 
-  writeFileSync(manifest, '{"name":"networkcanvas.com","version":"0.1.1"}\n');
-  git(cwd, 'add', '.');
-  git(cwd, 'commit', '-qm', 'base');
-  const baseSha = git(cwd, 'rev-parse', 'HEAD');
+  // A website bump releases nothing the suites test.
+  const websiteBump = commitManifest(
+    cwd,
+    'apps/networkcanvas.com/package.json',
+    '{"name":"networkcanvas.com","version":"0.1.2"}\n',
+    'release website',
+  );
+  assert.deepEqual(mergeGroupRequiredSuites(baseSha, websiteBump, cwd), {
+    interview: false,
+    interviewer: false,
+    architect: false,
+  });
 
-  writeFileSync(manifest, '{"name":"networkcanvas.com","version":"0.1.2"}\n');
-  git(cwd, 'commit', '-qam', 'release website');
-  const headSha = git(cwd, 'rev-parse', 'HEAD');
+  // An architect bump releases the architect app, which ships the interview
+  // runtime.
+  const architectBump = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1"}\n',
+    'release architect',
+  );
+  assert.deepEqual(mergeGroupRequiredSuites(websiteBump, architectBump, cwd), {
+    interview: true,
+    interviewer: false,
+    architect: true,
+  });
 
-  assert.equal(mergeGroupChangesReleaseVersion(baseSha, headSha, cwd), true);
+  // A library bump can ship in every app.
+  const libraryBump = commitManifest(
+    cwd,
+    'packages/protocol-validation/package.json',
+    '{"name":"@codaco/protocol-validation","version":"9.9.9"}\n',
+    'release library',
+  );
+  assert.deepEqual(mergeGroupRequiredSuites(architectBump, libraryBump, cwd), {
+    interview: true,
+    interviewer: true,
+    architect: true,
+  });
+
+  // Content-only manifest changes (no version movement) require nothing.
+  const scriptChange = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1","scripts":{}}\n',
+    'manifest content change',
+  );
+  assert.deepEqual(mergeGroupRequiredSuites(libraryBump, scriptChange, cwd), {
+    interview: false,
+    interviewer: false,
+    architect: false,
+  });
 });
 
 test('ordinary events do not require release E2E', () => {
-  assert.deepEqual(
-    releaseE2EPolicy({
-      eventName: 'pull_request',
-      headRef: 'feature/example',
-    }),
-    { required: false, releaseRef: '', snapshotBranch: '' },
-  );
-  assert.deepEqual(releaseE2EPolicy({ eventName: 'push', refName: 'main' }), {
-    required: false,
+  const none = {
+    interview: false,
+    interviewer: false,
+    architect: false,
     releaseRef: '',
     snapshotBranch: '',
-  });
+  };
+  assert.deepEqual(
+    releaseE2EPolicy({ eventName: 'pull_request', headRef: 'feature/example' }),
+    none,
+  );
+  assert.deepEqual(
+    releaseE2EPolicy({ eventName: 'push', refName: 'main' }),
+    none,
+  );
+});
+
+// Build a repo shaped like a merge-queue checkout: main, a release branch
+// with a version bump, and a merge commit of the branch into main (HEAD).
+// Returns the branch tip so tests can point origin/changeset-release/* at it.
+function initMergeQueueRepo({ advanceMainBeforeMerge = false } = {}) {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0"}\n',
+    'base',
+  );
+  git(cwd, 'checkout', '-qb', 'release');
+  const branchTip = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1"}\n',
+    'version architect',
+  );
+  git(cwd, 'checkout', '-q', 'main');
+  if (advanceMainBeforeMerge) {
+    commitManifest(cwd, 'README.md', 'moved\n', 'main moved');
+  }
+  git(cwd, 'merge', '-q', '--no-ff', '--no-edit', 'release');
+  return { cwd, branchTip };
+}
+
+function fakeGitHub({ jobs, failRuns = false }) {
+  return async (url) => {
+    if (failRuns) return { ok: false };
+    if (url.includes('/actions/workflows/')) {
+      return {
+        ok: true,
+        json: async () => ({
+          workflow_runs: [{ jobs_url: 'https://api.example.com/jobs' }],
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ jobs }) };
+  };
+}
+
+test('merge-queue skip validates suites from the dispatched run', async () => {
+  const { cwd, branchTip } = initMergeQueueRepo();
+  git(
+    cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    branchTip,
+  );
+  assert.deepEqual(
+    await alreadyValidatedSuites({
+      cwd,
+      repository: 'example/repo',
+      token: 'token',
+      fetcher: fakeGitHub({
+        jobs: [
+          { name: 'architect-e2e', conclusion: 'success' },
+          { name: 'interview-e2e', conclusion: 'success' },
+          { name: 'interviewer-e2e', conclusion: 'failure' },
+          { name: 'quality', conclusion: 'success' },
+        ],
+      }),
+    }),
+    { interview: true, interviewer: false, architect: true },
+  );
+});
+
+test('merge-queue skip fails closed', async () => {
+  const none = { interview: false, interviewer: false, architect: false };
+  const validatedJobs = [
+    { name: 'architect-e2e', conclusion: 'success' },
+    { name: 'interview-e2e', conclusion: 'success' },
+    { name: 'interviewer-e2e', conclusion: 'success' },
+  ];
+
+  // Main moved under the release PR: the merge tree no longer matches the
+  // validated branch tip.
+  const moved = initMergeQueueRepo({ advanceMainBeforeMerge: true });
+  git(
+    moved.cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    moved.branchTip,
+  );
+  assert.deepEqual(
+    await alreadyValidatedSuites({
+      cwd: moved.cwd,
+      repository: 'example/repo',
+      token: 'token',
+      fetcher: fakeGitHub({ jobs: validatedJobs }),
+    }),
+    none,
+  );
+
+  // The PR tip is not a generated release branch head: an ordinary PR that
+  // bumps a version must never satisfy the fast path.
+  const untrusted = initMergeQueueRepo();
+  assert.deepEqual(
+    await alreadyValidatedSuites({
+      cwd: untrusted.cwd,
+      repository: 'example/repo',
+      token: 'token',
+      fetcher: fakeGitHub({ jobs: validatedJobs }),
+    }),
+    none,
+  );
+
+  // API errors count as not validated.
+  const apiDown = initMergeQueueRepo();
+  git(
+    apiDown.cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    apiDown.branchTip,
+  );
+  assert.deepEqual(
+    await alreadyValidatedSuites({
+      cwd: apiDown.cwd,
+      repository: 'example/repo',
+      token: 'token',
+      fetcher: fakeGitHub({ jobs: [], failRuns: true }),
+    }),
+    none,
+  );
+  assert.deepEqual(
+    await alreadyValidatedSuites({
+      cwd: apiDown.cwd,
+      repository: 'example/repo',
+      token: 'token',
+      fetcher: async () => {
+        throw new Error('network down');
+      },
+    }),
+    none,
+  );
+
+  // Missing credentials count as not validated.
+  assert.deepEqual(
+    suiteFlags(
+      await alreadyValidatedSuites({
+        cwd: apiDown.cwd,
+        repository: '',
+        token: '',
+        fetcher: fakeGitHub({ jobs: validatedJobs }),
+      }),
+    ),
+    none,
+  );
 });

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -30,7 +30,9 @@ function git(cwd, ...args) {
 
 function initRepo() {
   const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-'));
-  git(cwd, 'init', '-q');
+  // -b main: the merge-queue tests check out `main` by name, which must not
+  // depend on the host's init.defaultBranch (CI runners default to master).
+  git(cwd, 'init', '-q', '-b', 'main');
   git(cwd, 'config', 'user.email', 'ci@example.com');
   git(cwd, 'config', 'user.name', 'ci');
   return cwd;


### PR DESCRIPTION
## Summary

Release E2E currently runs all three suites (Interview, Interviewer, Architect) for **every** release lane, twice per release (the dispatched release-branch run, then again in the merge queue) — roughly six ~45-minute suite executions per product release, plus re-runs on every open release PR each time `main` moves.

This PR cuts that down along three axes:

### 1. Per-lane E2E scoping
Each release lane now requires only the suites whose subject package ships in its deploy (`scripts/release-e2e-policy.mjs` emits per-suite flags instead of one `required` boolean):

| Lane | Suites |
| --- | --- |
| `changeset-release/main` (libraries) | interview, interviewer, architect |
| `changeset-release/architect` | architect + interview (Architect bundles the interview runtime for preview) |
| `changeset-release/interviewer` | interviewer + interview |
| `changeset-release/documentation` | none |
| `changeset-release/website` | none |

Merge groups map each version-bumped manifest to its lane and take the union. The mapping is hand-written for a simple CI hot path, but a new test **derives the expected mapping from the real package.json dependency graph** (transitive `dependencies` only), so it fails the moment an app gains or drops a suite subject.

### 2. Merge-queue skip for already-validated trees
A release PR's branch head is fully validated by the dispatched run before it can be enqueued (the required `quality` check includes the E2E verdicts). When the queue's merge commit has the **same tree** as that branch tip — `main` didn't move, nothing else was batched — the queue re-runs the suites against byte-identical code. The policy now skips a suite in exactly that case, verified via the Actions API.

Every guard fails closed (the suite runs):
- the merge commit's tree must equal its second parent's (the PR tip's) — batched groups and a moved `main` never match;
- the PR tip must be the **current head of a generated `changeset-release/*` branch** — an ordinary PR that happens to bump a version can never satisfy the fast path;
- the succeeded job must belong to a `workflow_dispatch` run of this workflow at that exact SHA; any API error or missing credential counts as not validated.

### 3. Push-to-main cruft
- `detect` no longer runs on push-to-main — its only consumers (docs-preview-checks, quality, carry-forward) never run there.
- The vestigial `retire-combined-release-pr` job (a no-op since the combined lane was retired) is deleted.

The `quality` gate now verifies each suite against its own requirement flag, and `pick-e2e-runner`/`e2e-queue-watchdog` key off the interview flag specifically. CLAUDE.md's release-E2E section is updated to match.

## Test plan
- [x] `pnpm test:scripts` — 60/60, including new tests: dependency-graph tripwire for the lane mapping, per-manifest merge-group scoping, and fail-closed behaviour of the merge-queue skip (tree mismatch, untrusted tip, API failure, missing credentials)
- [x] New workflow invariants in `ci-workflow.test.mjs`: detect excluded on push, each E2E job gated on its own flag, quality verifies per-suite, policy job has the token for the fast-path lookup
- [x] `oxlint` + `oxfmt --check` clean on touched files; `pnpm knip` clean
- [ ] After merge: confirm a docs/website release PR runs no E2E suites, and an Architect release PR runs only architect + interview
- [ ] After merge: confirm a release PR whose branch was freshly refreshed from `main` skips E2E in the merge queue (policy job log shows the skip reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)