### PR TITLE
Fix(architect): ego variable rename duplicate

### DIFF
--- a/.changeset/architect-ego-variable-rename-duplicate.md
+++ b/.changeset/architect-ego-variable-rename-duplicate.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Renaming an ego variable to a name already in use now shows an inline "already in use" message on the field, matching how node and edge variables behave. Previously it slipped past the inline check and surfaced a confusing "Misconfigured Protocol" dialog instead.

--- a/apps/architect/src/components/VariablePill.tsx
+++ b/apps/architect/src/components/VariablePill.tsx
@@ -142,11 +142,10 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
     setIsEditing(false);
   };
 
+  // Ego variables live at `codebook.ego.variables`, so `type` must stay
+  // undefined for them rather than defaulting to an entity type name.
   const subject = useMemo(
-    () => ({
-      entity: (entity || '') as 'node' | 'edge' | 'ego',
-      type: (entityType || 'node') as 'node' | 'edge' | 'ego',
-    }),
+    () => ({ entity: entity ?? 'node', type: entityType ?? undefined }),
     [entity, entityType],
   );
   const existingVariables = useAppSelector((state: RootState) =>
@@ -155,9 +154,9 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
 
   const existingVariableNames = useMemo(
     () =>
-      Object.keys(existingVariables)
-        .filter((variableId) => variableId !== uuid) // Exclude current variable being edited
-        .map((variableId) => get(existingVariables[variableId], 'name')),
+      Object.entries(existingVariables)
+        .filter(([variableId]) => variableId !== uuid) // Exclude current variable being edited
+        .map(([, existingVariable]) => get(existingVariable, 'name')),
     [existingVariables, uuid],
   );
 

--- a/apps/architect/src/components/VariablePill.tsx
+++ b/apps/architect/src/components/VariablePill.tsx
@@ -154,7 +154,7 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
 
   const existingVariableNames = useMemo(
     () =>
-      Object.entries(existingVariables)
+      Object.entries(existingVariables ?? {})
         .filter(([variableId]) => variableId !== uuid) // Exclude current variable being edited
         .map(([, existingVariable]) => get(existingVariable, 'name')),
     [existingVariables, uuid],

--- a/apps/architect/src/components/__tests__/VariablePill.test.tsx
+++ b/apps/architect/src/components/__tests__/VariablePill.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Codebook } from '@codaco/protocol-validation';
+
+type Subject = { entity: 'node' | 'edge' | 'ego'; type?: string };
+
+// A codebook holding one duplicate-name pair per scope: renaming `subject_var`
+// to `taken_var` must be rejected inline for ego and node variables alike.
+const codebook = {
+  ego: {
+    variables: {
+      'ego-subject': { name: 'subject_var', type: 'text' },
+      'ego-taken': { name: 'taken_var', type: 'text' },
+    },
+  },
+  node: {
+    person: {
+      variables: {
+        'node-subject': { name: 'subject_var', type: 'text' },
+        'node-taken': { name: 'taken_var', type: 'text' },
+      },
+    },
+  },
+} as unknown as Codebook;
+
+const variableFixtures = {
+  'ego-subject': {
+    uuid: 'ego-subject',
+    name: 'subject_var',
+    entity: 'ego' as const,
+    entityType: null,
+    type: 'text',
+  },
+  'node-subject': {
+    uuid: 'node-subject',
+    name: 'subject_var',
+    entity: 'node' as const,
+    entityType: 'person',
+    type: 'text',
+  },
+};
+
+const subjectsSeen: Subject[] = [];
+
+vi.mock('~/ducks/hooks', () => ({
+  useAppDispatch: () => vi.fn(),
+  useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+vi.mock('~/ducks/modules/protocol/codebook', () => ({
+  updateVariableByUUID: vi.fn(),
+}));
+
+vi.mock('~/selectors/codebook', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/selectors/codebook')>();
+  return {
+    ...actual,
+    // Resolve against the real selector, but record the subject the component
+    // builds so a regression to `type: 'node'` for ego is caught directly.
+    getVariablesForSubject: (_state: unknown, subject: Subject) => {
+      subjectsSeen.push(subject);
+      return actual.getVariablesForSubjectSelector(
+        { activeProtocol: { present: { codebook } } } as never,
+        subject,
+      );
+    },
+    makeGetVariableWithEntity: (uuid: string) => () =>
+      variableFixtures[uuid as keyof typeof variableFixtures],
+  };
+});
+
+const { default: EditableVariablePill } = await import('../VariablePill');
+
+const startEditing = async (uuid: string) => {
+  render(<EditableVariablePill uuid={uuid} />);
+  fireEvent.click(screen.getByRole('button', { name: /Rename variable/ }));
+  return screen.findByRole('textbox');
+};
+
+describe('EditableVariablePill', () => {
+  beforeEach(() => {
+    subjectsSeen.length = 0;
+  });
+
+  it('rejects renaming an ego variable to an existing ego variable name', async () => {
+    const input = await startEditing('ego-subject');
+    fireEvent.change(input, { target: { value: 'taken_var' } });
+
+    expect(await screen.findByText(/is already in use/)).toBeInTheDocument();
+    // Ego has no entity type; a `type` here resolves to the non-existent
+    // `codebook.ego.<type>.variables` and silently finds nothing.
+    expect(subjectsSeen.at(-1)).toEqual({ entity: 'ego', type: undefined });
+  });
+
+  it('rejects renaming a node variable to an existing name in the same type', async () => {
+    const input = await startEditing('node-subject');
+    fireEvent.change(input, { target: { value: 'taken_var' } });
+
+    expect(await screen.findByText(/is already in use/)).toBeInTheDocument();
+    expect(subjectsSeen.at(-1)).toEqual({ entity: 'node', type: 'person' });
+  });
+
+  it('allows an ego variable to keep its own name', async () => {
+    const input = await startEditing('ego-subject');
+    fireEvent.change(input, { target: { value: 'subject_var' } });
+
+    expect(screen.queryByText(/is already in use/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renaming an ego variable to an existing name now shows a clear inline “already in use” message.
  * Prevented misleading “Misconfigured Protocol” errors during duplicate-name validation.
  * Improved duplicate-name checks across ego and node variables while allowing variables to retain their current names.

* **Tests**
  * Added coverage for duplicate-name validation across supported variable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->