### PR TITLE
Fix Interviewer layout around iOS chrome and keyboard

### DIFF
--- a/.changeset/visible-ios-viewport-interviewer.md
+++ b/.changeset/visible-ios-viewport-interviewer.md
@@ -1,0 +1,5 @@
+---
+"@codaco/interviewer": patch
+---
+
+Keep interview prompts, Quick Add fields, and newly added nodes visible above Safari chrome and the iOS software keyboard.

--- a/apps/interviewer/e2e/README.md
+++ b/apps/interviewer/e2e/README.md
@@ -14,13 +14,13 @@ pnpm --filter @codaco/interviewer test:e2e
 # Regenerate visual baselines (also Docker — never regenerate locally)
 pnpm --filter @codaco/interviewer test:e2e:update-snapshots
 
-# Run headed against your local Chromium for debugging — functional
+# Run headed against your local Playwright browsers for debugging — functional
 # assertions only, no baseline regeneration
 pnpm --filter @codaco/interviewer test:e2e:headed
 ```
 
-`test:e2e:headed` may need a local Chromium binary installed once first:
-`pnpm --filter @codaco/interviewer exec playwright install chromium`.
+`test:e2e:headed` may need local Chromium and WebKit binaries installed once
+first: `pnpm --filter @codaco/interviewer exec playwright install chromium webkit`.
 
 ## Layout
 
@@ -93,6 +93,6 @@ runs Playwright with `CI=true` (so visual capture is active). `run.sh`
 forwards any extra arguments (e.g. `--update-snapshots`, a spec path).
 
 `pnpm test:e2e:headed` skips Docker: it builds locally, then runs Playwright
-headed against your own Chromium install. Useful for stepping through a spec,
-but visual assertions are skipped (see above) and results won't match the
-Docker/CI environment for anything font-sensitive.
+headed against your own Chromium and WebKit installs. Useful for stepping
+through a spec, but visual assertions are skipped (see above) and results won't
+match the Docker/CI environment for anything font-sensitive.

--- a/apps/interviewer/e2e/playwright.config.ts
+++ b/apps/interviewer/e2e/playwright.config.ts
@@ -58,5 +58,12 @@ export default defineConfig({
     timeout: 60_000,
   },
 
-  projects: [{ name: 'chromium', use: devices['Desktop Chrome'] }],
+  projects: [
+    { name: 'chromium', use: devices['Desktop Chrome'] },
+    {
+      name: 'webkit-visual-viewport',
+      use: devices['Desktop Safari'],
+      testMatch: /visual-viewport\.spec\.ts/,
+    },
+  ],
 });

--- a/apps/interviewer/e2e/specs/visual-viewport.spec.ts
+++ b/apps/interviewer/e2e/specs/visual-viewport.spec.ts
@@ -1,0 +1,176 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/test.js';
+import {
+  LEAN_E2E_PROTOCOL_NAME,
+  LEAN_E2E_PROTOCOL_PATH,
+} from '../helpers/protocol-paths.js';
+
+type TestVisualViewport = {
+  width: number;
+  height: number;
+  offsetLeft: number;
+  offsetTop: number;
+  pageLeft: number;
+  pageTop: number;
+  scale: number;
+};
+
+const LAYOUT_VIEWPORT = { width: 1_824, height: 1_368 };
+const LAYOUT_VISUAL_VIEWPORT: TestVisualViewport = {
+  ...LAYOUT_VIEWPORT,
+  offsetLeft: 0,
+  offsetTop: 0,
+  pageLeft: 0,
+  pageTop: 0,
+  scale: 1,
+};
+const BROWSER_VIEWPORT: TestVisualViewport = {
+  width: 1_824,
+  height: 1_192,
+  offsetLeft: 0,
+  offsetTop: 176,
+  pageLeft: 0,
+  pageTop: 176,
+  scale: 1,
+};
+const KEYBOARD_VIEWPORT: Partial<TestVisualViewport> = {
+  height: 526,
+};
+const SAMPLE_PROMPT =
+  'Within the past 6 months, who have you felt close to, or discussed important personal matters with?';
+
+test.use({ viewport: LAYOUT_VIEWPORT });
+
+async function installVisualViewportStub(
+  page: Page,
+  initial: TestVisualViewport,
+): Promise<void> {
+  await page.addInitScript((initialViewport) => {
+    const values = { ...initialViewport };
+    const viewport = new EventTarget();
+
+    for (const property of Object.keys(values) as Array<keyof typeof values>) {
+      Object.defineProperty(viewport, property, {
+        configurable: true,
+        enumerable: true,
+        get: () => values[property],
+      });
+    }
+
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: viewport,
+    });
+    Reflect.set(
+      window,
+      '__setTestVisualViewport',
+      (next: Partial<typeof values>) => {
+        Object.assign(values, next);
+        viewport.dispatchEvent(new Event('resize'));
+        viewport.dispatchEvent(new Event('scroll'));
+      },
+    );
+  }, initial);
+}
+
+async function setVisualViewport(
+  page: Page,
+  values: Partial<TestVisualViewport>,
+): Promise<void> {
+  await page.evaluate((next) => {
+    const setter = Reflect.get(window, '__setTestVisualViewport');
+    if (typeof setter !== 'function') {
+      throw new Error('VisualViewport test setter was not installed');
+    }
+    (setter as (update: Partial<TestVisualViewport>) => void)(next);
+  }, values);
+}
+
+async function getBox(locator: Locator) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  return box!;
+}
+
+async function expectInsideVisualViewport(
+  locator: Locator,
+  viewport: TestVisualViewport,
+): Promise<void> {
+  await expect(locator).toBeVisible();
+  await expect
+    .poll(async () => {
+      const box = await locator.boundingBox();
+      if (!box) return false;
+      return (
+        box.x >= viewport.pageLeft - 1 &&
+        box.y >= viewport.pageTop - 1 &&
+        box.x + box.width <= viewport.pageLeft + viewport.width + 1 &&
+        box.y + box.height <= viewport.pageTop + viewport.height + 1
+      );
+    })
+    .toBe(true);
+}
+
+test('keeps the Name Generator prompt, quick add, and new node inside the iOS visual viewport', async ({
+  protocol,
+  interviewNav,
+  page,
+}) => {
+  // Keep setup at the full layout size so the deck carousel cannot overlap
+  // the new-session dialog at this deliberately large test resolution. The
+  // regression begins once the interview is running and Safari chrome reduces
+  // and offsets the visible viewport.
+  await installVisualViewportStub(page, LAYOUT_VISUAL_VIEWPORT);
+  await protocol.import(LEAN_E2E_PROTOCOL_PATH, LEAN_E2E_PROTOCOL_NAME);
+  await page.getByRole('button', { name: 'Start new interview' }).click();
+  const caseId = page.getByTestId('new-session-case-id');
+  await caseId.fill('IOS-VIEWPORT');
+  // At this iPad-sized resolution, a fanned protocol card's 2D hit box
+  // overlaps the submit button even though the card is visually behind the
+  // dialog. Submitting the real form with Enter avoids that unrelated deck
+  // actionability quirk.
+  await caseId.press('Enter');
+  await expect(page).toHaveURL(/\/interview\//, { timeout: 15_000 });
+  await interviewNav.waitForStage();
+
+  await interviewNav.next(); // Information -> EgoForm
+  await interviewNav.fillEgoName('Ada');
+  await interviewNav.next(); // EgoForm -> NameGeneratorQuickAdd
+
+  await setVisualViewport(page, BROWSER_VIEWPORT);
+  const appFrame = page.locator('#root > [data-theme-interview]');
+  await expectInsideVisualViewport(appFrame, BROWSER_VIEWPORT);
+
+  const toggle = page.getByTestId('quick-add-toggle');
+  await toggle.click();
+  await setVisualViewport(page, KEYBOARD_VIEWPORT);
+  const keyboardViewport = { ...BROWSER_VIEWPORT, ...KEYBOARD_VIEWPORT };
+
+  // Exercise the wrapped text from the reported Sample Protocol without
+  // changing the lean protocol (and its committed visual baselines).
+  const prompt = page.getByTestId('prompt');
+  await prompt.locator('h2').evaluate((heading, text) => {
+    heading.textContent = text;
+  }, SAMPLE_PROMPT);
+
+  const input = page.getByTestId('quick-add-input');
+  await expectInsideVisualViewport(appFrame, keyboardViewport);
+  await expectInsideVisualViewport(prompt, keyboardViewport);
+  await expectInsideVisualViewport(input, keyboardViewport);
+
+  await input.fill('Grace');
+  await input.press('Enter');
+  const node = page.getByRole('option', { name: 'Grace' });
+  await expectInsideVisualViewport(node, keyboardViewport);
+  await expectInsideVisualViewport(input, keyboardViewport);
+
+  const inputBox = await getBox(input);
+  const nodeBox = await getBox(node);
+  const overlaps =
+    inputBox.x < nodeBox.x + nodeBox.width &&
+    inputBox.x + inputBox.width > nodeBox.x &&
+    inputBox.y < nodeBox.y + nodeBox.height &&
+    inputBox.y + inputBox.height > nodeBox.y;
+  expect(overlaps).toBe(false);
+});

--- a/apps/interviewer/src/lib/pwa/__tests__/visualViewportSizing.test.ts
+++ b/apps/interviewer/src/lib/pwa/__tests__/visualViewportSizing.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initVisualViewportSizing } from '../visualViewportSizing';
+
+type ViewportValues = {
+  width: number;
+  height: number;
+  offsetLeft: number;
+  offsetTop: number;
+  pageLeft: number;
+  pageTop: number;
+  scale: number;
+};
+
+class VisualViewportStub extends EventTarget {
+  width: number;
+  height: number;
+  offsetLeft: number;
+  offsetTop: number;
+  pageLeft: number;
+  pageTop: number;
+  scale: number;
+
+  constructor(values: ViewportValues) {
+    super();
+    this.width = values.width;
+    this.height = values.height;
+    this.offsetLeft = values.offsetLeft;
+    this.offsetTop = values.offsetTop;
+    this.pageLeft = values.pageLeft;
+    this.pageTop = values.pageTop;
+    this.scale = values.scale;
+  }
+
+  update(values: Partial<ViewportValues>, event: 'resize' | 'scroll') {
+    Object.assign(this, values);
+    this.dispatchEvent(new Event(event));
+  }
+}
+
+const DEFAULT_VIEWPORT: ViewportValues = {
+  width: 1_280,
+  height: 650,
+  offsetLeft: 0,
+  offsetTop: 70,
+  pageLeft: 0,
+  pageTop: 70,
+  scale: 1,
+};
+
+function installViewport(values: Partial<ViewportValues> = {}) {
+  const viewport = new VisualViewportStub({
+    ...DEFAULT_VIEWPORT,
+    ...values,
+  });
+  vi.stubGlobal('visualViewport', viewport);
+  return viewport;
+}
+
+function setInstalled(installed: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: installed && query === '(display-mode: standalone)',
+  }));
+}
+
+function root() {
+  const element = document.getElementById('root');
+  if (!element) throw new Error('Missing #root test fixture');
+  return element;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  setInstalled(false);
+  vi.stubGlobal('innerWidth', 1_280);
+  vi.stubGlobal('innerHeight', 720);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('initVisualViewportSizing', () => {
+  it('tracks the browser visual viewport height and position', () => {
+    const viewport = installViewport();
+
+    const cleanup = initVisualViewportSizing();
+
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+    expect(root().style.getPropertyValue('--app-viewport-width')).toBe(
+      '1280px',
+    );
+    expect(root().style.getPropertyValue('--app-viewport-height')).toBe(
+      '650px',
+    );
+    expect(root().style.getPropertyValue('--app-viewport-left')).toBe('0px');
+    expect(root().style.getPropertyValue('--app-viewport-top')).toBe('70px');
+
+    viewport.update({ height: 420, offsetTop: 90, pageTop: 90 }, 'resize');
+
+    expect(root().style.getPropertyValue('--app-viewport-height')).toBe(
+      '420px',
+    );
+    expect(root().style.getPropertyValue('--app-viewport-top')).toBe('90px');
+
+    viewport.update({ pageTop: 110, offsetTop: 110 }, 'scroll');
+    expect(root().style.getPropertyValue('--app-viewport-top')).toBe('110px');
+
+    cleanup();
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+    expect(root().getAttribute('style')).toBeNull();
+
+    viewport.update({ height: 300 }, 'resize');
+    expect(root().getAttribute('style')).toBeNull();
+  });
+
+  it('keeps the static 100vh fallback when VisualViewport is unavailable', () => {
+    vi.stubGlobal('visualViewport', undefined);
+
+    const cleanup = initVisualViewportSizing();
+
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+    expect(root().getAttribute('style')).toBeNull();
+    expect(cleanup).toBeTypeOf('function');
+  });
+
+  it('does not reflow the app while the visual viewport is pinch-zoomed', () => {
+    const viewport = installViewport({ scale: 2, height: 325 });
+
+    const cleanup = initVisualViewportSizing();
+
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    viewport.update({ scale: 1, height: 650 }, 'resize');
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+
+    cleanup();
+  });
+
+  it('preserves standalone full-height paint until a focused software keyboard shrinks the viewport', () => {
+    setInstalled(true);
+    vi.stubGlobal('innerWidth', 1_824);
+    vi.stubGlobal('innerHeight', 1_368);
+    const viewport = installViewport({
+      width: 1_824,
+      height: 1_320,
+      offsetTop: 0,
+      pageTop: 0,
+    });
+
+    const cleanup = initVisualViewportSizing();
+
+    // A short cold-start VisualViewport must not undo the 100vh fallback that
+    // reaches the bottom edge in an installed iPad PWA.
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.append(input);
+    input.focus();
+    viewport.update({ height: 526 }, 'resize');
+
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+    expect(root().style.getPropertyValue('--app-viewport-height')).toBe(
+      '526px',
+    );
+
+    // WebKit can blur the control before its keyboard-closing resize settles;
+    // keep the shrunken frame until the visual viewport recovers.
+    input.blur();
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+
+    viewport.update({ height: 1_320 }, 'resize');
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+    expect(root().getAttribute('style')).toBeNull();
+
+    cleanup();
+  });
+
+  it('ignores a standalone viewport anomaly when no text-entry session is active', () => {
+    setInstalled(true);
+    vi.stubGlobal('innerHeight', 1_368);
+    const viewport = installViewport({ height: 526, offsetTop: 0, pageTop: 0 });
+
+    const cleanup = initVisualViewportSizing();
+
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    viewport.update({ height: 400 }, 'resize');
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    cleanup();
+  });
+});

--- a/apps/interviewer/src/lib/pwa/visualViewportSizing.ts
+++ b/apps/interviewer/src/lib/pwa/visualViewportSizing.ts
@@ -1,0 +1,180 @@
+import { isRunningInstalled } from './isRunningInstalled';
+
+const ROOT_ID = 'root';
+const ACTIVE_ATTRIBUTE = 'data-visual-viewport';
+const ACTIVE_VALUE = 'active';
+const VIEWPORT_PROPERTIES = [
+  '--app-viewport-width',
+  '--app-viewport-height',
+  '--app-viewport-left',
+  '--app-viewport-top',
+] as const;
+
+// Safe-area and cold-start discrepancies are small; an on-screen keyboard is
+// not. Requiring a material reduction stops an initially short standalone-PWA
+// VisualViewport from undoing the static 100vh fallback that reaches the real
+// bottom edge on iPad.
+const MIN_KEYBOARD_REDUCTION = 120;
+const SCALE_EPSILON = 0.01;
+
+function isEditableElement(element: Element | null): boolean {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement ||
+    (element instanceof HTMLElement && element.isContentEditable)
+  );
+}
+
+function finiteMetric(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function positiveMetric(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function getLayoutViewportHeight(viewport: VisualViewport): number {
+  const documentHeight =
+    document.documentElement.getBoundingClientRect().height;
+  return Math.max(
+    viewport.height,
+    window.innerHeight,
+    document.documentElement.clientHeight,
+    documentHeight,
+  );
+}
+
+function clearVisualViewportFrame(root: HTMLElement): void {
+  root.removeAttribute(ACTIVE_ATTRIBUTE);
+  for (const property of VIEWPORT_PROPERTIES) {
+    root.style.removeProperty(property);
+  }
+  if (root.style.length === 0) {
+    root.removeAttribute('style');
+  }
+}
+
+/**
+ * Keep Interviewer's full-screen root aligned to the part of the page that is
+ * actually visible around Safari chrome and the software keyboard.
+ *
+ * The static 100vh root remains the fallback and the resting installed-PWA
+ * size. Browser tabs always follow VisualViewport; an installed PWA opts in
+ * only during a focused text-entry session with a material height reduction.
+ */
+export function initVisualViewportSizing(): () => void {
+  const root = document.getElementById(ROOT_ID);
+  const viewport = window.visualViewport;
+
+  if (!root || !viewport) {
+    return () => {};
+  }
+
+  const installed = isRunningInstalled();
+  let textEntrySession = isEditableElement(document.activeElement);
+  let firstFrame: number | undefined;
+  let secondFrame: number | undefined;
+
+  const applyViewportFrame = () => {
+    // Resizing the layout in response to pinch zoom causes a reflow feedback
+    // loop. Keep the most recent scale-1 frame until zoom returns to 100%.
+    if (Math.abs(viewport.scale - 1) > SCALE_EPSILON) {
+      return;
+    }
+
+    const editableActive = isEditableElement(document.activeElement);
+    if (editableActive) {
+      textEntrySession = true;
+    }
+
+    const layoutHeight = getLayoutViewportHeight(viewport);
+    const materiallyShrunken =
+      layoutHeight - viewport.height >= MIN_KEYBOARD_REDUCTION;
+
+    if (!editableActive && !materiallyShrunken) {
+      textEntrySession = false;
+    }
+
+    if (installed && !(textEntrySession && materiallyShrunken)) {
+      clearVisualViewportFrame(root);
+      return;
+    }
+
+    const width = positiveMetric(viewport.width, window.innerWidth);
+    const height = positiveMetric(viewport.height, window.innerHeight);
+    const left = Math.max(
+      0,
+      finiteMetric(
+        viewport.pageLeft,
+        window.scrollX + finiteMetric(viewport.offsetLeft, 0),
+      ),
+    );
+    const top = Math.max(
+      0,
+      finiteMetric(
+        viewport.pageTop,
+        window.scrollY + finiteMetric(viewport.offsetTop, 0),
+      ),
+    );
+
+    root.style.setProperty('--app-viewport-width', `${String(width)}px`);
+    root.style.setProperty('--app-viewport-height', `${String(height)}px`);
+    root.style.setProperty('--app-viewport-left', `${String(left)}px`);
+    root.style.setProperty('--app-viewport-top', `${String(top)}px`);
+    root.setAttribute(ACTIVE_ATTRIBUTE, ACTIVE_VALUE);
+  };
+
+  const cancelScheduledFrames = () => {
+    if (firstFrame !== undefined) {
+      window.cancelAnimationFrame(firstFrame);
+      firstFrame = undefined;
+    }
+    if (secondFrame !== undefined) {
+      window.cancelAnimationFrame(secondFrame);
+      secondFrame = undefined;
+    }
+  };
+
+  const handleViewportChange = () => {
+    // Apply immediately, then sample again after two paints. WebKit can emit a
+    // viewport event before its keyboard animation has committed final metrics.
+    applyViewportFrame();
+    cancelScheduledFrames();
+    firstFrame = window.requestAnimationFrame(() => {
+      firstFrame = undefined;
+      secondFrame = window.requestAnimationFrame(() => {
+        secondFrame = undefined;
+        applyViewportFrame();
+      });
+    });
+  };
+
+  handleViewportChange();
+
+  viewport.addEventListener('resize', handleViewportChange);
+  viewport.addEventListener('scroll', handleViewportChange);
+  viewport.addEventListener('scrollend', handleViewportChange);
+  window.addEventListener('resize', handleViewportChange);
+  window.addEventListener('scroll', handleViewportChange);
+  window.addEventListener('orientationchange', handleViewportChange);
+  window.addEventListener('pageshow', handleViewportChange);
+  document.addEventListener('focusin', handleViewportChange);
+  document.addEventListener('focusout', handleViewportChange);
+  document.addEventListener('visibilitychange', handleViewportChange);
+
+  return () => {
+    cancelScheduledFrames();
+    viewport.removeEventListener('resize', handleViewportChange);
+    viewport.removeEventListener('scroll', handleViewportChange);
+    viewport.removeEventListener('scrollend', handleViewportChange);
+    window.removeEventListener('resize', handleViewportChange);
+    window.removeEventListener('scroll', handleViewportChange);
+    window.removeEventListener('orientationchange', handleViewportChange);
+    window.removeEventListener('pageshow', handleViewportChange);
+    document.removeEventListener('focusin', handleViewportChange);
+    document.removeEventListener('focusout', handleViewportChange);
+    document.removeEventListener('visibilitychange', handleViewportChange);
+    clearVisualViewportFrame(root);
+  };
+}

--- a/apps/interviewer/src/main.tsx
+++ b/apps/interviewer/src/main.tsx
@@ -14,6 +14,7 @@ import {
 import { initInstallPromptCapture } from './lib/pwa/installPrompt';
 import { removeLoadingScreen } from './lib/pwa/loadingScreen';
 import { initSwipeNavigationGuard } from './lib/pwa/swipeNavigationGuard';
+import { initVisualViewportSizing } from './lib/pwa/visualViewportSizing';
 import {
   requestPersistentStorage,
   requestPersistentStorageOnFirstInteraction,
@@ -24,6 +25,14 @@ import {
 initInstallPromptCapture();
 
 initSwipeNavigationGuard();
+
+// Safari keeps the layout viewport behind its browser chrome and software
+// keyboard. Align the full-screen app root to VisualViewport before React
+// mounts so critical interview content is never laid out in the hidden region.
+const disposeVisualViewportSizing = initVisualViewportSizing();
+if (import.meta.hot) {
+  import.meta.hot.dispose(disposeVisualViewportSizing);
+}
 
 // OS-launched .netcanvas files (installed-PWA file handler) can arrive before
 // React mounts; capture them for Home to import after unlock.

--- a/apps/interviewer/src/styles/globals.css
+++ b/apps/interviewer/src/styles/globals.css
@@ -40,6 +40,26 @@ body {
   height: 100%;
 }
 
+/* Safari's browser chrome and software keyboard resize/offset VisualViewport
+   without changing the large layout viewport that 100vh represents. The
+   pre-React visualViewportSizing initializer opts #root into this frame in a
+   browser tab and while an installed PWA keyboard is open.
+
+   Keep #root in normal document flow: its border box reaches the visual
+   viewport's bottom/right edge, while padding reserves the hidden top/left
+   region. Because border-box sizing subtracts that padding, the h-full child
+   chain receives exactly the visible width and height. This preserves the
+   static 100vh edge-to-edge paint without turning #root into a transformed
+   containing block for fixed dialogs and backdrops. */
+#root[data-visual-viewport='active'] {
+  box-sizing: border-box;
+  width: calc(var(--app-viewport-left) + var(--app-viewport-width));
+  height: calc(var(--app-viewport-top) + var(--app-viewport-height));
+  padding-top: var(--app-viewport-top);
+  padding-left: var(--app-viewport-left);
+  overflow: hidden;
+}
+
 /* Disable the two-finger swipe-back/forward navigation gesture. Chromium
    reads this from the ROOT element (the body declaration below does not
    propagate to the viewport). Safari ignores it for the history swipe


### PR DESCRIPTION
## Summary
- size Interviewer's full-screen root from VisualViewport so Safari chrome and the software keyboard cannot hide critical interview content
- preserve the installed PWA's full-height resting layout while enabling keyboard-aware sizing during text entry
- add unit and Chromium/WebKit E2E coverage for the prompt, Quick Add input, and newly added nodes
- add an Interviewer patch changeset

## Test plan
- [x] pnpm check:changesets
- [x] pnpm knip
- [x] pnpm turbo run typecheck --filter=@codaco/interviewer
- [x] pnpm exec tsc --project apps/interviewer/e2e/tsconfig.json --noEmit
- [x] pnpm --filter @codaco/interviewer exec vitest run --project=unit --reporter=dot (390 tests)
- [x] pnpm turbo build --filter @codaco/interviewer
- [x] pnpm --filter @codaco/interviewer exec playwright test --config=e2e/playwright.config.ts e2e/specs/visual-viewport.spec.ts --project=chromium --project=webkit-visual-viewport
- [x] iPad Pro iOS 26.5 simulator in Safari with the software keyboard
- [x] iPad Pro iOS 26.5 simulator as an installed PWA with the software keyboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Interviewer experience on iOS Safari by keeping prompts, Quick Add fields, and newly added nodes visible above browser controls and the software keyboard.
  * Improved full-screen layout behavior during viewport resizing, scrolling, orientation changes, and text entry.

* **Tests**
  * Added automated coverage for iOS Safari visual viewport behavior and keyboard-related layout changes.

* **Documentation**
  * Clarified that headed end-to-end tests require both Chromium and WebKit browser installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->