### PR TITLE
fix(ci): stop cancelled e2e jobs from poisoning the self-hosted workspace

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -679,19 +679,29 @@ jobs:
     steps:
       - name: Ensure workspace is a healthy git repo
         # On the self-hosted runner the workspace persists between jobs, and a
-        # job cancelled mid-checkout can leave it without a usable .git;
-        # actions/checkout then hard-fails ("--local can only be used inside a
-        # git repository") on every subsequent run until the directory is
-        # wiped (observed 2026-07-16). If the workspace is non-empty but not a
-        # valid repo, wipe it so checkout falls back to a fresh clone. The
-        # chown reuses the runner's scoped sudo rule to make root-owned
-        # leftovers (Dockerized runs execute as container root) deletable.
-        # No-op on ephemeral GitHub-hosted VMs: the directory starts empty.
+        # CANCELLED predecessor leaves two hazards behind (observed
+        # 2026-07-16/17 breaking every release-lane run):
+        # 1) Its Dockerized test run outlives the job — cancellation kills the
+        #    `docker run` client, not the container — and keeps writing
+        #    root-owned files into the bind-mounted workspace. Remove it by
+        #    name BEFORE touching the tree, or the wipe below races a live
+        #    writer and checkout's delete-everything fallback throws EACCES
+        #    (which actions/checkout's finally-block then masks as "--local
+        #    can only be used inside a git repository").
+        # 2) Root-owned files it already wrote make `git clean` fail even
+        #    once the container is gone. The chown reuses the runner's scoped
+        #    sudo rule to reclaim them unconditionally — a valid repo with
+        #    root-owned leftovers is just as fatal to checkout as a broken
+        #    one.
+        # If the tree is non-empty but has no usable .git, wipe it so checkout
+        # falls back to a fresh clone. No-op on ephemeral GitHub-hosted VMs:
+        # the directory starts empty and no container pre-exists.
         run: |
+          docker rm -f interview-e2e-run 2>/dev/null || true
+          sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
           if [ -n "$(ls -A . 2>/dev/null)" ] \
             && ! git rev-parse --resolve-git-dir "$PWD/.git" >/dev/null 2>&1; then
             echo "workspace is not a valid git repo — wiping for a fresh checkout"
-            sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
             find . -mindepth 1 -delete
           fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -710,6 +720,15 @@ jobs:
           printf 'slug=%s\n' "$SLUG" >> "$GITHUB_OUTPUT"
       - name: Run E2E tests
         run: ./packages/interview/e2e/scripts/run.sh
+      - name: Stop the e2e container
+        # Cancellation kills the `docker run` client but not the container;
+        # left alive it keeps writing root-owned files into the persistent
+        # workspace and corrupts the next job's checkout. Must run BEFORE the
+        # ownership reclaim below so the chown covers everything the container
+        # wrote. No-op when the run exited normally (`--rm` already removed
+        # it) and on ephemeral GitHub-hosted VMs.
+        if: always()
+        run: docker rm -f interview-e2e-run 2>/dev/null || true
       - name: Classify snapshot-only failure
         id: snapshot_failure
         if: failure()

--- a/packages/interview/e2e/scripts/run.sh
+++ b/packages/interview/e2e/scripts/run.sh
@@ -76,7 +76,19 @@ for arg in "$@"; do
   FORWARDED_ARGS="${FORWARDED_ARGS} $(printf '%q' "$arg")"
 done
 
-docker run --rm \
+# The container carries a fixed name so it can be found and removed after the
+# fact: cancelling a CI job kills the `docker run` client but NOT the
+# container, which otherwise keeps writing root-owned artifacts into the
+# bind-mounted workspace for the rest of the suite (observed 2026-07-17
+# breaking every subsequent checkout on the persistent self-hosted runner).
+# CI removes strays by this name before checkout and after the test step; the
+# pre-remove here keeps local reruns idempotent. `--init` gives the container
+# a signal-forwarding PID 1, so a proxied SIGTERM from a graceful cancel
+# tears the whole container down instead of being swallowed by `sh`.
+CONTAINER_NAME="interview-e2e-run"
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+docker run --rm --init --name "$CONTAINER_NAME" \
   -e CI=true \
   -e PW_WORKERS \
   -v "$(pwd)":/workspace \


### PR DESCRIPTION
## Summary

Every changeset-release lane went red this morning (runs [#3296](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/29568131090), [#3299](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/29568383862), [#3303](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/29568655736)) with `interview-e2e` failing **at the checkout step** with `fatal: --local can only be used inside a git repository`.

### Root cause

That error is a red herring: it comes from actions/checkout's `finally`-block auth cleanup, which masks the original exception. The real chain:

1. Each push to `main` refreshes the generated `changeset-release/*` branches, routinely **cancelling** in-flight release runs (8 cancellations this morning alone).
2. Cancelling `interview-e2e` kills the `docker run` *client*, but the Playwright **container survives** and keeps running the suite — writing root-owned artifacts into the bind-mounted, persistent self-hosted workspace for many minutes (verified via wall-clock timestamps embedded in trace-resource filenames: artifacts were being written *during* the failing checkouts).
3. The next job's checkout then fails: `git clean` hits `Permission denied` on root-owned files → checkout falls back to "delete everything" → its recursive delete throws EACCES after `.git` is already gone → the `finally` cleanup masks the real error.
4. Yesterday's wipe pre-step (#1009-era mitigation) can't win this: the live container re-creates files in the ~200 ms between the wipe and checkout's delete loop, and the `if: always()` chown runs *before* the orphan's final writes.

The run at 09:01:11 (checkout onto a momentarily quiet workspace) succeeding — and the 09:12+ runs succeeding once the orphans exited — confirms the mechanism.

### Fix (three layers, all at the root cause)

- **`run.sh`**: give the container a fixed name (`interview-e2e-run`) so it can be found and removed, pre-remove strays for idempotent local reruns, and add `--init` so a proxied SIGTERM from a graceful cancel actually tears the container down.
- **Workflow, post-test**: new `if: always()` step force-removes the container immediately after the test step — *before* the ownership-reclaim chown, so the reclaim covers everything the container wrote.
- **Workflow, pre-checkout**: the workspace-health step now removes any stray container first and chowns **unconditionally** — static root-owned leftovers break `git clean` even when the repo is otherwise valid (that was run #3303's exact mode), and previously the chown only ran on the invalid-repo path.

## Test plan

- [x] `bash -n` on `run.sh`; workflow YAML parses
- [x] `docker run --rm --init --name interview-e2e-run …` smoke-tested locally; `docker rm -f` of a missing name is a silent no-op
- [x] oxfmt on the workflow file (no changes)
- [ ] After merge: confirm the next cancelled release run leaves the self-hosted runner's workspace healthy (following run's checkout succeeds)