### PR TITLE
ci: wipe broken persistent workspace before interview-e2e checkout

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -678,6 +678,23 @@ jobs:
       slug: ${{ steps.meta.outputs.slug }}
       snapshot_failure: ${{ steps.snapshot_failure.outputs.detected }}
     steps:
+      - name: Ensure workspace is a healthy git repo
+        # On the self-hosted runner the workspace persists between jobs, and a
+        # job cancelled mid-checkout can leave it without a usable .git;
+        # actions/checkout then hard-fails ("--local can only be used inside a
+        # git repository") on every subsequent run until the directory is
+        # wiped (observed 2026-07-16). If the workspace is non-empty but not a
+        # valid repo, wipe it so checkout falls back to a fresh clone. The
+        # chown reuses the runner's scoped sudo rule to make root-owned
+        # leftovers (Dockerized runs execute as container root) deletable.
+        # No-op on ephemeral GitHub-hosted VMs: the directory starts empty.
+        run: |
+          if [ -n "$(ls -A . 2>/dev/null)" ] \
+            && ! git rev-parse --resolve-git-dir "$PWD/.git" >/dev/null 2>&1; then
+            echo "workspace is not a valid git repo — wiping for a fresh checkout"
+            sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
+            find . -mindepth 1 -delete
+          fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           # The Dockerized test run mounts the workspace; don't leave the


### PR DESCRIPTION
## Summary

A job cancelled mid-checkout can leave the self-hosted runner's persistent `_work` workspace in a state where files exist but `.git` is missing or unusable. `actions/checkout` then hard-fails (`--local can only be used inside a git repository`) on subsequent `interview-e2e` runs until the directory is manually wiped — observed today (2026-07-16, job 87682778943) after a burst of superseding changeset-release runs cancelled each other.

This adds a guard step before checkout in `interview-e2e`: if the workspace is **non-empty but not a valid git repo**, reclaim ownership (root-owned leftovers from the Dockerized run, via the runner's scoped sudo-chown rule) and wipe it so checkout falls back to a clean clone.

- Healthy persistent workspace → untouched (incremental fetch keeps working)
- Ephemeral GitHub-hosted VMs → no-op (directory starts empty)
- Uses `git rev-parse --resolve-git-dir "$PWD/.git"` rather than plain `rev-parse --git-dir`, which would false-pass if any parent directory were a repo

## Testing

Exercised the guard logic on the self-hosted runner as the `runner` user across five scenarios: empty dir (keep), valid repo (keep), files without `.git` (wipe), corrupt `.git` (wipe), root-owned leftovers (chown + wipe). All behaved as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)