### PR TITLE
 fix(architect): stop stage editors from saving invalid protocols

### DIFF
--- a/.changeset/architect-codebook-property-preservation.md
+++ b/.changeset/architect-codebook-property-preservation.md
@@ -1,0 +1,7 @@
+---
+'@codaco/architect': patch
+---
+
+Stop the stage editors from silently discarding variable settings they don't manage. Adding an editable attribute to a Network Composer stage no longer clears the input control from the variable in your codebook, which previously broke every other stage that used the same variable. Interface-owned option sets, such as the Family Pedigree biological sex values, also keep their locked state when you edit a form field that uses them.
+
+Day offsets on a relative date picker can no longer be set to a negative number, and edge rules are no longer offered on side panels that draw their data from an external file, where they can never match. Switching an existing panel to an external file now offers to remove any edge rules its filter already contains.

--- a/apps/architect/src/components/Parameters/RelativeDatePicker.tsx
+++ b/apps/architect/src/components/Parameters/RelativeDatePicker.tsx
@@ -3,7 +3,7 @@ import type { ComponentType } from 'react';
 import { useState } from 'react';
 import { compose } from 'react-recompose';
 import { connect } from 'react-redux';
-import { change, Field, formValueSelector } from 'redux-form';
+import { change, formValueSelector } from 'redux-form';
 
 import InputField from '@codaco/fresco-ui/form/fields/InputField';
 import Heading from '@codaco/fresco-ui/typography/Heading';
@@ -73,28 +73,36 @@ const RelativeDatePickerParameters = ({
         Days before is the number of days prior to the anchor date that can be
         selected from. Defaults to 180 days if left blank.
       </Paragraph>
-      <Field
+      <ValidatedField
         label="Days before"
         component={FrescoReduxField}
         name={`${name}.before`}
-        placeholder="180"
-        fieldComponent={FrescoInputField}
-        type="number"
-        {...reduxIntegerValue}
+        validation={{ minValue: 0 }}
+        componentProps={{
+          placeholder: '180',
+          fieldComponent: FrescoInputField,
+          type: 'number',
+          min: 0,
+          ...reduxIntegerValue,
+        }}
       />
       <Heading level="h4">Days After</Heading>
       <Paragraph>
         Days after is the number of days after the anchor date that can be
         selected from. Defaults to 0 days if left blank.
       </Paragraph>
-      <Field
+      <ValidatedField
         label="Days after"
         component={FrescoReduxField}
         name={`${name}.after`}
-        placeholder="0"
-        fieldComponent={FrescoInputField}
-        type="number"
-        {...reduxIntegerValue}
+        validation={{ minValue: 0 }}
+        componentProps={{
+          placeholder: '0',
+          fieldComponent: FrescoInputField,
+          type: 'number',
+          min: 0,
+          ...reduxIntegerValue,
+        }}
       />
     </>
   );

--- a/apps/architect/src/components/Parameters/__tests__/RelativeDatePicker.test.tsx
+++ b/apps/architect/src/components/Parameters/__tests__/RelativeDatePicker.test.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentType } from 'react';
 import { Provider } from 'react-redux';
 import { reducer as formReducer, reduxForm } from 'redux-form';
@@ -43,4 +43,36 @@ describe('RelativeDatePicker parameters', () => {
       screen.getByRole('spinbutton', { name: 'Days after' }),
     ).toBeInTheDocument();
   });
+
+  it.each(['Days before', 'Days after'])(
+    'rejects a negative %s offset',
+    async (label) => {
+      renderPicker();
+      const input = screen.getByRole('spinbutton', { name: label });
+
+      fireEvent.change(input, { target: { value: '-5' } });
+      fireEvent.blur(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Must be at least 0')).toBeInTheDocument();
+      });
+    },
+  );
+
+  it.each(['Days before', 'Days after'])(
+    'accepts a non-negative %s offset',
+    async (label) => {
+      renderPicker();
+      const input = screen.getByRole('spinbutton', { name: label });
+
+      fireEvent.change(input, { target: { value: '30' } });
+      fireEvent.blur(input);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Must be at least 0'),
+        ).not.toBeInTheDocument();
+      });
+    },
+  );
 });

