### PR TITLE
docs: refresh monorepo workspace guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,20 @@ deleting branches, publishing releases).
 # Install all dependencies
 pnpm install
 
-# Start all applications in development mode
+# Start every workspace that has a development task
 pnpm dev
 
 # Start specific applications
 pnpm --filter @codaco/architect dev
-pnpm --filter analytics-web dev  # Next.js with turbopack
+pnpm --filter @codaco/interviewer dev
+pnpm --filter @codaco/documentation dev
+pnpm --filter networkcanvas.com dev
 ```
 
 ### Building & Testing
 
 ```bash
-# Build all packages and applications
+# Build the workspace through Turbo's dependency graph
 pnpm build
 
 # Run all tests
@@ -38,12 +40,11 @@ pnpm test
 # Run tests in watch mode
 pnpm test:watch
 
-# Type check all packages (always run before committing)
+# Type check the workspace (always run before committing)
 pnpm typecheck
 
-# Check for dead code and unused dependencies
+# Check for unused files, exports, and dependencies
 pnpm knip
-
 ```
 
 ### Running tasks through turbo
@@ -124,8 +125,9 @@ pnpm publish-packages
 
 #### Changeset lanes: libraries vs gated products
 
-- **Library packages** (`packages/*`) release to npm via `changesets/action` (the
-  "Version Packages" PR).
+- **Publishable library packages** under `packages/*` release to npm via
+  `changesets/action` (the "Version Packages" PR). Private packages stay in the
+  same dependency graph but are not published.
 - **Each gated product** has its own release PR: Architect and Interviewer release
   on a `-beta.N` line and create a GitHub release, while Documentation and
   networkcanvas.com use normal semver and receive a Git tag. Merging a product's
@@ -140,33 +142,47 @@ pnpm publish-packages
 
 ### Monorepo Structure
 
-This is a **pnpm workspace** monorepo with catalog dependencies for version consistency:
+This is a **pnpm workspace** monorepo with catalog dependencies for version
+consistency:
 
-- **Apps**: End-user applications
-  - `architect` - Protocol designer (Vite + Redux)
-  - `documentation` - Documentation site
-- **Packages**: Shared libraries and utilities
-  - `protocol-validation` - Zod schemas for protocol validation and migration
+- **Apps**: Products and websites
+  - `architect` - Offline-capable Vite/React PWA for designing, validating, and previewing protocols
+  - `architect-classic` - Maintenance-mode Electron version of the original Architect
+  - `documentation` - Localized Next.js documentation site built from Markdown/MDX
+  - `interviewer` - Offline-first Vite/React PWA for protocol management, local interviews, and data export
+  - `interviewer-classic` - Maintenance-mode Interviewer for Electron desktop and Capacitor mobile
+  - `networkcanvas.com` - Localized Next.js project website
+- **Packages**: Shared libraries, generated assets, and protocol content
+  - `art` - Shared animated backgrounds, blobs, patterns, and network-weave visuals
+  - `development-protocol` - Published compatibility package for the canonical development protocol
+  - `fresco-ui` - React component system, forms, dialogs, styles, and utilities
+  - `interface-images` - Generated responsive interview-interface screenshots and display component
+  - `interview` - Embeddable participant-facing interview engine and host session contract
+  - `network-exporters` - CSV and GraphML interview-data export pipeline
+  - `network-query` - Network filtering and querying utilities
   - `protocol-utilities` - Synthetic network generation and interview-payload builder
+  - `protocol-validation` - Protocol schemas, validation, hashing, and migration
+  - `protocols` - Private canonical source for bundled protocols, templates, downloads, and fixtures
+  - `sample-protocol` - Published compatibility package for the canonical sample protocol
   - `shared-consts` - Shared constants and TypeScript definitions
-  - `analytics` - PostHog analytics wrapper with installation ID tracking
-  - `ui` - React components (built on shadcn/ui and Tailwind CSS)
-  - `art` - Visual design components using blobs and d3-interpolate-path
-  - `development-protocol` - Development protocol assets for testing
-- **Tooling**: Build configuration
-  - `tailwind` - Shared Tailwind CSS configurations
+  - `site-navigation-element` - Self-contained Network Canvas navigation web component
+- **Tooling**: Shared build and code-quality configuration
+  - `tailwind` - Shared Tailwind theme, design tokens, fonts, and plugins
   - `typescript` - Shared TypeScript configurations
-- **Workers**: Cloudflare Workers for specific backend tasks
-  - `development-protocol` - Development protocol worker
-  - `posthog-proxy` - PostHog proxy worker
+  - `oxlint` - Shared React and accessibility lint rules
+- **Workers**: Cloudflare Workers
+  - `development-protocol` - Resolves and serves the latest released development protocol
+  - `posthog-proxy` - Proxies PostHog API and static-asset requests with CORS support
 
 ### Key Technologies
 
-- **Build**: Vite for apps, custom build scripts for packages
+- **Workspace orchestration**: pnpm workspaces and Turborepo
+- **Builds**: Vite for current web apps and libraries, Next.js for websites,
+  Electron Vite for classic desktop apps, and Wrangler for Cloudflare Workers
 - **Validation**: Zod with complex cross-reference validation patterns
-- **Frontend**: React with various stacks (Vite + Redux for desktop apps and architect, Next.js for documentation and others)
-- **Styling**: Tailwind CSS with shared configurations
-- **Testing**: Vitest across all packages
+- **Frontend**: React, with Redux or Zustand where application state requires it
+- **Styling**: Tailwind CSS, Base UI, and the shared Fresco design system
+- **Testing**: Vitest, Storybook/Chromatic, and Playwright
 
 #### @codaco/protocol-validation
 
@@ -190,21 +206,41 @@ Synthetic network generation and interview-payload builder for Network Canvas pr
 - **`generateNetwork`**: a pure function that produces an `NcNetwork` (plus stage metadata and step state) for a given codebook and stages, with optional seeding for deterministic output. Used by `architect`'s PreviewHost and by tests that need a deterministic network shape.
 - **`SyntheticInterview`**: a fluent builder for codebooks, stages, prompts, forms, and full interview payloads. Used by `@codaco/interview`'s Storybook stories.
 
+#### @codaco/interview
+
+Embeddable React interview engine containing the participant-facing interfaces,
+stage navigation, state management, analytics hooks, and the contract a host
+uses to synchronize and finish sessions. It is hosted by the current Interviewer
+app, Architect previews, and external consumers such as Fresco.
+
+#### @codaco/fresco-ui
+
+The shared React design system. It provides accessible Base UI-backed
+components, forms, dialogs, collection primitives, typography, layout, themes,
+and motion utilities. Its `package.json` exports and co-located Storybook stories
+are the authoritative component API.
+
 #### @codaco/shared-consts
 
 Shared constants and type definitions used across the ecosystem. Place shared code, types, and constants here to avoid circular dependencies between packages.
 
-#### @codaco/analytics
-
-PostHog analytics wrapper for Network Canvas applications with installation ID tracking and error reporting. Provides both client-side and server-side exports.
-
 #### @codaco/art
 
-Visual design components using blobs and d3-interpolate-path for animated blob graphics used throughout the Network Canvas UI.
+Animated backgrounds, blobs, patterns, and network-weave visuals shared across
+Network Canvas applications and websites.
 
-#### @codaco/development-protocol
+#### @codaco/network-exporters and @codaco/network-query
 
-Development protocol (protocol.json and assets/) for testing Network Canvas applications during development; it can be zipped into a .netcanvas file.
+`@codaco/network-exporters` provides the Effect pipeline for exporting interview
+data as CSV and GraphML. `@codaco/network-query` provides filtering and querying
+utilities shared by interview runtimes and applications.
+
+#### @codaco/protocols and compatibility packages
+
+`@codaco/protocols` is the private canonical source for development and sample
+protocols, Architect templates, documentation downloads, and E2E fixtures.
+`@codaco/development-protocol` and `@codaco/sample-protocol` are published
+compatibility packages synchronized from that canonical content.
 
 ### Protocol System
 
@@ -217,9 +253,10 @@ Network Canvas uses a protocol-based system where:
 
 ### Data Flow
 
-1. Protocols are designed in Architect (protocol builder)
-2. Validated using @codaco/protocol-validation
-3. Executed in Interviewer applications
+1. Protocols are designed in Architect.
+2. They are validated and migrated by `@codaco/protocol-validation`.
+3. The `@codaco/interview` runtime executes them in Interviewer or another host.
+4. Completed interview data can be transformed by `@codaco/network-exporters`.
 
 ## Development Guidelines
 
@@ -230,6 +267,10 @@ Network Canvas uses a protocol-based system where:
 - **NO `any` types** - explicitly forbidden, always use proper TypeScript typing
 - **No barrel files** - avoid index.js/ts except in exceptional circumstances
 - **Workspace dependencies**: Use `workspace:*` for dependencies used by multiple packages, or tooling dependencies. Use regular versioning for app-specific dependencies.
+- **Classic app dependencies**: Keep `architect-classic` on its GitHub
+  `protocol-validation` dependency and `interviewer-classic` on its external npm
+  `@codaco/protocol-validation` dependency. Do not migrate either to the
+  workspace package unless the task explicitly modernizes the classic apps.
 
 ### TypeScript
 
@@ -240,8 +281,9 @@ Network Canvas uses a protocol-based system where:
 ### Testing
 
 - Test files use `.test.ts` or `.test.tsx` extensions
-- Tests are co-located with source files in `__tests__/` directories
-- Uses Vitest for testing framework
+- Tests are co-located with the source they cover, either adjacent to it or in a
+  nearby `__tests__/` directory
+- Vitest is the default unit and component test framework; Playwright covers E2E
 - If a storybook exists for a component, consider creating interactive tests within storybook
 
 #### Chromatic and TurboSnap

--- a/README.md
+++ b/README.md
@@ -1,86 +1,102 @@
 # Network Canvas
 
-Network Canvas is a suite of applications for conducting network research interviews and data collection. This monorepo contains the core packages and applications that power the Network Canvas ecosystem.
+Network Canvas is a suite of tools for designing and conducting network
+research interviews. This monorepo contains the current browser applications,
+maintenance-mode desktop and mobile applications, shared libraries, websites,
+and supporting services used across the Network Canvas ecosystem.
 
-## Overview
-
-Network Canvas helps researchers collect data about social, personal, and professional networks through intuitive interfaces and powerful data management tools.
+Architect creates `.netcanvas` interview protocols. Interviewer installs and
+runs those protocols locally, stores interview data offline, and exports the
+resulting networks for analysis. The shared packages provide the protocol
+schema, interview runtime, design system, data utilities, and canonical protocol
+content used by those applications.
 
 ## Repository Structure
 
-This monorepo is organized into four main categories:
+The pnpm workspace is organized into four main categories.
 
 ### Apps
 
-| App                                                 | Description                                                                                          |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [`architect`](./apps/architect)                     | Protocol designer application (Vite + React + Redux) for creating Network Canvas interview protocols |
-| [`architect-classic`](./apps/architect-classic)     | Legacy Electron build of Architect, the Network Canvas protocol designer (maintenance mode)          |
-| [`interviewer`](./apps/interviewer)                 | Network Canvas Interviewer — offline-first PWA used to conduct interviews                            |
-| [`interviewer-classic`](./apps/interviewer-classic) | Legacy Network Canvas Interviewer (Electron + Cordova), maintenance mode                             |
-| [`documentation`](./apps/documentation)             | Next.js documentation website with MDX support and search functionality                              |
+| App                                                 | Description                                                                                                                                        |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`architect`](./apps/architect)                     | Offline-capable Vite/React PWA for designing, validating, and previewing Network Canvas interview protocols                                        |
+| [`architect-classic`](./apps/architect-classic)     | Maintenance-mode Electron version of the original Architect protocol designer                                                                      |
+| [`documentation`](./apps/documentation)             | Localized Next.js documentation site built from Markdown/MDX, with DocSearch and generated protocol downloads                                      |
+| [`interviewer`](./apps/interviewer)                 | Offline-first Vite/React PWA for managing protocols, conducting interviews, storing local sessions with optional encryption, and exporting data    |
+| [`interviewer-classic`](./apps/interviewer-classic) | Maintenance-mode Interviewer application for desktop (Electron) and native mobile (Capacitor)                                                      |
+| [`networkcanvas.com`](./apps/networkcanvas.com)     | Localized Next.js project website, including product information, research resources, publications, team information, and getting-started guidance |
 
 ### Packages
 
-| Package                                                           | Description                                                                                          |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [`@codaco/protocol-validation`](./packages/protocol-validation)   | Zod schemas for validating and migrating Network Canvas protocol files                               |
-| [`@codaco/shared-consts`](./packages/shared-consts)               | Shared constants and TypeScript definitions for the Network Canvas project                           |
-| [`@codaco/interview`](./packages/interview)                       | Network Canvas interview engine — Shell component, synthetic network generator, and session contract |
-| [`@codaco/network-exporters`](./packages/network-exporters)       | Effect-TS pipeline for exporting Network Canvas interview data as CSV and GraphML                    |
-| [`@codaco/network-query`](./packages/network-query)               | Network filtering and querying utilities for Network Canvas                                          |
-| [`@codaco/fresco-ui`](./packages/fresco-ui)                       | Fresco UI components, styles, and utilities built on Base UI and Tailwind CSS                        |
-| [`@codaco/art`](./packages/art)                                   | Visual design components using blobs and d3-interpolate-path for animated graphics                   |
-| [`@codaco/interface-images`](./packages/interface-images)         | Generated responsive screenshots of every interview interface, with a React `<picture>` component    |
-| [`@codaco/development-protocol`](./packages/development-protocol) | Development protocol assets for testing Network Canvas applications                                  |
+| Package                                                                 | Description                                                                                                                             |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@codaco/art`](./packages/art)                                         | Shared animated backgrounds, blobs, patterns, and network-weave visuals                                                                 |
+| [`@codaco/development-protocol`](./packages/development-protocol)       | Published compatibility package for the canonical development protocol in `@codaco/protocols`                                           |
+| [`@codaco/fresco-ui`](./packages/fresco-ui)                             | Reusable React components, forms, dialogs, styles, and utilities built with Base UI and Tailwind CSS                                    |
+| [`@codaco/interface-images`](./packages/interface-images)               | Generated responsive screenshots of the interview interfaces, plus the React component used to display them                             |
+| [`@codaco/interview`](./packages/interview)                             | Embeddable React interview engine containing the participant-facing interfaces, navigation, state management, and host session contract |
+| [`@codaco/network-exporters`](./packages/network-exporters)             | Effect pipeline for exporting Network Canvas interview data as CSV and GraphML                                                          |
+| [`@codaco/network-query`](./packages/network-query)                     | Network filtering and querying utilities                                                                                                |
+| [`@codaco/protocol-utilities`](./packages/protocol-utilities)           | Deterministic synthetic-network generation and a fluent interview-payload builder                                                       |
+| [`@codaco/protocol-validation`](./packages/protocol-validation)         | Zod schemas and utilities for validating, hashing, and migrating Network Canvas protocol files                                          |
+| [`@codaco/protocols`](./packages/protocols)                             | Private canonical source for development and sample protocols, Architect templates, documentation downloads, and E2E fixtures           |
+| [`@codaco/sample-protocol`](./packages/sample-protocol)                 | Published compatibility package for the canonical sample protocol in `@codaco/protocols`                                                |
+| [`@codaco/shared-consts`](./packages/shared-consts)                     | Shared constants and TypeScript definitions                                                                                             |
+| [`@codaco/site-navigation-element`](./packages/site-navigation-element) | Self-contained `<nc-site-navigation>` web component for non-React websites                                                              |
 
 ### Workers
 
-| Worker                                                          | Description                                                          |
-| --------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [`development-protocol-worker`](./workers/development-protocol) | Cloudflare Worker for serving development protocol files from GitHub |
-| [`posthog-proxy-worker`](./workers/posthog-proxy)               | Cloudflare Worker for proxying PostHog analytics requests            |
+| Worker                                                          | Description                                                                                     |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`development-protocol-worker`](./workers/development-protocol) | Cloudflare Worker that resolves and serves the latest released `Development.netcanvas` artifact |
+| [`posthog-proxy-worker`](./workers/posthog-proxy)               | Cloudflare Worker that proxies PostHog API and static-asset requests with CORS support          |
 
 ### Tooling
 
-| Config                                          | Description                                                                           |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
-| [`@codaco/tailwind-config`](./tooling/tailwind) | Shared Tailwind v4 theme, color palette, and plugins for Fresco and other Codaco apps |
-| [`@codaco/tsconfig`](./tooling/typescript)      | Shared TypeScript configurations                                                      |
-| [`oxlint`](./tooling/oxlint)                    | Shared oxlint configurations (React and Tailwind rule sets) extended by workspaces    |
+| Tooling                                         | Description                                                                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [`@codaco/tailwind-config`](./tooling/tailwind) | Shared Tailwind theme, design tokens, fonts, and plugins, with v3 compatibility and the preferred v4 surface |
+| [`@codaco/tsconfig`](./tooling/typescript)      | Shared TypeScript configurations                                                                             |
+| [`oxlint`](./tooling/oxlint)                    | Shared oxlint rule sets for React and accessibility                                                          |
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js >= 20.0.0
-- pnpm >= 10.0.0
+- Node.js 24, using the exact version in [`.nvmrc`](./.nvmrc)
+- pnpm 11, using the exact version pinned by `packageManager` in
+  [`package.json`](./package.json)
 
 ### Installation
 
 ```bash
 git clone https://github.com/complexdatacollective/network-canvas-monorepo.git
 cd network-canvas-monorepo
+corepack enable
 pnpm install
 ```
 
 ### Development
 
 ```bash
-# Start all applications in development mode
+# Start every workspace that has a development task
 pnpm dev
 
-# Build all packages and applications
+# Build the workspace through Turborepo's dependency graph
 pnpm build
 
-# Run tests across all packages
+# Run tests across the workspace
 pnpm test
 ```
 
-### Working with Individual Packages
+The root scripts invoke `turbo run`/`turbo watch`, so workspace dependencies are
+built or watched in the correct order. Prefer them over calling a package script
+directly when that task consumes another workspace package.
+
+### Working with Individual Workspaces
 
 ```bash
-# Work with a specific package
+# Work with a specific app or package
 pnpm --filter @codaco/protocol-validation build
 pnpm --filter @codaco/architect dev
 pnpm --filter @codaco/documentation dev
@@ -104,17 +120,21 @@ pnpm --filter posthog-proxy-worker deploy
 
 ## Development Tools
 
-- **Build System**: Vite for fast builds and development
-- **Package Manager**: pnpm with workspace support
-- **Code Formatting**: oxfmt for formatting and oxlint for linting
-- **Type Checking**: TypeScript with shared configurations
-- **Edge Computing**: Cloudflare Workers for serverless functions
-- **CI/CD**: GitHub Actions with optimized workflows
-- **Change Management**: Changesets for version management
+- **Workspace orchestration:** pnpm workspaces and Turborepo
+- **Application builds:** Vite for the current web apps and shared libraries,
+  Next.js for the websites, Electron Vite for the classic desktop apps, and
+  Wrangler for Cloudflare Workers
+- **UI:** React, Tailwind CSS, Base UI, and the shared Fresco design system
+- **Code quality:** TypeScript, oxlint, oxfmt, and knip
+- **Testing:** Vitest, Storybook/Chromatic, and Playwright
+- **CI/CD and releases:** GitHub Actions, Changesets, Netlify, npm, and
+  Cloudflare Workers
 
 ## Code Style
 
-This project uses [oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [oxfmt](https://github.com/oxc-project/oxfmt) for formatting. Style settings: 2-space indentation, 80-character line width, and single quotes.
+This project uses [oxlint](https://oxc.rs/docs/guide/usage/linter) for linting
+and [oxfmt](https://github.com/oxc-project/oxfmt) for formatting. Style settings:
+2-space indentation, 80-character line width, and single quotes.
 
 ```bash
 # Check formatting and linting
@@ -144,20 +164,28 @@ pnpm --filter @codaco/protocol-validation test
 # Run tests in watch mode
 pnpm test:watch
 
-# Type check all packages
+# Type check the workspace
 pnpm typecheck
+
+# Check for unused files, exports, and dependencies
+pnpm knip
 ```
 
 ## Version Management
 
-This project uses [Changesets](https://github.com/changesets/changesets) for version management and automated releases.
+This project uses [Changesets](https://github.com/changesets/changesets) for
+version management and automated releases.
 
 ```bash
 # Add a changeset for your changes
 pnpm changeset
 ```
 
-After merging a PR with changesets, a release PR will be created that bumps package versions. Merge that PR to publish the updated packages.
+Publishable library packages under `packages/*` share the npm release lane.
+Architect, Interviewer, Documentation, and networkcanvas.com each have an
+independent gated product release PR. Keep each changeset to one release lane:
+do not mix a gated product with libraries, or two gated products, in the same
+changeset. Classic apps are maintained and released separately.
 
 ## Interface Screenshots
 
@@ -195,8 +223,9 @@ the `regenerating-e2e-visual-snapshots` skill and the manual
 2. Create a feature branch
 3. Make your changes
 4. Add tests if applicable
-5. Run `pnpm lint:fix` and `pnpm typecheck`
-6. Submit a pull request
+5. Add a changeset when the change affects a releasable package or product
+6. Run `pnpm lint:fix`, `pnpm knip`, `pnpm typecheck`, and the relevant tests
+7. Submit a pull request
 
 ## Links
 


### PR DESCRIPTION
## Summary

- list every current app and top-level package in the README and agent guidance
- correct outdated platform, package responsibility, prerequisite, command, and tooling details
- document the current Turborepo workflow, independent release lanes, and classic-app dependency boundary
- keep `AGENTS.md` synchronized through its existing symlink to `CLAUDE.md`

## Test plan

- [x] `pnpm exec oxlint --threads=1 --quiet`
- [x] `pnpm exec oxfmt --check .`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] verify all README and CLAUDE workspace entries
- [x] verify README relative links and the `AGENTS.md` symlink

No changeset is required because these are repository documentation changes only.
