### PR TITLE
Docs: interface documentation fixes

### DIFF
--- a/apps/documentation/docs/design-protocols/interface-documentation/anonymisation.en.mdx
+++ b/apps/documentation/docs/design-protocols/interface-documentation/anonymisation.en.mdx
@@ -4,7 +4,10 @@ title: Anonymisation
 
 <InterfaceSummary type="Anonymisation">
 
-<InterfaceMeta type="Utility" creates="A passkey that can be used to anonymise user data" usesprompts="false"></InterfaceMeta>
+<InterfaceMeta type="Utility" creates="A passkey that can be used to anonymise user data" usesprompts="false">
+
+</InterfaceMeta>
+
 </InterfaceSummary>
 
 This interface is used to enable an advanced feature whereby participant data can be encrypted on-device, in such a way as to prevent anyone other than the participant, including the researcher, from accessing it.

--- a/apps/documentation/docs/design-protocols/interface-documentation/one-to-many-dyad-census.en.mdx
+++ b/apps/documentation/docs/design-protocols/interface-documentation/one-to-many-dyad-census.en.mdx
@@ -4,7 +4,9 @@ title: One-To-Many Dyad Census
 
 <InterfaceSummary type="OneToManyDyadCensus">
 
-<InterfaceMeta type="Edge Generator" creates="Edges of one or more types" usesprompts="true"></InterfaceMeta>
+<InterfaceMeta type="Edge Generator" creates="Edges of one or more types" usesprompts="true">
+
+</InterfaceMeta>
 
 </InterfaceSummary>
 

--- a/apps/documentation/lib/interfaceCompatibility.ts
+++ b/apps/documentation/lib/interfaceCompatibility.ts
@@ -13,6 +13,7 @@ export type AppRole = 'configure' | 'run';
 export type AppId =
   | 'architect-classic'
   | 'architect'
+  | 'interviewer-classic'
   | 'interviewer'
   | 'fresco';
 
@@ -27,6 +28,11 @@ const APPS: Record<AppId, { label: string; role: AppRole; maxSchema: number }> =
       label: 'Architect',
       role: 'configure',
       maxSchema: 8,
+    },
+    'interviewer-classic': {
+      label: 'Interviewer Classic',
+      role: 'run',
+      maxSchema: 7,
     },
     'interviewer': { label: 'Interviewer', role: 'run', maxSchema: 8 },
     'fresco': { label: 'Fresco', role: 'run', maxSchema: 8 },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility information for the Interviewer Classic app, including support for interfaces up to schema version 7.

* **Documentation**
  * Standardized metadata formatting across the Anonymisation and One-to-Many Dyad Census interface documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->