--- a/apps/architect/src/components/Parameters/__tests__/RelativeDatePicker.test.tsx
+++ b/apps/architect/src/components/Parameters/__tests__/RelativeDatePicker.test.tsx
@@ -60,14 +60,18 @@ describe('RelativeDatePicker parameters', () => {
   );
 
   it.each(['Days before', 'Days after'])(
-    'accepts a non-negative %s offset',
+    'clears the error once %s is corrected to zero',
     async (label) => {
       renderPicker();
       const input = screen.getByRole('spinbutton', { name: label });
 
-      fireEvent.change(input, { target: { value: '30' } });
+      fireEvent.change(input, { target: { value: '-5' } });
       fireEvent.blur(input);
+      await waitFor(() => {
+        expect(screen.getByText('Must be at least 0')).toBeInTheDocument();
+      });
 
+      fireEvent.change(input, { target: { value: '0' } });
       await waitFor(() => {
         expect(
           screen.queryByText('Must be at least 0'),

--- a/apps/architect/src/components/Query/Filter.tsx
+++ b/apps/architect/src/components/Query/Filter.tsx
@@ -7,6 +7,7 @@ type FilterProps = {
   codebook: Record<string, unknown>;
   join?: string;
   error?: string;
+  allowEdgeRules?: boolean;
 };
 
 const Filter = ({
@@ -15,6 +16,7 @@ const Filter = ({
   codebook,
   onChange,
   error,
+  allowEdgeRules,
 }: FilterProps) => (
   <Rules
     rules={rules}
@@ -22,6 +24,7 @@ const Filter = ({
     onChange={onChange}
     codebook={codebook}
     error={error}
+    allowEdgeRules={allowEdgeRules}
   />
 );
 

--- a/apps/architect/src/components/Query/Rules/Rules.tsx
+++ b/apps/architect/src/components/Query/Rules/Rules.tsx
@@ -19,6 +19,7 @@ const FrescoRadioGroupField = RadioGroupField as ComponentType<
 >;
 type RulesProps = {
   type?: 'filter' | 'query';
+  allowEdgeRules?: boolean;
   rules?: Rule[];
   join?: string | null;
   error?: string | null;
@@ -36,6 +37,7 @@ type RulesProps = {
 };
 const Rules = ({
   type = 'filter',
+  allowEdgeRules = true,
   rules = [],
   join = null,
   error = null,
@@ -167,13 +169,15 @@ const Rules = ({
         <Button type="button" color="info" onClick={handleCreateAlterRule}>
           Add alter rule
         </Button>
-        <Button
-          type="button"
-          color="destructive"
-          onClick={handleCreateEdgeRule}
-        >
-          Add edge rule
-        </Button>
+        {allowEdgeRules && (
+          <Button
+            type="button"
+            color="destructive"
+            onClick={handleCreateEdgeRule}
+          >
+            Add edge rule
+          </Button>
+        )}
         {type === 'query' && (
           <Button type="button" color="warning" onClick={handleCreateEgoRule}>
             Add ego rule
@@ -208,6 +212,7 @@ export default compose<
     onChange?: (value: unknown) => void;
     codebook?: Record<string, unknown>;
     type?: 'filter' | 'query';
+    allowEdgeRules?: boolean;
     error?: string | null;
     meta?: Record<string, unknown>;
   }

--- a/apps/architect/src/components/Query/Rules/__tests__/Rules.test.tsx
+++ b/apps/architect/src/components/Query/Rules/__tests__/Rules.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentType } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
+
+vi.mock('~/components/IssueAnchor', () => ({ default: () => null }));
+
+import Rules from '../Rules';
+
+const RulesComponent = Rules as unknown as ComponentType<{
+  codebook: Record<string, unknown>;
+  allowEdgeRules?: boolean;
+  onChange?: (value: unknown) => void;
+}>;
+
+const renderRules = (allowEdgeRules?: boolean) =>
+  render(
+    <DialogProvider>
+      <RulesComponent
+        codebook={{ node: {}, edge: {} }}
+        allowEdgeRules={allowEdgeRules}
+      />
+    </DialogProvider>,
+  );
+
+describe('Rules', () => {
+  it('offers an edge rule by default', () => {
+    renderRules();
+
+    expect(
+      screen.getByRole('button', { name: 'Add edge rule' }),
+    ).toBeInTheDocument();
+  });
+
+  it('offers an edge rule when they are allowed', () => {
+    renderRules(true);
+
+    expect(
+      screen.getByRole('button', { name: 'Add edge rule' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the edge rule button when edge rules are not allowed', () => {
+    renderRules(false);
+
+    expect(
+      screen.queryByRole('button', { name: 'Add edge rule' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Add alter rule' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/architect/src/components/VariablePill.tsx
+++ b/apps/architect/src/components/VariablePill.tsx
@@ -136,7 +136,7 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
   };
 
   const onEditComplete = () => {
-    const action = updateVariableByUUID(uuid, { name: newName }, true);
+    const action = updateVariableByUUID(uuid, { name: newName });
     void dispatch(action);
     setValidation(null);
     setIsEditing(false);

--- a/apps/architect/src/components/sections/Anonymisation/EncryptedVariables.tsx
+++ b/apps/architect/src/components/sections/Anonymisation/EncryptedVariables.tsx
@@ -1,4 +1,3 @@
-import { omit } from 'es-toolkit/compat';
 import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -45,11 +44,12 @@ const EncryptedVariables = (_props: StageEditorSectionProps) => {
     (state: RootState) => getNodeTypes(state) as Record<string, NodeType>,
   );
   const handleEncryptionToggle = useCallback(
-    (variableId: string, encrypted: boolean, variable: Variable) => {
-      const properties = encrypted
-        ? { ...variable, encrypted: true }
-        : omit(variable, 'encrypted');
-      void dispatch(updateVariableByUUID(variableId, properties, false));
+    (variableId: string, encrypted: boolean) => {
+      void dispatch(
+        updateVariableByUUID(variableId, encrypted ? { encrypted: true } : {}, [
+          'encrypted',
+        ]),
+      );
     },
     [dispatch],
   );
@@ -74,7 +74,7 @@ const EncryptedVariables = (_props: StageEditorSectionProps) => {
         Object.entries(nodeType.variables || {}).forEach(
           ([variableId, variable]) => {
             if (variable?.encrypted) {
-              handleEncryptionToggle(variableId, false, variable);
+              handleEncryptionToggle(variableId, false);
             }
           },
         );
@@ -158,11 +158,7 @@ const EncryptedVariables = (_props: StageEditorSectionProps) => {
                     ([variableId, variable]) => {
                       const shouldEncrypt = nextValueArray.includes(variableId);
                       if (variable?.encrypted !== shouldEncrypt) {
-                        handleEncryptionToggle(
-                          variableId,
-                          shouldEncrypt,
-                          variable,
-                        );
+                        handleEncryptionToggle(variableId, shouldEncrypt);
                       }
                     },
                   );

--- a/apps/architect/src/components/sections/CategoricalBinPrompts/withPromptChangeHandler.tsx
+++ b/apps/architect/src/components/sections/CategoricalBinPrompts/withPromptChangeHandler.tsx
@@ -37,7 +37,6 @@ const handlers = withHandlers({
         type: props.type,
         variable,
         configuration: { options: variableOptions } as Record<string, unknown>,
-        merge: true,
       });
 
       return { variable, ...rest };

--- a/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
@@ -27,6 +27,7 @@ import NewVariableWindow, {
 import EntitySelectField from '~/components/sections/fields/EntitySelectField/EntitySelectField';
 import FieldFields from '~/components/sections/Form/FieldFields';
 import {
+  CODEBOOK_PROPERTIES,
   getCodebookProperties,
   itemSelector,
   normalizeField,
@@ -365,30 +366,12 @@ const formHandlers = withHandlers({
         if (!current) {
           throw new SubmissionError({ _error: 'Variable not found' });
         }
-        const currentVar = current as {
-          component?: string;
-          type?: string;
-          name?: string;
-          encrypted?: boolean;
-        };
-        const baseProps = {
-          component: currentVar.component,
-          type: currentVar.type,
-          name: currentVar.name,
-          // `encrypted` is a data-protection flag set by the Anonymisation
-          // stage, not an editable form field. Because merge is false, it must
-          // be carried over explicitly or saving a field edit would strip it.
-          encrypted: currentVar.encrypted,
-        };
         await props.updateVariable({
           entity: 'node',
           type: nodeType ?? '',
           variable: variable ?? '',
-          configuration: { ...baseProps, ...configuration } as Record<
-            string,
-            unknown
-          >,
-          merge: false,
+          configuration: configuration as Record<string, unknown>,
+          replaceProperties: CODEBOOK_PROPERTIES,
         });
         return { variable, ...rest };
       }

--- a/apps/architect/src/components/sections/FamilyPedigree/__tests__/NodeConfigurationHandlers.test.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/__tests__/NodeConfigurationHandlers.test.tsx
@@ -111,8 +111,8 @@ vi.mock('~/components/Form/DialogArrayField', () => ({
 import NodeConfiguration from '../NodeConfiguration';
 
 type UpdateVariableArg = {
-  merge: boolean;
-  configuration: { encrypted?: boolean };
+  replaceProperties: readonly string[];
+  configuration: Record<string, unknown>;
 };
 const updateVariable = vi.fn((_arg: UpdateVariableArg) => ({
   unwrap: () => Promise.resolve({}),
@@ -149,12 +149,13 @@ const renderSection = () =>
   );
 
 describe('FamilyPedigree NodeConfiguration handleChangeFields', () => {
-  it('preserves the encrypted flag when saving a field edit (merge:false)', async () => {
+  it('does not claim readOnly, so a pedigree-owned option set survives a field edit', async () => {
     getVariable.mockReturnValue({
       component: 'Text',
       type: 'text',
       name: 'secret',
       encrypted: true,
+      readOnly: true,
     });
     renderSection();
     expect(screen.getByTestId('dialog-array-field')).toBeInTheDocument();
@@ -167,8 +168,14 @@ describe('FamilyPedigree NodeConfiguration handleChangeFields', () => {
 
     expect(updateVariable).toHaveBeenCalledTimes(1);
     const arg = updateVariable.mock.calls[0]![0];
-    expect(arg.merge).toBe(false);
-    expect(arg.configuration.encrypted).toBe(true);
+    expect(arg.replaceProperties).toEqual([
+      'options',
+      'parameters',
+      'component',
+      'validation',
+    ]);
+    expect(arg.replaceProperties).not.toContain('readOnly');
+    expect(arg.replaceProperties).not.toContain('encrypted');
   });
 
   it('surfaces a friendly error (not a TypeError) when variable creation rejects', async () => {

--- a/apps/architect/src/components/sections/Form/__tests__/withComposerFormHandlers.test.tsx
+++ b/apps/architect/src/components/sections/Form/__tests__/withComposerFormHandlers.test.tsx
@@ -38,13 +38,16 @@ const Wrapped: ComponentType<Record<string, unknown>> =
   withComposerFormHandlers(Probe as never);
 
 type UpdateVariableArg = {
-  merge: boolean;
-  configuration: { encrypted?: boolean };
+  replaceProperties: readonly string[];
+  configuration: Record<string, unknown>;
 };
 const updateVariable = vi.fn((_arg: UpdateVariableArg) => ({
   unwrap: () => Promise.resolve({}),
 }));
-const createVariable = vi.fn();
+type CreateVariableArg = { configuration: Record<string, unknown> };
+const createVariable = vi.fn((_arg?: CreateVariableArg) => ({
+  unwrap: () => Promise.resolve({ variable: 'new-v' }),
+}));
 const changeForm = vi.fn();
 const getVariable = vi.fn();
 
@@ -66,20 +69,46 @@ const renderHandler = () =>
   render(<Wrapped type="person" entity="node" form="edit-stage" />);
 
 describe('withComposerFormHandlers', () => {
-  it('preserves the encrypted flag when saving a field edit (merge:false)', async () => {
+  it('only claims options and validation, so the codebook keeps every property the composer does not own', async () => {
     getVariable.mockReturnValue({
       type: 'text',
       name: 'secret',
+      component: 'Text',
       encrypted: true,
+      readOnly: true,
     });
     renderHandler();
 
-    await capturedHandler({ variable: 'v1', component: 'Text', label: 'x' });
+    await capturedHandler({
+      variable: 'v1',
+      component: 'TextArea',
+      label: 'x',
+    });
 
     expect(updateVariable).toHaveBeenCalledTimes(1);
     const arg = updateVariable.mock.calls[0]![0];
-    expect(arg.merge).toBe(false);
-    expect(arg.configuration.encrypted).toBe(true);
+    expect(arg.replaceProperties).toEqual(['options', 'validation']);
+    expect(arg.replaceProperties).not.toContain('component');
+    expect(arg.replaceProperties).not.toContain('encrypted');
+    expect(arg.replaceProperties).not.toContain('readOnly');
+    expect(arg.configuration).not.toHaveProperty('component');
+  });
+
+  it('seeds component on a variable it creates, so a form field can reference it later', async () => {
+    renderHandler();
+
+    await capturedHandler({
+      _createNewVariable: 'age',
+      component: 'Number',
+    });
+
+    expect(createVariable).toHaveBeenCalledTimes(1);
+    const arg = createVariable.mock.calls[0]![0]!;
+    expect(arg.configuration).toMatchObject({
+      name: 'age',
+      type: 'number',
+      component: 'Number',
+    });
   });
 
   it('surfaces a friendly error (not a TypeError) when variable creation rejects', async () => {

--- a/apps/architect/src/components/sections/Form/__tests__/withFormHandlers.test.tsx
+++ b/apps/architect/src/components/sections/Form/__tests__/withFormHandlers.test.tsx
@@ -39,8 +39,8 @@ const Wrapped: ComponentType<Record<string, unknown>> = withFormHandlers(
 );
 
 type UpdateVariableArg = {
-  merge: boolean;
-  configuration: { encrypted?: boolean };
+  replaceProperties: readonly string[];
+  configuration: Record<string, unknown>;
 };
 const updateVariable = vi.fn((_arg: UpdateVariableArg) => ({
   unwrap: () => Promise.resolve({}),
@@ -67,12 +67,13 @@ const renderHandler = () =>
   render(<Wrapped type="person" entity="node" form="edit-stage" />);
 
 describe('withFormHandlers', () => {
-  it('preserves the encrypted flag when saving a field edit (merge:false)', async () => {
+  it('only claims the codebook properties it edits, leaving protection flags to the reducer', async () => {
     getVariable.mockReturnValue({
       component: 'Text',
       type: 'text',
       name: 'secret',
       encrypted: true,
+      readOnly: true,
     });
     renderHandler();
 
@@ -80,8 +81,14 @@ describe('withFormHandlers', () => {
 
     expect(updateVariable).toHaveBeenCalledTimes(1);
     const arg = updateVariable.mock.calls[0]![0];
-    expect(arg.merge).toBe(false);
-    expect(arg.configuration.encrypted).toBe(true);
+    expect(arg.replaceProperties).toEqual([
+      'options',
+      'parameters',
+      'component',
+      'validation',
+    ]);
+    expect(arg.replaceProperties).not.toContain('encrypted');
+    expect(arg.replaceProperties).not.toContain('readOnly');
   });
 
   it('surfaces a friendly error (not a TypeError) when variable creation rejects', async () => {

--- a/apps/architect/src/components/sections/Form/composerHelpers.ts
+++ b/apps/architect/src/components/sections/Form/composerHelpers.ts
@@ -1,12 +1,16 @@
 import { get, omit } from 'es-toolkit/compat';
 import { formValueSelector } from 'redux-form';
 
+import type { VariablePropertyKey } from '@codaco/protocol-validation';
 import type { RootState } from '~/ducks/modules/root';
 import { getVariablesForSubject } from '~/selectors/codebook';
 
 // Codebook props that, for NetworkComposer, stay on the codebook variable.
 // `component`/`parameters` are intentionally NOT here — they live on the field.
-const COMPOSER_CODEBOOK_PROPERTIES = ['options', 'validation'] as const;
+export const COMPOSER_CODEBOOK_PROPERTIES = [
+  'options',
+  'validation',
+] as const satisfies readonly VariablePropertyKey[];
 
 export const composerNormalizeField = (field: Record<string, unknown>) => {
   // Keep `id` so the list item retains a stable, unique React key.

--- a/apps/architect/src/components/sections/Form/helpers.tsx
+++ b/apps/architect/src/components/sections/Form/helpers.tsx
@@ -1,16 +1,16 @@
 import { get, omit, reduce } from 'es-toolkit/compat';
 import { formValueSelector } from 'redux-form';
 
+import type { VariablePropertyKey } from '@codaco/protocol-validation';
 import type { RootState } from '~/ducks/modules/root';
 import { getVariablesForSubject } from '~/selectors/codebook';
 
-// Internal config - not exported
-const CODEBOOK_PROPERTIES = [
+export const CODEBOOK_PROPERTIES = [
   'options',
   'parameters',
   'component',
   'validation',
-];
+] as const satisfies readonly VariablePropertyKey[];
 
 export const getCodebookProperties = (
   properties: Record<string, unknown>,

--- a/apps/architect/src/components/sections/Form/withComposerFormHandlers.tsx
+++ b/apps/architect/src/components/sections/Form/withComposerFormHandlers.tsx
@@ -12,6 +12,7 @@ import type { RootState } from '~/ducks/modules/root';
 import { ensureError } from '~/utils/ensureError';
 
 import { makeGetVariable } from '../../../selectors/codebook';
+import { COMPOSER_CODEBOOK_PROPERTIES } from './composerHelpers';
 
 type Entity = 'node' | 'edge' | 'ego';
 
@@ -52,12 +53,9 @@ const composerFormHandlers = withHandlers({
           [key: string]: unknown;
         };
 
-      const variableType = getTypeForComponent(
-        rest.component as string | undefined,
-      );
-      // Codebook keeps type/options/validation only — NOT component/parameters.
+      const component = rest.component as string | undefined;
+      const variableType = getTypeForComponent(component);
       const codebookConfiguration = {
-        type: variableType,
         ...(options !== undefined ? { options } : {}),
         ...(validation !== undefined ? { validation } : {}),
       };
@@ -68,25 +66,12 @@ const composerFormHandlers = withHandlers({
         const current = props.getVariable(variable ?? '');
         if (!current)
           throw new SubmissionError({ _error: 'Variable not found' });
-        const currentVar = current as {
-          type?: string;
-          name?: string;
-          encrypted?: boolean;
-        };
         await props.updateVariable({
           entity: props.entity as Entity,
           type: props.type,
           variable: variable ?? '',
-          configuration: {
-            ...codebookConfiguration,
-            type: currentVar.type,
-            name: currentVar.name,
-            // `encrypted` is a data-protection flag set by the Anonymisation
-            // stage, not an editable form field. Because merge is false, it must
-            // be carried over explicitly or saving a field edit would strip it.
-            encrypted: currentVar.encrypted,
-          } as Record<string, unknown>,
-          merge: false,
+          configuration: codebookConfiguration as Record<string, unknown>,
+          replaceProperties: COMPOSER_CODEBOOK_PROPERTIES,
         });
         return { variable, ...rest }; // rest retains component + parameters
       }
@@ -101,6 +86,8 @@ const composerFormHandlers = withHandlers({
             type: props.type,
             configuration: {
               ...codebookConfiguration,
+              type: variableType,
+              component,
               name: _createNewVariable,
             } as Record<string, unknown>,
           })

--- a/apps/architect/src/components/sections/Form/withFormHandlers.tsx
+++ b/apps/architect/src/components/sections/Form/withFormHandlers.tsx
@@ -15,7 +15,7 @@ import type { RootState } from '~/ducks/modules/root';
 import { ensureError } from '~/utils/ensureError';
 
 import { makeGetVariable } from '../../../selectors/codebook';
-import { getCodebookProperties } from './helpers';
+import { CODEBOOK_PROPERTIES, getCodebookProperties } from './helpers';
 
 const mapDispatchToProps = {
   changeForm: change as (
@@ -72,33 +72,12 @@ const formHandlers = withHandlers({
           });
         }
 
-        const currentVar = current as {
-          component?: string;
-          type?: string;
-          name?: string;
-          encrypted?: boolean;
-        };
-        // `encrypted` is a data-protection flag set by the Anonymisation stage,
-        // not an editable form field. Because merge is false below, it must be
-        // carried over explicitly or saving a field edit would strip it.
-        const baseProps = {
-          component: currentVar.component,
-          type: currentVar.type,
-          name: currentVar.name,
-          encrypted: currentVar.encrypted,
-        };
-
-        // Merge is set to false below so that properties that were removed, such
-        // as 'options: []' and 'parameters: {}' get deleted.
         await props.updateVariable({
           entity: props.entity as Entity,
           type: props.type,
           variable: variable ?? '',
-          configuration: { ...baseProps, ...configuration } as Record<
-            string,
-            unknown
-          >,
-          merge: false,
+          configuration: configuration as Record<string, unknown>,
+          replaceProperties: CODEBOOK_PROPERTIES,
         });
 
         return {

--- a/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
+++ b/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
@@ -1,5 +1,8 @@
 import { Trash2 } from 'lucide-react';
 import type { ComponentType } from 'react';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { change, formValueSelector } from 'redux-form';
 
 import { IconButton } from '@codaco/fresco-ui/Button';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
@@ -11,11 +14,28 @@ import type { FrescoReduxArrayFieldItemProps } from '~/components/Form/FrescoRed
 import FrescoReduxField from '~/components/Form/FrescoReduxField';
 import ValidatedField from '~/components/Form/ValidatedField';
 import NetworkFilter from '~/components/sections/fields/NetworkFilter';
+import { useAppDispatch } from '~/ducks/hooks';
+import type { RootState } from '~/ducks/modules/root';
 import { getFieldId } from '~/utils/issues';
 
 import Section from '../../EditorLayout/Section';
 
 const FrescoInputField = InputField as ComponentType<Record<string, unknown>>;
+
+const EXISTING_DATA_SOURCE = 'existing';
+
+type PanelFilter = { join?: string; rules?: { type?: string }[] } | null;
+
+export const hasEdgeRules = (filter: PanelFilter): boolean =>
+  (filter?.rules ?? []).some((rule) => rule.type === 'edge');
+
+export const stripEdgeRules = (filter: PanelFilter): PanelFilter => {
+  const remaining = (filter?.rules ?? []).filter(
+    (rule) => rule.type !== 'edge',
+  );
+  if (remaining.length === 0) return null;
+  return { ...filter, rules: remaining };
+};
 
 export type NodePanelValue = Record<string, unknown> & {
   id: string;
@@ -39,6 +59,7 @@ const NodePanel = ({
   readOnly,
 }: NodePanelProps) => {
   const { confirm } = useDialog();
+  const dispatch = useAppDispatch();
   const interactionDisabled = disabled || readOnly;
   const handleDelete = () => {
     void confirm({
@@ -50,6 +71,41 @@ const NodePanel = ({
       onConfirm: onDelete,
     });
   };
+
+  const dataSource = useSelector((state: RootState) =>
+    formValueSelector(form)(state, `${fieldName}.dataSource`),
+  ) as string | undefined;
+  const filter = useSelector((state: RootState) =>
+    formValueSelector(form)(state, `${fieldName}.filter`),
+  ) as PanelFilter;
+
+  const handleDataSourceChange = useCallback(
+    (_raw: unknown, newValue: string, previousValue: string) => {
+      if (newValue === previousValue || newValue === EXISTING_DATA_SOURCE) {
+        return;
+      }
+      if (!hasEdgeRules(filter)) return;
+
+      void (async () => {
+        const confirmed = await confirm({
+          title: 'This will remove your edge rules',
+          description:
+            'An external data file contains only nodes, so edge rules cannot be applied to it. Switching will delete the edge rules in this panel’s filter. Do you want to continue?',
+          confirmLabel: 'Remove edge rules',
+          cancelLabel: 'Cancel',
+          intent: 'warning',
+          onConfirm: () => {},
+        });
+
+        dispatch(
+          confirmed
+            ? change(form, `${fieldName}.filter`, stripEdgeRules(filter))
+            : change(form, `${fieldName}.dataSource`, previousValue),
+        );
+      })();
+    },
+    [confirm, dispatch, filter, form, fieldName],
+  );
 
   return (
     <div className="flex w-full items-center gap-4">
@@ -113,6 +169,7 @@ const NodePanel = ({
             validation={{ required: true }}
             componentProps={{
               canUseExisting: true,
+              onChange: handleDataSourceChange,
             }}
           />
         </Section>
@@ -120,6 +177,7 @@ const NodePanel = ({
           form={form}
           variant="contrast"
           name={`${fieldName}.filter`}
+          allowEdgeRules={dataSource === EXISTING_DATA_SOURCE}
         />
       </div>
       <IconButton

--- a/apps/architect/src/components/sections/NodePanels/__tests__/NodePanel.test.tsx
+++ b/apps/architect/src/components/sections/NodePanels/__tests__/NodePanel.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasEdgeRules, stripEdgeRules } from '../NodePanel';
+
+const alterRule = { type: 'alter', id: 'a1' };
+const edgeRule = { type: 'edge', id: 'e1' };
+
+describe('hasEdgeRules', () => {
+  it.each([
+    ['a null filter', null, false],
+    ['a filter with no rules', { rules: [] }, false],
+    ['a filter with only alter rules', { rules: [alterRule] }, false],
+    ['a filter with an edge rule', { rules: [alterRule, edgeRule] }, true],
+  ])('is %s → %s', (_label, filter, expected) => {
+    expect(hasEdgeRules(filter)).toBe(expected);
+  });
+});
+
+describe('stripEdgeRules', () => {
+  it('removes edge rules and keeps the rest of the filter intact', () => {
+    expect(
+      stripEdgeRules({ join: 'AND', rules: [alterRule, edgeRule] }),
+    ).toEqual({ join: 'AND', rules: [alterRule] });
+  });
+
+  it('clears the filter entirely when every rule was an edge rule', () => {
+    expect(stripEdgeRules({ join: 'AND', rules: [edgeRule] })).toBeNull();
+  });
+
+  it('leaves a filter with no edge rules unchanged', () => {
+    expect(stripEdgeRules({ join: 'AND', rules: [alterRule] })).toEqual({
+      join: 'AND',
+      rules: [alterRule],
+    });
+  });
+
+  it('handles a null filter', () => {
+    expect(stripEdgeRules(null)).toBeNull();
+  });
+});

--- a/apps/architect/src/components/sections/TieStrengthCensusPrompts/withPromptChangeHandler.tsx
+++ b/apps/architect/src/components/sections/TieStrengthCensusPrompts/withPromptChangeHandler.tsx
@@ -52,7 +52,6 @@ const handlers = withHandlers<
         type: createEdge,
         variable: edgeVariable,
         configuration: { options: variableOptions },
-        merge: true,
       });
       return { edgeVariable, createEdge, ...rest };
     },

--- a/apps/architect/src/components/sections/fields/NetworkFilter.tsx
+++ b/apps/architect/src/components/sections/fields/NetworkFilter.tsx
@@ -29,11 +29,13 @@ type NetworkFilterProps = {
   form: string;
   name?: string;
   variant?: 'contrast';
+  allowEdgeRules?: boolean;
 };
 const NetworkFilter = ({
   form,
   name = 'filter',
   variant,
+  allowEdgeRules,
 }: NetworkFilterProps) => {
   const dispatch = useAppDispatch();
   const { confirm } = useDialog();
@@ -87,7 +89,12 @@ const NetworkFilter = ({
       handleToggleChange={handleToggleChange}
       {...contrastProps}
     >
-      <Field name={name} component={FilterField} validate={ruleValidator} />
+      <Field
+        name={name}
+        component={FilterField}
+        validate={ruleValidator}
+        allowEdgeRules={allowEdgeRules}
+      />
     </Section>
   );
 };

--- a/apps/architect/src/ducks/modules/protocol/__tests__/codebook.integration.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/codebook.integration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateProtocol } from '@codaco/protocol-validation';
+import developmentProtocol from '@codaco/protocols/development';
+
+import codebookReducer, { test } from '../codebook';
+
+const AGE = 'c5fee926-855d-4419-b5bb-54e89010cea6';
+
+type Vars = Record<string, { component?: string }>;
+type NodeTypes = Record<string, { variables?: Vars }>;
+
+const findAge = (codebook: { node?: NodeTypes }) => {
+  for (const nodeType of Object.values(codebook.node ?? {})) {
+    const found = nodeType.variables?.[AGE];
+    if (found) return found;
+  }
+  return undefined;
+};
+
+describe('codebook writes against the real development protocol', () => {
+  it('keeps the protocol valid when a composer edit touches a form-referenced variable', async () => {
+    const protocol = structuredClone(developmentProtocol) as unknown as {
+      codebook: { node?: NodeTypes };
+    };
+
+    expect(findAge(protocol.codebook)?.component).toBe('Number');
+    const before = await validateProtocol(protocol as never);
+    expect(before.success).toBe(true);
+
+    const codebook = codebookReducer(
+      protocol.codebook as never,
+      test.updateVariable({
+        variable: AGE,
+        configuration: {},
+        replaceProperties: ['options', 'validation'],
+      }),
+    );
+
+    expect(findAge(codebook)?.component).toBe('Number');
+
+    const after = await validateProtocol({ ...protocol, codebook } as never);
+    expect(after.success).toBe(true);
+  });
+});

--- a/apps/architect/src/ducks/modules/protocol/__tests__/codebook.integration.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/codebook.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Codebook } from '@codaco/protocol-validation';
 import { validateProtocol } from '@codaco/protocol-validation';
 import developmentProtocol from '@codaco/protocols/development';
 
@@ -7,13 +8,12 @@ import codebookReducer, { test } from '../codebook';
 
 const AGE = 'c5fee926-855d-4419-b5bb-54e89010cea6';
 
-type Vars = Record<string, { component?: string }>;
-type NodeTypes = Record<string, { variables?: Vars }>;
-
-const findAge = (codebook: { node?: NodeTypes }) => {
+const findAgeComponent = (codebook: Codebook): string | undefined => {
   for (const nodeType of Object.values(codebook.node ?? {})) {
-    const found = nodeType.variables?.[AGE];
-    if (found) return found;
+    const variable = nodeType.variables?.[AGE];
+    if (variable) {
+      return 'component' in variable ? variable.component : undefined;
+    }
   }
   return undefined;
 };
@@ -21,15 +21,15 @@ const findAge = (codebook: { node?: NodeTypes }) => {
 describe('codebook writes against the real development protocol', () => {
   it('keeps the protocol valid when a composer edit touches a form-referenced variable', async () => {
     const protocol = structuredClone(developmentProtocol) as unknown as {
-      codebook: { node?: NodeTypes };
+      codebook: Codebook;
     };
 
-    expect(findAge(protocol.codebook)?.component).toBe('Number');
+    expect(findAgeComponent(protocol.codebook)).toBe('Number');
     const before = await validateProtocol(protocol as never);
     expect(before.success).toBe(true);
 
     const codebook = codebookReducer(
-      protocol.codebook as never,
+      protocol.codebook,
       test.updateVariable({
         variable: AGE,
         configuration: {},
@@ -37,7 +37,7 @@ describe('codebook writes against the real development protocol', () => {
       }),
     );
 
-    expect(findAge(codebook)?.component).toBe('Number');
+    expect(findAgeComponent(codebook)).toBe('Number');
 
     const after = await validateProtocol({ ...protocol, codebook } as never);
     expect(after.success).toBe(true);

--- a/apps/architect/src/ducks/modules/protocol/__tests__/codebook.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/codebook.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Codebook, Variable } from '@codaco/protocol-validation';
+
+import reducer, { test } from '../codebook';
+
+const AGE = 'c5fee926-855d-4419-b5bb-54e89010cea6';
+
+const ageVariable = {
+  name: 'age',
+  type: 'number',
+  component: 'Number',
+  validation: { maxValue: 99 },
+} as unknown as Variable;
+
+const codebookWith = (variable: Variable): Codebook =>
+  ({
+    node: { person: { name: 'person', variables: { [AGE]: variable } } },
+    edge: {},
+  }) as unknown as Codebook;
+
+const getAge = (state: Codebook) =>
+  (state.node!.person!.variables as Record<string, Variable>)[
+    AGE
+  ] as unknown as Record<string, unknown> | undefined;
+
+describe('codebook.updateVariable', () => {
+  it('preserves properties the caller does not claim', () => {
+    const next = reducer(
+      codebookWith(ageVariable),
+      test.updateVariable({
+        variable: AGE,
+        configuration: { validation: { maxValue: 120 } } as Partial<Variable>,
+        replaceProperties: ['options', 'validation'],
+      }),
+    );
+
+    expect(getAge(next)).toEqual({
+      name: 'age',
+      type: 'number',
+      component: 'Number',
+      validation: { maxValue: 120 },
+    });
+  });
+
+  it('deletes a claimed property when the payload omits it', () => {
+    const next = reducer(
+      codebookWith(ageVariable),
+      test.updateVariable({
+        variable: AGE,
+        configuration: {},
+        replaceProperties: ['validation'],
+      }),
+    );
+
+    expect(getAge(next)).not.toHaveProperty('validation');
+    expect(getAge(next)).toMatchObject({ name: 'age', component: 'Number' });
+  });
+
+  it('does not delete an unclaimed property when the payload omits it', () => {
+    const next = reducer(
+      codebookWith(ageVariable),
+      test.updateVariable({
+        variable: AGE,
+        configuration: {},
+        replaceProperties: ['options'],
+      }),
+    );
+
+    expect(getAge(next)).toEqual(ageVariable);
+  });
+
+  it('keeps component when a composer-style edit claims only options and validation', () => {
+    const next = reducer(
+      codebookWith(ageVariable),
+      test.updateVariable({
+        variable: AGE,
+        configuration: {} as Partial<Variable>,
+        replaceProperties: ['options', 'validation'],
+      }),
+    );
+
+    expect(getAge(next)!.component).toBe('Number');
+  });
+
+  it('keeps readOnly and encrypted through a form-field edit', () => {
+    const guarded = {
+      ...ageVariable,
+      encrypted: true,
+      readOnly: true,
+    } as unknown as Variable;
+
+    const next = reducer(
+      codebookWith(guarded),
+      test.updateVariable({
+        variable: AGE,
+        configuration: {
+          component: 'Number',
+          type: 'number',
+        } as Partial<Variable>,
+        replaceProperties: ['options', 'parameters', 'component', 'validation'],
+      }),
+    );
+
+    expect(getAge(next)).toMatchObject({ encrypted: true, readOnly: true });
+  });
+
+  it('defaults to a pure merge when no properties are claimed', () => {
+    const next = reducer(
+      codebookWith(ageVariable),
+      test.updateVariable({
+        variable: AGE,
+        configuration: { name: 'age_years' } as Partial<Variable>,
+      }),
+    );
+
+    expect(getAge(next)).toEqual({ ...ageVariable, name: 'age_years' });
+  });
+
+  it('ignores an update for a variable that is not in the codebook', () => {
+    const state = codebookWith(ageVariable);
+    const next = reducer(
+      state,
+      test.updateVariable({
+        variable: 'not-a-real-uuid',
+        configuration: { name: 'nope' } as Partial<Variable>,
+      }),
+    );
+
+    expect(next).toEqual(state);
+  });
+});

--- a/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
@@ -372,16 +372,15 @@ describe('protocol.stages', () => {
           dispatched.some((a) => a.type === 'PROTOCOL/UPDATE_VARIABLE'),
         ).toBe(false);
 
-        // The cleanup config must drop both the synthetic `id` and the
-        // `encrypted` flag rather than writing them back into the codebook.
-        const configuration = (
-          updateVariableAction?.payload as
-            | { configuration: Record<string, unknown> }
-            | undefined
-        )?.configuration;
-        expect(configuration).not.toHaveProperty('id');
-        expect(configuration).not.toHaveProperty('encrypted');
-        expect(configuration).toMatchObject({ name: 'ssn', type: 'text' });
+        const payload = updateVariableAction?.payload as
+          | {
+              configuration: Record<string, unknown>;
+              replaceProperties: readonly string[];
+            }
+          | undefined;
+        expect(payload?.replaceProperties).toEqual(['encrypted']);
+        expect(payload?.configuration).not.toHaveProperty('id');
+        expect(payload?.configuration).not.toHaveProperty('encrypted');
 
         expect(dispatched.some((a) => a.type === 'stages/deleteStage')).toBe(
           true,

--- a/apps/architect/src/ducks/modules/protocol/codebook.ts
+++ b/apps/architect/src/ducks/modules/protocol/codebook.ts
@@ -9,6 +9,7 @@ import type {
   EdgeDefinition,
   EntityDefinition,
   Variable,
+  VariablePropertyKey,
 } from '@codaco/protocol-validation';
 import { createAppAsyncThunk } from '~/ducks/createAppAsyncThunk';
 import {
@@ -50,7 +51,7 @@ type CreateVariablePayload = {
 type UpdateVariablePayload = {
   variable: string;
   configuration: Partial<Variable>;
-  merge?: boolean;
+  replaceProperties?: readonly VariablePropertyKey[];
 };
 
 type DeleteVariablePayload = {
@@ -201,13 +202,13 @@ export const updateVariableAsync = createAppAsyncThunk(
       type,
       variable,
       configuration,
-      merge = false,
+      replaceProperties = [],
     }: {
       entity?: Entity;
       type?: string;
       variable: string;
       configuration: Partial<Variable>;
-      merge?: boolean;
+      replaceProperties?: readonly VariablePropertyKey[];
     },
     { dispatch, getState },
   ) => {
@@ -231,7 +232,7 @@ export const updateVariableAsync = createAppAsyncThunk(
     const payload: UpdateVariablePayload = {
       variable,
       configuration: prune(configuration),
-      merge,
+      replaceProperties,
     };
 
     dispatch(codebookSlice.actions.updateVariable(payload));
@@ -301,7 +302,7 @@ const getStateWithUpdatedVariable = (
   type: string | undefined,
   variable: string,
   configuration: Partial<Variable>,
-  merge = false,
+  replaceProperties: readonly VariablePropertyKey[] = [],
 ): Codebook => {
   if (entity !== 'ego' && !type) {
     throw Error('Type must be specified for non ego nodes');
@@ -310,14 +311,14 @@ const getStateWithUpdatedVariable = (
   const entityPath = entity === 'ego' ? [entity] : [entity, type as string];
 
   const existingVariable = get(state, [...entityPath, 'variables', variable]);
-  const variableConfiguration: Variable = merge
-    ? ({
-        ...(existingVariable && typeof existingVariable === 'object'
-          ? (existingVariable as Partial<Variable>)
-          : {}),
-        ...configuration,
-      } as Variable)
-    : (configuration as Variable);
+  const preservedProperties =
+    existingVariable && typeof existingVariable === 'object'
+      ? omit(existingVariable as Partial<Variable>, replaceProperties)
+      : {};
+  const variableConfiguration = {
+    ...preservedProperties,
+    ...configuration,
+  } as Variable;
 
   const existingVariables = get(state, [...entityPath, 'variables']);
   const newVariables: Record<string, Variable> = {
@@ -372,11 +373,14 @@ const codebookSlice = createSlice({
         type,
         variable,
         configuration,
-        false,
       );
     },
     updateVariable: (state, action: PayloadAction<UpdateVariablePayload>) => {
-      const { variable, configuration, merge = false } = action.payload;
+      const {
+        variable,
+        configuration,
+        replaceProperties = [],
+      } = action.payload;
 
       // Use current() to get a non-draft version of state for the selector
       const currentState = current(state);
@@ -394,7 +398,7 @@ const codebookSlice = createSlice({
         entityType ?? undefined,
         variable,
         configuration,
-        merge,
+        replaceProperties,
       );
     },
     deleteVariable: (state, action: PayloadAction<DeleteVariablePayload>) => {
@@ -418,8 +422,18 @@ const codebookSlice = createSlice({
 export const updateVariableByUUID = (
   variable: string,
   properties: Partial<Variable>,
-  merge = false,
-) => updateVariableAsync({ variable, configuration: properties, merge });
+  replaceProperties: readonly VariablePropertyKey[] = [],
+) =>
+  updateVariableAsync({
+    variable,
+    configuration: properties,
+    replaceProperties,
+  });
+
+export const test = {
+  updateVariable: (payload: UpdateVariablePayload) =>
+    codebookSlice.actions.updateVariable(payload),
+};
 
 // Export the reducer as default
 export default codebookSlice.reducer;

--- a/apps/architect/src/ducks/modules/protocol/stages.ts
+++ b/apps/architect/src/ducks/modules/protocol/stages.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { invariant } from 'es-toolkit';
-import { compact, omit } from 'es-toolkit/compat';
+import { compact } from 'es-toolkit/compat';
 import { v1 as uuid } from 'uuid';
 
 import type { SkipLogicDestination, Stage } from '@codaco/protocol-validation';
@@ -173,11 +173,7 @@ const deleteStageAsync = createAppAsyncThunk(
       await Promise.all(
         encryptedVariables.map((variable) =>
           dispatch(
-            updateVariableByUUID(
-              variable.id,
-              omit(variable, ['encrypted', 'id']),
-              false,
-            ),
+            updateVariableByUUID(variable.id, {}, ['encrypted']),
           ).unwrap(),
         ),
       );


### PR DESCRIPTION
Adding an "Editable attribute" to a Network Composer stage and picking an existing
variable made two untouched NameGenerator stages fail validation:

```
Form field variable "c5fee926-…" must define a component (input control) to be
rendered as a form field.
```

The variable (`age`) is defined correctly on disk. Architect deleted `component`
from the shared codebook entry on save, breaking every other stage that used it.

## Root cause

`updateVariable` replaced the codebook variable wholesale, and each caller
hand-listed the properties to carry forward. That list had already drifted twice
(`encrypted`, then `readOnly`). The composer deliberately doesn't own `component`
— the input control lives on its stage field — but under wholesale replace, "I
don't own this" and "delete this" were the same action.

Not caused by the recent schema tightening: the strip has existed since 2026-06-30
and the tightening only made it visible. Before that it shipped protocols that
crashed the interview when the form rendered.

## Changes

Swept all 13 tightened hard-fail rules against the editors; 3 were reachable:

1. **Codebook properties** — callers now declare only what they own via
   `replaceProperties`; everything else is preserved structurally. This also fixes a
   silent instance: all three form handlers dropped `readOnly`, quietly unlocking
   interface-owned option sets like the FamilyPedigree biological-sex values. Since
   `readOnly` is optional in the schema, nothing ever reported it.
2. **Negative day offsets** on RelativeDatePicker are now rejected.
3. **Edge rules on external-data panels** are hidden, and switching an existing
   panel to an external file offers to remove any it already has.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-defined variable settings when editing codebook fields across stages.
  * Retained locked states for interface-owned option sets.
  * Prevented relative date offsets from accepting negative values.
  * Removed unavailable edge-rule options when using external data files.
  * Added a confirmation prompt before removing existing edge rules during data-source changes.

* **Tests**
  * Expanded coverage for variable preservation, date validation, edge-rule visibility, and data-source switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->