### PR TITLE
Hide resume pill during new interview setup

### DIFF
--- a/.changeset/calm-resume-pill.md
+++ b/.changeset/calm-resume-pill.md
@@ -1,0 +1,6 @@
+---
+'@codaco/interviewer': patch
+---
+
+Animate the resume-last-interview notification out while entering a case ID for
+a new interview, then bring it back when returning to the protocol card.

--- a/apps/interviewer/e2e/specs/home-protocols.spec.ts
+++ b/apps/interviewer/e2e/specs/home-protocols.spec.ts
@@ -70,6 +70,28 @@ test.describe('protocol import & delete', () => {
     });
   });
 
+  test('hides the resume notification while the case ID form is open', async ({
+    protocol,
+    interviewNav,
+    page,
+  }) => {
+    await protocol.import(LEAN_E2E_PROTOCOL_PATH, LEAN_E2E_PROTOCOL_NAME);
+    await interviewNav.startNewSession('P-resume');
+    await page.goto('/');
+
+    const resumeNotification = page.getByRole('button', {
+      name: /Resume last interview/,
+    });
+    await expect(resumeNotification).toBeVisible();
+
+    await page.getByRole('button', { name: 'Start new interview' }).click();
+    await expect(page.getByTestId('new-session-case-id')).toBeVisible();
+    await expect(resumeNotification).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(resumeNotification).toBeVisible();
+  });
+
   test(
     'deletes a protocol via the confirm dialog',
     {

--- a/apps/interviewer/src/routes/Home.tsx
+++ b/apps/interviewer/src/routes/Home.tsx
@@ -66,6 +66,8 @@ export function HomeRoute() {
   // When it does, the pill occupies the band just below the header in
   // portrait, so the protocols column reserves top space to clear it.
   const hasResumableSession = sessions.some((s) => s.finishedAt === null);
+  const showResumePill =
+    view === 'protocols' && !newSessionActive && hasResumableSession;
 
   // Default the active card to the user's last-used protocol; fall back to
   // the most-recently-imported one if they've never opened a protocol (or
@@ -197,7 +199,7 @@ export function HomeRoute() {
             breakpoint and pull the pill up into the header. */}
         <div className="tablet-landscape:px-11 tablet-landscape:pt-9 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-6 landscape:translate-y-0">
           <AnimatePresence>
-            {view === 'protocols' ? (
+            {showResumePill ? (
               <ResumePill key="resume-pill" sessions={sessions} />
             ) : null}
           </AnimatePresence>
@@ -217,7 +219,7 @@ export function HomeRoute() {
             // protocol deck starts below it — only in portrait, and only when a
             // resumable session actually renders the pill (pill is h-20 = 80px).
             className={`flex min-h-0 w-full flex-1 flex-col gap-8 ${
-              hasResumableSession ? 'portrait:pt-24' : ''
+              showResumePill ? 'portrait:pt-24' : ''
             }`}
           >
             <ProtocolDeck

--- a/apps/interviewer/src/routes/__tests__/Home.test.tsx
+++ b/apps/interviewer/src/routes/__tests__/Home.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CurrentProtocol } from '@codaco/protocol-validation';
+import type { ProtocolWithCounts, StoredSessionLite } from '~/lib/db/types';
+import { DEFAULT_SETTINGS } from '~/lib/db/types';
+
+const { useHomeDataMock } = vi.hoisted(() => ({
+  useHomeDataMock: vi.fn(),
+}));
+
+vi.mock('../useHomeData', () => ({
+  useHomeData: useHomeDataMock,
+}));
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/', vi.fn()],
+}));
+
+vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
+  default: () => ({ openDialog: vi.fn() }),
+}));
+
+vi.mock('@codaco/fresco-ui/Toast', () => ({
+  useToast: () => ({ add: vi.fn() }),
+}));
+
+vi.mock('~/lib/db/api', () => ({
+  deleteProtocol: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+
+vi.mock('~/lib/protocol/useProtocolImport', () => ({
+  useProtocolImport: () => ({
+    pendingImports: [],
+    startImport: vi.fn(),
+  }),
+}));
+
+vi.mock('~/lib/pwa/useLaunchedProtocolImport', () => ({
+  useLaunchedProtocolImport: vi.fn(),
+}));
+
+vi.mock('~/lib/pwa/useLaunchFailureToast', () => ({
+  useLaunchFailureToast: vi.fn(),
+}));
+
+vi.mock('~/components/BrandHeader', () => ({
+  BrandHeader: () => null,
+}));
+
+vi.mock('~/components/DataView/DataView', () => ({
+  DataView: () => null,
+}));
+
+vi.mock('~/components/InstallBanner', () => ({
+  InstallBanner: () => null,
+}));
+
+type ProtocolDeckMockProps = {
+  newSessionProtocolHash?: string | null;
+  onStartInterview: (protocolHash: string) => void;
+  onCancelNewSession?: () => void;
+};
+
+vi.mock('~/components/ProtocolCarousel/ProtocolDeck', () => ({
+  ProtocolDeck: ({
+    newSessionProtocolHash,
+    onStartInterview,
+    onCancelNewSession,
+  }: ProtocolDeckMockProps) =>
+    newSessionProtocolHash ? (
+      <button type="button" onClick={onCancelNewSession}>
+        Cancel new interview
+      </button>
+    ) : (
+      <button type="button" onClick={() => onStartInterview('protocol-hash')}>
+        Start new interview
+      </button>
+    ),
+}));
+
+vi.mock('~/components/ResumePill', () => ({
+  ResumePill: () => <div>Resume last interview</div>,
+}));
+
+vi.mock('~/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+}));
+
+vi.mock('~/components/StatusRow', () => ({
+  StatusRow: () => null,
+}));
+
+vi.mock('~/components/TopActionBar', () => ({
+  TopActionBar: () => null,
+}));
+
+import { HomeRoute } from '../Home';
+
+const protocolDefinition: CurrentProtocol = {
+  name: 'Test protocol',
+  description: 'A test protocol.',
+  schemaVersion: 8,
+  codebook: {},
+  stages: [],
+};
+
+const protocol: ProtocolWithCounts = {
+  id: 'protocol-id',
+  hash: 'protocol-hash',
+  name: protocolDefinition.name,
+  description: protocolDefinition.description,
+  schemaVersion: protocolDefinition.schemaVersion,
+  codebook: protocolDefinition.codebook,
+  protocol: protocolDefinition,
+  importedAt: '2026-07-17T09:00:00.000Z',
+  sessionCount: 1,
+};
+
+const resumableSession: StoredSessionLite = {
+  id: 'session-id',
+  protocolHash: protocol.hash,
+  protocolName: protocol.name,
+  caseId: 'P01',
+  startedAt: '2026-07-17T09:30:00.000Z',
+  lastUpdatedAt: '2026-07-17T10:00:00.000Z',
+  finishedAt: null,
+  exportedAt: null,
+  currentStep: 1,
+  statusKind: 'in-progress',
+  progressPercent: 25,
+};
+
+describe('HomeRoute resume notification', () => {
+  beforeEach(() => {
+    useHomeDataMock.mockReturnValue({
+      protocols: [protocol],
+      sessions: [resumableSession],
+      settings: DEFAULT_SETTINGS,
+      reload: vi.fn(),
+    });
+  });
+
+  it('hides while the case ID form is active and returns when it closes', async () => {
+    render(<HomeRoute />);
+
+    expect(screen.getByText('Resume last interview')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start new interview' }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Resume last interview'),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Cancel new interview' }),
+    );
+
+    expect(
+      await screen.findByText('Resume last interview'),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- animate the resume-last-interview notification out while the case ID form is active
- restore the notification and its portrait spacing when the protocol card returns to normal
- cover the state transition with route-level unit and production-build Playwright regressions

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/interviewer test -- src/routes/__tests__/Home.test.tsx`
- [x] `VITE_DISABLE_ANALYTICS=true pnpm turbo run build --filter=@codaco/interviewer`
- [x] `VITE_DISABLE_ANALYTICS=true pnpm --filter @codaco/interviewer exec playwright test --config=e2e/playwright.config.ts --grep hides`
- [x] `./apps/interviewer/e2e/scripts/run.sh --grep hides`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Resume last interview” notification behavior when starting a new interview.
  * The notification now hides while entering a new case ID and reappears when returning to the protocol view.
  * Updated the home screen layout to correctly reserve space only when the notification is visible.

* **Tests**
  * Added coverage for resuming, starting a new interview, cancelling, and notification visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

