### PR TITLE
fix(networkcanvas.com): remove iPhone/iPad download option

### DIFF
--- a/.changeset/remove-ios-classic-download.md
+++ b/.changeset/remove-ios-classic-download.md
@@ -1,0 +1,5 @@
+---
+"networkcanvas.com": patch
+---
+
+Remove the iPhone and iPad download option for Interviewer Classic. The linked App Store listing is no longer available, and Interviewer is not intended for phones.

--- a/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
+++ b/apps/networkcanvas.com/components/get-started/AppChoiceCard.tsx
@@ -34,7 +34,6 @@ const platformIcons = {
   'apple-intel': Apple,
   'windows': Monitor,
   'linux': Terminal,
-  'ios': Apple,
   'android': Smartphone,
 } satisfies Record<PlatformId, LucideIcon>;
 

--- a/apps/networkcanvas.com/components/get-started/__tests__/AppChoiceCard.test.tsx
+++ b/apps/networkcanvas.com/components/get-started/__tests__/AppChoiceCard.test.tsx
@@ -134,17 +134,9 @@ describe('AppChoiceCard', () => {
     }
   });
 
-  it('keeps the Classic tablet download options available', () => {
+  it('keeps the Classic Android download option available', () => {
     renderWithIntl(<AppChoiceCard app={interviewerClassic} />);
 
-    expect(
-      screen.getByRole('link', {
-        name: 'iPhone and iPad for Interviewer Classic',
-      }),
-    ).toHaveAttribute(
-      'href',
-      'https://apps.apple.com/us/app/network-canvas-interviewer/id1538673677',
-    );
     expect(
       screen.getByRole('link', {
         name: 'Android for Interviewer Classic',

--- a/apps/networkcanvas.com/lib/__tests__/getStarted.test.ts
+++ b/apps/networkcanvas.com/lib/__tests__/getStarted.test.ts
@@ -36,7 +36,7 @@ describe('get started content', () => {
       ({ id }) => id === 'interviewer-classic',
     );
     expect(interviewer?.platforms.map(({ id }) => id)).toEqual(
-      expect.arrayContaining(['ios', 'android']),
+      expect.arrayContaining(['android']),
     );
   });
 

--- a/apps/networkcanvas.com/lib/getStarted.ts
+++ b/apps/networkcanvas.com/lib/getStarted.ts
@@ -6,7 +6,6 @@ export type PlatformId =
   | 'apple-intel'
   | 'windows'
   | 'linux'
-  | 'ios'
   | 'android';
 
 type AppAction = {
@@ -54,7 +53,6 @@ type PlatformLink = {
     | 'platforms.appleIntel'
     | 'platforms.windows'
     | 'platforms.linux'
-    | 'platforms.ios'
     | 'platforms.android';
   href: string;
 };
@@ -228,11 +226,6 @@ export const classicApps = [
         id: 'linux',
         labelKey: 'platforms.linux',
         href: classicDestinations.interviewerRelease,
-      },
-      {
-        id: 'ios',
-        labelKey: 'platforms.ios',
-        href: 'https://apps.apple.com/us/app/network-canvas-interviewer/id1538673677',
       },
       {
         id: 'android',

--- a/apps/networkcanvas.com/messages/en.json
+++ b/apps/networkcanvas.com/messages/en.json
@@ -197,7 +197,6 @@
       "appleIntel": "Apple Intel",
       "windows": "Windows",
       "linux": "Linux",
-      "ios": "iPhone and iPad",
       "android": "Android"
     },
     "apps": {

--- a/apps/networkcanvas.com/messages/es.json
+++ b/apps/networkcanvas.com/messages/es.json
@@ -197,7 +197,6 @@
       "appleIntel": "Apple Intel",
       "windows": "Windows",
       "linux": "Linux",
-      "ios": "iPhone y iPad",
       "android": "Android"
     },
     "apps": {


### PR DESCRIPTION
This pull request removes support and references for the iOS ("ios") platform option for the Interviewer Classic app across the codebase, ensuring that only the Android option remains available for Classic. The changes update the app data, UI components, tests, and translations to reflect this removal.

**Removal of iOS platform for Interviewer Classic:**

* Removed the `ios` platform ID from the `PlatformId` type and all related platform link definitions in `getStarted.ts`. [[1]](diffhunk://#diff-39da5b3b1de5bf30a3f711259e0a234e40b086d0985b004b5442ff39eaf2f37bL9) [[2]](diffhunk://#diff-39da5b3b1de5bf30a3f711259e0a234e40b086d0985b004b5442ff39eaf2f37bL57)
* Deleted the iOS platform entry from the `classicApps` array, so Interviewer Classic is no longer offered for iOS.
* Removed the iOS icon mapping from the `platformIcons` object in `AppChoiceCard.tsx`.

**Test and translation updates:**

* Updated tests to expect only the Android option for Interviewer Classic, removing checks for iOS. [[1]](diffhunk://#diff-1d7d9e5478a4a9dd43060815db1dd97de539bc0389895d1d5ff7611c8a49d5d0L137-L147) [[2]](diffhunk://#diff-21299693f06027948b0a400a9893c663b7e4ab5b19d72c1bc997328aac70f159L39-R39)
* Removed the iOS platform label from both English and Spanish translation files. [[1]](diffhunk://#diff-edd9c7aa2c4725a1bdea305dc334c526e2a214f38023115289d0f8256bb513daL200) [[2]](diffhunk://#diff-cf1c523266bcb1fbe7e77e973ad7c48011c09f5570a4ebde851ef4bf74a0b6a4L200)