### PR TITLE
Show numeric keyboards for number fields

### DIFF
--- a/.changeset/numeric-keyboards-interviewer.md
+++ b/.changeset/numeric-keyboards-interviewer.md
@@ -1,0 +1,5 @@
+---
+"@codaco/interviewer": patch
+---
+
+Show a numeric keyboard for number entry on iOS and Android.

--- a/.changeset/yummy-shirts-strive.md
+++ b/.changeset/yummy-shirts-strive.md
@@ -1,0 +1,5 @@
+---
+"@codaco/fresco-ui": patch
+---
+
+Show a numeric keyboard on iOS and Android when InputField uses type="number".

--- a/apps/interviewer/src/components/__tests__/ManageAuthenticator.test.tsx
+++ b/apps/interviewer/src/components/__tests__/ManageAuthenticator.test.tsx
@@ -145,6 +145,10 @@ describe('ManageAuthenticator — change PIN', () => {
     // digit advances focus through the rest. Two groups exist (New PIN and
     // Confirm new PIN), so target each group's first digit by index.
     const firstDigitInputs = screen.getAllByLabelText(/digit 1 of 8/i);
+    expect(firstDigitInputs).toHaveLength(2);
+    firstDigitInputs.forEach((input) =>
+      expect(input).toHaveAttribute('inputmode', 'numeric'),
+    );
     await user.type(firstDigitInputs[0]!, '87654321');
     await user.type(firstDigitInputs[1]!, '87654321');
     await user.click(screen.getByRole('button', { name: /save new pin/i }));

--- a/packages/fresco-ui/src/form/fields/InputField.tsx
+++ b/packages/fresco-ui/src/form/fields/InputField.tsx
@@ -150,6 +150,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       nativeOnChange,
       onKeyDown,
       type = 'text',
+      inputMode,
       disabled,
       readOnly,
       ...inputProps
@@ -214,6 +215,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
           // field (e.g. the glass treatment) would double-apply onto the input.
           className={inputVariants()}
           type={type}
+          inputMode={inputMode ?? (isNumber ? 'decimal' : undefined)}
           {...inputProps}
           onChange={(e) => {
             onChange?.(e.target.value);

--- a/packages/fresco-ui/src/form/fields/__tests__/InputFieldKeyboard.test.tsx
+++ b/packages/fresco-ui/src/form/fields/__tests__/InputFieldKeyboard.test.tsx
@@ -29,6 +29,24 @@ function ControlledNumberInput({
 }
 
 describe('InputField number keyboard stepping', () => {
+  it('requests a decimal numeric keyboard by default', () => {
+    render(<InputField type="number" aria-label="Count" />);
+
+    expect(screen.getByRole('spinbutton', { name: 'Count' })).toHaveAttribute(
+      'inputmode',
+      'decimal',
+    );
+  });
+
+  it('allows consumers to override the numeric keyboard mode', () => {
+    render(<InputField type="number" inputMode="numeric" aria-label="Count" />);
+
+    expect(screen.getByRole('spinbutton', { name: 'Count' })).toHaveAttribute(
+      'inputmode',
+      'numeric',
+    );
+  });
+
   it('keeps the controlled value in sync with ArrowUp and ArrowDown', async () => {
     const user = userEvent.setup();
     render(<ControlledNumberInput />);


### PR DESCRIPTION
## Summary
- make `InputField type="number"` request a decimal-capable numeric keyboard on mobile
- preserve explicit `inputMode` overrides for integer-only and code-like inputs
- cover Fresco's default/override behavior and Interviewer's numeric PIN entry

## Test plan
- [x] `pnpm --filter @codaco/fresco-ui test -- src/form/fields/__tests__/InputFieldKeyboard.test.tsx`
- [x] `pnpm --filter @codaco/interviewer test -- src/components/__tests__/ManageAuthenticator.test.tsx`
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm turbo run build --filter=@codaco/interviewer`
