### PR TITLE
ci: skip release E2E re-runs via equivalence reuse

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,3 +11,8 @@ reviews:
   path_filters:
     - '!packages/interview/e2e/aria-snapshots/**'
     - '!packages/interview/e2e/visual-snapshots/**'
+    # Implementation plans are point-in-time execution artifacts for
+    # agent-driven task execution, not living documentation — the spec and
+    # CLAUDE.md are the reviewed sources of truth — so reviewing them
+    # generates noise about intentionally frozen historical snippets.
+    - '!docs/superpowers/plans/**'

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -153,6 +153,7 @@ jobs:
   e2e-policy:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       interview: ${{ steps.policy.outputs.interview }}
       interviewer: ${{ steps.policy.outputs.interviewer }}
@@ -180,7 +181,8 @@ jobs:
           # for fork PRs.
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          # Read-only, for the merge-queue already-validated lookup.
+          # Read-only, feeds both the PR-time and merge-queue equivalence
+          # lookups.
           GH_TOKEN: ${{ github.token }}
         run: |
           policy=$(node scripts/release-e2e-policy.mjs)

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -146,8 +146,10 @@ jobs:
 
   # Decides per suite whether release E2E must run for this ref: each release
   # lane requires only the suites whose subject package ships in its deploy,
-  # and a merge-group run skips suites already validated by the native PR run
-  # on an identical tree (see scripts/release-e2e-policy.mjs).
+  # and both release-PR refreshes and merge-group runs skip suites already
+  # validated by an earlier native PR run whose commit differs only in paths
+  # that cannot affect the suite (equivalence reuse — see
+  # scripts/release-e2e-policy.mjs; every guard fails closed).
   e2e-policy:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
@@ -172,7 +174,12 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
           BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          # On PRs, HEAD_SHA is the branch tip the equivalence reuse diffs
+          # against prior validated runs; on merge groups it stays the
+          # group's head for release detection. HEAD_REPO guards reuse off
+          # for fork PRs.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           # Read-only, for the merge-queue already-validated lookup.
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -1707,9 +1714,10 @@ jobs:
   # First push on a PR: no prior runs exist, so nothing to carry; the
   # detect logic already runs the relevant jobs at least once because
   # the push diff IS the cumulative PR diff on the first commit.
-  # E2E jobs are deliberately excluded: release PRs run all three on every
-  # push and the required quality gate checks their live results; non-release
-  # PRs must never inherit an E2E verdict from an earlier commit.
+  # E2E jobs are deliberately excluded: on release PRs the e2e-policy job
+  # itself decides when a refresh may skip a suite (equivalence reuse) and
+  # the required quality gate checks its decision; non-release PRs must
+  # never inherit an E2E verdict from an earlier commit.
   carry-forward-statuses:
     needs:
       - detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,10 +335,11 @@ Generated release branches and their merge groups use equivalence reuse: a
 suite is skipped when a prior successful native pull-request run of it exists
 on the same branch and the diff since that commit touches only paths that
 provably cannot affect the suite — files in workspace packages outside the
