### PR TITLE
Release Website

### DIFF
--- a/.changeset/bright-principles-connect.md
+++ b/.changeset/bright-principles-connect.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Redesign the homepage design principles as wider, fully linked cards with original illustrations, and refresh the localized summer announcement copy.

--- a/.changeset/bright-summer-canvas.md
+++ b/.changeset/bright-summer-canvas.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": minor
----
-
-Introduce a localized Summer 2026 update page for the redesigned Architect and Interviewer apps, Fresco 4.0.0, and the Schema 8 protocol format. Publish the complete announcement in English and Spanish, and refresh shared website headings, buttons, navigation, and footer composition to support it.

--- a/.changeset/bright-website-partners.md
+++ b/.changeset/bright-website-partners.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Improve the homepage with a wider recent-publications grid, a compact scientific-advisors subsection, and larger, visually balanced institution logos.

--- a/.changeset/homepage-background-and-copy-tweaks.md
+++ b/.changeset/homepage-background-and-copy-tweaks.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Rename the site navigation "Docs" link to "Documentation", and calm the homepage background: the network weave now waits for the hero entrance before it appears, then eases its focus toward the viewport origin as the hero video scrolls away, with ribbons that retain their direction throughout the movement, instead of roaming between page sections as you scroll. Also reword the tools introduction to mention "apps" for survey design and interviewing, and refresh the Fresco description.

--- a/.changeset/remove-ios-classic-download.md
+++ b/.changeset/remove-ios-classic-download.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Remove the iPhone and iPad download option for Interviewer Classic. The linked App Store listing is no longer available, and Interviewer is not intended for phones.

--- a/.changeset/smooth-homepage-weave.md
+++ b/.changeset/smooth-homepage-weave.md
@@ -1,5 +1,0 @@
----
-'networkcanvas.com': patch
----
-
-Smooth the homepage background weave as visitors scroll beyond the hero.

--- a/.changeset/summer-announcement-page.md
+++ b/.changeset/summer-announcement-page.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Publish the Summer 2026 release announcement, refresh the homepage app screenshots and latest-news ticker, and refine the shared visual treatment across the website.

--- a/.changeset/tidy-screenshot-frames.md
+++ b/.changeset/tidy-screenshot-frames.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Show complete announcement screenshots in source-matched frames, localize the homepage announcement link, and keep the weave hidden until its entrance begins.

--- a/.changeset/vivid-pages-flow.md
+++ b/.changeset/vivid-pages-flow.md
@@ -1,5 +1,0 @@
----
-'networkcanvas.com': patch
----
-
-Add scroll-linked motion to the homepage and Get Started experience, including a pinned recent-publications rail, improve responsive tool cards, prevent animation-wrapper key warnings, and restore working mailing-list subscriptions.

--- a/.changeset/website-fluid-root-size.md
+++ b/.changeset/website-fluid-root-size.md
@@ -1,7 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Opt the marketing site into the shared fluid root-size ramp, so typography and
-spacing grow smoothly on wide and high-resolution displays while staying compact
-at standard sizes.

--- a/.changeset/website-weave-stacking.md
+++ b/.changeset/website-weave-stacking.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Keep the background weave behind page content so translucent surfaces retain their blur during entrance animations and scrolling, while team photos remain opaque.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,26 @@
 # networkcanvas.com
 
+## 0.2.0
+
+### Minor Changes
+
+- Introduce a localized Summer 2026 update page for the redesigned Architect and Interviewer apps, Fresco 4.0.0, and the Schema 8 protocol format. Publish the complete announcement in English and Spanish, and refresh shared website headings, buttons, navigation, and footer composition to support it.
+
+### Patch Changes
+
+- Redesign the homepage design principles as wider, fully linked cards with original illustrations, and refresh the localized summer announcement copy.
+- Improve the homepage with a wider recent-publications grid, a compact scientific-advisors subsection, and larger, visually balanced institution logos.
+- Rename the site navigation "Docs" link to "Documentation", and calm the homepage background: the network weave now waits for the hero entrance before it appears, then eases its focus toward the viewport origin as the hero video scrolls away, with ribbons that retain their direction throughout the movement, instead of roaming between page sections as you scroll. Also reword the tools introduction to mention "apps" for survey design and interviewing, and refresh the Fresco description.
+- Remove the iPhone and iPad download option for Interviewer Classic. The linked App Store listing is no longer available, and Interviewer is not intended for phones.
+- Smooth the homepage background weave as visitors scroll beyond the hero.
+- Publish the Summer 2026 release announcement, refresh the homepage app screenshots and latest-news ticker, and refine the shared visual treatment across the website.
+- Show complete announcement screenshots in source-matched frames, localize the homepage announcement link, and keep the weave hidden until its entrance begins.
+- Add scroll-linked motion to the homepage and Get Started experience, including a pinned recent-publications rail, improve responsive tool cards, prevent animation-wrapper key warnings, and restore working mailing-list subscriptions.
+- Opt the marketing site into the shared fluid root-size ramp, so typography and
+  spacing grow smoothly on wide and high-resolution displays while staying compact
+  at standard sizes.
+- Keep the background weave behind page content so translucent surfaces retain their blur during entrance animations and scrolling, while team photos remain opaque.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.1.1 | 0.2.0 |

### networkcanvas.com@0.2.0

### Minor Changes

- Introduce a localized Summer 2026 update page for the redesigned Architect and Interviewer apps, Fresco 4.0.0, and the Schema 8 protocol format. Publish the complete announcement in English and Spanish, and refresh shared website headings, buttons, navigation, and footer composition to support it.

### Patch Changes

- Redesign the homepage design principles as wider, fully linked cards with original illustrations, and refresh the localized summer announcement copy.
- Improve the homepage with a wider recent-publications grid, a compact scientific-advisors subsection, and larger, visually balanced institution logos.
- Rename the site navigation "Docs" link to "Documentation", and calm the homepage background: the network weave now waits for the hero entrance before it appears, then eases its focus toward the viewport origin as the hero video scrolls away, with ribbons that retain their direction throughout the movement, instead of roaming between page sections as you scroll. Also reword the tools introduction to mention "apps" for survey design and interviewing, and refresh the Fresco description.
- Remove the iPhone and iPad download option for Interviewer Classic. The linked App Store listing is no longer available, and Interviewer is not intended for phones.
- Smooth the homepage background weave as visitors scroll beyond the hero.
- Publish the Summer 2026 release announcement, refresh the homepage app screenshots and latest-news ticker, and refine the shared visual treatment across the website.
- Show complete announcement screenshots in source-matched frames, localize the homepage announcement link, and keep the weave hidden until its entrance begins.
- Add scroll-linked motion to the homepage and Get Started experience, including a pinned recent-publications rail, improve responsive tool cards, prevent animation-wrapper key warnings, and restore working mailing-list subscriptions.
- Opt the marketing site into the shared fluid root-size ramp, so typography and
  spacing grow smoothly on wide and high-resolution displays while staying compact
  at standard sizes.
- Keep the background weave behind page content so translucent surfaces retain their blur during entrance animations and scrolling, while team photos remain opaque.
