### PR TITLE
ci: run generated release PR checks natively

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -146,7 +146,7 @@ jobs:
 
   # Decides per suite whether release E2E must run for this ref: each release
   # lane requires only the suites whose subject package ships in its deploy,
-  # and a merge-group run skips suites already validated by the dispatched run
+  # and a merge-group run skips suites already validated by the native PR run
   # on an identical tree (see scripts/release-e2e-policy.mjs).
   e2e-policy:
     if: github.event_name != 'push'

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -966,7 +966,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       id-token: write
@@ -996,13 +995,11 @@ jobs:
           publish: pnpm run publish-packages
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A fine-grained PAT makes the generated PR's pull_request event run
+          # normally. GITHUB_TOKEN-created PR events always require manual
+          # workflow approval, which previously forced a duplicate dispatch.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-      - name: Run CI on the Version Packages branch
-        if: steps.changesets.outputs.hasChangesets == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run ci-and-release.yml --ref changeset-release/main
 
   # Maintains one gated release PR per product (siblings of the library "Version
   # Packages" PR). On every push to main each matrix entry re-runs the version
@@ -1033,7 +1030,6 @@ jobs:
       group: product-release-pr-${{ matrix.slug }}
       cancel-in-progress: false
     permissions:
-      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -1060,20 +1056,15 @@ jobs:
         id: product_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          # Use the dedicated PAT so the generated PR triggers its native
+          # pull_request CI run without an approval prompt.
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
           branch: changeset-release/${{ matrix.slug }}
           base: main
           delete-branch: true
           title: 'Release ${{ matrix.product }}'
           commit-message: 'chore(release): version ${{ matrix.slug }}'
           body-path: ${{ runner.temp }}/product-release-body.md
-      - name: Run CI on the ${{ matrix.product }} release branch
-        if: >-
-          ${{ steps.product_pr.outputs['pull-request-operation'] == 'created'
-          || steps.product_pr.outputs['pull-request-operation'] == 'updated' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_REF: changeset-release/${{ matrix.slug }}
-        run: gh workflow run ci-and-release.yml --ref "$RELEASE_REF"
 
   # On a push to main that changes a gated product version (i.e. one product's
   # release PR just merged), detect which product moved. Idempotency is a local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,15 +280,15 @@ earlier commit.
 
 A merge-queue run skips a suite only in one narrow case: the queued merge
 commit's tree is byte-identical to the tip of a generated release branch, and
-a dispatched run of this workflow already ran that suite successfully at that
+a native pull-request run of this workflow already ran that suite successfully at that
 exact SHA. Every guard fails closed (tree mismatch, non-release tip, or any
 Actions-API doubt reruns the suite), so batched merge groups and moved `main`
 always re-run E2E.
 
-The release jobs explicitly dispatch `ci-and-release.yml` after creating or
-updating a generated branch. Normal release PRs therefore do not need a
-manual E2E trigger, even though GitHub does not start PR workflows for branch
-updates made with the repository token.
+The release jobs create and update generated branches with the fine-grained PAT
+stored as `RELEASE_PR_TOKEN`. That causes the normal `pull_request` workflow to
+start without manual approval. Do not add a separate workflow dispatch: it would
+duplicate the native CI run and its release-only E2E suites.
 
 #### E2E visual snapshot baselines
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -97,3 +97,23 @@ test('release job prunes ignored-lane changesets before changesets/action', () =
     'prune step must run before changesets/action reads changeset state',
   );
 });
+
+test('generated release PRs use the dedicated PAT and rely on native PR CI', () => {
+  const releaseJob = job('release');
+  assert.ok(releaseJob, 'release job exists');
+  assert.match(
+    releaseJob,
+    /GITHUB_TOKEN: \$\{\{ secrets\.RELEASE_PR_TOKEN \}\}/,
+  );
+  assert.doesNotMatch(releaseJob, /gh workflow run ci-and-release\.yml/);
+  assert.doesNotMatch(releaseJob, /actions: write/);
+
+  const productReleaseJob = job('product-release-pr');
+  assert.ok(productReleaseJob, 'product release PR job exists');
+  assert.match(
+    productReleaseJob,
+    /token: \$\{\{ secrets\.RELEASE_PR_TOKEN \}\}/,
+  );
+  assert.doesNotMatch(productReleaseJob, /gh workflow run ci-and-release\.yml/);
+  assert.doesNotMatch(productReleaseJob, /actions: write/);
+});

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -167,19 +167,19 @@ export function releaseE2EPolicy(
 }
 
 // Merge-queue fast path: a release PR's branch head was already fully
-// E2E-validated by the workflow_dispatch run fired when the branch was
+// E2E-validated by the native pull_request run fired when the branch was
 // created/updated (the required `quality` check means the PR could not have
 // been enqueued otherwise). When the queue's merge commit has the SAME TREE
 // as that branch tip — main did not move and nothing else was batched — the
 // queue would re-run the suites against byte-identical code, so each suite
-// whose dispatched job succeeded on that exact SHA can be skipped.
+// whose PR job succeeded on that exact SHA can be skipped.
 //
 // Every guard fails closed (the suite runs):
 //  * the merge commit's tree must equal its second parent's (the PR tip's);
 //  * the PR tip must be the current head of a generated changeset-release/*
 //    branch, so only trusted generated branches — never an arbitrary PR that
 //    happens to bump a version — can satisfy the fast path;
-//  * the succeeded job must belong to a workflow_dispatch run of THIS
+//  * the succeeded job must belong to a pull_request run of THIS
 //    workflow at that SHA, looked up via the Actions API; any API error
 //    counts as not validated.
 export async function alreadyValidatedSuites({
@@ -211,7 +211,7 @@ export async function alreadyValidatedSuites({
   };
   try {
     const runsResponse = await fetcher(
-      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=workflow_dispatch&head_sha=${prTip}&per_page=100`,
+      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=pull_request&head_sha=${prTip}&per_page=100`,
       apiOptions,
     );
     if (!runsResponse.ok) return validated;

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -305,6 +305,8 @@ function fakeGitHub({ jobs, failRuns = false }) {
   return async (url) => {
     if (failRuns) return { ok: false };
     if (url.includes('/actions/workflows/')) {
+      assert.match(url, /[?&]event=pull_request(?:&|$)/);
+      assert.doesNotMatch(url, /[?&]event=workflow_dispatch(?:&|$)/);
       return {
         ok: true,
         json: async () => ({
@@ -316,7 +318,7 @@ function fakeGitHub({ jobs, failRuns = false }) {
   };
 }
 
-test('merge-queue skip validates suites from the dispatched run', async () => {
+test('merge-queue skip validates suites from the native PR run', async () => {
   const { cwd, branchTip } = initMergeQueueRepo();
   git(
     cwd,


### PR DESCRIPTION
## Summary
- create and update changeset release PRs with the repository-scoped `RELEASE_PR_TOKEN` fine-grained PAT
- rely on the native `pull_request` workflow run instead of dispatching duplicate CI
- remove no-longer-needed `actions: write` permissions and cover the token/trigger contract with a workflow test

## Test plan
- [x] `pnpm test:scripts`
- [x] `pnpm check:changesets`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm lint`

## Changeset
- Not required: CI/tooling-only change.