### PR TITLE
Preserve optional Interviewer security setup state

### DIFF
--- a/.changeset/gentle-wizards-remember.md
+++ b/.changeset/gentle-wizards-remember.md
@@ -1,0 +1,7 @@
+---
+'@codaco/interviewer': patch
+---
+
+Preserve the existing analytics preference when app security is enabled from
+Settings, and keep mandatory setup available after the optional wizard is
+exited without choosing a security method.

--- a/apps/interviewer/e2e/specs/settings.spec.ts
+++ b/apps/interviewer/e2e/specs/settings.spec.ts
@@ -170,6 +170,24 @@ test.describe('settings', () => {
     );
   });
 
+  test('Exiting optional security setup preserves the installed setup gate', async ({
+    page,
+  }) => {
+    await openSettings(page);
+    await page.getByRole('tab', { name: 'Security' }).click();
+    await page.getByRole('button', { name: 'Get started' }).click();
+
+    await page.getByTestId('wizard-cancel').click();
+    await expect(page.getByRole('dialog').last()).toContainText('Exit setup?');
+    await page.getByTestId('dialog-primary').click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    await page.evaluate(() => window.dispatchEvent(new Event('appinstalled')));
+
+    await expect(page).toHaveURL(/\/welcome$/);
+    await expect(page.getByText("Let's set up this device.")).toBeVisible();
+  });
+
   test('Synthetic data tab sees a protocol imported just before Settings opened', async ({
     page,
     protocol,

--- a/apps/interviewer/src/components/SetupWizardDialog.tsx
+++ b/apps/interviewer/src/components/SetupWizardDialog.tsx
@@ -8,7 +8,7 @@ import { useAnalytics } from '~/lib/analytics/AnalyticsProvider';
 import * as authApi from '~/lib/auth/api';
 import { useAuth } from '~/lib/auth/AuthContext';
 import type { IdleTimeoutMinutes } from '~/lib/auth/AuthContext';
-import { updateSettings } from '~/lib/db/api';
+import { getSettings, updateSettings } from '~/lib/db/api';
 
 import { ExternalLink } from './ExternalLink';
 import AuthorisationGlyph from './SetupWizard/AuthorisationGlyph';
@@ -30,7 +30,8 @@ export type SetupWizardData = {
     requireUnlockOnExit: boolean;
     requireUnlockOnExport: boolean;
   };
-  // Undefined when the user never touched the toggle — defaults to enabled.
+  // Undefined when the user never touched the toggle. The wizard launch mode
+  // supplies the preference that should be preserved in that case.
   analyticsEnabled?: boolean;
 };
 
@@ -69,9 +70,26 @@ export function useSetupWizard({
   const toast = useToast();
 
   const openSetupWizard = async (): Promise<void> => {
-    const initialAnalyticsEnabled = preserveExistingData
-      ? analytics.enabled
-      : true;
+    let initialAnalyticsEnabled = true;
+    if (preserveExistingData) {
+      // Settings are readable before vault enrolment. Use the persisted row
+      // rather than AnalyticsProvider's safe pre-unlock fallback so an
+      // untouched toggle preserves the user's actual preference.
+      try {
+        initialAnalyticsEnabled = (await getSettings()).analyticsEnabled;
+      } catch (cause) {
+        toast.add({
+          title: 'Setup could not be opened',
+          description:
+            cause instanceof Error
+              ? cause.message
+              : 'Stored settings could not be read. Please try again.',
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+
     const result = await openDialog({
       type: 'wizard',
       title: '🔑 Secure this device',
@@ -216,13 +234,10 @@ export function useSetupWizard({
     // welcome screen with no feedback — they stay on /welcome and can retry.
     try {
       if (!result) {
-        // Dismissed.
-        if (preserveExistingData) {
-          const status = await authApi.status();
-          if (!status.configured || status.mode === 'none') {
-            await authApi.enrolWithoutLock();
-          }
-        } else {
+        // The Settings wizard is optional. Dismissing it must leave the vault
+        // exactly as it was so a fresh browser remains unconfigured and still
+        // receives mandatory setup if it is later installed.
+        if (!preserveExistingData) {
           await enrolWithoutSecurity();
         }
       } else {

--- a/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
+++ b/apps/interviewer/src/components/__tests__/SetupWizardDialog.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockEnrolWithoutLock,
+  mockGetSettings,
   mockOpenDialog,
   mockRefresh,
   mockRevoke,
@@ -13,6 +14,7 @@ const {
   mockUpdateSettings,
 } = vi.hoisted(() => ({
   mockEnrolWithoutLock: vi.fn(),
+  mockGetSettings: vi.fn(),
   mockOpenDialog: vi.fn(),
   mockRefresh: vi.fn(),
   mockRevoke: vi.fn(),
@@ -48,6 +50,7 @@ vi.mock('~/lib/auth/api', () => ({
 }));
 
 vi.mock('~/lib/db/api', () => ({
+  getSettings: mockGetSettings,
   updateSettings: mockUpdateSettings,
 }));
 
@@ -61,6 +64,10 @@ function SetupLauncher() {
     </button>
   );
 }
+
+beforeEach(() => {
+  mockGetSettings.mockResolvedValue({ analyticsEnabled: true });
+});
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -91,23 +98,20 @@ describe('settings-launched setup wizard', () => {
     );
   });
 
-  it('continues without a lock when dismissed before enrolment', async () => {
+  it('leaves the vault unconfigured when dismissed before enrolment', async () => {
     mockOpenDialog.mockResolvedValue(null);
-    mockStatus.mockResolvedValue({
-      configured: false,
-      locked: false,
-    });
-    mockEnrolWithoutLock.mockResolvedValue({ ok: true });
 
     render(<SetupLauncher />);
     await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
 
     await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
-    expect(mockEnrolWithoutLock).toHaveBeenCalledOnce();
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockEnrolWithoutLock).not.toHaveBeenCalled();
     expect(mockRevoke).not.toHaveBeenCalled();
   });
 
   it('preserves an existing analytics opt-out when the toggle is untouched', async () => {
+    mockGetSettings.mockResolvedValue({ analyticsEnabled: false });
     mockOpenDialog.mockResolvedValue({
       selectedMethod: 'pin',
       enrolmentCommitted: true,
@@ -118,6 +122,20 @@ describe('settings-launched setup wizard', () => {
 
     await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
     expect(mockSetAnalyticsEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('preserves stored analytics opt-in before the provider has loaded it', async () => {
+    mockOpenDialog.mockResolvedValue({
+      selectedMethod: 'pin',
+      enrolmentCommitted: true,
+    });
+
+    render(<SetupLauncher />);
+    await userEvent.click(screen.getByRole('button', { name: 'Launch setup' }));
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalledOnce());
+    expect(mockGetSettings).toHaveBeenCalledOnce();
+    expect(mockSetAnalyticsEnabled).toHaveBeenCalledWith(true);
   });
 
   it('refreshes auth when a post-enrolment settings write fails', async () => {


### PR DESCRIPTION
## Summary
- seed Settings-launched security setup from the persisted analytics preference instead of the provider's pre-unlock fallback
- leave vault state unchanged when the optional browser setup is exited so a later install still requires setup
- add unit and built-PWA E2E regressions for both outstanding review findings from #1029

## Test plan
- [x] `pnpm --filter @codaco/interviewer test`
- [x] `apps/interviewer/e2e/scripts/run.sh --grep installed.setup.gate --project=chromium`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`