### PR TITLE
Let browser users start Interviewer security setup

### DIFF
--- a/.changeset/secure-interviewer-settings.md
+++ b/.changeset/secure-interviewer-settings.md
@@ -1,0 +1,7 @@
+---
+'@codaco/interviewer': patch
+---
+
+Let browser users enable app security from the Security settings with the Get
+started wizard. Settings-launched setup preserves existing data if it is exited
+after a device lock has been created.

--- a/apps/interviewer/e2e/specs/settings.spec.ts
+++ b/apps/interviewer/e2e/specs/settings.spec.ts
@@ -153,11 +153,21 @@ test.describe('settings', () => {
       page.getByRole('heading', { name: 'Device lock' }),
     ).toBeVisible();
     await expect(
+      page.getByText(
+        /Use the Get started wizard below to enable app security/i,
+      ),
+    ).toBeVisible();
+    await expect(
       page.getByRole('button', { name: 'Reset device' }),
     ).toBeVisible();
     await expect(
       page.getByRole('button', { name: 'Revoke', exact: true }),
     ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Get started' }).click();
+    await expect(page.getByRole('dialog')).toContainText(
+      'Setting up your device',
+    );
   });
 
   test('Synthetic data tab sees a protocol imported just before Settings opened', async ({

--- a/apps/interviewer/src/components/ManageAuthenticator.tsx
+++ b/apps/interviewer/src/components/ManageAuthenticator.tsx
@@ -244,8 +244,8 @@ export function ManageAuthenticator() {
       {hasNoLock && (
         <Paragraph intent="smallText" emphasis="muted">
           No device lock is configured. Data on this device is not encrypted at
-          the app layer. To enable a lock, reset the device first and run setup
-          again.
+          the app layer. Use the Get started wizard below to enable app security
+          and encrypt data stored by Interviewer.
         </Paragraph>
       )}
       <dl className="font-monospace mt-4 mb-6 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">

--- a/apps/interviewer/src/components/SettingsDialog.tsx
+++ b/apps/interviewer/src/components/SettingsDialog.tsx
@@ -33,6 +33,7 @@ import SecurityBehaviorControls, {
   type Behavior,
 } from '~/components/SecurityBehaviorControls';
 import { SettingsRow } from '~/components/SettingsRow';
+import { useSetupWizard } from '~/components/SetupWizardDialog';
 import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import { APP_VERSION } from '~/lib/appVersion';
 import { useAuth } from '~/lib/auth/AuthContext';
@@ -99,6 +100,7 @@ export function SettingsDialog({
   const analytics = useAnalytics();
   const toast = useToast();
   const { confirm } = useDialog();
+  const { openSetupWizard } = useSetupWizard({ preserveExistingData: true });
   const [section, setSection] = useState<Section>('about');
   const [settings, setSettings] = useState<StoredSettings | null>(null);
   const [storage, setStorage] = useState<StorageEstimate>({
@@ -300,6 +302,14 @@ export function SettingsDialog({
     requireUnlockOnEnter: settings?.requireUnlockOnEnter ?? true,
     requireUnlockOnExit: settings?.requireUnlockOnExit ?? false,
     requireUnlockOnExport: settings?.requireUnlockOnExport ?? false,
+  };
+  const hasNoDeviceLock =
+    auth.kind === 'unconfigured' ||
+    (auth.kind === 'unlocked' && auth.mode === 'none');
+
+  const handleStartSetup = () => {
+    onClose();
+    void openSetupWizard();
   };
 
   return (
@@ -537,6 +547,22 @@ export function SettingsDialog({
             {settings ? (
               <>
                 <ManageAuthenticator />
+                {hasNoDeviceLock ? (
+                  <SettingsRow
+                    title="Enable app security"
+                    desc="Run the Get started wizard to configure a device lock and choose your security preferences."
+                    control={
+                      <Button
+                        onClick={handleStartSetup}
+                        icon={
+                          <ShieldCheck className="size-4" aria-hidden="true" />
+                        }
+                      >
+                        Get started
+                      </Button>
+                    }
+                  />
+                ) : null}
                 {auth.kind === 'unlocked' && auth.mode !== 'none' ? (
                   <>
                     <Alert variant="info">

--- a/apps/interviewer/src/components/SetupWizard/Step2MethodPicker.tsx
+++ b/apps/interviewer/src/components/SetupWizard/Step2MethodPicker.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
 import { useWizard } from '@codaco/fresco-ui/dialogs/useWizard';
 import RichSelectGroupField from '@codaco/fresco-ui/form/fields/RichSelectGroup';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { useBiometric } from '~/lib/auth/useBiometric';
 import {
   hasPasskeyWindowLimitation,
@@ -22,13 +23,18 @@ function isWizardSelectedMethod(value: unknown): value is WizardSelectedMethod {
   return typeof value === 'string' && WIZARD_METHODS.some((m) => m === value);
 }
 
-export default function Step2MethodPicker() {
+export default function Step2MethodPicker({
+  lockCommittedMethod = false,
+}: {
+  lockCommittedMethod?: boolean;
+}) {
   const { data, setStepData, setNextEnabled } = useWizard();
   const { confirm } = useDialog();
   const biometric = useBiometric();
 
   const rawMethod = data.selectedMethod;
   const selectedMethod = isWizardSelectedMethod(rawMethod) ? rawMethod : null;
+  const methodLocked = lockCommittedMethod && data.enrolmentCommitted === true;
 
   useEffect(() => {
     setNextEnabled(selectedMethod !== null);
@@ -61,27 +67,37 @@ export default function Step2MethodPicker() {
       : `Use Face ID, Touch ID, Windows Hello, or another biometric sensor on this device.${macInstallCaveat}`;
 
   return (
-    <Step2MethodPickerView
-      value={selectedMethod}
-      onChange={(value) => {
-        if (value === 'none') {
-          void confirm({
-            title: 'Continue without security?',
-            description:
-              'Your data will not be protected by an app lock or encryption managed by this app. Anyone with access to this device may be able to view collected data.',
-            confirmLabel: 'Continue without security',
-            intent: 'warning',
-            onConfirm: () => {
-              commitMethod('none');
-            },
-          });
-          return;
-        }
-        commitMethod(value);
-      }}
-      biometricDisabled={biometricDisabled}
-      biometricDescription={biometricDescription}
-    />
+    <>
+      {methodLocked ? (
+        <Paragraph intent="smallText" emphasis="muted">
+          This device lock is already protecting stored data. Finish setup
+          before changing it from the Security settings.
+        </Paragraph>
+      ) : null}
+      <Step2MethodPickerView
+        value={selectedMethod}
+        onChange={(value) => {
+          if (methodLocked && value !== selectedMethod) return;
+          if (value === 'none') {
+            void confirm({
+              title: 'Continue without security?',
+              description:
+                'Your data will not be protected by an app lock or encryption managed by this app. Anyone with access to this device may be able to view collected data.',
+              confirmLabel: 'Continue without security',
+              intent: 'warning',
+              onConfirm: () => {
+                commitMethod('none');
+              },
+            });
+            return;
+          }
+          commitMethod(value);
+        }}
+        biometricDisabled={biometricDisabled}
+        biometricDescription={biometricDescription}
+        lockedMethod={methodLocked ? selectedMethod : null}
+      />
+    </>
   );
 }
 
@@ -90,30 +106,34 @@ export function Step2MethodPickerView({
   onChange,
   biometricDisabled,
   biometricDescription,
+  lockedMethod = null,
 }: {
   value: WizardSelectedMethod | null;
   onChange: (value: WizardSelectedMethod) => void;
   biometricDisabled: boolean;
   biometricDescription: string;
+  lockedMethod?: WizardSelectedMethod | null;
 }) {
   const options = [
     {
       value: 'biometric' as const,
       label: 'Biometric authentication',
       description: biometricDescription,
-      disabled: biometricDisabled,
+      disabled:
+        biometricDisabled ||
+        (lockedMethod !== null && lockedMethod !== 'biometric'),
     },
     {
       value: 'pin' as const,
       label: 'PIN code',
       description: 'An 8-digit numeric PIN.',
-      disabled: false,
+      disabled: lockedMethod !== null && lockedMethod !== 'pin',
     },
     {
       value: 'passphrase' as const,
       label: 'Passphrase',
       description: 'A password of at least 12 characters.',
-      disabled: false,
+      disabled: lockedMethod !== null && lockedMethod !== 'passphrase',
     },
     { type: 'spacer' as const },
     {
@@ -121,6 +141,7 @@ export function Step2MethodPickerView({
       label: 'No security (not recommended)',
       description:
         'Skip app security. Your data will not be protected by the app.',
+      disabled: lockedMethod !== null && lockedMethod !== 'none',
     },
   ];
   return (

--- a/apps/interviewer/src/components/SetupWizard/Step3Configure.tsx
+++ b/apps/interviewer/src/components/SetupWizard/Step3Configure.tsx
@@ -23,7 +23,11 @@ function asSelectedMethod(v: unknown): WizardSelectedMethod | null {
   return null;
 }
 
-export default function Step3Configure() {
+export default function Step3Configure({
+  allowChange = true,
+}: {
+  allowChange?: boolean;
+}) {
   const wizard = useWizard();
   const method = asSelectedMethod(wizard.data.selectedMethod);
   const enrolmentCommitted = Boolean(wizard.data.enrolmentCommitted);
@@ -33,7 +37,11 @@ export default function Step3Configure() {
 
   if (enrolmentCommitted && !editing) {
     return (
-      <ReadOnlySummary method={method} onChange={() => setEditing(true)} />
+      <ReadOnlySummary
+        method={method}
+        allowChange={allowChange}
+        onChange={() => setEditing(true)}
+      />
     );
   }
 
@@ -57,9 +65,11 @@ export default function Step3Configure() {
 // into the configure form so Next actually re-enrols.
 function ReadOnlySummary({
   method,
+  allowChange,
   onChange,
 }: {
   method: WizardSelectedMethod;
+  allowChange: boolean;
   onChange: () => void;
 }) {
   const wizard = useWizard();
@@ -116,9 +126,11 @@ function ReadOnlySummary({
   return (
     <>
       <Paragraph>{label}</Paragraph>
-      <Button type="button" color="primary" onClick={onChange}>
-        Change
-      </Button>
+      {allowChange ? (
+        <Button type="button" color="primary" onClick={onChange}>
+          Change
+        </Button>
+      ) : null}
     </>
   );
 }

--- a/apps/interviewer/src/components/SetupWizard/Step5Analytics.tsx
+++ b/apps/interviewer/src/components/SetupWizard/Step5Analytics.tsx
@@ -6,15 +6,23 @@ import UnconnectedField from '@codaco/fresco-ui/form/Field/UnconnectedField';
 import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 
-// Analytics defaults to on. The wizard reads `data.analyticsEnabled`; an
-// undefined value (the user never touched the toggle) is treated as enabled.
-function asAnalyticsEnabled(value: unknown): boolean {
-  return typeof value === 'boolean' ? value : true;
+// First-run setup defaults analytics to on. A Settings-launched wizard supplies
+// the user's current preference instead, so leaving the toggle untouched cannot
+// silently opt an existing user back in.
+function asAnalyticsEnabled(value: unknown, initialEnabled: boolean): boolean {
+  return typeof value === 'boolean' ? value : initialEnabled;
 }
 
-export default function Step5Analytics() {
+export default function Step5Analytics({
+  initialEnabled = true,
+}: {
+  initialEnabled?: boolean;
+}) {
   const wizard = useWizard();
-  const enabled = asAnalyticsEnabled(wizard.data.analyticsEnabled);
+  const enabled = asAnalyticsEnabled(
+    wizard.data.analyticsEnabled,
+    initialEnabled,
+  );
 
   useEffect(() => {
     wizard.setNextEnabled(true);

--- a/apps/interviewer/src/components/SetupWizard/__tests__/Step2MethodPicker.test.tsx
+++ b/apps/interviewer/src/components/SetupWizard/__tests__/Step2MethodPicker.test.tsx
@@ -82,4 +82,19 @@ describe('Step2MethodPicker — method change clears prior enrolment', () => {
       expect.objectContaining({ enrolmentCommitted: false }),
     );
   });
+
+  it('locks a committed method when preserving an existing database', async () => {
+    wizardData.selectedMethod = 'pin';
+    wizardData.enrolmentCommitted = true;
+    render(<Step2MethodPicker lockCommittedMethod />);
+
+    expect(screen.getByText('Passphrase').closest('button')).toBeDisabled();
+    expect(
+      screen.getByText(/already protecting stored data/i),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Passphrase'));
+
+    expect(setStepDataMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/interviewer/src/components/SetupWizard/__tests__/Step3Configure.test.tsx
+++ b/apps/interviewer/src/components/SetupWizard/__tests__/Step3Configure.test.tsx
@@ -77,6 +77,22 @@ describe('Step3Configure — read-only summary reconciliation', () => {
     );
   });
 
+  it('does not offer to replace a committed method while preserving stored data', async () => {
+    wizardData = { selectedMethod: 'pin', enrolmentCommitted: true };
+    statusMock.mockResolvedValue({
+      configured: true,
+      locked: false,
+      mode: 'pin',
+    });
+
+    render(<Step3Configure allowChange={false} />);
+
+    expect(await screen.findByText('PIN configured.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Change' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('drops back into the configure form when a committed enrolment no longer matches the vault', async () => {
     // A same-method biometric "Change" revoked the old vault, then the user
     // cancelled the OS sheet: enrolmentCommitted is still true but the vault is

--- a/apps/interviewer/src/components/SetupWizardDialog.tsx
+++ b/apps/interviewer/src/components/SetupWizardDialog.tsx
@@ -51,7 +51,18 @@ async function enrolWithoutSecurity() {
   await authApi.enrolWithoutLock();
 }
 
-export function useSetupWizard() {
+type UseSetupWizardOptions = {
+  /**
+   * A Settings-launched wizard may be securing an already-populated database.
+   * Once enrolment has re-encrypted those records, leaving or changing methods
+   * must not revoke the new vault because revoke() also wipes the database.
+   */
+  preserveExistingData?: boolean;
+};
+
+export function useSetupWizard({
+  preserveExistingData = false,
+}: UseSetupWizardOptions = {}) {
   const { openDialog } = useDialog();
   const { refresh } = useAuth();
   const analytics = useAnalytics();
@@ -62,14 +73,17 @@ export function useSetupWizard() {
       type: 'wizard',
       title: '🔑 Secure this device',
       confirmCancel: {
-        intent: 'destructive',
-        title: 'Skip the wizard?',
-        description:
-          'Your device will be left unsecured, and default preferences will be assumed. Are you sure you want to skip the setup wizard?',
-        primaryLabel: 'Use app without security',
+        intent: preserveExistingData ? 'warning' : 'destructive',
+        title: preserveExistingData ? 'Exit setup?' : 'Skip the wizard?',
+        description: preserveExistingData
+          ? 'If you have already configured a device lock, it will remain active. Otherwise, Interviewer will continue without app security.'
+          : 'Your device will be left unsecured, and default preferences will be assumed. Are you sure you want to skip the setup wizard?',
+        primaryLabel: preserveExistingData
+          ? 'Exit setup'
+          : 'Use app without security',
         cancelLabel: 'Go back to wizard',
       },
-      cancelLabel: 'Skip Wizard',
+      cancelLabel: preserveExistingData ? 'Exit setup' : 'Skip Wizard',
       steps: [
         {
           title: 'Setting up your device',
@@ -169,11 +183,13 @@ export function useSetupWizard() {
           title: 'Choose an authentication method',
           description:
             'Choose between the options below to determine how you will be prompted to unlock the app.',
-          content: Step2MethodPicker,
+          content: () => (
+            <Step2MethodPicker lockCommittedMethod={preserveExistingData} />
+          ),
         },
         {
           title: 'Set up your method',
-          content: Step3Configure,
+          content: () => <Step3Configure allowChange={!preserveExistingData} />,
           skip: ({ data }) => data.selectedMethod === 'none',
         },
         {
@@ -196,7 +212,14 @@ export function useSetupWizard() {
     try {
       if (!result) {
         // Dismissed.
-        await enrolWithoutSecurity();
+        if (preserveExistingData) {
+          const status = await authApi.status();
+          if (!status.configured || status.mode === 'none') {
+            await authApi.enrolWithoutLock();
+          }
+        } else {
+          await enrolWithoutSecurity();
+        }
       } else {
         const data = result as SetupWizardData;
         if (data.selectedMethod === 'none') {

--- a/apps/interviewer/src/components/SetupWizardDialog.tsx
+++ b/apps/interviewer/src/components/SetupWizardDialog.tsx
@@ -69,6 +69,9 @@ export function useSetupWizard({
   const toast = useToast();
 
   const openSetupWizard = async (): Promise<void> => {
+    const initialAnalyticsEnabled = preserveExistingData
+      ? analytics.enabled
+      : true;
     const result = await openDialog({
       type: 'wizard',
       title: '🔑 Secure this device',
@@ -200,7 +203,9 @@ export function useSetupWizard({
         },
         {
           title: 'Help improve the app',
-          content: Step5Analytics,
+          content: () => (
+            <Step5Analytics initialEnabled={initialAnalyticsEnabled} />
+          ),
           nextLabel: 'Finish',
         },
       ],
@@ -233,13 +238,15 @@ export function useSetupWizard({
           requireUnlockOnExit: behavior.requireUnlockOnExit,
           requireUnlockOnExport: behavior.requireUnlockOnExport,
         });
-        // Persist + apply the analytics choice (defaults to enabled). Routes
-        // through the provider so opt-in/out and the native preference mirror
-        // take effect immediately.
-        await analytics.setEnabled(data.analyticsEnabled ?? true);
+        // First-run setup defaults to enabled. A Settings-launched wizard is
+        // seeded from the current preference so leaving the toggle untouched
+        // preserves an existing opt-out.
+        await analytics.setEnabled(
+          data.analyticsEnabled ?? initialAnalyticsEnabled,
+        );
       }
 
-      await refresh();
+      if (!preserveExistingData) await refresh();
     } catch (cause) {
       toast.add({
         title: 'Setup could not be completed',
@@ -249,6 +256,25 @@ export function useSetupWizard({
             : 'Something went wrong while setting up this device. Please try again.',
         variant: 'destructive',
       });
+    } finally {
+      // Settings closes before opening the wizard, leaving Home mounted behind
+      // it. Always reconcile auth after that flow, even if enrolment succeeded
+      // but a later preference write failed; otherwise Home keeps stale
+      // unconfigured/no-lock state until reload.
+      if (preserveExistingData) {
+        try {
+          await refresh();
+        } catch (cause) {
+          toast.add({
+            title: 'Security status could not be refreshed',
+            description:
+              cause instanceof Error
+                ? cause.message
+                : 'Reload Interviewer to refresh this device’s security status.',
+            variant: 'destructive',
+          });
+        }
+      }
     }
   };
 

--- a/apps/interviewer/src/components/__tests__/SettingsDialog.test.tsx
+++ b/apps/interviewer/src/components/__tests__/SettingsDialog.test.tsx
@@ -8,13 +8,19 @@ import type { AuthStateKind } from '~/lib/auth/AuthContext';
 import { DEFAULT_SETTINGS } from '~/lib/db/types';
 import type { ProtocolWithCounts } from '~/lib/db/types';
 
-const { mockEstimateStorage, mockIsPersisted, mockUseAuth, mockListProtocols } =
-  vi.hoisted(() => ({
-    mockEstimateStorage: vi.fn(),
-    mockIsPersisted: vi.fn(),
-    mockUseAuth: vi.fn(),
-    mockListProtocols: vi.fn(),
-  }));
+const {
+  mockEstimateStorage,
+  mockIsPersisted,
+  mockUseAuth,
+  mockListProtocols,
+  mockOpenSetupWizard,
+} = vi.hoisted(() => ({
+  mockEstimateStorage: vi.fn(),
+  mockIsPersisted: vi.fn(),
+  mockUseAuth: vi.fn(),
+  mockListProtocols: vi.fn(),
+  mockOpenSetupWizard: vi.fn(),
+}));
 
 vi.mock('~/lib/storage', async () => {
   const actual =
@@ -36,6 +42,10 @@ vi.mock('~/lib/db/api', () => ({
 
 vi.mock('~/lib/auth/AuthContext', () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('~/components/SetupWizardDialog', () => ({
+  useSetupWizard: () => ({ openSetupWizard: mockOpenSetupWizard }),
 }));
 
 vi.mock('~/lib/analytics/AnalyticsProvider', () => ({
@@ -216,6 +226,40 @@ describe('SettingsDialog Security tab — step-up controls gating', () => {
       }
     },
   );
+
+  it('opens the Get started wizard from an unconfigured Security tab', async () => {
+    mockAuth('unconfigured');
+    mockOpenSetupWizard.mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<SettingsDialog open onClose={onClose} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Security' }));
+
+    expect(
+      await screen.findByText(
+        /Use the Get started wizard below to enable app security/i,
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Get started' }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(mockOpenSetupWizard).toHaveBeenCalledOnce();
+  });
+
+  it('does not offer the Get started wizard when a lock is configured', async () => {
+    mockAuth('unlocked', 'pin');
+    const user = userEvent.setup();
+    render(<SettingsDialog open onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Security' }));
+
+    await screen.findByRole('heading', { name: 'Authenticator' });
+    expect(
+      screen.queryByRole('button', { name: 'Get started' }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('SettingsDialog synthetic tab — protocol import race', () => {

--- a/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
+++ b/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockEnrolWithoutLock,
+  mockOpenDialog,
+  mockRefresh,
+  mockRevoke,
+  mockStatus,
+} = vi.hoisted(() => ({
+  mockEnrolWithoutLock: vi.fn(),
+  mockOpenDialog: vi.fn(),
+  mockRefresh: vi.fn(),
+  mockRevoke: vi.fn(),
+  mockStatus: vi.fn(),
+}));
+
+vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
+  default: () => ({ openDialog: mockOpenDialog }),
+}));
+
+vi.mock('@codaco/fresco-ui/Toast', () => ({
+  useToast: () => ({ add: vi.fn() }),
+}));
+
+vi.mock('~/lib/analytics/AnalyticsProvider', () => ({
+  useAnalytics: () => ({ setEnabled: vi.fn() }),
+}));
+
+vi.mock('~/lib/auth/AuthContext', () => ({
+  useAuth: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock('~/lib/auth/api', () => ({
+  enrolWithoutLock: mockEnrolWithoutLock,
+  revoke: mockRevoke,
+  status: mockStatus,
+}));
+
+vi.mock('~/lib/db/api', () => ({
+  updateSettings: vi.fn(),
+}));
+
+import { useSetupWizard } from '../SetupWizardDialog';
+
+function SetupLauncher() {
+  const { openSetupWizard } = useSetupWizard({ preserveExistingData: true });
+  return (
+    <button type="button" onClick={() => void openSetupWizard()}>
+      Launch setup
+    </button>
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('settings-launched setup wizard', () => {
+  it('keeps a newly configured lock when the wizard is dismissed', async () => {
+    mockOpenDialog.mockResolvedValue(null);
+    mockStatus.mockResolvedValue({
+      configured: true,
+      locked: false,
+      mode: 'pin',
+    });
+
+    render(<SetupLauncher />);
+    await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
+    expect(mockRevoke).not.toHaveBeenCalled();
+    expect(mockEnrolWithoutLock).not.toHaveBeenCalled();
+    expect(mockOpenDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cancelLabel: 'Exit setup',
+        confirmCancel: expect.objectContaining({
+          primaryLabel: 'Exit setup',
+        }),
+      }),
+    );
+  });
+
+  it('continues without a lock when dismissed before enrolment', async () => {
+    mockOpenDialog.mockResolvedValue(null);
+    mockStatus.mockResolvedValue({
+      configured: false,
+      locked: false,
+    });
+    mockEnrolWithoutLock.mockResolvedValue({ ok: true });
+
+    render(<SetupLauncher />);
+    await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
+    expect(mockEnrolWithoutLock).toHaveBeenCalledOnce();
+    expect(mockRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
+++ b/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
@@ -7,13 +7,19 @@ const {
   mockOpenDialog,
   mockRefresh,
   mockRevoke,
+  mockSetAnalyticsEnabled,
   mockStatus,
+  mockToastAdd,
+  mockUpdateSettings,
 } = vi.hoisted(() => ({
   mockEnrolWithoutLock: vi.fn(),
   mockOpenDialog: vi.fn(),
   mockRefresh: vi.fn(),
   mockRevoke: vi.fn(),
+  mockSetAnalyticsEnabled: vi.fn(),
   mockStatus: vi.fn(),
+  mockToastAdd: vi.fn(),
+  mockUpdateSettings: vi.fn(),
 }));
 
 vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
@@ -21,11 +27,14 @@ vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
 }));
 
 vi.mock('@codaco/fresco-ui/Toast', () => ({
-  useToast: () => ({ add: vi.fn() }),
+  useToast: () => ({ add: mockToastAdd }),
 }));
 
 vi.mock('~/lib/analytics/AnalyticsProvider', () => ({
-  useAnalytics: () => ({ setEnabled: vi.fn() }),
+  useAnalytics: () => ({
+    enabled: false,
+    setEnabled: mockSetAnalyticsEnabled,
+  }),
 }));
 
 vi.mock('~/lib/auth/AuthContext', () => ({
@@ -39,7 +48,7 @@ vi.mock('~/lib/auth/api', () => ({
 }));
 
 vi.mock('~/lib/db/api', () => ({
-  updateSettings: vi.fn(),
+  updateSettings: mockUpdateSettings,
 }));
 
 import { useSetupWizard } from '../SetupWizardDialog';
@@ -96,5 +105,37 @@ describe('settings-launched setup wizard', () => {
     await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
     expect(mockEnrolWithoutLock).toHaveBeenCalledOnce();
     expect(mockRevoke).not.toHaveBeenCalled();
+  });
+
+  it('preserves an existing analytics opt-out when the toggle is untouched', async () => {
+    mockOpenDialog.mockResolvedValue({
+      selectedMethod: 'pin',
+      enrolmentCommitted: true,
+    });
+
+    render(<SetupLauncher />);
+    await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
+    expect(mockSetAnalyticsEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('refreshes auth when a post-enrolment settings write fails', async () => {
+    mockOpenDialog.mockResolvedValue({
+      selectedMethod: 'pin',
+      enrolmentCommitted: true,
+    });
+    mockUpdateSettings.mockRejectedValue(new Error('settings unavailable'));
+
+    render(<SetupLauncher />);
+    await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
+    expect(mockToastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Setup could not be completed',
+        description: 'settings unavailable',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a Get started action to Settings → Security when no device lock is configured
- update the Security guidance to explain that the wizard enables app security and encrypts stored Interviewer data
- preserve existing data when settings-launched setup is exited after enrolment, and prevent destructive method replacement mid-wizard
- add an Interviewer patch changeset

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/interviewer test`
- [x] `VITE_DISABLE_ANALYTICS=true pnpm --filter @codaco/interviewer build`
- [x] focused Chromium settings E2E