### PR TITLE
fix(interview): center Lucide icons in Name Generator add buttons

### DIFF
--- a/.changeset/name-generator-add-button-icon-centering.md
+++ b/.changeset/name-generator-add-button-icon-centering.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Fix the icon on the Name Generator add buttons drifting to the top of the circle when a node type uses a Lucide icon. The quick-add toggle and the create-new-node button now keep their icon vertically centred.

--- a/packages/interview/src/interfaces/NameGenerator/components/NodeForm.stories.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/NodeForm.stories.tsx
@@ -402,6 +402,24 @@ export const CreateNewNode: Story = {
   },
 };
 
+export const CreateNewNodeWithLucideIcon: Story = {
+  args: {
+    selectedNode: null,
+    form: basicForm,
+    disabled: false,
+    icon: 'Smartphone',
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Create-new-node button whose node type uses a Lucide icon (`Smartphone`) instead of a custom kebab-case icon. Verifies the icon stays vertically centred inside the toggle circle.',
+      },
+    },
+  },
+};
+
 export const EditExistingNode: Story = {
   args: {
     selectedNode: {

--- a/packages/interview/src/interfaces/NameGenerator/components/NodeForm.stories.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/NodeForm.stories.tsx
@@ -409,6 +409,7 @@ export const CreateNewNodeWithLucideIcon: Story = {
     disabled: false,
     icon: 'Smartphone',
   },
+  render: ({ icon: _icon, ...args }) => <NodeForm {...args} />,
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/packages/interview/src/interfaces/NameGenerator/components/NodeForm.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/NodeForm.tsx
@@ -185,7 +185,7 @@ const NodeForm = (props: NodeFormProps) => {
               )}
               style={{ backgroundColor: 'var(--primary)' }}
             >
-              <motion.div className="h-full">
+              <motion.div className="flex h-full items-center justify-center">
                 <Icon
                   name={icon as InterviewerIconName}
                   className={actionIconClass}

--- a/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.stories.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.stories.tsx
@@ -224,6 +224,26 @@ export const Default: Story = {
   },
 };
 
+export const WithLucideIcon: Story = {
+  args: {
+    name: 'name',
+    placeholder: 'Type a name and press enter...',
+    disabled: false,
+    icon: 'Smartphone',
+  },
+  render: ({ icon: _icon, ...args }) => (
+    <QuickAddFieldWrapper {...args} onFormSubmit={formSubmitAction} />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'QuickAddField whose node type uses a Lucide icon (`Smartphone`) instead of a custom kebab-case icon. Verifies the icon stays vertically centred inside the toggle circle.',
+      },
+    },
+  },
+};
+
 export const WithValidation: Story = {
   args: {
     name: 'name',

--- a/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
+++ b/packages/interview/src/interfaces/NameGenerator/components/QuickAddField.tsx
@@ -320,7 +320,7 @@ export default function QuickAddField({
                     initial={{ y: '100%' }}
                     animate={{ y: 0 }}
                     exit={{ y: '100%' }}
-                    className="h-full"
+                    className="flex h-full items-center justify-center"
                   >
                     <Icon
                       name={icon as InterviewerIconName}


### PR DESCRIPTION
Fixes this: 

<img width="227" height="265" alt="image" src="https://github.com/user-attachments/assets/9044c900-1d05-4c04-8bf2-a224f3ffb3dc" />