-suite subject's dependency+devDependency closure, or the inert `docs/`,
-`.changeset/`, `*.md` set. Every guard fails closed: an unfetchable commit,
-Actions-API doubt, a fork head, a conclusive failure as the newest verdict,
-or any unrecognised path (root configs, `.github/`, `scripts/`, the
+suite subject's declared workspace dependency closure (dependencies,
+devDependencies, peerDependencies, optionalDependencies), or the inert
+`docs/`, `.changeset/`, `*.md` set. Every guard fails closed: an unfetchable
+commit, Actions-API doubt, a fork head, a conclusive failure as the newest
+verdict, or any unrecognised path (root configs, `.github/`, `scripts/`, the
 lockfile) re-runs the suite. Force-pushed refreshes of a release PR after
 unrelated merges to `main` therefore keep their E2E verdicts without
 re-running, while any change that ships in the lane re-runs as before (see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,15 +328,22 @@ the Documentation and Website lanes run none. The mapping lives in
 `scripts/release-e2e-policy.mjs`, and its test derives the expected lanes from
 the real package.json dependency graph so the table cannot silently drift.
 The required `quality` check requires exactly the suites the policy selects.
-Ordinary PRs skip E2E, and E2E verdicts are never carried forward from an
-earlier commit.
+Ordinary PRs skip E2E and never inherit an E2E verdict from an earlier
+commit.
 
-A merge-queue run skips a suite only in one narrow case: the queued merge
-commit's tree is byte-identical to the tip of a generated release branch, and
-a native pull-request run of this workflow already ran that suite successfully at that
-exact SHA. Every guard fails closed (tree mismatch, non-release tip, or any
-Actions-API doubt reruns the suite), so batched merge groups and moved `main`
-always re-run E2E.
+Generated release branches and their merge groups use equivalence reuse: a
+suite is skipped when a prior successful native pull-request run of it exists
+on the same branch and the diff since that commit touches only paths that
+provably cannot affect the suite — files in workspace packages outside the
+suite subject's dependency+devDependency closure, or the inert `docs/`,
+`.changeset/`, `*.md` set. Every guard fails closed: an unfetchable commit,
+Actions-API doubt, a fork head, a conclusive failure as the newest verdict,
+or any unrecognised path (root configs, `.github/`, `scripts/`, the
+lockfile) re-runs the suite. Force-pushed refreshes of a release PR after
+unrelated merges to `main` therefore keep their E2E verdicts without
+re-running, while any change that ships in the lane re-runs as before (see
+`scripts/release-e2e-policy.mjs` and
+`docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md`).
 
 The release jobs create and update generated branches with the fine-grained PAT
 stored as `RELEASE_PR_TOKEN`. That causes the normal `pull_request` workflow to

--- a/docs/superpowers/plans/2026-07-17-release-e2e-equivalence-reuse.md
+++ b/docs/superpowers/plans/2026-07-17-release-e2e-equivalence-reuse.md
@@ -1,0 +1,1104 @@
+# Release E2E Equivalence Reuse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop force-pushed refreshes of generated release PRs from re-running release E2E suites when nothing relevant to a suite changed, by adding equivalence-based suite reuse to `scripts/release-e2e-policy.mjs` (spec: `docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md`).
+
+**Architecture:** Branch generation is untouched. The `e2e-policy` job's script gains an equivalence primitive: a suite is skipped when the newest conclusive native `pull_request` run of that suite on the same `changeset-release/*` branch succeeded at commit X, and `git diff X→H` touches only paths that provably cannot affect the suite. The primitive is applied at PR time (H = PR tip) and merge-queue time (H = merge commit, replacing the byte-identical fast path, which becomes the empty-diff trivial case). Every doubt fails closed (suite runs).
+
+**Tech Stack:** Plain Node ESM scripts (`scripts/*.mjs`), `node --test` (`pnpm test:scripts`), GitHub Actions workflow YAML, GitHub Actions REST API.
+
+## Global Constraints
+
+- Fail closed everywhere: any API error, unfetchable commit, unrecognised path, missing input, or fork context means the suite RUNS. Never invert this.
+- Ordinary (non-release) PRs must never inherit an E2E verdict — reuse applies only to `changeset-release/*` refs (`pull_request` and `merge_group` events; never `workflow_dispatch`).
+- A conclusive `failure`/`timed_out` as the newest verdict is never walked past to an older success.
+- No new dependencies. No `any`-style shortcuts (plain JS here, but keep JSDoc-free style consistent with the existing file).
+- Comment only what the code cannot say (constraints, invariants) — match the existing comment style in `release-e2e-policy.mjs`.
+- Never re-export or add exports beyond what tests/consumers actually import.
+- Commit messages: conventional style (`feat:`/`fix:`/`ci:`/`test:`/`docs:`), no Co-Authored-By/attribution lines. Before committing run `eval "$(fnm env 2>/dev/null)"` so the husky hook finds pnpm.
+- Run tests with `pnpm test:scripts` (wraps `node --test scripts/*.test.mjs`). A single file: `node --test scripts/release-e2e-policy.test.mjs`.
+- Work happens on branch `claude/ci-release-pr-force-push-4968a1` in this worktree.
+
+---
+
+### Task 1: Path-relevance helpers
+
+**Files:**
+
+- Modify: `scripts/release-e2e-policy.mjs`
+- Test: `scripts/release-e2e-policy.test.mjs`
+
+**Interfaces:**
+
+- Consumes: nothing new (existing `E2E_SUITE_SUBJECTS`, `SUITE_KEYS` untouched).
+- Produces (used by Task 2's primitive and Task 1/2 tests):
+  - `collectWorkspacePackages(cwd: string): Map<string, {dir: string, workspaceDeps: string[]}>` — scans `packages/`, `apps/`, `tooling/`, `workers/` for `<group>/<name>/package.json`; `dir` is the repo-relative directory (e.g. `"apps/architect"`), `workspaceDeps` is the merged key list of `dependencies` + `devDependencies` (names, unfiltered — non-workspace names simply miss the map during traversal).
+  - `relevanceDirsForSubject(subjectName: string, packages: ReturnType<typeof collectWorkspacePackages>): Set<string>` — dirs of the subject package plus its transitive workspace dependency/devDependency closure.
+  - `diffIrrelevantToSuite(changedPaths: string[], relevanceDirs: Set<string>, packages: ReturnType<typeof collectWorkspacePackages>): boolean` — true only when EVERY path is inert (`docs/`, `.changeset/`, `*.md`) or inside a workspace package dir NOT in `relevanceDirs`. Any other path (root configs, `.github/`, `scripts/`, `pnpm-lock.yaml`, unknown dirs) → false.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/release-e2e-policy.test.mjs` (extend the existing import list from `./release-e2e-policy.mjs` with the three new names):
+
+```js
+// Scaffold a repo-shaped directory tree (no git needed for these tests):
+// interviewer app depends on the interview package; architect app is a
+// sibling product that also depends on interview.
+function writeWorkspaceFixture() {
+  const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-graph-'));
+  const manifests = {
+    'packages/interview/package.json': {
+      name: '@codaco/interview',
+      version: '1.0.0',
+      devDependencies: { '@codaco/e2e-helpers': 'workspace:*' },
+    },
+    'packages/e2e-helpers/package.json': {
+      name: '@codaco/e2e-helpers',
+      version: '1.0.0',
+    },
+    'apps/interviewer/package.json': {
+      name: '@codaco/interviewer',
+      version: '1.0.0',
+      dependencies: { '@codaco/interview': 'workspace:*' },
+    },
+    'apps/architect/package.json': {
+      name: '@codaco/architect',
+      version: '1.0.0',
+      dependencies: { '@codaco/interview': 'workspace:*' },
+    },
+  };
+  for (const [file, contents] of Object.entries(manifests)) {
+    mkdirSync(join(cwd, file, '..'), { recursive: true });
+    writeFileSync(join(cwd, file), `${JSON.stringify(contents)}\n`);
+  }
+  return cwd;
+}
+
+test('relevance closure follows dependencies and devDependencies', () => {
+  const cwd = writeWorkspaceFixture();
+  const packages = collectWorkspacePackages(cwd);
+  assert.deepEqual(
+    [...relevanceDirsForSubject('@codaco/interviewer', packages)].sort(),
+    ['apps/interviewer', 'packages/e2e-helpers', 'packages/interview'],
+  );
+  // devDependency edge: interview pulls in its e2e helpers.
+  assert.deepEqual(
+    [...relevanceDirsForSubject('@codaco/interview', packages)].sort(),
+    ['packages/e2e-helpers', 'packages/interview'],
+  );
+});
+
+test('diff classification is fail-closed', () => {
+  const cwd = writeWorkspaceFixture();
+  const packages = collectWorkspacePackages(cwd);
+  const relevance = relevanceDirsForSubject('@codaco/interviewer', packages);
+
+  // Sibling-product and inert paths cannot affect the interviewer suite.
+  assert.equal(
+    diffIrrelevantToSuite(
+      [
+        'apps/architect/package.json',
+        'apps/architect/CHANGELOG.md',
+        '.changeset/lucky-pandas-dance.md',
+        'docs/superpowers/specs/example.md',
+        'README.md',
+      ],
+      relevance,
+      packages,
+    ),
+    true,
+  );
+
+  // Anything in the closure is relevant — including non-markdown baselines.
+  for (const relevantPath of [
+    'apps/interviewer/src/main.tsx',
+    'packages/interview/e2e/baseline.png',
+    'packages/e2e-helpers/src/index.ts',
+  ]) {
+    assert.equal(
+      diffIrrelevantToSuite([relevantPath], relevance, packages),
+      false,
+      `${relevantPath} must be relevant`,
+    );
+  }
+
+  // Paths outside every workspace package fail closed.
+  for (const unrecognised of [
+    '.github/workflows/ci-and-release.yml',
+    'scripts/release-e2e-policy.mjs',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'turbo.json',
+    '.nvmrc',
+  ]) {
+    assert.equal(
+      diffIrrelevantToSuite([unrecognised], relevance, packages),
+      false,
+      `${unrecognised} must be relevant`,
+    );
+  }
+
+  // One relevant path among many irrelevant ones is enough to run.
+  assert.equal(
+    diffIrrelevantToSuite(
+      ['apps/architect/package.json', 'pnpm-lock.yaml'],
+      relevance,
+      packages,
+    ),
+    false,
+  );
+
+  // An empty diff is trivially irrelevant (byte-identical case).
+  assert.equal(diffIrrelevantToSuite([], relevance, packages), true);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/release-e2e-policy.test.mjs`
+Expected: FAIL — `collectWorkspacePackages` is not exported.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `scripts/release-e2e-policy.mjs`, extend the imports:
+
+```js
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+```
+
+Then add below the `E2E_JOB_NAMES` constant:
+
+```js
+const WORKSPACE_GROUPS = ['packages', 'apps', 'tooling', 'workers'];
+
+// Mirrors the `test` job's inert set: docs, changesets, and markdown cannot
+// change what an E2E suite executes or asserts.
+function isInertPath(path) {
+  return (
+    path.startsWith('docs/') ||
+    path.startsWith('.changeset/') ||
+    path.endsWith('.md')
+  );
+}
+
+export function collectWorkspacePackages(cwd) {
+  const packages = new Map();
+  for (const group of WORKSPACE_GROUPS) {
+    let entries;
+    try {
+      entries = readdirSync(join(cwd, group), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      let manifest;
+      try {
+        manifest = JSON.parse(
+          readFileSync(join(cwd, group, entry.name, 'package.json'), 'utf8'),
+        );
+      } catch {
+        continue;
+      }
+      if (typeof manifest.name !== 'string') continue;
+      packages.set(manifest.name, {
+        dir: `${group}/${entry.name}`,
+        // devDependencies participate: they carry Playwright configs, e2e
+        // helpers, and build tooling that shape suite outcomes.
+        workspaceDeps: [
+          ...Object.keys(manifest.dependencies ?? {}),
+          ...Object.keys(manifest.devDependencies ?? {}),
+        ],
+      });
+    }
+  }
+  return packages;
+}
+
+export function relevanceDirsForSubject(subjectName, packages) {
+  const dirs = new Set();
+  const seen = new Set();
+  const queue = [subjectName];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const pkg = packages.get(name);
+    if (!pkg) continue;
+    dirs.add(pkg.dir);
+    queue.push(...pkg.workspaceDeps);
+  }
+  return dirs;
+}
+
+// True only when EVERY changed path provably cannot affect the suite: it is
+// inert, or it lives inside a workspace package outside the suite's relevance
+// closure. Any other path — root configs, .github/, scripts/, the lockfile,
+// anything unrecognised — is relevant, so the suite runs (fail closed).
+export function diffIrrelevantToSuite(changedPaths, relevanceDirs, packages) {
+  const packageDirs = [...packages.values()].map((pkg) => pkg.dir);
+  return changedPaths.every((changedPath) => {
+    if (isInertPath(changedPath)) return true;
+    const owner = packageDirs.find((dir) => changedPath.startsWith(`${dir}/`));
+    return owner !== undefined && !relevanceDirs.has(owner);
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test scripts/release-e2e-policy.test.mjs`
+Expected: PASS (all existing tests plus the two new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+git add scripts/release-e2e-policy.mjs scripts/release-e2e-policy.test.mjs
+git commit -m "ci: add suite path-relevance helpers to release E2E policy"
+```
+
+---
+
+### Task 2: The equivalence primitive
+
+**Files:**
+
+- Modify: `scripts/release-e2e-policy.mjs`
+- Test: `scripts/release-e2e-policy.test.mjs`
+
+**Interfaces:**
+
+- Consumes (from Task 1): `collectWorkspacePackages(cwd)`, `relevanceDirsForSubject(subjectName, packages)`, `diffIrrelevantToSuite(changedPaths, relevanceDirs, packages)`. Also existing internals `suites()`, `git(args, cwd)`, `tryGit(args, cwd)`, `SUITE_KEYS`, `E2E_JOB_NAMES`, `E2E_SUITE_SUBJECTS`.
+- Produces (used by Task 3's `main()` and tests):
+  - `equivalentValidatedSuites({cwd, repository, token, branch, headSha, requiredSuites, fetcher = fetch}): Promise<{interview: boolean, interviewer: boolean, architect: boolean}>` — `true` means the suite is validated-equivalent and may be skipped. `requiredSuites` is a suites-shaped object; suites not required are never looked up.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/release-e2e-policy.test.mjs` (add `equivalentValidatedSuites` to the import list). These use real temp git repos (existing `initRepo`/`commitManifest` helpers) plus a fake Actions API:
+
+```js
+// A fake Actions REST API: one runs-listing endpoint plus per-run jobs
+// endpoints, keyed by run id embedded in jobs_url.
+function fakeActionsApi({ runs, jobsByRun, failRuns = false, failJobs = false }) {
+  return async (url) => {
+    if (url.includes('/actions/workflows/')) {
+      if (failRuns) return { ok: false };
+      assert.match(url, /[?&]event=pull_request(?:&|$)/);
+      assert.match(url, /[?&]branch=changeset-release%2F/);
+      return { ok: true, json: async () => ({ workflow_runs: runs }) };
+    }
+    if (failJobs) return { ok: false };
+    const runId = url.match(/\/fake-jobs\/(\d+)\?/)?.[1];
+    return { ok: true, json: async () => ({ jobs: jobsByRun[runId] ?? [] }) };
+  };
+}
+
+// Higher id = newer run (created_at day tracks the id).
+function fakeRun(id, headSha, createdAt = `2026-07-${String(id).padStart(2, '0')}T00:00:00Z`) {
+  return {
+    id,
+    head_sha: headSha,
+    created_at: createdAt,
+    head_repository: { full_name: 'example/repo' },
+    jobs_url: `https://api.example.com/fake-jobs/${id}`,
+  };
+}
+
+// Release-branch history with a real workspace graph committed, so the
+// primitive can classify diffs: interviewer + architect apps both depend on
+// the interview package.
+function initReleaseBranchRepo() {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'packages/interview/package.json',
+    '{"name":"@codaco/interview","version":"1.0.0"}\n',
+    'add interview',
+  );
+  commitManifest(
+    cwd,
+    'apps/interviewer/package.json',
+    '{"name":"@codaco/interviewer","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add interviewer',
+  );
+  const validatedSha = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add architect',
+  );
+  return { cwd, validatedSha };
+}
+
+const INTERVIEWER_LANE = {
+  interview: true,
+  interviewer: true,
+  architect: false,
+};
+
+function interviewerLaneCall(cwd, headSha, fetcher) {
+  return equivalentValidatedSuites({
+    cwd,
+    repository: 'example/repo',
+    token: 'token',
+    branch: 'changeset-release/interviewer',
+    headSha,
+    requiredSuites: INTERVIEWER_LANE,
+    fetcher,
+  });
+}
+
+const INTERVIEWER_LANE_SUCCESS_JOBS = [
+  { name: 'interview-e2e', conclusion: 'success' },
+  { name: 'interviewer-e2e', conclusion: 'success' },
+  { name: 'quality', conclusion: 'success' },
+];
+
+test('equivalence reuse skips suites when the delta cannot affect them', async () => {
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  // Sibling release merge shape: architect bump + consumed changeset + docs.
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'sibling release',
+  );
+  const headSha = commitManifest(cwd, '.changeset/config.md', 'consumed\n', 'changesets');
+
+  const fetcher = fakeActionsApi({
+    runs: [fakeRun(1, validatedSha)],
+    jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+  });
+  assert.deepEqual(await interviewerLaneCall(cwd, headSha, fetcher), {
+    interview: true,
+    interviewer: true,
+    architect: false,
+  });
+
+  // Byte-identical head (re-run at the validated SHA) is the trivial case.
+  assert.deepEqual(await interviewerLaneCall(cwd, validatedSha, fetcher), {
+    interview: true,
+    interviewer: true,
+    architect: false,
+  });
+});
+
+test('equivalence reuse fails closed on relevant or unrecognised deltas', async () => {
+  const relevant = initReleaseBranchRepo();
+  const relevantHead = commitManifest(
+    relevant.cwd,
+    'packages/interview/src/index.ts',
+    'export {};\n',
+    'interview change',
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      relevant.cwd,
+      relevantHead,
+      fakeActionsApi({
+        runs: [fakeRun(1, relevant.validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+
+  const unrecognised = initReleaseBranchRepo();
+  const unrecognisedHead = commitManifest(
+    unrecognised.cwd,
+    'scripts/new-tool.mjs',
+    'export {};\n',
+    'root script',
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      unrecognised.cwd,
+      unrecognisedHead,
+      fakeActionsApi({
+        runs: [fakeRun(1, unrecognised.validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+});
+
+test('the newest conclusive verdict is authoritative', async () => {
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  const headSha = commitManifest(cwd, '.changeset/x.md', 'irrelevant\n', 'refresh');
+
+  // Newest conclusive run FAILED interviewer-e2e: never walk past it to the
+  // older green, even though the diff is irrelevant.
+  const failedThenGreen = fakeActionsApi({
+    runs: [fakeRun(2, headSha), fakeRun(1, validatedSha)],
+    jobsByRun: {
+      2: [
+        { name: 'interview-e2e', conclusion: 'success' },
+        { name: 'interviewer-e2e', conclusion: 'failure' },
+      ],
+      1: INTERVIEWER_LANE_SUCCESS_JOBS,
+    },
+  });
+  assert.deepEqual(await interviewerLaneCall(cwd, headSha, failedThenGreen), {
+    interview: true,
+    interviewer: false,
+    architect: false,
+  });
+
+  // Non-conclusive runs (cancelled / in-flight / policy-skipped) are walked
+  // past to the older native success.
+  const cancelledThenGreen = fakeActionsApi({
+    runs: [fakeRun(2, headSha), fakeRun(1, validatedSha)],
+    jobsByRun: {
+      2: [
+        { name: 'interview-e2e', conclusion: 'cancelled' },
+        { name: 'interviewer-e2e', conclusion: 'skipped' },
+      ],
+      1: INTERVIEWER_LANE_SUCCESS_JOBS,
+    },
+  });
+  assert.deepEqual(await interviewerLaneCall(cwd, headSha, cancelledThenGreen), {
+    interview: true,
+    interviewer: true,
+    architect: false,
+  });
+});
+
+test('equivalence reuse trusts only same-repo runs and healthy inputs', async () => {
+  const none = { interview: false, interviewer: false, architect: false };
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  const headSha = commitManifest(cwd, '.changeset/x.md', 'irrelevant\n', 'refresh');
+
+  // Fork runs sharing the branch name never vouch for ours.
+  const forkRun = {
+    ...fakeRun(1, validatedSha),
+    head_repository: { full_name: 'attacker/fork' },
+  };
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({ runs: [forkRun], jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS } }),
+    ),
+    none,
+  );
+
+  // An unfetchable validated commit fails closed (no origin remote here, so
+  // the fetch fallback cannot resolve it).
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, '0123456789abcdef0123456789abcdef01234567')],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    none,
+  );
+
+  // Actions API failures (runs listing or jobs listing) fail closed.
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({ runs: [], jobsByRun: {}, failRuns: true }),
+    ),
+    none,
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+        failJobs: true,
+      }),
+    ),
+    none,
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(cwd, headSha, async () => {
+      throw new Error('network down');
+    }),
+    none,
+  );
+
+  // Missing inputs fail closed.
+  assert.deepEqual(
+    await equivalentValidatedSuites({
+      cwd,
+      repository: '',
+      token: '',
+      branch: '',
+      headSha: '',
+      requiredSuites: INTERVIEWER_LANE,
+    }),
+    none,
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/release-e2e-policy.test.mjs`
+Expected: FAIL — `equivalentValidatedSuites` is not exported.
+
+- [ ] **Step 3: Implement the primitive**
+
+In `scripts/release-e2e-policy.mjs`, add below the Task 1 helpers:
+
+```js
+const CONCLUSIVE = new Set(['success', 'failure', 'timed_out']);
+// One bounded page of the branch's runs. A verdict older than this is stale
+// enough that re-running is the right call anyway (fail closed past the cap).
+const MAX_RUNS_SCANNED = 50;
+
+function ensureCommit(sha, cwd) {
+  if (tryGit(['rev-parse', '--verify', `${sha}^{commit}`], cwd)) return true;
+  // Force-pushed-away release tips stay fetchable by SHA on GitHub.
+  tryGit(['fetch', '--depth=1', 'origin', sha], cwd);
+  return tryGit(['rev-parse', '--verify', `${sha}^{commit}`], cwd) !== null;
+}
+
+// Equivalence reuse: suite S may be skipped at head H when the newest
+// conclusive native pull_request run of S on this generated release branch
+// succeeded at commit X and diff(X→H) touches only paths that provably
+// cannot affect S (see diffIrrelevantToSuite). Every failure mode — missing
+// input, API error, unfetchable commit, conclusive failure, fork run —
+// leaves the suite required (fail closed). Visual baselines are committed
+// in-tree inside the subject packages, so the diff covers them too.
+export async function equivalentValidatedSuites({
+  cwd,
+  repository,
+  token,
+  branch,
+  headSha,
+  requiredSuites,
+  fetcher = fetch,
+}) {
+  const validated = suites();
+  if (!repository || !token || !branch || !headSha) return validated;
+  const required = SUITE_KEYS.filter((key) => requiredSuites[key]);
+  if (required.length === 0) return validated;
+  if (!ensureCommit(headSha, cwd)) return validated;
+
+  const apiOptions = {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+    },
+  };
+  try {
+    const runsResponse = await fetcher(
+      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=pull_request&branch=${encodeURIComponent(branch)}&per_page=${MAX_RUNS_SCANNED}`,
+      apiOptions,
+    );
+    if (!runsResponse.ok) return validated;
+    const { workflow_runs: runs = [] } = await runsResponse.json();
+
+    // Same-repo runs only: a fork branch may share the generated branch's
+    // name, but its runs must never vouch for ours. Sort defensively even
+    // though the API returns newest-first.
+    const trustedRuns = runs
+      .filter((run) => run.head_repository?.full_name === repository)
+      .sort((a, b) => Date.parse(b.created_at ?? 0) - Date.parse(a.created_at ?? 0));
+
+    const jobsByRun = new Map();
+    const jobsFor = async (run) => {
+      if (!jobsByRun.has(run.id)) {
+        const jobsResponse = await fetcher(`${run.jobs_url}?per_page=100`, apiOptions);
+        jobsByRun.set(
+          run.id,
+          jobsResponse.ok ? ((await jobsResponse.json()).jobs ?? []) : null,
+        );
+      }
+      return jobsByRun.get(run.id);
+    };
+
+    const packages = collectWorkspacePackages(cwd);
+    for (const key of required) {
+      // The newest conclusive verdict is authoritative: a failure is never
+      // walked past to an older green.
+      let candidate = null;
+      for (const run of trustedRuns) {
+        const jobs = await jobsFor(run);
+        if (jobs === null) break;
+        const job = jobs.find((j) => j.name === E2E_JOB_NAMES[key]);
+        if (!job || !CONCLUSIVE.has(job.conclusion)) continue;
+        if (job.conclusion === 'success') candidate = run;
+        break;
+      }
+      if (!candidate?.head_sha) continue;
+      if (!ensureCommit(candidate.head_sha, cwd)) continue;
+      const diff = tryGit(
+        ['diff', '--name-only', candidate.head_sha, headSha],
+        cwd,
+      );
+      if (diff === null) continue;
+      const changedPaths = diff.split('\n').filter(Boolean);
+      const relevanceDirs = relevanceDirsForSubject(
+        E2E_SUITE_SUBJECTS[key],
+        packages,
+      );
+      if (diffIrrelevantToSuite(changedPaths, relevanceDirs, packages)) {
+        validated[key] = true;
+      }
+    }
+  } catch {
+    return suites();
+  }
+  return validated;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test scripts/release-e2e-policy.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+git add scripts/release-e2e-policy.mjs scripts/release-e2e-policy.test.mjs
+git commit -m "ci: add equivalence-based release E2E suite reuse primitive"
+```
+
+---
+
+### Task 3: Wire reuse into the policy entrypoint (PR time + merge queue)
+
+**Files:**
+
+- Modify: `scripts/release-e2e-policy.mjs`
+- Test: `scripts/release-e2e-policy.test.mjs`
+
+**Interfaces:**
+
+- Consumes (from Task 2): `equivalentValidatedSuites({cwd, repository, token, branch, headSha, requiredSuites, fetcher})`; test helpers already present in `scripts/release-e2e-policy.test.mjs` from Task 2 — `fakeActionsApi({runs, jobsByRun, failRuns, failJobs})` and `fakeRun(id, headSha, createdAt?)` (higher id = newer run).
+- Produces:
+  - `releaseBranchForMergeQueue(cwd: string): string` — the `changeset-release/*` ref name whose `origin/<ref>` tip equals `HEAD^2`, or `''`.
+  - `main()` behaviour consumed by the workflow (Task 4): reads new envs `HEAD_SHA` and `HEAD_REPO` on `pull_request` events; existing `EVENT_NAME`, `HEAD_REF`, `REF_NAME`, `GITHUB_REPOSITORY`, `GH_TOKEN` unchanged. Output JSON shape unchanged.
+  - REMOVES `alreadyValidatedSuites` (fully replaced; nothing else imports it — verify with `grep -rn alreadyValidatedSuites scripts/ .github/`).
+
+- [ ] **Step 1: Rewrite the merge-queue tests for the new semantics**
+
+In `scripts/release-e2e-policy.test.mjs`:
+
+1. Remove `alreadyValidatedSuites` from the import list; add `releaseBranchForMergeQueue`.
+2. Extend `initMergeQueueRepo` so main can move with an arbitrary file (replace the existing `advanceMainBeforeMerge` boolean and its call sites):
+
+```js
+// Build a repo shaped like a merge-queue checkout: main, a release branch
+// with a version bump, and a merge commit of the branch into main (HEAD).
+// Returns the branch tip so tests can point origin/changeset-release/* at it.
+function initMergeQueueRepo({ advanceMainWith = '' } = {}) {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0"}\n',
+    'base',
+  );
+  git(cwd, 'checkout', '-qb', 'release');
+  const branchTip = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1"}\n',
+    'version architect',
+  );
+  git(cwd, 'checkout', '-q', 'main');
+  if (advanceMainWith) {
+    commitManifest(cwd, advanceMainWith, 'moved\n', 'main moved');
+  }
+  git(cwd, 'merge', '-q', '--no-ff', '--no-edit', 'release');
+  return { cwd, branchTip };
+}
+```
+
+3. Delete the old `fakeGitHub` helper and the two tests `'merge-queue skip validates suites from the native PR run'` and `'merge-queue skip fails closed'`. Replace with:
+
+```js
+function architectLaneQueueCall(cwd, fetcher) {
+  const branch = releaseBranchForMergeQueue(cwd);
+  return equivalentValidatedSuites({
+    cwd,
+    repository: 'example/repo',
+    token: 'token',
+    branch,
+    headSha: git(cwd, 'rev-parse', 'HEAD'),
+    requiredSuites: { interview: true, interviewer: false, architect: true },
+    fetcher,
+  });
+}
+
+const ARCHITECT_LANE_SUCCESS_JOBS = [
+  { name: 'architect-e2e', conclusion: 'success' },
+  { name: 'interview-e2e', conclusion: 'success' },
+  { name: 'quality', conclusion: 'success' },
+];
+
+test('merge queue identifies the release lane from the merge second parent', () => {
+  const { cwd, branchTip } = initMergeQueueRepo();
+  assert.equal(releaseBranchForMergeQueue(cwd), '');
+  git(
+    cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    branchTip,
+  );
+  assert.equal(
+    releaseBranchForMergeQueue(cwd),
+    'changeset-release/architect',
+  );
+});
+
+test('merge-queue reuse skips suites validated at the branch tip', async () => {
+  const { cwd, branchTip } = initMergeQueueRepo();
+  git(
+    cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    branchTip,
+  );
+  // The merge added nothing beyond the branch: empty diff, trivial case.
+  assert.deepEqual(
+    await architectLaneQueueCall(
+      cwd,
+      fakeActionsApi({
+        runs: [fakeRun(1, branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: true, interviewer: false, architect: true },
+  );
+});
+
+test('merge-queue reuse classifies batched main movement by relevance', async () => {
+  // Main moved with a file inside the architect subject: the architect suite
+  // re-runs. The interview suite may still skip — apps/architect is outside
+  // the interview package's closure, so its e2e outcome cannot change.
+  const relevant = initMergeQueueRepo({
+    advanceMainWith: 'apps/architect/src/main.tsx',
+  });
+  git(
+    relevant.cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    relevant.branchTip,
+  );
+  assert.deepEqual(
+    await architectLaneQueueCall(
+      relevant.cwd,
+      fakeActionsApi({
+        runs: [fakeRun(1, relevant.branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: true, interviewer: false, architect: false },
+  );
+
+  // Main moved with an inert file (README): the batched merge still cannot
+  // affect the suites, so reuse holds. (Old byte-identical semantics re-ran
+  // here; relevance classification is the intended improvement.)
+  const inert = initMergeQueueRepo({ advanceMainWith: 'README.md' });
+  git(
+    inert.cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    inert.branchTip,
+  );
+  assert.deepEqual(
+    await architectLaneQueueCall(
+      inert.cwd,
+      fakeActionsApi({
+        runs: [fakeRun(1, inert.branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: true, interviewer: false, architect: true },
+  );
+
+  // An ordinary PR that bumps a version must never satisfy reuse: without a
+  // matching origin/changeset-release/* tip there is no branch to walk.
+  const untrusted = initMergeQueueRepo();
+  assert.equal(releaseBranchForMergeQueue(untrusted.cwd), '');
+});
+```
+
+Note: `fakeActionsApi` asserts the `branch=` query param starts with `changeset-release%2F`, which these calls satisfy.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `node --test scripts/release-e2e-policy.test.mjs`
+Expected: FAIL — `releaseBranchForMergeQueue` is not exported (and the removed-import tests are gone).
+
+- [ ] **Step 3: Implement `releaseBranchForMergeQueue`, rewire `main()`, delete `alreadyValidatedSuites`**
+
+In `scripts/release-e2e-policy.mjs`:
+
+1. Delete the entire `alreadyValidatedSuites` function and its doc comment. First verify nothing else references it: `grep -rn alreadyValidatedSuites scripts/ .github/` must only show the definition and `main()`.
+2. Add:
+
+```js
+// Trust guard for merge-queue reuse: the queued merge's second parent must be
+// the current tip of a generated release branch — never an arbitrary PR that
+// happens to bump a version.
+export function releaseBranchForMergeQueue(cwd) {
+  const prTip = tryGit(['rev-parse', 'HEAD^2'], cwd);
+  if (!prTip) return '';
+  return (
+    Object.keys(SUITES_BY_RELEASE_REF).find(
+      (ref) => tryGit(['rev-parse', `origin/${ref}`], cwd) === prTip,
+    ) ?? ''
+  );
+}
+```
+
+3. Replace `main()` with:
+
+```js
+async function main() {
+  const eventName = process.env.EVENT_NAME ?? '';
+  const policy = releaseE2EPolicy({
+    eventName,
+    headRef: process.env.HEAD_REF ?? '',
+    refName: process.env.REF_NAME ?? '',
+    baseSha: process.env.BASE_SHA ?? '',
+    headSha: process.env.HEAD_SHA ?? '',
+  });
+
+  if (SUITE_KEYS.some((key) => policy[key])) {
+    const cwd = process.cwd();
+    const repository = process.env.GITHUB_REPOSITORY ?? '';
+    let reuse = null;
+    if (eventName === 'pull_request' && policy.releaseRef) {
+      // Fork PRs never reuse; dispatches are explicit rerun requests and are
+      // not eligible either (eventName gate above).
+      if ((process.env.HEAD_REPO ?? '') === repository && process.env.HEAD_SHA) {
+        reuse = { branch: policy.releaseRef, headSha: process.env.HEAD_SHA };
+      }
+    } else if (eventName === 'merge_group') {
+      const branch = releaseBranchForMergeQueue(cwd);
+      const headSha = tryGit(['rev-parse', 'HEAD'], cwd);
+      if (branch && headSha) reuse = { branch, headSha };
+    }
+    if (reuse) {
+      const validated = await equivalentValidatedSuites({
+        cwd,
+        repository,
+        token: process.env.GH_TOKEN ?? '',
+        requiredSuites: policy,
+        ...reuse,
+      });
+      for (const key of SUITE_KEYS) {
+        if (policy[key] && validated[key]) {
+          policy[key] = false;
+          console.error(
+            `${E2E_JOB_NAMES[key]}: skipping — an earlier successful run on ${reuse.branch} validated this suite and nothing relevant to it has changed since.`,
+          );
+        }
+      }
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify(policy)}\n`);
+}
+```
+
+Note the pre-existing quirk this preserves: `HEAD_SHA` doubles as the merge-group head SHA input to `releaseE2EPolicy` (set from `github.event.merge_group.head_sha` on merge groups) and, after Task 4, as the PR tip on pull_request events. The two events never overlap, and `releaseE2EPolicy` ignores `headSha` outside merge groups.
+
+- [ ] **Step 4: Run the full script test suite**
+
+Run: `pnpm test:scripts`
+Expected: PASS — all files, including the untouched detect/versioning tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+git add scripts/release-e2e-policy.mjs scripts/release-e2e-policy.test.mjs
+git commit -m "ci: apply release E2E equivalence reuse at PR time and in the merge queue"
+```
+
+---
+
+### Task 4: Workflow wiring and workflow tests
+
+**Files:**
+
+- Modify: `.github/workflows/ci-and-release.yml`
+- Test: `scripts/ci-workflow.test.mjs`
+
+**Interfaces:**
+
+- Consumes (from Task 3): `main()` reads `HEAD_SHA` (already wired for merge groups) and the new `HEAD_REPO` env; needs the checkout to allow `git fetch origin <sha>` (anonymous fetch works — public repo — and failures fail closed).
+- Produces: no new outputs; job/step names unchanged so branch protection and `quality` are unaffected.
+
+- [ ] **Step 1: Write the failing workflow test**
+
+Append to `scripts/ci-workflow.test.mjs`:
+
+```js
+test('e2e-policy receives the equivalence-reuse inputs', () => {
+  const policyJob = job('e2e-policy');
+  assert.ok(policyJob, 'e2e-policy job exists');
+  assert.match(
+    policyJob,
+    /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \}\}/,
+    'policy step receives the PR tip (or merge-group head) as HEAD_SHA',
+  );
+  assert.match(
+    policyJob,
+    /HEAD_REPO: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}/,
+    'policy step receives the head repo for the fork guard',
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test scripts/ci-workflow.test.mjs`
+Expected: FAIL — `HEAD_SHA` env does not match the new expression.
+
+- [ ] **Step 3: Update the workflow**
+
+In `.github/workflows/ci-and-release.yml`:
+
+1. In the `e2e-policy` job's policy step env block, replace
+
+```yaml
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+```
+
+with
+
+```yaml
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          # On PRs, HEAD_SHA is the branch tip the equivalence reuse diffs
+          # against prior validated runs; on merge groups it stays the
+          # group's head for release detection. HEAD_REPO guards reuse off
+          # for fork PRs.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+```
+
+2. Replace the `e2e-policy` job's leading comment (currently "Decides per suite whether release E2E must run for this ref: each release lane requires only the suites whose subject package ships in its deploy, and a merge-group run skips suites already validated by the native PR run on an identical tree (see scripts/release-e2e-policy.mjs).") with:
+
+```yaml
+  # Decides per suite whether release E2E must run for this ref: each release
+  # lane requires only the suites whose subject package ships in its deploy,
+  # and both release-PR refreshes and merge-group runs skip suites already
+  # validated by an earlier native PR run whose commit differs only in paths
+  # that cannot affect the suite (equivalence reuse — see
+  # scripts/release-e2e-policy.mjs; every guard fails closed).
+```
+
+3. In the `carry-forward-statuses` comment, replace the sentence
+
+```
+  # E2E jobs are deliberately excluded: release PRs run all three on every
+  # push and the required quality gate checks their live results; non-release
+  # PRs must never inherit an E2E verdict from an earlier commit.
+```
+
+with
+
+```
+  # E2E jobs are deliberately excluded: on release PRs the e2e-policy job
+  # itself decides when a refresh may skip a suite (equivalence reuse) and
+  # the required quality gate checks its decision; non-release PRs must
+  # never inherit an E2E verdict from an earlier commit.
+```
+
+- [ ] **Step 4: Run the workflow tests**
+
+Run: `node --test scripts/ci-workflow.test.mjs`
+Expected: PASS (including the untouched existing assertions — job names, policy flags, quality gate).
+
+- [ ] **Step 5: Commit**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+git add .github/workflows/ci-and-release.yml scripts/ci-workflow.test.mjs
+git commit -m "ci: feed release E2E equivalence reuse from the pull_request event"
+```
+
+---
+
+### Task 5: Documentation and full verification
+
+**Files:**
+
+- Modify: `CLAUDE.md` (the `#### Release-only E2E checks` section; `AGENTS.md` is a symlink — do not touch it separately)
+
+**Interfaces:**
+
+- Consumes: final behaviour from Tasks 1–4.
+- Produces: nothing consumed by other tasks.
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+In the `#### Release-only E2E checks` section, replace these two paragraphs:
+
+```
+Ordinary PRs skip E2E, and E2E verdicts are never carried forward from an
+earlier commit.
+
+A merge-queue run skips a suite only in one narrow case: the queued merge
+commit's tree is byte-identical to the tip of a generated release branch, and
+a native pull-request run of this workflow already ran that suite successfully at that
+exact SHA. Every guard fails closed (tree mismatch, non-release tip, or any
+Actions-API doubt reruns the suite), so batched merge groups and moved `main`
+always re-run E2E.
+```
+
+with:
+
+```
+Ordinary PRs skip E2E and never inherit an E2E verdict from an earlier
+commit.
+
+Generated release branches and their merge groups use equivalence reuse: a
+suite is skipped when a prior successful native pull-request run of it exists
+on the same branch and the diff since that commit touches only paths that
+provably cannot affect the suite — files in workspace packages outside the
+suite subject's dependency+devDependency closure, or the inert `docs/`,
+`.changeset/`, `*.md` set. Every guard fails closed: an unfetchable commit,
+Actions-API doubt, a fork head, a conclusive failure as the newest verdict,
+or any unrecognised path (root configs, `.github/`, `scripts/`, the
+lockfile) re-runs the suite. Force-pushed refreshes of a release PR after
+unrelated merges to `main` therefore keep their E2E verdicts without
+re-running, while any change that ships in the lane re-runs as before (see
+`scripts/release-e2e-policy.mjs` and
+`docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md`).
+```
+
+- [ ] **Step 2: Full verification**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+pnpm test:scripts
+pnpm knip
+pnpm typecheck
+```
+
+Expected: all pass. (`knip`/`typecheck` should be unaffected — scripts are plain JS and the new exports are consumed by tests — but run them because exports changed and the repo requires it before a PR.)
+
+No changeset is needed: the change touches CI scripts, a workflow, and docs — no publishable package or gated product releases from it. `pnpm check:changesets` passes with no new changeset.
+
+- [ ] **Step 3: Commit**
+
+```bash
+eval "$(fnm env 2>/dev/null)"
+git add CLAUDE.md
+git commit -m "docs: describe release E2E equivalence reuse policy"
+```

--- a/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
@@ -1,0 +1,154 @@
+# Release E2E equivalence reuse
+
+**Date:** 2026-07-17
+**Status:** Approved, not yet implemented
+
+## Problem
+
+Every push to `main` rebuilds every open generated release branch. The
+`product-release-pr` job runs on all main pushes and recreates each
+`changeset-release/<slug>` branch on the new main tip via
+`peter-evans/create-pull-request`; `changesets/action` does the same for the
+library branch `changeset-release/main`. Even when a lane's release content
+(version bump + changelog) is byte-for-byte identical, the parent commit
+changed, so the branch is force-pushed. Each force-push fires a fresh
+`pull_request` run, and because the ref matches `changeset-release/*`, the
+release-only E2E suites re-run — 13–40 minutes across several runners, times
+two or three suites per lane, times every open release PR, on **every** merge
+to main (the open Release Interviewer PR was force-pushed eight times in one
+day). Merging one product's release PR resetting all sibling release PRs is
+the most visible instance, but any merge triggers it.
+
+The refresh itself cannot simply be skipped:
+
+- The merge-queue fast path in `scripts/release-e2e-policy.mjs`
+  (`alreadyValidatedSuites`) only skips queue-time E2E when the queue's merge
+  commit tree is **byte-identical** to a branch tip that passed a native
+  `pull_request` run. Stale branches would push the full E2E cost into the
+  merge queue on every release merge.
+- Release PRs are meant to validate the release against the main they will
+  actually deploy with.
+- The visual-snapshot auto-regeneration flow triggers off release-PR E2E
+  failures, so PR-time E2E must keep running whenever a change could alter
+  suite outcomes.
+- `changesets/action` force-pushes its branch unconditionally; suppressing
+  that would mean forking the action.
+
+## Rejected alternatives
+
+- **Skip no-op branch refreshes** (don't push when version + changelog are
+  unchanged): cannot cover the `changesets/action` library lane — the most
+  expensive one, gated by all three suites — and leaves branches stale, so
+  every release merge pays full E2E in the merge queue and the snapshot
+  auto-regen flow stops firing for main-side regressions.
+- **Merge-queue-only E2E**: failures surface at merge time, every release
+  merge waits out the suites in the queue, and the snapshot auto-regen flow
+  breaks entirely.
+
+## Design
+
+Branch generation is untouched. The decision moves entirely into the
+`e2e-policy` job / `scripts/release-e2e-policy.mjs`: a suite whose outcome
+provably cannot have changed since its last successful run on the same
+release branch is skipped, and the `quality` aggregate accepts that through
+the existing "policy says not required" path. Ordinary PRs are unaffected —
+they still never inherit an E2E verdict.
+
+### The equivalence primitive
+
+Suite **S** may be skipped for candidate head **H** when ALL of the following
+hold. Every failure mode — API error, unfetchable commit, unrecognised path,
+pagination cap — means "run the suite".
+
+1. **Trusted context.** The run is for a generated `changeset-release/*`
+   branch and, on `pull_request` events, the head repository is this
+   repository (fork PRs never get reuse).
+2. **A prior conclusive native run exists.** Walking this branch's prior
+   `pull_request` runs of `ci-and-release.yml` (Actions API, newest first,
+   bounded), take the **newest run whose job for S has a conclusive verdict**
+   (`success`/`failure`/`timed_out`; skipped and cancelled runs are walked
+   past — a policy-skipped suite leaves no conclusive verdict, so chains of
+   skips collapse onto the original native run without provenance tracking).
+   Only a `success` at that run's head SHA **X** can qualify; a conclusive
+   failure means the suite runs — never walk past a failure to an older green.
+3. **The delta cannot affect S.** `git diff --name-only X H` (fetching X by
+   SHA; force-pushed commits remain fetchable) contains only paths that are
+   either
+   - inside a workspace package directory that is **not** in S's relevance
+     closure — the subject package plus its transitive workspace
+     `dependencies` **and** `devDependencies` (dev edges carry Playwright
+     configs and e2e helpers) — or
+   - in the inert set the `test` job already uses: `docs/`, `.changeset/`,
+     `*.md`.
+
+   Anything else is relevant and forces a run: root configs, `.github/`,
+   `scripts/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`,
+   `.nvmrc`, and any path not positively recognised.
+
+4. **Baselines have not moved.** The last commit on `e2e-snapshots/main`
+   predates run X's start time (suites read visual baselines from that
+   branch, so its movement invalidates equivalence). Missing or unreadable
+   ref data fails closed.
+
+### PR time (the fix)
+
+On a `pull_request` run for a release ref, `e2e-policy` applies the primitive
+to each lane-required suite with H = the PR tip, before requiring it. A
+sibling product's release merge (its app dir, changelogs, consumed
+changesets) is outside the other lanes' relevance closures → their refreshes
+skip E2E and `quality` goes green in minutes. A merge touching
+`packages/interview` is inside every lane's closure → all lanes re-run
+exactly as today, preserving the snapshot auto-regen flow.
+
+PR-time comparison uses branch tips rather than the synthetic merge commits
+of the two runs; because release branches are regenerated on top of current
+main, tip and merge trees coincide at refresh time, and any drift from main
+moving mid-window is caught by the queue-time check below.
+
+### Merge-queue time
+
+The byte-identical fast path becomes the trivial case of the same primitive:
+H = the queue's merge commit, with the existing guard that the merge commit's
+second parent is the current tip of a generated release branch. X = the
+newest conclusive native success on that branch (no longer required to be the
+current tip — after a PR-time skip, the tip has no native run of its own, so
+without this generalisation every skip would be repaid with a full queue-time
+re-run). An empty diff reproduces today's behaviour; a batched group whose
+extra changes are irrelevant to S now also skips; anything relevant runs.
+
+### What does not change
+
+- `product-release-pr`, `changesets/action`, and all branch generation.
+- The lane → suites table (`SUITES_BY_RELEASE_REF`) and its graph-derived
+  test.
+- The `quality` aggregate contract and required-check configuration.
+- Ordinary (non-release) PRs: E2E verdicts are still never carried forward.
+- The snapshot auto-regen and snapshot-update-PR flows.
+
+## Testing
+
+Extend `scripts/release-e2e-policy.test.mjs`:
+
+- Relevance closures derived from the real package.json workspace graph (the
+  existing anti-drift pattern), including dev-dependency edges.
+- Skip: diff confined to a non-subject package dir; diff confined to the
+  inert set; empty diff (byte-identical queue case).
+- Run (fail closed): subject-graph path; any root/`.github/`/`scripts/`/
+  lockfile/workspace-config path; unfetchable X; Actions API error or
+  pagination cap; newest conclusive verdict is a failure; snapshot branch
+  moved after X's run started; fork head repo; non-release ref.
+- Chained refreshes: skipped-suite runs are walked past to the older native
+  success and the diff is taken from there.
+
+`scripts/ci-workflow.test.mjs` asserts the workflow wiring (envs passed to
+the policy step for head SHA / head repo, fetch strategy) where practical.
+
+## Documentation
+
+- CLAUDE.md "Release-only E2E checks": replace "E2E verdicts are never
+  carried forward from an earlier commit" with the refined rule — never on
+  ordinary PRs; on generated release branches a suite may be skipped when the
+  current tree is provably equivalent for that suite per the primitive above,
+  failing closed.
+- Header comments in `release-e2e-policy.mjs` describing the primitive and
+  its guards.

--- a/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
@@ -71,19 +71,26 @@ pagination cap — means "run the suite".
    skips collapse onto the original native run without provenance tracking).
    Only a `success` at that run's head SHA **X** can qualify; a conclusive
    failure means the suite runs — never walk past a failure to an older green.
-3. **The delta cannot affect S.** `git diff --name-only X H` (fetching X by
-   SHA; force-pushed commits remain fetchable) contains only paths that are
-   either
+3. **The delta cannot affect S.** `git diff --no-renames --name-only X H`
+   (fetching X by SHA; force-pushed commits remain fetchable) contains only
+   paths that are either
    - inside a workspace package directory that is **not** in S's relevance
      closure — the subject package plus its transitive workspace
-     `dependencies` **and** `devDependencies` (dev edges carry Playwright
-     configs and e2e helpers) — or
+     `dependencies`, `devDependencies`, `peerDependencies`, **and**
+     `optionalDependencies` (dev edges carry Playwright configs and e2e
+     helpers; this repo also declares some workspace edges — e.g. the
+     styling/theme packages an e2e host renders with — as peerDependencies
+     rather than dependencies or devDependencies, so peer edges must be
+     walked too) — or
    - in the inert set the `test` job already uses: `docs/`, `.changeset/`,
      `*.md`.
 
    Anything else is relevant and forces a run: root configs, `.github/`,
    `scripts/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`,
-   `.nvmrc`, and any path not positively recognised.
+   `.nvmrc`, and any path not positively recognised. `--no-renames` matters
+   here: with rename detection on, `git diff --name-only` reports only a
+   renamed file's destination path, so a relevant file moved to an inert path
+   would otherwise vanish from the diff instead of surfacing its source path.
 
 4. **Correction (2026-07-17): no separate baseline guard.** An earlier draft
    required `e2e-snapshots/main` not to have moved since run X. That branch
@@ -132,7 +139,8 @@ extra changes are irrelevant to S now also skips; anything relevant runs.
 Extend `scripts/release-e2e-policy.test.mjs`:
 
 - Relevance closures derived from the real package.json workspace graph (the
-  existing anti-drift pattern), including dev-dependency edges.
+  existing anti-drift pattern), including dev-dependency and
+  peer-dependency edges.
 - Skip: diff confined to a non-subject package dir; diff confined to the
   inert set; empty diff (byte-identical queue case).
 - Run (fail closed): subject-graph path; any root/`.github/`/`scripts/`/

--- a/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
@@ -85,10 +85,12 @@ pagination cap — means "run the suite".
    `scripts/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`,
    `.nvmrc`, and any path not positively recognised.
 
-4. **Baselines have not moved.** The last commit on `e2e-snapshots/main`
-   predates run X's start time (suites read visual baselines from that
-   branch, so its movement invalidates equivalence). Missing or unreadable
-   ref data fails closed.
+4. **Correction (2026-07-17): no separate baseline guard.** An earlier draft
+   required `e2e-snapshots/main` not to have moved since run X. That branch
+   is only the accumulation target for the snapshot-update PR flow; the
+   suites read visual baselines committed in-tree, inside their subject
+   packages' own directories. Baseline movement is therefore already covered
+   by guard 3's diff, and no branch-time guard exists.
 
 ### PR time (the fix)
 
@@ -135,8 +137,8 @@ Extend `scripts/release-e2e-policy.test.mjs`:
   inert set; empty diff (byte-identical queue case).
 - Run (fail closed): subject-graph path; any root/`.github/`/`scripts/`/
   lockfile/workspace-config path; unfetchable X; Actions API error or
-  pagination cap; newest conclusive verdict is a failure; snapshot branch
-  moved after X's run started; fork head repo; non-release ref.
+  pagination cap; newest conclusive verdict is a failure; fork head repo;
+  non-release ref.
 - Chained refreshes: skipped-suite runs are walked past to the older native
   success and the diff is taken from there.
 

--- a/packages/interview/e2e/helpers/protocol-paths.ts
+++ b/packages/interview/e2e/helpers/protocol-paths.ts
@@ -1,20 +1,22 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+const require = createRequire(import.meta.url);
+
 // Single source of truth for the SILOS .netcanvas fixture used by the dev host
-// and any extraction scripts. Resolved relative to this canonical protocols
-// package so it is independent of the caller's working directory.
-export const SILOS_PROTOCOL_PATH = path.resolve(
-  import.meta.dirname,
-  '../../../protocols/e2e/silos/silos_chicago-2026-06-02_17-31.netcanvas',
-);
+// and any extraction scripts. Resolved by package name via
+// createRequire(...).resolve rather than a relative path so knip's
+// dependency-usage analysis credits packages/interview's devDependency on
+// @codaco/protocols — and, load-bearing, so packages/protocols sits inside
+// @codaco/interview's declared dependency closure, keeping fixture changes
+// visible to the release E2E equivalence-reuse classifier.
+export const SILOS_PROTOCOL_PATH =
+  require.resolve('@codaco/protocols/e2e/silos/silos_chicago-2026-06-02_17-31.netcanvas');
 
 export const TARGETED_SKIP_CONSENT_PROTOCOL_PATH = path.resolve(
   import.meta.dirname,
   '../protocols/targeted-skip-consent.json',
 );
-
-const require = createRequire(import.meta.url);
 
 // Single source of truth for the development protocol's assets directory,
 // used by matrix scenarios that need a real image/audio/video/CSV/JSON asset

--- a/packages/interview/e2e/helpers/protocol-paths.ts
+++ b/packages/interview/e2e/helpers/protocol-paths.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 // Single source of truth for the SILOS .netcanvas fixture used by the dev host
@@ -11,4 +12,19 @@ export const SILOS_PROTOCOL_PATH = path.resolve(
 export const TARGETED_SKIP_CONSENT_PROTOCOL_PATH = path.resolve(
   import.meta.dirname,
   '../protocols/targeted-skip-consent.json',
+);
+
+const require = createRequire(import.meta.url);
+
+// Single source of truth for the development protocol's assets directory,
+// used by matrix scenarios that need a real image/audio/video/CSV/JSON asset
+// to attach. Resolved by package name via createRequire(...).resolve rather
+// than a relative path so knip's dependency-usage analysis credits
+// packages/interview's devDependency on @codaco/development-protocol —
+// scenarios only ever read files under its assets/ directory, never import
+// from the package itself, so a plain relative path would leave the
+// dependency looking unused.
+export const DEV_PROTOCOL_ASSETS_DIR = path.join(
+  path.dirname(require.resolve('@codaco/development-protocol')),
+  'assets',
 );

--- a/packages/interview/e2e/matrix/family-pedigree.scenarios.ts
+++ b/packages/interview/e2e/matrix/family-pedigree.scenarios.ts
@@ -12,12 +12,8 @@ import {
 import { FamilyPedigreeFixture } from '../fixtures/family-pedigree-fixture.js';
 import { expect } from '../fixtures/matrix-test.js';
 import type { ProtocolFixture } from '../fixtures/protocol-fixture.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { InterfaceScenarios, ScenarioDefinition } from './types.js';
-
-const DEV_PROTOCOL_ASSETS = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 const ATTR = entityAttributesProperty;
 const PK = entityPrimaryKeyProperty;
@@ -539,7 +535,7 @@ function introScreenAssetImage(): ScenarioDefinition {
         name: 'quadrant',
         type: 'image',
         source: 'quadrant.png',
-        localPath: path.join(DEV_PROTOCOL_ASSETS, 'quadrant.png'),
+        localPath: path.join(DEV_PROTOCOL_ASSETS_DIR, 'quadrant.png'),
       },
     ],
     build: () => si,

--- a/packages/interview/e2e/matrix/information.scenarios.ts
+++ b/packages/interview/e2e/matrix/information.scenarios.ts
@@ -3,12 +3,8 @@ import path from 'node:path';
 import { SyntheticInterview } from '@codaco/protocol-utilities';
 
 import { expect } from '../fixtures/matrix-test.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { InterfaceScenarios } from './types.js';
-
-const DEV_PROTOCOL_ASSETS = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 export const informationScenarios: InterfaceScenarios = {
   interfaceType: 'Information',
@@ -119,7 +115,7 @@ export const informationScenarios: InterfaceScenarios = {
           name: 'quadrant',
           type: 'image',
           source: 'quadrant.png',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'quadrant.png'),
+          localPath: path.join(DEV_PROTOCOL_ASSETS_DIR, 'quadrant.png'),
         },
       ],
       run: async ({ page }) => {
@@ -186,7 +182,7 @@ export const informationScenarios: InterfaceScenarios = {
           name: 'clip',
           type: 'audio',
           source: 'click_the_thing.mp3',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'click_the_thing.mp3'),
+          localPath: path.join(DEV_PROTOCOL_ASSETS_DIR, 'click_the_thing.mp3'),
         },
       ],
       run: async ({ page }) => {
@@ -233,7 +229,7 @@ export const informationScenarios: InterfaceScenarios = {
           name: 'intro',
           type: 'video',
           source: 'withSound.mp4',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'withSound.mp4'),
+          localPath: path.join(DEV_PROTOCOL_ASSETS_DIR, 'withSound.mp4'),
         },
       ],
       run: async ({ page }) => {
@@ -313,7 +309,7 @@ export const informationScenarios: InterfaceScenarios = {
           name: 'quadrant',
           type: 'image',
           source: 'quadrant.png',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'quadrant.png'),
+          localPath: path.join(DEV_PROTOCOL_ASSETS_DIR, 'quadrant.png'),
         },
       ],
       run: async ({ page }) => {

--- a/packages/interview/e2e/matrix/name-generator-quick-add.scenarios.ts
+++ b/packages/interview/e2e/matrix/name-generator-quick-add.scenarios.ts
@@ -7,12 +7,8 @@ import {
 } from '@codaco/shared-consts';
 
 import { expect } from '../fixtures/matrix-test.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { InterfaceScenarios } from './types.js';
-
-const DEV_PROTOCOL_ASSETS = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 export const nameGeneratorQuickAddScenarios: InterfaceScenarios = {
   interfaceType: 'NameGeneratorQuickAdd',
@@ -298,7 +294,10 @@ export const nameGeneratorQuickAddScenarios: InterfaceScenarios = {
           name: 'previousInterview.json',
           type: 'network',
           source: 'previousInterview.json',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'previousInterview.json'),
+          localPath: path.join(
+            DEV_PROTOCOL_ASSETS_DIR,
+            'previousInterview.json',
+          ),
         },
       ],
       run: async ({ page, stage, protocol, interview }) => {

--- a/packages/interview/e2e/matrix/name-generator-roster.scenarios.ts
+++ b/packages/interview/e2e/matrix/name-generator-roster.scenarios.ts
@@ -5,14 +5,11 @@ import { entityAttributesProperty } from '@codaco/shared-consts';
 
 import { expect } from '../fixtures/matrix-test.js';
 import { NameGeneratorRosterFixture } from '../fixtures/name-generator-roster-fixture.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { SyntheticAssetSpec } from '../helpers/synthetic-payload.js';
 import type { InterfaceScenarios } from './types.js';
 
 const DATA_DIR = path.resolve(import.meta.dirname, '../fixtures/data');
-const DEV_PROTOCOL_ASSETS = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 const rosterSmallAsset = (assetId: string): SyntheticAssetSpec => ({
   assetId,
@@ -193,7 +190,10 @@ export const nameGeneratorRosterScenarios: InterfaceScenarios = {
           name: 'Previous Interview CSV',
           type: 'network',
           source: 'previousInterview.csv',
-          localPath: path.join(DEV_PROTOCOL_ASSETS, 'previousInterview.csv'),
+          localPath: path.join(
+            DEV_PROTOCOL_ASSETS_DIR,
+            'previousInterview.csv',
+          ),
         },
         {
           assetId: 'csvRosterCoercion',

--- a/packages/interview/e2e/matrix/network-composer.scenarios.ts
+++ b/packages/interview/e2e/matrix/network-composer.scenarios.ts
@@ -5,13 +5,9 @@ import { entityAttributesProperty } from '@codaco/shared-consts';
 
 import { expect } from '../fixtures/matrix-test.js';
 import { NetworkComposerFixture } from '../fixtures/network-composer-fixture.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { SyntheticAssetSpec } from '../helpers/synthetic-payload.js';
 import type { InterfaceScenarios } from './types.js';
-
-const DEV_PROTOCOL_ASSETS_DIR = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 /** Narrow an unknown attribute value to a canvas {x,y} position. */
 function isPosition(value: unknown): value is { x: number; y: number } {

--- a/packages/interview/e2e/matrix/sociogram.scenarios.ts
+++ b/packages/interview/e2e/matrix/sociogram.scenarios.ts
@@ -11,12 +11,8 @@ import {
 } from '@codaco/shared-consts';
 
 import { expect } from '../fixtures/matrix-test.js';
+import { DEV_PROTOCOL_ASSETS_DIR } from '../helpers/protocol-paths.js';
 import type { InterfaceScenarios, ScenarioDefinition } from './types.js';
-
-const DEV_PROTOCOL_ASSETS_DIR = path.resolve(
-  import.meta.dirname,
-  '../../../development-protocol/assets',
-);
 
 // --- module-private helpers ------------------------------------------------
 

--- a/packages/interview/package.json
+++ b/packages/interview/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "catalog:",
+    "@codaco/development-protocol": "workspace:*",
     "@codaco/fresco-ui": "workspace:*",
     "@codaco/interface-images": "workspace:*",
     "@codaco/protocol-utilities": "workspace:*",

--- a/packages/interview/package.json
+++ b/packages/interview/package.json
@@ -79,6 +79,7 @@
     "@codaco/fresco-ui": "workspace:*",
     "@codaco/interface-images": "workspace:*",
     "@codaco/protocol-utilities": "workspace:*",
+    "@codaco/protocols": "workspace:*",
     "@codaco/tsconfig": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
     "@playwright/test": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1762,6 +1762,9 @@ importers:
       '@codaco/protocol-utilities':
         specifier: workspace:*
         version: link:../protocol-utilities
+      '@codaco/protocols':
+        specifier: workspace:*
+        version: link:../protocols
       '@codaco/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1750,6 +1750,9 @@ importers:
       '@chromatic-com/storybook':
         specifier: 'catalog:'
         version: 5.2.1(storybook@10.5.0(@types/react@19.2.17)(prettier@2.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@codaco/development-protocol':
+        specifier: workspace:*
+        version: link:../development-protocol
       '@codaco/fresco-ui':
         specifier: workspace:*
         version: link:../fresco-ui

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -117,3 +117,18 @@ test('generated release PRs use the dedicated PAT and rely on native PR CI', () 
   assert.doesNotMatch(productReleaseJob, /gh workflow run ci-and-release\.yml/);
   assert.doesNotMatch(productReleaseJob, /actions: write/);
 });
+
+test('e2e-policy receives the equivalence-reuse inputs', () => {
+  const policyJob = job('e2e-policy');
+  assert.ok(policyJob, 'e2e-policy job exists');
+  assert.match(
+    policyJob,
+    /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \}\}/,
+    'policy step receives the PR tip (or merge-group head) as HEAD_SHA',
+  );
+  assert.match(
+    policyJob,
+    /HEAD_REPO: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}/,
+    'policy step receives the head repo for the fork guard',
+  );
+});

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -350,75 +350,17 @@ export function releaseE2EPolicy(
   return { ...suites(), releaseRef: '', snapshotBranch: '' };
 }
 
-// Merge-queue fast path: a release PR's branch head was already fully
-// E2E-validated by the native pull_request run fired when the branch was
-// created/updated (the required `quality` check means the PR could not have
-// been enqueued otherwise). When the queue's merge commit has the SAME TREE
-// as that branch tip — main did not move and nothing else was batched — the
-// queue would re-run the suites against byte-identical code, so each suite
-// whose PR job succeeded on that exact SHA can be skipped.
-//
-// Every guard fails closed (the suite runs):
-//  * the merge commit's tree must equal its second parent's (the PR tip's);
-//  * the PR tip must be the current head of a generated changeset-release/*
-//    branch, so only trusted generated branches — never an arbitrary PR that
-//    happens to bump a version — can satisfy the fast path;
-//  * the succeeded job must belong to a pull_request run of THIS
-//    workflow at that SHA, looked up via the Actions API; any API error
-//    counts as not validated.
-export async function alreadyValidatedSuites({
-  cwd,
-  repository,
-  token,
-  fetcher = fetch,
-}) {
-  const validated = suites();
-
-  const headTree = tryGit(['rev-parse', 'HEAD^{tree}'], cwd);
+// Trust guard for merge-queue reuse: the queued merge's second parent must be
+// the current tip of a generated release branch — never an arbitrary PR that
+// happens to bump a version.
+export function releaseBranchForMergeQueue(cwd) {
   const prTip = tryGit(['rev-parse', 'HEAD^2'], cwd);
-  const prTree = tryGit(['rev-parse', 'HEAD^2^{tree}'], cwd);
-  if (!headTree || !prTip || !prTree || headTree !== prTree) {
-    return validated;
-  }
-
-  const isReleaseBranchTip = Object.keys(SUITES_BY_RELEASE_REF).some(
-    (ref) => tryGit(['rev-parse', `origin/${ref}`], cwd) === prTip,
+  if (!prTip) return '';
+  return (
+    Object.keys(SUITES_BY_RELEASE_REF).find(
+      (ref) => tryGit(['rev-parse', `origin/${ref}`], cwd) === prTip,
+    ) ?? ''
   );
-  if (!isReleaseBranchTip) return validated;
-  if (!repository || !token) return validated;
-
-  const apiOptions = {
-    headers: {
-      accept: 'application/vnd.github+json',
-      authorization: `Bearer ${token}`,
-    },
-  };
-  try {
-    const runsResponse = await fetcher(
-      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=pull_request&head_sha=${prTip}&per_page=100`,
-      apiOptions,
-    );
-    if (!runsResponse.ok) return validated;
-    const { workflow_runs: runs = [] } = await runsResponse.json();
-
-    for (const run of runs) {
-      const jobsResponse = await fetcher(
-        `${run.jobs_url}?per_page=100`,
-        apiOptions,
-      );
-      if (!jobsResponse.ok) continue;
-      const { jobs = [] } = await jobsResponse.json();
-      for (const job of jobs) {
-        if (job.conclusion !== 'success') continue;
-        for (const key of SUITE_KEYS) {
-          if (job.name === E2E_JOB_NAMES[key]) validated[key] = true;
-        }
-      }
-    }
-  } catch {
-    return suites();
-  }
-  return validated;
 }
 
 async function main() {
@@ -431,18 +373,39 @@ async function main() {
     headSha: process.env.HEAD_SHA ?? '',
   });
 
-  if (eventName === 'merge_group' && SUITE_KEYS.some((key) => policy[key])) {
-    const validated = await alreadyValidatedSuites({
-      cwd: process.cwd(),
-      repository: process.env.GITHUB_REPOSITORY ?? '',
-      token: process.env.GH_TOKEN ?? '',
-    });
-    for (const key of SUITE_KEYS) {
-      if (policy[key] && validated[key]) {
-        policy[key] = false;
-        console.error(
-          `${E2E_JOB_NAMES[key]}: skipping — this merge group's tree is identical to a release branch tip it already passed on.`,
-        );
+  if (SUITE_KEYS.some((key) => policy[key])) {
+    const cwd = process.cwd();
+    const repository = process.env.GITHUB_REPOSITORY ?? '';
+    let reuse = null;
+    if (eventName === 'pull_request' && policy.releaseRef) {
+      // Fork PRs never reuse; dispatches are explicit rerun requests and are
+      // not eligible either (eventName gate above).
+      if (
+        (process.env.HEAD_REPO ?? '') === repository &&
+        process.env.HEAD_SHA
+      ) {
+        reuse = { branch: policy.releaseRef, headSha: process.env.HEAD_SHA };
+      }
+    } else if (eventName === 'merge_group') {
+      const branch = releaseBranchForMergeQueue(cwd);
+      const headSha = tryGit(['rev-parse', 'HEAD'], cwd);
+      if (branch && headSha) reuse = { branch, headSha };
+    }
+    if (reuse) {
+      const validated = await equivalentValidatedSuites({
+        cwd,
+        repository,
+        token: process.env.GH_TOKEN ?? '',
+        requiredSuites: policy,
+        ...reuse,
+      });
+      for (const key of SUITE_KEYS) {
+        if (policy[key] && validated[key]) {
+          policy[key] = false;
+          console.error(
+            `${E2E_JOB_NAMES[key]}: skipping — an earlier successful run on ${reuse.branch} validated this suite and nothing relevant to it has changed since.`,
+          );
+        }
       }
     }
   }

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -55,10 +55,16 @@ export function collectWorkspacePackages(cwd) {
       packages.set(manifest.name, {
         dir: `${group}/${entry.name}`,
         // devDependencies participate: they carry Playwright configs, e2e
-        // helpers, and build tooling that shape suite outcomes.
+        // helpers, and build tooling that shape suite outcomes. peer and
+        // optional edges participate too: this repo declares some workspace
+        // edges (e.g. the styling/theme packages an e2e host renders with)
+        // as peerDependencies rather than dependencies or devDependencies.
+        // Non-workspace names harmlessly miss the package map below.
         workspaceDeps: [
           ...Object.keys(manifest.dependencies ?? {}),
           ...Object.keys(manifest.devDependencies ?? {}),
+          ...Object.keys(manifest.peerDependencies ?? {}),
+          ...Object.keys(manifest.optionalDependencies ?? {}),
         ],
       });
     }
@@ -149,7 +155,8 @@ export async function equivalentValidatedSuites({
     const trustedRuns = runs
       .filter((run) => run.head_repository?.full_name === repository)
       .toSorted(
-        (a, b) => Date.parse(b.created_at ?? 0) - Date.parse(a.created_at ?? 0),
+        (a, b) =>
+          Date.parse(b.created_at ?? '') - Date.parse(a.created_at ?? ''),
       );
 
     const jobsByRun = new Map();
@@ -182,8 +189,12 @@ export async function equivalentValidatedSuites({
       }
       if (!candidate?.head_sha) continue;
       if (!ensureCommit(candidate.head_sha, cwd)) continue;
+      // --no-renames: with rename detection on, git lists only a renamed
+      // file's destination path. A relevant file moved to an inert path
+      // (e.g. out of a package directory) would then vanish from the diff
+      // entirely instead of surfacing its source path as changed.
       const diff = tryGit(
-        ['diff', '--name-only', candidate.head_sha, headSha],
+        ['diff', '--no-renames', '--name-only', candidate.head_sha, headSha],
         cwd,
       );
       if (diff === null) continue;

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -1,4 +1,6 @@
 import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 export const SUITE_KEYS = ['interview', 'interviewer', 'architect'];
@@ -17,6 +19,81 @@ const E2E_JOB_NAMES = {
   interviewer: 'interviewer-e2e',
   architect: 'architect-e2e',
 };
+
+const WORKSPACE_GROUPS = ['packages', 'apps', 'tooling', 'workers'];
+
+// Mirrors the `test` job's inert set: docs, changesets, and markdown cannot
+// change what an E2E suite executes or asserts.
+function isInertPath(path) {
+  return (
+    path.startsWith('docs/') ||
+    path.startsWith('.changeset/') ||
+    path.endsWith('.md')
+  );
+}
+
+export function collectWorkspacePackages(cwd) {
+  const packages = new Map();
+  for (const group of WORKSPACE_GROUPS) {
+    let entries;
+    try {
+      entries = readdirSync(join(cwd, group), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      let manifest;
+      try {
+        manifest = JSON.parse(
+          readFileSync(join(cwd, group, entry.name, 'package.json'), 'utf8'),
+        );
+      } catch {
+        continue;
+      }
+      if (typeof manifest.name !== 'string') continue;
+      packages.set(manifest.name, {
+        dir: `${group}/${entry.name}`,
+        // devDependencies participate: they carry Playwright configs, e2e
+        // helpers, and build tooling that shape suite outcomes.
+        workspaceDeps: [
+          ...Object.keys(manifest.dependencies ?? {}),
+          ...Object.keys(manifest.devDependencies ?? {}),
+        ],
+      });
+    }
+  }
+  return packages;
+}
+
+export function relevanceDirsForSubject(subjectName, packages) {
+  const dirs = new Set();
+  const seen = new Set();
+  const queue = [subjectName];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const pkg = packages.get(name);
+    if (!pkg) continue;
+    dirs.add(pkg.dir);
+    queue.push(...pkg.workspaceDeps);
+  }
+  return dirs;
+}
+
+// True only when EVERY changed path provably cannot affect the suite: it is
+// inert, or it lives inside a workspace package outside the suite's relevance
+// closure. Any other path — root configs, .github/, scripts/, the lockfile,
+// anything unrecognised — is relevant, so the suite runs (fail closed).
+export function diffIrrelevantToSuite(changedPaths, relevanceDirs, packages) {
+  const packageDirs = [...packages.values()].map((pkg) => pkg.dir);
+  return changedPaths.every((changedPath) => {
+    if (isInertPath(changedPath)) return true;
+    const owner = packageDirs.find((dir) => changedPath.startsWith(`${dir}/`));
+    return owner !== undefined && !relevanceDirs.has(owner);
+  });
+}
 
 function suites(...keys) {
   return Object.fromEntries(SUITE_KEYS.map((key) => [key, keys.includes(key)]));

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -43,14 +43,34 @@ export function collectWorkspacePackages(cwd) {
     }
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
+      // ENOENT (no package.json) means this directory is simply not a pnpm
+      // workspace member — continue silently, matching pnpm's own glob
+      // semantics. Any other read failure, or a parse failure on a manifest
+      // that IS present, means the workspace graph is broken and must not be
+      // silently treated as empty: that would misclassify every path inside
+      // it as "outside every workspace package", which fails OPEN for
+      // equivalence reuse. Propagate so the caller fails closed instead.
+      const manifestPath = join(cwd, group, entry.name, 'package.json');
+      let raw;
+      try {
+        raw = readFileSync(manifestPath, 'utf8');
+      } catch (error) {
+        if (error.code === 'ENOENT') continue;
+        throw error;
+      }
       let manifest;
       try {
-        manifest = JSON.parse(
-          readFileSync(join(cwd, group, entry.name, 'package.json'), 'utf8'),
+        manifest = JSON.parse(raw);
+      } catch (error) {
+        throw new Error(
+          `Unable to read workspace manifest ${group}/${entry.name}/package.json`,
+          { cause: error },
         );
-      } catch {
-        continue;
       }
+      // pnpm tolerates nameless private workspace members. Such a package can
+      // never be depended on, and the fail-closed diff path already treats
+      // its directory as unrecognised (and therefore relevant), so skipping
+      // it here does not weaken equivalence reuse.
       if (typeof manifest.name !== 'string') continue;
       packages.set(manifest.name, {
         dir: `${group}/${entry.name}`,
@@ -166,16 +186,27 @@ export async function equivalentValidatedSuites({
           `${run.jobs_url}?per_page=100`,
           apiOptions,
         );
-        jobsByRun.set(
-          run.id,
-          jobsResponse.ok ? ((await jobsResponse.json()).jobs ?? []) : null,
-        );
+        if (!jobsResponse.ok) {
+          jobsByRun.set(run.id, null);
+        } else {
+          // A run with more than one page of jobs could hide a conclusive
+          // FAILURE beyond this page, letting the walk wrongly continue to an
+          // older green. Treat a truncated listing as API doubt (null; fails
+          // closed) rather than trusting the partial page.
+          const { jobs = [], total_count: totalCount = jobs.length } =
+            await jobsResponse.json();
+          jobsByRun.set(run.id, totalCount > jobs.length ? null : jobs);
+        }
       }
       return jobsByRun.get(run.id);
     };
 
     const packages = collectWorkspacePackages(cwd);
     for (const key of required) {
+      // If the suite's own subject package isn't in the discovered graph, no
+      // relevance judgment about it can be trusted — fail closed rather than
+      // reason about a closure that's missing its own root.
+      if (!packages.has(E2E_SUITE_SUBJECTS[key])) continue;
       // The newest conclusive verdict is authoritative: a failure is never
       // walked past to an older green.
       let candidate = null;

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -95,6 +95,113 @@ export function diffIrrelevantToSuite(changedPaths, relevanceDirs, packages) {
   });
 }
 
+const CONCLUSIVE = new Set(['success', 'failure', 'timed_out']);
+// One bounded page of the branch's runs. A verdict older than this is stale
+// enough that re-running is the right call anyway (fail closed past the cap).
+const MAX_RUNS_SCANNED = 50;
+
+function ensureCommit(sha, cwd) {
+  if (tryGit(['rev-parse', '--verify', `${sha}^{commit}`], cwd)) return true;
+  // Force-pushed-away release tips stay fetchable by SHA on GitHub.
+  tryGit(['fetch', '--depth=1', 'origin', sha], cwd);
+  return tryGit(['rev-parse', '--verify', `${sha}^{commit}`], cwd) !== null;
+}
+
+// Equivalence reuse: suite S may be skipped at head H when the newest
+// conclusive native pull_request run of S on this generated release branch
+// succeeded at commit X and diff(X→H) touches only paths that provably
+// cannot affect S (see diffIrrelevantToSuite). Every failure mode — missing
+// input, API error, unfetchable commit, conclusive failure, fork run —
+// leaves the suite required (fail closed). Visual baselines are committed
+// in-tree inside the subject packages, so the diff covers them too.
+export async function equivalentValidatedSuites({
+  cwd,
+  repository,
+  token,
+  branch,
+  headSha,
+  requiredSuites,
+  fetcher = fetch,
+}) {
+  const validated = suites();
+  if (!repository || !token || !branch || !headSha) return validated;
+  const required = SUITE_KEYS.filter((key) => requiredSuites[key]);
+  if (required.length === 0) return validated;
+  if (!ensureCommit(headSha, cwd)) return validated;
+
+  const apiOptions = {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+    },
+  };
+  try {
+    const runsResponse = await fetcher(
+      `https://api.github.com/repos/${repository}/actions/workflows/ci-and-release.yml/runs?event=pull_request&branch=${encodeURIComponent(branch)}&per_page=${MAX_RUNS_SCANNED}`,
+      apiOptions,
+    );
+    if (!runsResponse.ok) return validated;
+    const { workflow_runs: runs = [] } = await runsResponse.json();
+
+    // Same-repo runs only: a fork branch may share the generated branch's
+    // name, but its runs must never vouch for ours. Sort defensively even
+    // though the API returns newest-first.
+    const trustedRuns = runs
+      .filter((run) => run.head_repository?.full_name === repository)
+      .toSorted(
+        (a, b) => Date.parse(b.created_at ?? 0) - Date.parse(a.created_at ?? 0),
+      );
+
+    const jobsByRun = new Map();
+    const jobsFor = async (run) => {
+      if (!jobsByRun.has(run.id)) {
+        const jobsResponse = await fetcher(
+          `${run.jobs_url}?per_page=100`,
+          apiOptions,
+        );
+        jobsByRun.set(
+          run.id,
+          jobsResponse.ok ? ((await jobsResponse.json()).jobs ?? []) : null,
+        );
+      }
+      return jobsByRun.get(run.id);
+    };
+
+    const packages = collectWorkspacePackages(cwd);
+    for (const key of required) {
+      // The newest conclusive verdict is authoritative: a failure is never
+      // walked past to an older green.
+      let candidate = null;
+      for (const run of trustedRuns) {
+        const jobs = await jobsFor(run);
+        if (jobs === null) break;
+        const job = jobs.find((j) => j.name === E2E_JOB_NAMES[key]);
+        if (!job || !CONCLUSIVE.has(job.conclusion)) continue;
+        if (job.conclusion === 'success') candidate = run;
+        break;
+      }
+      if (!candidate?.head_sha) continue;
+      if (!ensureCommit(candidate.head_sha, cwd)) continue;
+      const diff = tryGit(
+        ['diff', '--name-only', candidate.head_sha, headSha],
+        cwd,
+      );
+      if (diff === null) continue;
+      const changedPaths = diff.split('\n').filter(Boolean);
+      const relevanceDirs = relevanceDirsForSubject(
+        E2E_SUITE_SUBJECTS[key],
+        packages,
+      );
+      if (diffIrrelevantToSuite(changedPaths, relevanceDirs, packages)) {
+        validated[key] = true;
+      }
+    }
+  } catch {
+    return suites();
+  }
+  return validated;
+}
+
 function suites(...keys) {
   return Object.fromEntries(SUITE_KEYS.map((key) => [key, keys.includes(key)]));
 }

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -16,6 +16,7 @@ import {
   alreadyValidatedSuites,
   collectWorkspacePackages,
   diffIrrelevantToSuite,
+  equivalentValidatedSuites,
   E2E_SUITE_SUBJECTS,
   mergeGroupRequiredSuites,
   releaseE2EPolicy,
@@ -543,4 +544,296 @@ test('diff classification is fail-closed', () => {
 
   // An empty diff is trivially irrelevant (byte-identical case).
   assert.equal(diffIrrelevantToSuite([], relevance, packages), true);
+});
+
+// A fake Actions REST API: one runs-listing endpoint plus per-run jobs
+// endpoints, keyed by run id embedded in jobs_url.
+function fakeActionsApi({
+  runs,
+  jobsByRun,
+  failRuns = false,
+  failJobs = false,
+}) {
+  return async (url) => {
+    if (url.includes('/actions/workflows/')) {
+      if (failRuns) return { ok: false };
+      assert.match(url, /[?&]event=pull_request(?:&|$)/);
+      assert.match(url, /[?&]branch=changeset-release%2F/);
+      return { ok: true, json: async () => ({ workflow_runs: runs }) };
+    }
+    if (failJobs) return { ok: false };
+    const runId = url.match(/\/fake-jobs\/(\d+)\?/)?.[1];
+    return { ok: true, json: async () => ({ jobs: jobsByRun[runId] ?? [] }) };
+  };
+}
+
+// Higher id = newer run (created_at day tracks the id).
+function fakeRun(
+  id,
+  headSha,
+  createdAt = `2026-07-${String(id).padStart(2, '0')}T00:00:00Z`,
+) {
+  return {
+    id,
+    head_sha: headSha,
+    created_at: createdAt,
+    head_repository: { full_name: 'example/repo' },
+    jobs_url: `https://api.example.com/fake-jobs/${id}`,
+  };
+}
+
+// Release-branch history with a real workspace graph committed, so the
+// primitive can classify diffs: interviewer + architect apps both depend on
+// the interview package.
+function initReleaseBranchRepo() {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'packages/interview/package.json',
+    '{"name":"@codaco/interview","version":"1.0.0"}\n',
+    'add interview',
+  );
+  commitManifest(
+    cwd,
+    'apps/interviewer/package.json',
+    '{"name":"@codaco/interviewer","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add interviewer',
+  );
+  const validatedSha = commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add architect',
+  );
+  return { cwd, validatedSha };
+}
+
+const INTERVIEWER_LANE = {
+  interview: true,
+  interviewer: true,
+  architect: false,
+};
+
+function interviewerLaneCall(cwd, headSha, fetcher) {
+  return equivalentValidatedSuites({
+    cwd,
+    repository: 'example/repo',
+    token: 'token',
+    branch: 'changeset-release/interviewer',
+    headSha,
+    requiredSuites: INTERVIEWER_LANE,
+    fetcher,
+  });
+}
+
+const INTERVIEWER_LANE_SUCCESS_JOBS = [
+  { name: 'interview-e2e', conclusion: 'success' },
+  { name: 'interviewer-e2e', conclusion: 'success' },
+  { name: 'quality', conclusion: 'success' },
+];
+
+test('equivalence reuse skips suites when the delta cannot affect them', async () => {
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  // Sibling release merge shape: architect bump + consumed changeset + docs.
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.1","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'sibling release',
+  );
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/config.md',
+    'consumed\n',
+    'changesets',
+  );
+
+  const fetcher = fakeActionsApi({
+    runs: [fakeRun(1, validatedSha)],
+    jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+  });
+  assert.deepEqual(await interviewerLaneCall(cwd, headSha, fetcher), {
+    interview: true,
+    interviewer: true,
+    architect: false,
+  });
+
+  // Byte-identical head (re-run at the validated SHA) is the trivial case.
+  assert.deepEqual(await interviewerLaneCall(cwd, validatedSha, fetcher), {
+    interview: true,
+    interviewer: true,
+    architect: false,
+  });
+});
+
+test('equivalence reuse fails closed on relevant or unrecognised deltas', async () => {
+  const relevant = initReleaseBranchRepo();
+  const relevantHead = commitManifest(
+    relevant.cwd,
+    'packages/interview/src/index.ts',
+    'export {};\n',
+    'interview change',
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      relevant.cwd,
+      relevantHead,
+      fakeActionsApi({
+        runs: [fakeRun(1, relevant.validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+
+  const unrecognised = initReleaseBranchRepo();
+  const unrecognisedHead = commitManifest(
+    unrecognised.cwd,
+    'scripts/new-tool.mjs',
+    'export {};\n',
+    'root script',
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      unrecognised.cwd,
+      unrecognisedHead,
+      fakeActionsApi({
+        runs: [fakeRun(1, unrecognised.validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+});
+
+test('the newest conclusive verdict is authoritative', async () => {
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/x.md',
+    'irrelevant\n',
+    'refresh',
+  );
+
+  // Newest conclusive run FAILED interviewer-e2e: never walk past it to the
+  // older green, even though the diff is irrelevant.
+  const failedThenGreen = fakeActionsApi({
+    runs: [fakeRun(2, headSha), fakeRun(1, validatedSha)],
+    jobsByRun: {
+      2: [
+        { name: 'interview-e2e', conclusion: 'success' },
+        { name: 'interviewer-e2e', conclusion: 'failure' },
+      ],
+      1: INTERVIEWER_LANE_SUCCESS_JOBS,
+    },
+  });
+  assert.deepEqual(await interviewerLaneCall(cwd, headSha, failedThenGreen), {
+    interview: true,
+    interviewer: false,
+    architect: false,
+  });
+
+  // Non-conclusive runs (cancelled / in-flight / policy-skipped) are walked
+  // past to the older native success.
+  const cancelledThenGreen = fakeActionsApi({
+    runs: [fakeRun(2, headSha), fakeRun(1, validatedSha)],
+    jobsByRun: {
+      2: [
+        { name: 'interview-e2e', conclusion: 'cancelled' },
+        { name: 'interviewer-e2e', conclusion: 'skipped' },
+      ],
+      1: INTERVIEWER_LANE_SUCCESS_JOBS,
+    },
+  });
+  assert.deepEqual(
+    await interviewerLaneCall(cwd, headSha, cancelledThenGreen),
+    {
+      interview: true,
+      interviewer: true,
+      architect: false,
+    },
+  );
+});
+
+test('equivalence reuse trusts only same-repo runs and healthy inputs', async () => {
+  const none = { interview: false, interviewer: false, architect: false };
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/x.md',
+    'irrelevant\n',
+    'refresh',
+  );
+
+  // Fork runs sharing the branch name never vouch for ours.
+  const forkRun = {
+    ...fakeRun(1, validatedSha),
+    head_repository: { full_name: 'attacker/fork' },
+  };
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [forkRun],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    none,
+  );
+
+  // An unfetchable validated commit fails closed (no origin remote here, so
+  // the fetch fallback cannot resolve it).
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, '0123456789abcdef0123456789abcdef01234567')],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    none,
+  );
+
+  // Actions API failures (runs listing or jobs listing) fail closed.
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({ runs: [], jobsByRun: {}, failRuns: true }),
+    ),
+    none,
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+        failJobs: true,
+      }),
+    ),
+    none,
+  );
+  assert.deepEqual(
+    await interviewerLaneCall(cwd, headSha, async () => {
+      throw new Error('network down');
+    }),
+    none,
+  );
+
+  // Missing inputs fail closed.
+  assert.deepEqual(
+    await equivalentValidatedSuites({
+      cwd,
+      repository: '',
+      token: '',
+      branch: '',
+      headSha: '',
+      requiredSuites: INTERVIEWER_LANE,
+    }),
+    none,
+  );
 });

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -308,6 +308,15 @@ test('ordinary events do not require release E2E', () => {
 // Returns the branch tip so tests can point origin/changeset-release/* at it.
 function initMergeQueueRepo({ advanceMainWith = '' } = {}) {
   const cwd = initRepo();
+  // @codaco/interview must be a real discovered package: equivalence reuse
+  // now refuses to trust a relevance judgment about a suite whose subject is
+  // missing from the graph entirely.
+  commitManifest(
+    cwd,
+    'packages/interview/package.json',
+    '{"name":"@codaco/interview","version":"1.0.0"}\n',
+    'add interview',
+  );
   commitManifest(
     cwd,
     'apps/architect/package.json',
@@ -467,12 +476,20 @@ function writeWorkspaceFixture() {
     mkdirSync(join(cwd, file, '..'), { recursive: true });
     writeFileSync(join(cwd, file), `${JSON.stringify(contents)}\n`);
   }
+  // A workspace group can contain a directory with no package.json at all
+  // (e.g. a scratch or generated directory). pnpm's own glob semantics
+  // tolerate this, so discovery must too: ENOENT reading the manifest is not
+  // a broken workspace member, just a directory that isn't one.
+  mkdirSync(join(cwd, 'packages/no-manifest'), { recursive: true });
   return cwd;
 }
 
 test('relevance closure follows dependencies, devDependencies, and peerDependencies', () => {
   const cwd = writeWorkspaceFixture();
   const packages = collectWorkspacePackages(cwd);
+  // The fixture's packages/no-manifest directory (no package.json) is
+  // tolerated silently and does not appear as a discovered package.
+  assert.equal(packages.size, 5);
   assert.deepEqual(
     [...relevanceDirsForSubject('@codaco/interviewer', packages)].toSorted(
       (a, b) => a.localeCompare(b),
@@ -559,10 +576,13 @@ test('diff classification is fail-closed', () => {
 });
 
 // A fake Actions REST API: one runs-listing endpoint plus per-run jobs
-// endpoints, keyed by run id embedded in jobs_url.
+// endpoints, keyed by run id embedded in jobs_url. totalCountByRun defaults
+// each run's total_count to its own jobs array length, matching a
+// single-page response, so existing callers are unaffected.
 function fakeActionsApi({
   runs,
   jobsByRun,
+  totalCountByRun = {},
   failRuns = false,
   failJobs = false,
 }) {
@@ -575,7 +595,14 @@ function fakeActionsApi({
     }
     if (failJobs) return { ok: false };
     const runId = url.match(/\/fake-jobs\/(\d+)\?/)?.[1];
-    return { ok: true, json: async () => ({ jobs: jobsByRun[runId] ?? [] }) };
+    const jobs = jobsByRun[runId] ?? [];
+    return {
+      ok: true,
+      json: async () => ({
+        jobs,
+        total_count: totalCountByRun[runId] ?? jobs.length,
+      }),
+    };
   };
 }
 
@@ -895,4 +922,120 @@ test('a relevant file renamed to an inert path still forces the suite to run', a
     headSha,
   );
   assert.equal(renameCollapsed, 'docs/feature.ts');
+});
+
+test('equivalence reuse fails closed when a workspace manifest is malformed', async () => {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'packages/interview/package.json',
+    '{"name":"@codaco/interview","version":"1.0.0"}\n',
+    'add interview',
+  );
+  commitManifest(
+    cwd,
+    'apps/interviewer/package.json',
+    '{"name":"@codaco/interviewer","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add interviewer',
+  );
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:*"}}\n',
+    'add architect',
+  );
+  // The broken manifest is committed BEFORE the validated SHA is captured,
+  // so it is unchanged between validatedSha and headSha — the scenario where
+  // the old silent-skip in collectWorkspacePackages could go fail-open even
+  // though nothing in the actual diff touches it.
+  const validatedSha = commitManifest(
+    cwd,
+    'packages/broken/package.json',
+    'not json',
+    'add malformed manifest',
+  );
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/x.md',
+    'irrelevant\n',
+    'refresh',
+  );
+
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+});
+
+test('equivalence reuse rejects a suite whose subject package is missing from the workspace graph', async () => {
+  const cwd = initRepo();
+  const validatedSha = commitManifest(
+    cwd,
+    'packages/other/package.json',
+    '{"name":"@codaco/other","version":"1.0.0"}\n',
+    'add unrelated package',
+  );
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/x.md',
+    'irrelevant\n',
+    'refresh',
+  );
+
+  // The graph never contains @codaco/interview at all, so no relevance
+  // judgment about the interview suite can be trusted — reuse must be
+  // rejected even though the diff itself is inert and the fake API reports a
+  // conclusive success.
+  assert.deepEqual(
+    await equivalentValidatedSuites({
+      cwd,
+      repository: 'example/repo',
+      token: 'token',
+      branch: 'changeset-release/interviewer',
+      headSha,
+      requiredSuites: {
+        interview: true,
+        interviewer: false,
+        architect: false,
+      },
+      fetcher: fakeActionsApi({
+        runs: [fakeRun(1, validatedSha)],
+        jobsByRun: { 1: [{ name: 'interview-e2e', conclusion: 'success' }] },
+      }),
+    }),
+    { interview: false, interviewer: false, architect: false },
+  );
+});
+
+test('equivalence reuse fails closed when a jobs listing is truncated', async () => {
+  const { cwd, validatedSha } = initReleaseBranchRepo();
+  const headSha = commitManifest(
+    cwd,
+    '.changeset/x.md',
+    'irrelevant\n',
+    'refresh',
+  );
+
+  // The jobs page reports fewer jobs than total_count claims: a conclusive
+  // FAILURE for interviewer-e2e could be sitting beyond this page, so the
+  // listing must be treated as API doubt rather than trusted as-is.
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, validatedSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+        totalCountByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS.length + 1 },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
 });

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -151,13 +151,15 @@ test('release lane suites match the workspace dependency graph', () => {
 });
 
 test('interview relevance closure covers peer-declared and asset-only workspace edges', () => {
-  // Anti-drift guard for two review findings: tooling/tailwind is a
+  // Anti-drift guard for review findings: tooling/tailwind is a
   // peerDependency of @codaco/interview (the theme tokens the e2e host
-  // renders with) rather than a dependency/devDependency, and
+  // renders with) rather than a dependency/devDependency,
   // @codaco/development-protocol is a devDependency the e2e matrix scenarios
-  // resolve by package name to reach fixture assets. Reading the real
-  // package.json graph means a future edge-type or dependency drop is caught
-  // here instead of silently classifying a relevant change as irrelevant.
+  // resolve by package name to reach fixture assets, and @codaco/protocols
+  // is a devDependency the e2e SILOS fixture resolves by package name.
+  // Reading the real package.json graph means a future edge-type or
+  // dependency drop is caught here instead of silently classifying a
+  // relevant change as irrelevant.
   const dirs = relevanceDirsForSubject(
     '@codaco/interview',
     collectWorkspacePackages(REPO_ROOT),
@@ -169,6 +171,10 @@ test('interview relevance closure covers peer-declared and asset-only workspace 
   assert.ok(
     dirs.has('packages/development-protocol'),
     'packages/development-protocol (devDependency) is in the interview closure',
+  );
+  assert.ok(
+    dirs.has('packages/protocols'),
+    'packages/protocols (devDependency) is in the interview closure',
   );
 });
 

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -14,10 +14,13 @@ import { fileURLToPath } from 'node:url';
 
 import {
   alreadyValidatedSuites,
+  collectWorkspacePackages,
+  diffIrrelevantToSuite,
   E2E_SUITE_SUBJECTS,
   mergeGroupRequiredSuites,
   releaseE2EPolicy,
   releaseRefForEvent,
+  relevanceDirsForSubject,
   SUITE_KEYS,
   SUITES_BY_RELEASE_REF,
 } from './release-e2e-policy.mjs';
@@ -425,4 +428,119 @@ test('merge-queue skip fails closed', async () => {
     ),
     none,
   );
+});
+
+// Scaffold a repo-shaped directory tree (no git needed for these tests):
+// interviewer app depends on the interview package; architect app is a
+// sibling product that also depends on interview.
+function writeWorkspaceFixture() {
+  const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-graph-'));
+  const manifests = {
+    'packages/interview/package.json': {
+      name: '@codaco/interview',
+      version: '1.0.0',
+      devDependencies: { '@codaco/e2e-helpers': 'workspace:*' },
+    },
+    'packages/e2e-helpers/package.json': {
+      name: '@codaco/e2e-helpers',
+      version: '1.0.0',
+    },
+    'apps/interviewer/package.json': {
+      name: '@codaco/interviewer',
+      version: '1.0.0',
+      dependencies: { '@codaco/interview': 'workspace:*' },
+    },
+    'apps/architect/package.json': {
+      name: '@codaco/architect',
+      version: '1.0.0',
+      dependencies: { '@codaco/interview': 'workspace:*' },
+    },
+  };
+  for (const [file, contents] of Object.entries(manifests)) {
+    mkdirSync(join(cwd, file, '..'), { recursive: true });
+    writeFileSync(join(cwd, file), `${JSON.stringify(contents)}\n`);
+  }
+  return cwd;
+}
+
+test('relevance closure follows dependencies and devDependencies', () => {
+  const cwd = writeWorkspaceFixture();
+  const packages = collectWorkspacePackages(cwd);
+  assert.deepEqual(
+    [...relevanceDirsForSubject('@codaco/interviewer', packages)].toSorted(
+      (a, b) => a.localeCompare(b),
+    ),
+    ['apps/interviewer', 'packages/e2e-helpers', 'packages/interview'],
+  );
+  // devDependency edge: interview pulls in its e2e helpers.
+  assert.deepEqual(
+    [...relevanceDirsForSubject('@codaco/interview', packages)].toSorted(
+      (a, b) => a.localeCompare(b),
+    ),
+    ['packages/e2e-helpers', 'packages/interview'],
+  );
+});
+
+test('diff classification is fail-closed', () => {
+  const cwd = writeWorkspaceFixture();
+  const packages = collectWorkspacePackages(cwd);
+  const relevance = relevanceDirsForSubject('@codaco/interviewer', packages);
+
+  // Sibling-product and inert paths cannot affect the interviewer suite.
+  assert.equal(
+    diffIrrelevantToSuite(
+      [
+        'apps/architect/package.json',
+        'apps/architect/CHANGELOG.md',
+        '.changeset/lucky-pandas-dance.md',
+        'docs/superpowers/specs/example.md',
+        'README.md',
+      ],
+      relevance,
+      packages,
+    ),
+    true,
+  );
+
+  // Anything in the closure is relevant — including non-markdown baselines.
+  for (const relevantPath of [
+    'apps/interviewer/src/main.tsx',
+    'packages/interview/e2e/baseline.png',
+    'packages/e2e-helpers/src/index.ts',
+  ]) {
+    assert.equal(
+      diffIrrelevantToSuite([relevantPath], relevance, packages),
+      false,
+      `${relevantPath} must be relevant`,
+    );
+  }
+
+  // Paths outside every workspace package fail closed.
+  for (const unrecognised of [
+    '.github/workflows/ci-and-release.yml',
+    'scripts/release-e2e-policy.mjs',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'turbo.json',
+    '.nvmrc',
+  ]) {
+    assert.equal(
+      diffIrrelevantToSuite([unrecognised], relevance, packages),
+      false,
+      `${unrecognised} must be relevant`,
+    );
+  }
+
+  // One relevant path among many irrelevant ones is enough to run.
+  assert.equal(
+    diffIrrelevantToSuite(
+      ['apps/architect/package.json', 'pnpm-lock.yaml'],
+      relevance,
+      packages,
+    ),
+    false,
+  );
+
+  // An empty diff is trivially irrelevant (byte-identical case).
+  assert.equal(diffIrrelevantToSuite([], relevance, packages), true);
 });

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -13,12 +13,12 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
-  alreadyValidatedSuites,
   collectWorkspacePackages,
   diffIrrelevantToSuite,
   equivalentValidatedSuites,
   E2E_SUITE_SUBJECTS,
   mergeGroupRequiredSuites,
+  releaseBranchForMergeQueue,
   releaseE2EPolicy,
   releaseRefForEvent,
   relevanceDirsForSubject,
@@ -49,10 +49,6 @@ function commitManifest(cwd, manifest, contents, message) {
   git(cwd, 'add', '.');
   git(cwd, 'commit', '-qm', message);
   return git(cwd, 'rev-parse', 'HEAD');
-}
-
-function suiteFlags(policy) {
-  return Object.fromEntries(SUITE_KEYS.map((key) => [key, policy[key]]));
 }
 
 test('recognises only the generated release PR refs', () => {
@@ -282,7 +278,7 @@ test('ordinary events do not require release E2E', () => {
 // Build a repo shaped like a merge-queue checkout: main, a release branch
 // with a version bump, and a merge commit of the branch into main (HEAD).
 // Returns the branch tip so tests can point origin/changeset-release/* at it.
-function initMergeQueueRepo({ advanceMainBeforeMerge = false } = {}) {
+function initMergeQueueRepo({ advanceMainWith = '' } = {}) {
   const cwd = initRepo();
   commitManifest(
     cwd,
@@ -298,31 +294,45 @@ function initMergeQueueRepo({ advanceMainBeforeMerge = false } = {}) {
     'version architect',
   );
   git(cwd, 'checkout', '-q', 'main');
-  if (advanceMainBeforeMerge) {
-    commitManifest(cwd, 'README.md', 'moved\n', 'main moved');
+  if (advanceMainWith) {
+    commitManifest(cwd, advanceMainWith, 'moved\n', 'main moved');
   }
   git(cwd, 'merge', '-q', '--no-ff', '--no-edit', 'release');
   return { cwd, branchTip };
 }
 
-function fakeGitHub({ jobs, failRuns = false }) {
-  return async (url) => {
-    if (failRuns) return { ok: false };
-    if (url.includes('/actions/workflows/')) {
-      assert.match(url, /[?&]event=pull_request(?:&|$)/);
-      assert.doesNotMatch(url, /[?&]event=workflow_dispatch(?:&|$)/);
-      return {
-        ok: true,
-        json: async () => ({
-          workflow_runs: [{ jobs_url: 'https://api.example.com/jobs' }],
-        }),
-      };
-    }
-    return { ok: true, json: async () => ({ jobs }) };
-  };
+function architectLaneQueueCall(cwd, fetcher) {
+  const branch = releaseBranchForMergeQueue(cwd);
+  return equivalentValidatedSuites({
+    cwd,
+    repository: 'example/repo',
+    token: 'token',
+    branch,
+    headSha: git(cwd, 'rev-parse', 'HEAD'),
+    requiredSuites: { interview: true, interviewer: false, architect: true },
+    fetcher,
+  });
 }
 
-test('merge-queue skip validates suites from the native PR run', async () => {
+const ARCHITECT_LANE_SUCCESS_JOBS = [
+  { name: 'architect-e2e', conclusion: 'success' },
+  { name: 'interview-e2e', conclusion: 'success' },
+  { name: 'quality', conclusion: 'success' },
+];
+
+test('merge queue identifies the release lane from the merge second parent', () => {
+  const { cwd, branchTip } = initMergeQueueRepo();
+  assert.equal(releaseBranchForMergeQueue(cwd), '');
+  git(
+    cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    branchTip,
+  );
+  assert.equal(releaseBranchForMergeQueue(cwd), 'changeset-release/architect');
+});
+
+test('merge-queue reuse skips suites validated at the branch tip', async () => {
   const { cwd, branchTip } = initMergeQueueRepo();
   git(
     cwd,
@@ -330,105 +340,68 @@ test('merge-queue skip validates suites from the native PR run', async () => {
     'refs/remotes/origin/changeset-release/architect',
     branchTip,
   );
+  // The merge added nothing beyond the branch: empty diff, trivial case.
   assert.deepEqual(
-    await alreadyValidatedSuites({
+    await architectLaneQueueCall(
       cwd,
-      repository: 'example/repo',
-      token: 'token',
-      fetcher: fakeGitHub({
-        jobs: [
-          { name: 'architect-e2e', conclusion: 'success' },
-          { name: 'interview-e2e', conclusion: 'success' },
-          { name: 'interviewer-e2e', conclusion: 'failure' },
-          { name: 'quality', conclusion: 'success' },
-        ],
+      fakeActionsApi({
+        runs: [fakeRun(1, branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
       }),
-    }),
+    ),
     { interview: true, interviewer: false, architect: true },
   );
 });
 
-test('merge-queue skip fails closed', async () => {
-  const none = { interview: false, interviewer: false, architect: false };
-  const validatedJobs = [
-    { name: 'architect-e2e', conclusion: 'success' },
-    { name: 'interview-e2e', conclusion: 'success' },
-    { name: 'interviewer-e2e', conclusion: 'success' },
-  ];
-
-  // Main moved under the release PR: the merge tree no longer matches the
-  // validated branch tip.
-  const moved = initMergeQueueRepo({ advanceMainBeforeMerge: true });
+test('merge-queue reuse classifies batched main movement by relevance', async () => {
+  // Main moved with a file inside the architect subject: the architect suite
+  // re-runs. The interview suite may still skip — apps/architect is outside
+  // the interview package's closure, so its e2e outcome cannot change.
+  const relevant = initMergeQueueRepo({
+    advanceMainWith: 'apps/architect/src/main.tsx',
+  });
   git(
-    moved.cwd,
+    relevant.cwd,
     'update-ref',
     'refs/remotes/origin/changeset-release/architect',
-    moved.branchTip,
+    relevant.branchTip,
   );
   assert.deepEqual(
-    await alreadyValidatedSuites({
-      cwd: moved.cwd,
-      repository: 'example/repo',
-      token: 'token',
-      fetcher: fakeGitHub({ jobs: validatedJobs }),
-    }),
-    none,
-  );
-
-  // The PR tip is not a generated release branch head: an ordinary PR that
-  // bumps a version must never satisfy the fast path.
-  const untrusted = initMergeQueueRepo();
-  assert.deepEqual(
-    await alreadyValidatedSuites({
-      cwd: untrusted.cwd,
-      repository: 'example/repo',
-      token: 'token',
-      fetcher: fakeGitHub({ jobs: validatedJobs }),
-    }),
-    none,
-  );
-
-  // API errors count as not validated.
-  const apiDown = initMergeQueueRepo();
-  git(
-    apiDown.cwd,
-    'update-ref',
-    'refs/remotes/origin/changeset-release/architect',
-    apiDown.branchTip,
-  );
-  assert.deepEqual(
-    await alreadyValidatedSuites({
-      cwd: apiDown.cwd,
-      repository: 'example/repo',
-      token: 'token',
-      fetcher: fakeGitHub({ jobs: [], failRuns: true }),
-    }),
-    none,
-  );
-  assert.deepEqual(
-    await alreadyValidatedSuites({
-      cwd: apiDown.cwd,
-      repository: 'example/repo',
-      token: 'token',
-      fetcher: async () => {
-        throw new Error('network down');
-      },
-    }),
-    none,
-  );
-
-  // Missing credentials count as not validated.
-  assert.deepEqual(
-    suiteFlags(
-      await alreadyValidatedSuites({
-        cwd: apiDown.cwd,
-        repository: '',
-        token: '',
-        fetcher: fakeGitHub({ jobs: validatedJobs }),
+    await architectLaneQueueCall(
+      relevant.cwd,
+      fakeActionsApi({
+        runs: [fakeRun(1, relevant.branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
       }),
     ),
-    none,
+    { interview: true, interviewer: false, architect: false },
   );
+
+  // Main moved with an inert file (README): the batched merge still cannot
+  // affect the suites, so reuse holds. (Old byte-identical semantics re-ran
+  // here; relevance classification is the intended improvement.)
+  const inert = initMergeQueueRepo({ advanceMainWith: 'README.md' });
+  git(
+    inert.cwd,
+    'update-ref',
+    'refs/remotes/origin/changeset-release/architect',
+    inert.branchTip,
+  );
+  assert.deepEqual(
+    await architectLaneQueueCall(
+      inert.cwd,
+      fakeActionsApi({
+        runs: [fakeRun(1, inert.branchTip)],
+        jobsByRun: { 1: ARCHITECT_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: true, interviewer: false, architect: true },
+  );
+
+  // An ordinary PR that bumps a version must never satisfy reuse: without a
+  // matching origin/changeset-release/* tip there is no branch to walk.
+  const untrusted = initMergeQueueRepo();
+  assert.equal(releaseBranchForMergeQueue(untrusted.cwd), '');
 });
 
 // Scaffold a repo-shaped directory tree (no git needed for these tests):

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -150,6 +150,28 @@ test('release lane suites match the workspace dependency graph', () => {
   }
 });
 
+test('interview relevance closure covers peer-declared and asset-only workspace edges', () => {
+  // Anti-drift guard for two review findings: tooling/tailwind is a
+  // peerDependency of @codaco/interview (the theme tokens the e2e host
+  // renders with) rather than a dependency/devDependency, and
+  // @codaco/development-protocol is a devDependency the e2e matrix scenarios
+  // resolve by package name to reach fixture assets. Reading the real
+  // package.json graph means a future edge-type or dependency drop is caught
+  // here instead of silently classifying a relevant change as irrelevant.
+  const dirs = relevanceDirsForSubject(
+    '@codaco/interview',
+    collectWorkspacePackages(REPO_ROOT),
+  );
+  assert.ok(
+    dirs.has('tooling/tailwind'),
+    'tooling/tailwind (peerDependency) is in the interview closure',
+  );
+  assert.ok(
+    dirs.has('packages/development-protocol'),
+    'packages/development-protocol (devDependency) is in the interview closure',
+  );
+});
+
 test('all release policies share the central snapshot PR target', () => {
   for (const [eventName, releaseRef] of [
     ['pull_request', 'changeset-release/main'],
@@ -414,9 +436,14 @@ function writeWorkspaceFixture() {
       name: '@codaco/interview',
       version: '1.0.0',
       devDependencies: { '@codaco/e2e-helpers': 'workspace:*' },
+      peerDependencies: { '@codaco/theme-peer': 'workspace:*' },
     },
     'packages/e2e-helpers/package.json': {
       name: '@codaco/e2e-helpers',
+      version: '1.0.0',
+    },
+    'packages/theme-peer/package.json': {
+      name: '@codaco/theme-peer',
       version: '1.0.0',
     },
     'apps/interviewer/package.json': {
@@ -437,21 +464,27 @@ function writeWorkspaceFixture() {
   return cwd;
 }
 
-test('relevance closure follows dependencies and devDependencies', () => {
+test('relevance closure follows dependencies, devDependencies, and peerDependencies', () => {
   const cwd = writeWorkspaceFixture();
   const packages = collectWorkspacePackages(cwd);
   assert.deepEqual(
     [...relevanceDirsForSubject('@codaco/interviewer', packages)].toSorted(
       (a, b) => a.localeCompare(b),
     ),
-    ['apps/interviewer', 'packages/e2e-helpers', 'packages/interview'],
+    [
+      'apps/interviewer',
+      'packages/e2e-helpers',
+      'packages/interview',
+      'packages/theme-peer',
+    ],
   );
-  // devDependency edge: interview pulls in its e2e helpers.
+  // devDependency edge: interview pulls in its e2e helpers. peerDependency
+  // edge: interview pulls in its peer theme package.
   assert.deepEqual(
     [...relevanceDirsForSubject('@codaco/interview', packages)].toSorted(
       (a, b) => a.localeCompare(b),
     ),
-    ['packages/e2e-helpers', 'packages/interview'],
+    ['packages/e2e-helpers', 'packages/interview', 'packages/theme-peer'],
   );
 });
 
@@ -809,4 +842,51 @@ test('equivalence reuse trusts only same-repo runs and healthy inputs', async ()
     }),
     none,
   );
+});
+
+test('a relevant file renamed to an inert path still forces the suite to run', async () => {
+  const { cwd } = initReleaseBranchRepo();
+  // Force rename detection on for this repo so the assertion below proves
+  // --no-renames overrides it, rather than merely relying on whatever this
+  // machine's git defaults to.
+  git(cwd, 'config', 'diff.renames', 'true');
+
+  const preRenameSha = commitManifest(
+    cwd,
+    'packages/interview/src/feature.ts',
+    'export {};\n',
+    'add feature file',
+  );
+  mkdirSync(join(cwd, 'docs'), { recursive: true });
+  git(cwd, 'mv', 'packages/interview/src/feature.ts', 'docs/feature.ts');
+  git(cwd, 'commit', '-qm', 'move feature file out of interview');
+  const headSha = git(cwd, 'rev-parse', 'HEAD');
+
+  // With rename detection, `git diff --name-only` would report only
+  // docs/feature.ts (inert) and hide that the source lived inside the
+  // interview package's closure. --no-renames must surface the deleted
+  // packages/interview/src/feature.ts path too, keeping both suites required.
+  assert.deepEqual(
+    await interviewerLaneCall(
+      cwd,
+      headSha,
+      fakeActionsApi({
+        runs: [fakeRun(1, preRenameSha)],
+        jobsByRun: { 1: INTERVIEWER_LANE_SUCCESS_JOBS },
+      }),
+    ),
+    { interview: false, interviewer: false, architect: false },
+  );
+
+  // Sanity check: confirm this repo's git actually would have collapsed the
+  // rename to a single destination path without --no-renames, so the
+  // assertion above is exercising the guard and not a no-op.
+  const renameCollapsed = git(
+    cwd,
+    'diff',
+    '--name-only',
+    preRenameSha,
+    headSha,
+  );
+  assert.equal(renameCollapsed, 'docs/feature.ts');
 });


### PR DESCRIPTION
## Summary

Every push to `main` force-pushes all open generated `changeset-release/*` branches (the product lanes via `peter-evans/create-pull-request` and the library lane via `changesets/action`), resetting their CI and re-running 15–40 minutes of release E2E per lane even when nothing relevant changed — the open Release Interviewer PR was force-pushed eight times in one day.

This PR leaves branch generation untouched and moves the decision into the `e2e-policy` job: a suite is skipped when a prior successful native `pull_request` run of it exists on the same release branch and `git diff --no-renames X→H` touches only paths that provably cannot affect that suite. Applied at PR time (H = PR tip) and merge-queue time (H = merge commit — the old byte-identical fast path `alreadyValidatedSuites` becomes the empty-diff trivial case and is replaced).

**Every doubt fails closed** (the suite runs): missing inputs, Actions-API errors, unfetchable commits, fork heads, pagination cap, a conclusive failure as the newest verdict, and any unrecognised path (root configs, `.github/`, `scripts/`, lockfile). A suite's relevance closure is its subject package plus transitive declared workspace edges of every type (`dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`); the only inert paths are `docs/`, `.changeset/`, `*.md` (the `test` job's existing precedent). Ordinary PRs still never inherit an E2E verdict.

Also fixed along the way (found by review): `packages/interview`'s e2e matrix scenarios consumed `packages/development-protocol/assets` via an undeclared relative path — now a declared devDependency resolved by package name through a shared helper, so asset changes correctly re-run interview-e2e.

Design and rationale: `docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md`.

## Test plan

- [x] `pnpm test:scripts` 73/73 (17 policy tests incl. real-repo closure anti-drift test pinning `tooling/tailwind` + `packages/development-protocol` in the interview closure, forced-rename fail-closed test, fork/API-failure/unfetchable-commit/newest-failure guards; 8 workflow-wiring tests)
- [x] `pnpm knip` clean (no new ignores)
- [x] `pnpm typecheck` 15/15
- [ ] After merge: confirm the next unrelated merge to main refreshes the open release PRs with E2E skipped by policy (`e2e-policy` logs the reuse decision) and `quality` green in minutes
- [ ] After merge: confirm a `packages/interview` change still re-runs all lanes' suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release E2E checks can now reuse validated results when subsequent changes are proven unrelated to a suite.
  * Applies to both release pull requests and merge-queue validation.
  * Relevant changes, uncertain conditions, fork-based runs, and failures continue to trigger fresh E2E runs.

* **Bug Fixes**
  * Improved E2E fixture and asset resolution for more reliable scenario execution.

* **Documentation**
  * Expanded guidance and added design documentation for release E2E result reuse and its safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->