### PR TITLE
Fix/architect upgrade dialog spinner zindex

### DIFF
--- a/.changeset/architect-upgrade-dialog-spinner.md
+++ b/.changeset/architect-upgrade-dialog-spinner.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Fix the loading spinner covering the protocol upgrade dialog, which made the "Create upgraded copy" button unclickable when opening an older protocol.

--- a/apps/architect/src/components/Home/Home.tsx
+++ b/apps/architect/src/components/Home/Home.tsx
@@ -27,6 +27,7 @@ import {
   openBundledTemplate,
   openLibraryProtocol,
   openLocalNetcanvas,
+  type ProtocolOpenResult,
 } from '~/ducks/modules/userActions/userActions';
 import {
   BUNDLED_TEMPLATES,
@@ -74,14 +75,20 @@ const Home = () => {
     const id = setInterval(() => setVisibleCount((c) => c + 1), 2400);
     return () => clearInterval(id);
   }, []);
-  const runAction = useCallback(async (action: () => Promise<unknown>) => {
-    setIsLoading(true);
-    try {
-      await action();
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  // The loading overlay covers async work (dispatch, asset loading) only. It
+  // must be dismissed before any dialog is awaited, otherwise the spinner
+  // (rendered at a high z-index) paints over the dialog and blocks its buttons.
+  const runAction = useCallback(
+    async <T,>(action: () => Promise<T>): Promise<T> => {
+      setIsLoading(true);
+      try {
+        return await action();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
   const handleCreate = useCallback(
     (values: { name: string; description?: string }) => {
       setShowNewDialog(false);
@@ -93,14 +100,18 @@ const Home = () => {
   );
   const handleOpenLocalFile = useCallback(
     async (file: File) => {
-      const result = await dispatch(openLocalNetcanvas({ file })).unwrap();
+      const result = await runAction(() =>
+        dispatch(openLocalNetcanvas({ file })).unwrap(),
+      );
       await showProtocolOpenResultDialog({
         result,
         openDialog,
         onApproveMigration: async () => {
-          const approvedResult = await dispatch(
-            openLocalNetcanvas({ file, migrationApproved: true }),
-          ).unwrap();
+          const approvedResult = await runAction(() =>
+            dispatch(
+              openLocalNetcanvas({ file, migrationApproved: true }),
+            ).unwrap(),
+          );
           await showProtocolOpenResultDialog({
             result: approvedResult,
             openDialog,
@@ -108,14 +119,12 @@ const Home = () => {
         },
       });
     },
-    [dispatch, openDialog],
+    [dispatch, openDialog, runAction],
   );
   const onDrop = (files: File[]) => {
     const file = files[0];
     if (file) {
-      void runAction(async () => {
-        await handleOpenLocalFile(file);
-      });
+      void handleOpenLocalFile(file);
     }
   };
   const {
@@ -171,12 +180,22 @@ const Home = () => {
       const template = pendingTemplate;
       setPendingTemplate(null);
       if (!template) return;
-      void runAction(async () => {
-        let assets: ExtractedAsset[] | undefined;
+      void (async () => {
+        let result: ProtocolOpenResult;
         try {
-          assets = template.loadAssets
-            ? await template.loadAssets()
-            : undefined;
+          result = await runAction(async () => {
+            const assets: ExtractedAsset[] | undefined = template.loadAssets
+              ? await template.loadAssets()
+              : undefined;
+            return dispatch(
+              openBundledTemplate({
+                protocol: template.protocol,
+                name,
+                assets,
+                sourceRef: template.sourceRef,
+              }),
+            ).unwrap();
+          });
         } catch (error) {
           const { message } = reportError(error);
           void openDialog({
@@ -188,25 +207,19 @@ const Home = () => {
           });
           return;
         }
-        const result = await dispatch(
-          openBundledTemplate({
-            protocol: template.protocol,
-            name,
-            assets,
-            sourceRef: template.sourceRef,
-          }),
-        ).unwrap();
         await showProtocolOpenResultDialog({ result, openDialog });
-      });
+      })();
     },
     [dispatch, openDialog, pendingTemplate, runAction],
   );
   const handleOpenLibraryProtocol = useCallback(
     (id: string) => {
-      void runAction(async () => {
-        const result = await dispatch(openLibraryProtocol(id)).unwrap();
+      void (async () => {
+        const result = await runAction(() =>
+          dispatch(openLibraryProtocol(id)).unwrap(),
+        );
         await showProtocolOpenResultDialog({ result, openDialog });
-      });
+      })();
     },
     [dispatch, openDialog, runAction],
   );

--- a/apps/architect/src/components/Home/__tests__/Home.test.tsx
+++ b/apps/architect/src/components/Home/__tests__/Home.test.tsx
@@ -1,16 +1,22 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 const openFileDialogMock = vi.hoisted(() => vi.fn());
+const dropzoneRef = vi.hoisted(() => ({
+  onDrop: undefined as ((files: File[]) => void) | undefined,
+}));
 
 vi.mock('react-dropzone', () => ({
-  useDropzone: () => ({
-    getRootProps: () => ({}),
-    getInputProps: () => ({}),
-    isDragActive: false,
-    open: openFileDialogMock,
-  }),
+  useDropzone: (options: { onDrop: (files: File[]) => void }) => {
+    dropzoneRef.onDrop = options.onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      open: openFileDialogMock,
+    };
+  },
 }));
 
 vi.mock('~/components/AppUpdate/AppUpdatePill', () => ({
@@ -25,12 +31,16 @@ vi.mock('~/components/ProjectNav/NavShell', () => ({
   default: ({ trailing }: { trailing: ReactNode }) => <nav>{trailing}</nav>,
 }));
 
+const showProtocolOpenResultDialogMock = vi.hoisted(() => vi.fn());
+
 vi.mock('~/components/protocolOpenDialogs', () => ({
-  showProtocolOpenResultDialog: vi.fn(),
+  showProtocolOpenResultDialog: showProtocolOpenResultDialogMock,
 }));
 
+const dispatchMock = vi.hoisted(() => vi.fn());
+
 vi.mock('~/ducks/hooks', () => ({
-  useAppDispatch: () => vi.fn(),
+  useAppDispatch: () => dispatchMock,
 }));
 
 vi.mock('~/ducks/modules/userActions/userActions', () => ({
@@ -50,7 +60,10 @@ vi.mock('~/templates/sample-protocol', () => ({
 }));
 
 vi.mock('../LibraryPanel', () => ({ default: () => null }));
-vi.mock('../ProtocolLoadingOverlay', () => ({ default: () => null }));
+vi.mock('../ProtocolLoadingOverlay', () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="protocol-loading-overlay" /> : null,
+}));
 vi.mock('../TransitMap', () => ({ default: () => null }));
 
 import Home from '../Home';
@@ -78,5 +91,33 @@ describe('<Home />', () => {
       '[--component-text:var(--accent)]',
       'focus:outline-accent',
     );
+  });
+
+  it('keeps the loading overlay off while a protocol-open dialog is awaited', async () => {
+    dispatchMock.mockReturnValue({
+      unwrap: () => Promise.resolve({ status: 'migration-required' }),
+    });
+    // Leave the dialog pending to represent the user reading it and deciding.
+    let resolveDialog: (() => void) | undefined;
+    showProtocolOpenResultDialogMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDialog = resolve;
+        }),
+    );
+
+    render(<Home />);
+
+    await act(async () => {
+      dropzoneRef.onDrop?.([new File(['{}'], 'protocol.netcanvas')]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(showProtocolOpenResultDialogMock).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByTestId('protocol-loading-overlay'),
+    ).not.toBeInTheDocument();
+
+    resolveDialog?.();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the loading spinner could block interaction with the protocol upgrade dialog.
  * Restored clickability of the “Create upgraded copy” button when opening older protocols.
  * Improved loading behavior when opening local protocols, templates, and library protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->