### PR TITLE
Simplify Fresco UI table header spacing

### DIFF
--- a/.changeset/nine-jars-joke.md
+++ b/.changeset/nine-jars-joke.md
@@ -1,0 +1,5 @@
+---
+"@codaco/fresco-ui": patch
+---
+
+Improve table headers by removing default vertical padding and alignment, with an example for wrapping long labels.

--- a/packages/fresco-ui/src/Table.stories.tsx
+++ b/packages/fresco-ui/src/Table.stories.tsx
@@ -263,6 +263,34 @@ export const WithLongContent: Story = {
   ),
 };
 
+export const WithLongWrappingHeader: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead className="w-48 whitespace-normal">
+            Current role and access level for this workspace
+          </TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Alice Johnson</TableCell>
+          <TableCell>Administrator</TableCell>
+          <TableCell>Active</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Bob Smith</TableCell>
+          <TableCell>Standard user</TableCell>
+          <TableCell>Active</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+};
+
 export const EmptyTable: Story = {
   render: () => (
     <Table>

--- a/packages/fresco-ui/src/Table.tsx
+++ b/packages/fresco-ui/src/Table.tsx
@@ -107,7 +107,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cx(
-      'w-0 px-6 py-3 align-bottom whitespace-nowrap',
+      'w-0 px-6 whitespace-nowrap',
       'text-left font-medium last:w-auto',
       className,
     )}


### PR DESCRIPTION
## Summary
- remove the default vertical padding and bottom alignment from Table header cells
- add a Storybook example showing a constrained long header wrapping across multiple lines
- add a patch changeset for `@codaco/fresco-ui`

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/fresco-ui test:storybook -- Table.stories.tsx`
- [x] verify the wrapping header renders across three lines in Storybook
- [x] regenerate Architect E2E visual snapshots in CI; both canonical PNGs are byte-identical