### PR TITLE
fix(architect, protocol-validation): close schema-8 invalid protocol states

### DIFF
--- a/.changeset/architect-schema8-editor-guards.md
+++ b/.changeset/architect-schema8-editor-guards.md
@@ -1,0 +1,10 @@
+---
+'@codaco/architect': patch
+---
+
+Closed several ways a protocol could be left in a state the validator rejects, where saving previously appeared to work but the stage silently reverted:
+
+- Mapping a variable to a node shape now requires a variable to be chosen, and a breakpoint mapping requires at least one threshold with strictly increasing values. New thresholds start above the previous one, and an incomplete mapping blocks saving with an explanation instead of reverting without warning.
+- Changing the node type of a Family Pedigree stage is now blocked, with an explanation, while a Narrative Pedigree stage depends on it — preventing a broken reference to a variable that no longer exists on the new type.
+- The map stage now reads feature properties from every feature in a GeoJSON file rather than only the first, so the property selector appears whenever any feature has properties. When no feature has any, saving is blocked with a clear message rather than failing validation later.
+- The codebook's "used in" display now names shape settings as a place a variable is used.

--- a/.changeset/protocol-validation-schema8-migration-guards.md
+++ b/.changeset/protocol-validation-schema8-migration-guards.md
@@ -1,0 +1,11 @@
+---
+'@codaco/protocol-validation': patch
+---
+
+Migrating a protocol from schema 7 to schema 8 now repairs several legacy shapes that schema 8 would otherwise reject, so older protocols import cleanly instead of failing validation:
+
+- External-data side panels no longer keep edge rules, which can never match on an external data source; these rules are stripped during migration.
+- Filters with more than one rule but no join are backfilled to `OR`, matching the query runtime's default.
+- Form fields bound to a non-renderable variable (a layout or location variable) are dropped, and any form left with no fields is removed.
+
+Shape-to-variable mappings on node types are now recorded as variable references, so where-used reporting and dangling-reference validation account for them.

--- a/apps/architect/src/components/Codebook/EntityTypeDialog.tsx
+++ b/apps/architect/src/components/Codebook/EntityTypeDialog.tsx
@@ -7,6 +7,7 @@ import InlineEditScreen from '~/components/InlineEditScreen/InlineEditScreen';
 import { format, parse } from '~/components/TypeEditor/convert';
 import getNewTypeTemplate from '~/components/TypeEditor/getNewTypeTemplate';
 import TypeEditor from '~/components/TypeEditor/TypeEditor';
+import validateEntityType from '~/components/TypeEditor/validateEntityType';
 import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
 import {
   createTypeAsync,
@@ -168,6 +169,7 @@ const EntityTypeDialog = ({
       onSubmit={handleSubmit as (values: unknown) => void}
       onCancel={handleCancel}
       initialValues={initialValues}
+      validate={validateEntityType}
     >
       <TypeEditor form={formName} entity={entity} type={type} isNew={isNew} />
     </InlineEditScreen>

--- a/apps/architect/src/components/Codebook/helpers.ts
+++ b/apps/architect/src/components/Codebook/helpers.ts
@@ -40,8 +40,6 @@ const getVariableMetaByIndex = createSelector([getCodebook], (codebook) => {
   return variables;
 });
 
-// Node/edge type id -> name, so type-level usage references (e.g. a node type's
-// shape mapping) can be labelled with the type's name rather than its id.
 const getTypeMetaByIndex = createSelector([getCodebook], (codebook) => {
   const typeNames: Record<string, string> = {};
   if (!codebook) return typeNames;
@@ -128,9 +126,6 @@ export const getUsageAsStageMeta = (
           : undefined;
         codebookVariableNames.add(variable?.name || 'unknown');
       } else if (segments.includes('shape')) {
-        // A type-level shape mapping reference — `codebook.<entity>.<typeId>.
-        // shape.dynamic.variable` — has no `variables` segment because the
-        // reference lives on the type, not inside a variable definition.
         const typeId = segments[2];
         const typeName = typeId ? typeMetaByIndex[typeId] : undefined;
         shapeMappingTypeNames.add(typeName || 'unknown');

--- a/apps/architect/src/components/Codebook/helpers.ts
+++ b/apps/architect/src/components/Codebook/helpers.ts
@@ -40,6 +40,23 @@ const getVariableMetaByIndex = createSelector([getCodebook], (codebook) => {
   return variables;
 });
 
+// Node/edge type id -> name, so type-level usage references (e.g. a node type's
+// shape mapping) can be labelled with the type's name rather than its id.
+const getTypeMetaByIndex = createSelector([getCodebook], (codebook) => {
+  const typeNames: Record<string, string> = {};
+  if (!codebook) return typeNames;
+  for (const entity of ['node', 'edge'] as const) {
+    const types = codebook[entity];
+    if (!types) continue;
+    for (const [id, definition] of Object.entries(types)) {
+      if (definition && typeof definition.name === 'string') {
+        typeNames[id] = definition.name;
+      }
+    }
+  }
+  return typeNames;
+});
+
 /**
  * Takes an object in the format of `{[path]: variableID}` and a variableID to
  * search for. Returns an array of paths that match the variableID.
@@ -89,8 +106,10 @@ export const getUsageAsStageMeta = (
   stageMetaByIndex: StageMeta[],
   variableMetaByIndex: Variables,
   usageArray: string[],
+  typeMetaByIndex: Record<string, string> = {},
 ): UsageMeta[] => {
   const codebookVariableNames = new Set<string>();
+  const shapeMappingTypeNames = new Set<string>();
   const stageIndexSet = new Set<number>();
 
   for (const key of usageArray) {
@@ -102,15 +121,29 @@ export const getUsageAsStageMeta = (
       }
     } else if (segments[0] === 'codebook') {
       const variablesPos = segments.indexOf('variables');
-      const variableId =
-        variablesPos !== -1 ? segments[variablesPos + 1] : undefined;
-      const variable = variableId ? variableMetaByIndex[variableId] : undefined;
-      codebookVariableNames.add(variable?.name || 'unknown');
+      if (variablesPos !== -1) {
+        const variableId = segments[variablesPos + 1];
+        const variable = variableId
+          ? variableMetaByIndex[variableId]
+          : undefined;
+        codebookVariableNames.add(variable?.name || 'unknown');
+      } else if (segments.includes('shape')) {
+        // A type-level shape mapping reference — `codebook.<entity>.<typeId>.
+        // shape.dynamic.variable` — has no `variables` segment because the
+        // reference lives on the type, not inside a variable definition.
+        const typeId = segments[2];
+        const typeName = typeId ? typeMetaByIndex[typeId] : undefined;
+        shapeMappingTypeNames.add(typeName || 'unknown');
+      }
     }
   }
 
   const codebookVariablesWithMeta: UsageMeta[] = [...codebookVariableNames].map(
     (name) => ({ label: `Used as validation for "${name}"` }),
+  );
+
+  const shapeMappingsWithMeta: UsageMeta[] = [...shapeMappingTypeNames].map(
+    (name) => ({ label: `Used in shape settings for "${name}"` }),
   );
 
   const stageVariablesWithMeta = compact(
@@ -119,7 +152,11 @@ export const getUsageAsStageMeta = (
     ),
   );
 
-  return [...stageVariablesWithMeta, ...codebookVariablesWithMeta];
+  return [
+    ...stageVariablesWithMeta,
+    ...codebookVariablesWithMeta,
+    ...shapeMappingsWithMeta,
+  ];
 };
 
 /**
@@ -151,8 +188,8 @@ export const makeGetEntityWithUsage = (
   mergeProps: Record<string, unknown>,
 ) =>
   createSelector(
-    [getStageMetaByIndex, getVariableMetaByIndex],
-    (stageMetaByIndex, variableMetaByIndex) => {
+    [getStageMetaByIndex, getVariableMetaByIndex, getTypeMetaByIndex],
+    (stageMetaByIndex, variableMetaByIndex, typeMetaByIndex) => {
       const search = utils.buildSearch([index]);
 
       return (_: unknown, id: string) => {
@@ -162,6 +199,7 @@ export const makeGetEntityWithUsage = (
               stageMetaByIndex,
               variableMetaByIndex,
               getUsage(index, id),
+              typeMetaByIndex,
             )
           : [];
 
@@ -234,6 +272,7 @@ export const getEntityProperties = (
 
   const variableIndex = getVariableIndex(state);
   const variableMeta = getVariableMetaByIndex(state);
+  const typeMeta = getTypeMetaByIndex(state);
   const stageMetaByIndex = getStageMetaByIndex(state);
   const isUsedIndex = makeGetIsUsed({ formNames: [] })(state);
 
@@ -257,6 +296,7 @@ export const getEntityProperties = (
       stageMetaByIndex,
       variableMeta,
       getUsage(variableIndex, id),
+      typeMeta,
     ).toSorted(sortByLabel);
 
     const usageString = usage

--- a/apps/architect/src/components/Form/ValidatedField.tsx
+++ b/apps/architect/src/components/Form/ValidatedField.tsx
@@ -25,6 +25,7 @@ type ValidatedFieldProps<T = Record<string, never>> = Omit<
   inline?: boolean;
   entityType?: string;
   promptBeforeChange?: string;
+  blockChangeReason?: string | null;
 } & InputHTMLAttributes<HTMLInputElement>;
 
 /**

--- a/apps/architect/src/components/InlineEditScreen/Form.tsx
+++ b/apps/architect/src/components/InlineEditScreen/Form.tsx
@@ -45,9 +45,6 @@ type WrappedFormProps = {
   id?: string;
   onSubmit?: (values: unknown) => void | Promise<void>;
   initialValues?: unknown;
-  // Optional redux-form synchronous validator. reduxForm reads `validate` from
-  // props, so consumers can supply a form-specific one without baking it into
-  // this shared HOC (which also backs NewVariableWindow and others).
   validate?: (values: Record<string, unknown>) => Record<string, unknown>;
 };
 

--- a/apps/architect/src/components/InlineEditScreen/Form.tsx
+++ b/apps/architect/src/components/InlineEditScreen/Form.tsx
@@ -45,6 +45,10 @@ type WrappedFormProps = {
   id?: string;
   onSubmit?: (values: unknown) => void | Promise<void>;
   initialValues?: unknown;
+  // Optional redux-form synchronous validator. reduxForm reads `validate` from
+  // props, so consumers can supply a form-specific one without baking it into
+  // this shared HOC (which also backs NewVariableWindow and others).
+  validate?: (values: Record<string, unknown>) => Record<string, unknown>;
 };
 
 /**

--- a/apps/architect/src/components/InlineEditScreen/InlineEditScreen.tsx
+++ b/apps/architect/src/components/InlineEditScreen/InlineEditScreen.tsx
@@ -16,6 +16,7 @@ type InlineEditScreenProps = {
   onCancel: () => void;
   children?: React.ReactNode;
   initialValues?: Record<string, unknown>;
+  validate?: (values: Record<string, unknown>) => Record<string, unknown>;
 };
 
 const InlineEditScreen = ({
@@ -26,6 +27,7 @@ const InlineEditScreen = ({
   onCancel,
   children = null,
   initialValues,
+  validate,
 }: InlineEditScreenProps) => {
   const dispatch = useAppDispatch();
   const submitting = useAppSelector(isSubmitting(form));
@@ -58,7 +60,12 @@ const InlineEditScreen = ({
       }
     >
       <Layout>
-        <Form form={form} onSubmit={onSubmit} initialValues={initialValues}>
+        <Form
+          form={form}
+          onSubmit={onSubmit}
+          initialValues={initialValues}
+          validate={validate}
+        >
           {children}
         </Form>
       </Layout>

--- a/apps/architect/src/components/InlineEditScreen/__tests__/validate.test.tsx
+++ b/apps/architect/src/components/InlineEditScreen/__tests__/validate.test.tsx
@@ -1,0 +1,78 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { reducer as formReducer } from 'redux-form';
+import { describe, expect, it, vi } from 'vitest';
+
+import validateEntityType from '~/components/TypeEditor/validateEntityType';
+
+import InlineEditScreen from '../InlineEditScreen';
+
+const renderScreen = (
+  validate: (values: Record<string, unknown>) => Record<string, unknown>,
+  initialValues: Record<string, unknown>,
+) => {
+  const onSubmit = vi.fn();
+  const store = configureStore({
+    reducer: { form: formReducer },
+    middleware: (getDefault) => getDefault({ serializableCheck: false }),
+  });
+
+  render(
+    <Provider store={store}>
+      <InlineEditScreen
+        show
+        form="TEST_FORM"
+        onSubmit={onSubmit}
+        onCancel={() => undefined}
+        initialValues={initialValues}
+        validate={validate}
+      >
+        <div>body</div>
+      </InlineEditScreen>
+    </Provider>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save and Close' }));
+
+  return onSubmit;
+};
+
+// redux-form's isValid only inspects errors on registered fields, and the shape
+// mapping is built from unconnected controls — so a per-field error alone lets
+// the save through. These guard the form-level _error that actually blocks it.
+describe('InlineEditScreen validation', () => {
+  it('blocks the save when a breakpoint mapping has no thresholds', () => {
+    const onSubmit = renderScreen(validateEntityType, {
+      shape: {
+        default: 'circle',
+        dynamic: { variable: 'v1', type: 'breakpoints', thresholds: [] },
+      },
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('blocks the save when a shape mapping has no variable', () => {
+    const onSubmit = renderScreen(validateEntityType, {
+      shape: { default: 'circle', dynamic: {} },
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('saves when the shape mapping is complete', () => {
+    const onSubmit = renderScreen(validateEntityType, {
+      shape: {
+        default: 'circle',
+        dynamic: {
+          variable: 'v1',
+          type: 'breakpoints',
+          thresholds: [{ value: 1, shape: 'square' }],
+        },
+      },
+    });
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/apps/architect/src/components/TypeEditor/ShapePicker.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapePicker.tsx
@@ -16,11 +16,14 @@ export const SHAPES: Array<{ value: NodeShape; label: string }> = [
   { value: 'diamond', label: 'Diamond' },
 ];
 
+const isNodeShape = (value: unknown): value is NodeShape =>
+  SHAPES.some((shape) => shape.value === value);
+
 type ShapePickerControlProps = {
   'id'?: string;
   'name'?: string;
-  'value'?: string;
-  'onChange'?: (value: string) => void;
+  'value'?: NodeShape;
+  'onChange'?: (value: NodeShape) => void;
   'onBlur'?: FocusEventHandler;
   'onFocus'?: FocusEventHandler;
   'small'?: boolean;
@@ -61,7 +64,7 @@ export const ShapePickerControl = ({
       name={name}
       value={value ?? ''}
       onValueChange={(nextValue) => {
-        if (!readOnly && typeof nextValue === 'string') onChange?.(nextValue);
+        if (!readOnly && isNodeShape(nextValue)) onChange?.(nextValue);
       }}
       disabled={disabled}
       readOnly={readOnly}

--- a/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -212,9 +212,6 @@ const ShapeVariableMapping = ({
   const selectedVar =
     selectedVarId && variables ? variables[selectedVarId] : undefined;
   const thresholdConfig = getThresholdInputConfig(selectedVar);
-  // Surface the type-editor's synchronous validation once a save has been
-  // attempted, so a blocked submit explains itself rather than silently
-  // no-op-ing. Before the first submit the guidance below stays out of the way.
   const submitFailed = useAppSelector((state: RootState) =>
     hasSubmitFailed(form)(state),
   );
@@ -224,9 +221,6 @@ const ShapeVariableMapping = ({
           ?.shape?.dynamic
       : undefined,
   );
-  // New thresholds seed one step above the current maximum (bounded by the
-  // variable's range) so successive "Add threshold" clicks stay strictly
-  // ascending instead of stacking duplicate zeros.
   const getNextThresholdValue = (): number => {
     const existing = dynamic?.thresholds ?? [];
     const step =

--- a/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -229,7 +229,11 @@ const ShapeVariableMapping = ({
   };
   const handleToggle = () => {
     if (enabled) {
-      dispatch(change(form, 'shape.dynamic', undefined));
+      // redux-form only deletes a value whose `initial` counterpart is
+      // undefined, so change('shape.dynamic', undefined) silently no-ops for a
+      // mapping loaded from the protocol. Replacing the whole shape object
+      // drops `dynamic` for saved and unsaved mappings alike.
+      dispatch(change(form, 'shape', { default: defaultShape ?? 'circle' }));
     } else {
       dispatch(change(form, 'shape.dynamic', {}));
     }

--- a/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -1,6 +1,11 @@
 import { Trash2 } from 'lucide-react';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import { change, formValueSelector } from 'redux-form';
+import {
+  change,
+  formValueSelector,
+  getFormSyncErrors,
+  hasSubmitFailed,
+} from 'redux-form';
 
 import { IconButton } from '@codaco/fresco-ui/Button';
 import UnconnectedField from '@codaco/fresco-ui/form/Field/UnconnectedField';
@@ -17,6 +22,7 @@ import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/store';
 
 import { ShapePickerControl, SHAPES } from './ShapePicker';
+import type { EntityTypeFormErrors } from './validateEntityType';
 const DISCRETE_TYPES = new Set(['categorical', 'ordinal', 'boolean']);
 const BREAKPOINT_TYPES = new Set(['number', 'scalar']);
 const ELIGIBLE_TYPES = new Set([...DISCRETE_TYPES, ...BREAKPOINT_TYPES]);
@@ -205,6 +211,34 @@ const ShapeVariableMapping = ({
   const selectedVarId = dynamic?.variable;
   const selectedVar =
     selectedVarId && variables ? variables[selectedVarId] : undefined;
+  const thresholdConfig = getThresholdInputConfig(selectedVar);
+  // Surface the type-editor's synchronous validation once a save has been
+  // attempted, so a blocked submit explains itself rather than silently
+  // no-op-ing. Before the first submit the guidance below stays out of the way.
+  const submitFailed = useAppSelector((state: RootState) =>
+    hasSubmitFailed(form)(state),
+  );
+  const dynamicErrors = useAppSelector((state: RootState) =>
+    submitFailed
+      ? (getFormSyncErrors(form)(state) as EntityTypeFormErrors | undefined)
+          ?.shape?.dynamic
+      : undefined,
+  );
+  // New thresholds seed one step above the current maximum (bounded by the
+  // variable's range) so successive "Add threshold" clicks stay strictly
+  // ascending instead of stacking duplicate zeros.
+  const getNextThresholdValue = (): number => {
+    const existing = dynamic?.thresholds ?? [];
+    const step =
+      typeof thresholdConfig.step === 'number' ? thresholdConfig.step : 1;
+    const base =
+      existing.length > 0
+        ? Math.max(...existing.map((threshold) => threshold.value)) + step
+        : (thresholdConfig.min ?? 0);
+    return thresholdConfig.max !== undefined
+      ? Math.min(base, thresholdConfig.max)
+      : base;
+  };
   const handleToggle = () => {
     if (enabled) {
       dispatch(change(form, 'shape.dynamic', undefined));
@@ -313,6 +347,11 @@ const ShapeVariableMapping = ({
             options={variableOptions}
             disallowCreation
           />
+          {dynamicErrors?.variable && (
+            <Paragraph className="text-destructive mt-1 text-sm">
+              {dynamicErrors.variable}
+            </Paragraph>
+          )}
 
           {selectedVar && dynamic?.type === 'discrete' && (
             <div className="flex flex-col gap-3">
@@ -385,7 +424,7 @@ const ShapeVariableMapping = ({
               </Surface>
               <ThresholdItemContext.Provider
                 value={{
-                  config: getThresholdInputConfig(selectedVar),
+                  config: thresholdConfig,
                   nodeColor,
                 }}
               >
@@ -399,12 +438,20 @@ const ShapeVariableMapping = ({
                   value={dynamic.thresholds ?? []}
                   onChange={(next) => handleThresholdsChange(next ?? [])}
                   itemComponent={ThresholdItem}
-                  itemTemplate={() => ({ value: 0, shape: 'square' })}
+                  itemTemplate={() => ({
+                    value: getNextThresholdValue(),
+                    shape: 'square',
+                  })}
                   addButtonLabel="Add threshold"
                   emptyStateMessage="No thresholds yet — every value uses the default shape."
                   itemClasses={ITEM_ROW_CLASSES}
                 />
               </ThresholdItemContext.Provider>
+              {dynamicErrors?.thresholds && (
+                <Paragraph className="text-destructive mt-1 text-sm">
+                  {dynamicErrors.thresholds}
+                </Paragraph>
+              )}
             </div>
           )}
         </div>

--- a/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -284,7 +284,7 @@ const ShapeVariableMapping = ({
   // re-sorts by value before it is stored. `toSorted` keeps the same item
   // references, so ArrayField's identity tracking follows items across the sort.
   const handleThresholdsChange = (next: ShapeThreshold[]) => {
-    const sorted = [...next].toSorted((a, b) => a.value - b.value);
+    const sorted = next.toSorted((a, b) => a.value - b.value);
     dispatch(change(form, 'shape.dynamic.thresholds', sorted));
   };
   const getDiscreteOptions = (): Array<{

--- a/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
+++ b/apps/architect/src/components/TypeEditor/ShapeVariableMapping.tsx
@@ -17,26 +17,38 @@ import ToggleField from '@codaco/fresco-ui/form/fields/ToggleField';
 import Surface from '@codaco/fresco-ui/layout/Surface';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+import type {
+  NodeShape,
+  Validation,
+  VariableOptions,
+  VariableType,
+} from '@codaco/protocol-validation';
 import { VariablePickerControl } from '~/components/Form/Fields/VariablePicker/VariablePicker';
 import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
 import type { RootState } from '~/ducks/store';
 
+import type {
+  DiscreteShapeMapEntry,
+  ShapeMappingDraft,
+  ShapeThreshold,
+} from './shapeMappingTypes';
 import { ShapePickerControl, SHAPES } from './ShapePicker';
 import type { EntityTypeFormErrors } from './validateEntityType';
-const DISCRETE_TYPES = new Set(['categorical', 'ordinal', 'boolean']);
-const BREAKPOINT_TYPES = new Set(['number', 'scalar']);
-const ELIGIBLE_TYPES = new Set([...DISCRETE_TYPES, ...BREAKPOINT_TYPES]);
+const DISCRETE_TYPES = new Set<VariableType>([
+  'categorical',
+  'ordinal',
+  'boolean',
+]);
+const BREAKPOINT_TYPES = new Set<VariableType>(['number', 'scalar']);
+const ELIGIBLE_TYPES = new Set<VariableType>([
+  ...DISCRETE_TYPES,
+  ...BREAKPOINT_TYPES,
+]);
 type Variable = {
   name: string;
-  type: string;
-  options?: Array<{
-    label: string;
-    value: string | number | boolean;
-  }>;
-  validation?: {
-    minValue?: number;
-    maxValue?: number;
-  };
+  type: VariableType;
+  options?: VariableOptions;
+  validation?: Pick<Validation, 'minValue' | 'maxValue'>;
 };
 const parseThresholdValue = (value: string | undefined): number | null => {
   if (typeof value !== 'string' || value.trim() === '') {
@@ -76,11 +88,6 @@ const MAX_THRESHOLDS = SHAPES.length - 1;
 const ITEM_ROW_CLASSES =
   'bg-input text-input-contrast flex w-full min-h-20 items-center gap-3 rounded-lg px-4';
 
-type ThresholdData = {
-  value: number;
-  shape: string;
-};
-
 // The item component is a stable top-level component (so ArrayField never
 // remounts rows); the per-variable input bounds and the node colour reach it
 // through context rather than being closed over in the render.
@@ -102,10 +109,10 @@ const ThresholdItem = ({
   index,
   onUpdate,
   onDelete,
-}: ArrayFieldItemProps<ThresholdData>) => {
+}: ArrayFieldItemProps<ShapeThreshold>) => {
   const { config, nodeColor } = useContext(ThresholdItemContext);
   const value = item.value ?? 0;
-  const shape = item.shape ?? '';
+  const shape = item.shape;
   const [draft, setDraft] = useState(() => String(value));
 
   useEffect(() => {
@@ -172,23 +179,10 @@ const ShapeVariableMapping = ({
   ) as Record<string, Variable> | undefined;
   const dynamic = useAppSelector((state: RootState) =>
     formSelector(state, 'shape.dynamic'),
-  ) as
-    | {
-        variable?: string;
-        type?: string;
-        map?: Array<{
-          value: string | number | boolean;
-          shape: string;
-        }>;
-        thresholds?: Array<{
-          value: number;
-          shape: string;
-        }>;
-      }
-    | undefined;
+  ) as ShapeMappingDraft | undefined;
   const defaultShape = useAppSelector((state: RootState) =>
     formSelector(state, 'shape.default'),
-  ) as string | undefined;
+  ) as NodeShape | undefined;
   const enabled = !!dynamic;
   const eligibleVariables = useMemo(() => {
     if (!variables) return [];
@@ -265,17 +259,14 @@ const ShapeVariableMapping = ({
     }
   };
   const handleDiscreteShapeChange = (
-    value: string | number | boolean,
-    shape: string,
+    value: DiscreteShapeMapEntry['value'],
+    shape: NodeShape,
   ) => {
     const currentMap = dynamic?.map ?? [];
     const existingIndex = currentMap.findIndex(
       (entry) => JSON.stringify(entry.value) === JSON.stringify(value),
     );
-    let newMap: Array<{
-      value: string | number | boolean;
-      shape: string;
-    }>;
+    let newMap: DiscreteShapeMapEntry[];
     if (existingIndex >= 0) {
       newMap = currentMap.map((entry, i) =>
         i === existingIndex ? { ...entry, shape } : entry,
@@ -288,13 +279,13 @@ const ShapeVariableMapping = ({
   // The schema requires thresholds strictly ascending, so every mutation
   // re-sorts by value before it is stored. `toSorted` keeps the same item
   // references, so ArrayField's identity tracking follows items across the sort.
-  const handleThresholdsChange = (next: ThresholdData[]) => {
+  const handleThresholdsChange = (next: ShapeThreshold[]) => {
     const sorted = [...next].toSorted((a, b) => a.value - b.value);
     dispatch(change(form, 'shape.dynamic.thresholds', sorted));
   };
   const getDiscreteOptions = (): Array<{
     label: string;
-    value: string | number | boolean;
+    value: DiscreteShapeMapEntry['value'];
   }> => {
     if (!selectedVar) return [];
     if (selectedVar.type === 'boolean') {
@@ -308,12 +299,11 @@ const ShapeVariableMapping = ({
     }
     return selectedVar.options ?? [];
   };
-  const getShapeForValue = (value: string | number | boolean): string => {
-    const entry = dynamic?.map?.find(
-      (m) => JSON.stringify(m.value) === JSON.stringify(value),
-    );
-    return entry?.shape ?? '';
-  };
+  const getShapeForValue = (
+    value: DiscreteShapeMapEntry['value'],
+  ): NodeShape | undefined =>
+    dynamic?.map?.find((m) => JSON.stringify(m.value) === JSON.stringify(value))
+      ?.shape;
   return (
     <div className="mt-5">
       <div className="border-surface-2 border-t py-2.5">
@@ -422,7 +412,7 @@ const ShapeVariableMapping = ({
                   nodeColor,
                 }}
               >
-                <ArrayField<ThresholdData>
+                <ArrayField<ShapeThreshold>
                   aria-label="Thresholds"
                   className="w-full gap-3 border-0 bg-transparent p-0"
                   sortable={false}

--- a/apps/architect/src/components/TypeEditor/__tests__/shapeToggle.test.tsx
+++ b/apps/architect/src/components/TypeEditor/__tests__/shapeToggle.test.tsx
@@ -1,0 +1,80 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import {
+  formValueSelector,
+  initialize,
+  reducer as formReducer,
+} from 'redux-form';
+import { describe, expect, it } from 'vitest';
+
+import ShapeVariableMapping from '../ShapeVariableMapping';
+
+const FORM = 'TEST_FORM';
+
+const MAPPING = {
+  variable: 'v1',
+  type: 'breakpoints',
+  thresholds: [{ value: 1, shape: 'square' }],
+};
+
+const renderWithShape = (shape: Record<string, unknown>) => {
+  const store = configureStore({
+    reducer: {
+      form: formReducer,
+      activeProtocol: () => ({
+        present: { codebook: { node: {}, edge: {} }, stages: [] },
+      }),
+    },
+    middleware: (getDefault) => getDefault({ serializableCheck: false }),
+  });
+
+  store.dispatch(
+    initialize(FORM, {
+      variables: { v1: { name: 'age', type: 'number' } },
+      shape,
+    }),
+  );
+
+  render(
+    <Provider store={store}>
+      <ShapeVariableMapping form={FORM} />
+    </Provider>,
+  );
+
+  return store;
+};
+
+describe('ShapeVariableMapping toggle', () => {
+  it('turns shape mapping on', () => {
+    const store = renderWithShape({ default: 'circle' });
+
+    fireEvent.click(screen.getByLabelText('Map variable to shape'));
+
+    expect(formValueSelector(FORM)(store.getState(), 'shape.dynamic')).toEqual(
+      {},
+    );
+  });
+
+  // redux-form only deletes a value whose `initial` counterpart is undefined,
+  // so a mapping that came from the saved protocol could not be turned off.
+  it('turns off a mapping that was loaded from the protocol', () => {
+    const store = renderWithShape({ default: 'diamond', dynamic: MAPPING });
+
+    fireEvent.click(screen.getByLabelText('Map variable to shape'));
+
+    expect(
+      formValueSelector(FORM)(store.getState(), 'shape.dynamic'),
+    ).toBeUndefined();
+  });
+
+  it('keeps the default shape when turning a mapping off', () => {
+    const store = renderWithShape({ default: 'diamond', dynamic: MAPPING });
+
+    fireEvent.click(screen.getByLabelText('Map variable to shape'));
+
+    expect(formValueSelector(FORM)(store.getState(), 'shape.default')).toBe(
+      'diamond',
+    );
+  });
+});

--- a/apps/architect/src/components/TypeEditor/__tests__/shapeToggle.test.tsx
+++ b/apps/architect/src/components/TypeEditor/__tests__/shapeToggle.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import {
   formValueSelector,
-  initialize,
   reducer as formReducer,
+  reduxForm,
 } from 'redux-form';
 import { describe, expect, it } from 'vitest';
 
@@ -12,11 +12,19 @@ import ShapeVariableMapping from '../ShapeVariableMapping';
 
 const FORM = 'TEST_FORM';
 
+type FormValues = {
+  variables: Record<string, { name: string; type: string }>;
+  shape: Record<string, unknown>;
+};
+
 const MAPPING = {
   variable: 'v1',
   type: 'breakpoints',
   thresholds: [{ value: 1, shape: 'square' }],
 };
+
+const Harness = () => <ShapeVariableMapping form={FORM} />;
+const ReduxHarness = reduxForm<FormValues>({ form: FORM })(Harness);
 
 const renderWithShape = (shape: Record<string, unknown>) => {
   const store = configureStore({
@@ -29,16 +37,14 @@ const renderWithShape = (shape: Record<string, unknown>) => {
     middleware: (getDefault) => getDefault({ serializableCheck: false }),
   });
 
-  store.dispatch(
-    initialize(FORM, {
-      variables: { v1: { name: 'age', type: 'number' } },
-      shape,
-    }),
-  );
-
   render(
     <Provider store={store}>
-      <ShapeVariableMapping form={FORM} />
+      <ReduxHarness
+        initialValues={{
+          variables: { v1: { name: 'age', type: 'number' } },
+          shape,
+        }}
+      />
     </Provider>,
   );
 

--- a/apps/architect/src/components/TypeEditor/__tests__/validateEntityType.test.ts
+++ b/apps/architect/src/components/TypeEditor/__tests__/validateEntityType.test.ts
@@ -37,7 +37,6 @@ describe('validateEntityType()', () => {
     ).toEqual({});
   });
 
-  // Gap 6: toggled on but no variable/type selected (`shape.dynamic = {}`).
   it('flags a dynamic mapping with no variable selected', () => {
     const errors = validateEntityType({
       shape: { default: 'circle', dynamic: {} },
@@ -46,7 +45,6 @@ describe('validateEntityType()', () => {
     expect(errors.shape?.dynamic?.thresholds).toBeUndefined();
   });
 
-  // Gap 4: a breakpoints mapping saved with zero thresholds.
   it('flags a breakpoints mapping with no thresholds', () => {
     const errors = validateEntityType({
       shape: {
@@ -58,7 +56,6 @@ describe('validateEntityType()', () => {
     expect(errors.shape?.dynamic?.variable).toBeUndefined();
   });
 
-  // Gap 5: duplicate / descending threshold values.
   it('flags duplicate threshold values', () => {
     const errors = validateEntityType({
       shape: {

--- a/apps/architect/src/components/TypeEditor/__tests__/validateEntityType.test.ts
+++ b/apps/architect/src/components/TypeEditor/__tests__/validateEntityType.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import validateEntityType from '../validateEntityType';
+
+describe('validateEntityType()', () => {
+  it('returns no errors when there is no dynamic shape mapping', () => {
+    expect(validateEntityType({ name: 'Person' })).toEqual({});
+    expect(validateEntityType({ shape: { default: 'circle' } })).toEqual({});
+  });
+
+  it('accepts a complete discrete mapping', () => {
+    expect(
+      validateEntityType({
+        shape: {
+          default: 'circle',
+          dynamic: { variable: 'var-1', type: 'discrete', map: [] },
+        },
+      }),
+    ).toEqual({});
+  });
+
+  it('accepts a breakpoints mapping with strictly ascending thresholds', () => {
+    expect(
+      validateEntityType({
+        shape: {
+          default: 'circle',
+          dynamic: {
+            variable: 'var-1',
+            type: 'breakpoints',
+            thresholds: [
+              { value: 1, shape: 'square' },
+              { value: 5, shape: 'diamond' },
+            ],
+          },
+        },
+      }),
+    ).toEqual({});
+  });
+
+  // Gap 6: toggled on but no variable/type selected (`shape.dynamic = {}`).
+  it('flags a dynamic mapping with no variable selected', () => {
+    const errors = validateEntityType({
+      shape: { default: 'circle', dynamic: {} },
+    });
+    expect(errors.shape?.dynamic?.variable).toBeTruthy();
+    expect(errors.shape?.dynamic?.thresholds).toBeUndefined();
+  });
+
+  // Gap 4: a breakpoints mapping saved with zero thresholds.
+  it('flags a breakpoints mapping with no thresholds', () => {
+    const errors = validateEntityType({
+      shape: {
+        default: 'circle',
+        dynamic: { variable: 'var-1', type: 'breakpoints', thresholds: [] },
+      },
+    });
+    expect(errors.shape?.dynamic?.thresholds).toBeTruthy();
+    expect(errors.shape?.dynamic?.variable).toBeUndefined();
+  });
+
+  // Gap 5: duplicate / descending threshold values.
+  it('flags duplicate threshold values', () => {
+    const errors = validateEntityType({
+      shape: {
+        default: 'circle',
+        dynamic: {
+          variable: 'var-1',
+          type: 'breakpoints',
+          thresholds: [
+            { value: 0, shape: 'square' },
+            { value: 0, shape: 'diamond' },
+          ],
+        },
+      },
+    });
+    expect(errors.shape?.dynamic?.thresholds).toBeTruthy();
+  });
+
+  it('flags descending threshold values', () => {
+    const errors = validateEntityType({
+      shape: {
+        default: 'circle',
+        dynamic: {
+          variable: 'var-1',
+          type: 'breakpoints',
+          thresholds: [
+            { value: 5, shape: 'square' },
+            { value: 1, shape: 'diamond' },
+          ],
+        },
+      },
+    });
+    expect(errors.shape?.dynamic?.thresholds).toBeTruthy();
+  });
+});

--- a/apps/architect/src/components/TypeEditor/shapeMappingTypes.ts
+++ b/apps/architect/src/components/TypeEditor/shapeMappingTypes.ts
@@ -1,0 +1,15 @@
+import type { NodeDefinition } from '@codaco/protocol-validation';
+
+type ShapeMapping = NonNullable<NodeDefinition['shape']['dynamic']>;
+type DiscreteShapeMapping = Extract<ShapeMapping, { type: 'discrete' }>;
+type BreakpointShapeMapping = Extract<ShapeMapping, { type: 'breakpoints' }>;
+
+export type ShapeMappingType = ShapeMapping['type'];
+export type DiscreteShapeMapEntry = DiscreteShapeMapping['map'][number];
+export type ShapeThreshold = BreakpointShapeMapping['thresholds'][number];
+
+// The editor holds shape.dynamic mid-edit, before it satisfies either mapping
+// variant, so every field is optional and `type` may be unset.
+export type ShapeMappingDraft = Partial<
+  Omit<DiscreteShapeMapping, 'type'> & Omit<BreakpointShapeMapping, 'type'>
+> & { type?: ShapeMappingType };

--- a/apps/architect/src/components/TypeEditor/validateEntityType.ts
+++ b/apps/architect/src/components/TypeEditor/validateEntityType.ts
@@ -1,6 +1,10 @@
 import type { ShapeMappingType, ShapeThreshold } from './shapeMappingTypes';
 
 export type EntityTypeFormErrors = {
+  // redux-form's isValid only inspects errors on *registered* fields, and the
+  // shape mapping is built from unconnected controls. The form-level _error is
+  // what actually makes the form invalid and blocks the save.
+  _error?: string;
   shape?: {
     dynamic?: Partial<Record<'variable' | 'thresholds', string>>;
   };
@@ -12,6 +16,8 @@ const THRESHOLDS_MIN_MESSAGE =
   'Add at least one threshold, or turn off shape mapping.';
 const THRESHOLDS_ASCENDING_MESSAGE =
   'Thresholds must increase in value, with no duplicates.';
+const SHAPE_MAPPING_INCOMPLETE_MESSAGE =
+  'Finish the shape mapping, or turn off shape mapping, before saving.';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -61,7 +67,10 @@ const validateEntityType = (
     return {};
   }
 
-  return { shape: { dynamic: dynamicErrors } };
+  return {
+    _error: SHAPE_MAPPING_INCOMPLETE_MESSAGE,
+    shape: { dynamic: dynamicErrors },
+  };
 };
 
 export default validateEntityType;

--- a/apps/architect/src/components/TypeEditor/validateEntityType.ts
+++ b/apps/architect/src/components/TypeEditor/validateEntityType.ts
@@ -1,0 +1,87 @@
+// redux-form synchronous validation for the node/edge type editor. The dynamic
+// shape mapping (`shape.dynamic`) is written imperatively via `change()` in
+// ShapeVariableMapping and never flows through a ValidatedField, so nothing
+// otherwise stops a malformed mapping from being committed to the codebook and
+// then rejected by the schema-8 validator. This asserts the mapping is complete
+// and well-ordered before submit, surfacing the reason and blocking the save.
+
+type ShapeThreshold = {
+  value: number;
+  shape: string;
+};
+
+type ShapeDynamic = {
+  variable?: unknown;
+  type?: unknown;
+  thresholds?: unknown;
+};
+
+export type EntityTypeFormErrors = {
+  shape?: {
+    dynamic?: {
+      variable?: string;
+      thresholds?: string;
+    };
+  };
+};
+
+const SELECT_VARIABLE_MESSAGE =
+  'Select a variable to map to a shape, or turn off shape mapping.';
+const THRESHOLDS_MIN_MESSAGE =
+  'Add at least one threshold, or turn off shape mapping.';
+const THRESHOLDS_ASCENDING_MESSAGE =
+  'Thresholds must increase in value, with no duplicates.';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isThreshold = (value: unknown): value is ShapeThreshold =>
+  isRecord(value) && typeof value.value === 'number';
+
+const validateEntityType = (
+  values: Record<string, unknown>,
+): EntityTypeFormErrors => {
+  const shape = values.shape;
+  if (!isRecord(shape) || !isRecord(shape.dynamic)) {
+    return {};
+  }
+
+  const dynamic = shape.dynamic as ShapeDynamic;
+  const dynamicErrors: NonNullable<
+    NonNullable<EntityTypeFormErrors['shape']>['dynamic']
+  > = {};
+
+  // Gap 6: the mapping was toggled on but left incomplete. Both union arms
+  // require a variable and a discriminating type; an empty `{}` matches neither.
+  if (
+    typeof dynamic.variable !== 'string' ||
+    dynamic.variable.length === 0 ||
+    (dynamic.type !== 'discrete' && dynamic.type !== 'breakpoints')
+  ) {
+    dynamicErrors.variable = SELECT_VARIABLE_MESSAGE;
+  } else if (dynamic.type === 'breakpoints') {
+    const thresholds = Array.isArray(dynamic.thresholds)
+      ? dynamic.thresholds.filter(isThreshold)
+      : [];
+    // Gap 4: a breakpoints mapping needs at least one threshold.
+    if (thresholds.length === 0) {
+      dynamicErrors.thresholds = THRESHOLDS_MIN_MESSAGE;
+    } else if (
+      // Gap 5: thresholds must be strictly ascending, with no duplicates.
+      thresholds.some(
+        (threshold, index) =>
+          index > 0 && threshold.value <= (thresholds[index - 1]?.value ?? 0),
+      )
+    ) {
+      dynamicErrors.thresholds = THRESHOLDS_ASCENDING_MESSAGE;
+    }
+  }
+
+  if (Object.keys(dynamicErrors).length === 0) {
+    return {};
+  }
+
+  return { shape: { dynamic: dynamicErrors } };
+};
+
+export default validateEntityType;

--- a/apps/architect/src/components/TypeEditor/validateEntityType.ts
+++ b/apps/architect/src/components/TypeEditor/validateEntityType.ts
@@ -1,20 +1,8 @@
-type ShapeThreshold = {
-  value: number;
-  shape: string;
-};
-
-type ShapeDynamic = {
-  variable?: unknown;
-  type?: unknown;
-  thresholds?: unknown;
-};
+import type { ShapeMappingType, ShapeThreshold } from './shapeMappingTypes';
 
 export type EntityTypeFormErrors = {
   shape?: {
-    dynamic?: {
-      variable?: string;
-      thresholds?: string;
-    };
+    dynamic?: Partial<Record<'variable' | 'thresholds', string>>;
   };
 };
 
@@ -28,8 +16,11 @@ const THRESHOLDS_ASCENDING_MESSAGE =
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const isThreshold = (value: unknown): value is ShapeThreshold =>
+const isThreshold = (value: unknown): value is Pick<ShapeThreshold, 'value'> =>
   isRecord(value) && typeof value.value === 'number';
+
+const isShapeMappingType = (value: unknown): value is ShapeMappingType =>
+  value === 'discrete' || value === 'breakpoints';
 
 const validateEntityType = (
   values: Record<string, unknown>,
@@ -39,7 +30,7 @@ const validateEntityType = (
     return {};
   }
 
-  const dynamic = shape.dynamic as ShapeDynamic;
+  const dynamic = shape.dynamic;
   const dynamicErrors: NonNullable<
     NonNullable<EntityTypeFormErrors['shape']>['dynamic']
   > = {};
@@ -47,7 +38,7 @@ const validateEntityType = (
   if (
     typeof dynamic.variable !== 'string' ||
     dynamic.variable.length === 0 ||
-    (dynamic.type !== 'discrete' && dynamic.type !== 'breakpoints')
+    !isShapeMappingType(dynamic.type)
   ) {
     dynamicErrors.variable = SELECT_VARIABLE_MESSAGE;
   } else if (dynamic.type === 'breakpoints') {

--- a/apps/architect/src/components/TypeEditor/validateEntityType.ts
+++ b/apps/architect/src/components/TypeEditor/validateEntityType.ts
@@ -1,10 +1,3 @@
-// redux-form synchronous validation for the node/edge type editor. The dynamic
-// shape mapping (`shape.dynamic`) is written imperatively via `change()` in
-// ShapeVariableMapping and never flows through a ValidatedField, so nothing
-// otherwise stops a malformed mapping from being committed to the codebook and
-// then rejected by the schema-8 validator. This asserts the mapping is complete
-// and well-ordered before submit, surfacing the reason and blocking the save.
-
 type ShapeThreshold = {
   value: number;
   shape: string;
@@ -51,8 +44,6 @@ const validateEntityType = (
     NonNullable<EntityTypeFormErrors['shape']>['dynamic']
   > = {};
 
-  // Gap 6: the mapping was toggled on but left incomplete. Both union arms
-  // require a variable and a discriminating type; an empty `{}` matches neither.
   if (
     typeof dynamic.variable !== 'string' ||
     dynamic.variable.length === 0 ||
@@ -63,11 +54,9 @@ const validateEntityType = (
     const thresholds = Array.isArray(dynamic.thresholds)
       ? dynamic.thresholds.filter(isThreshold)
       : [];
-    // Gap 4: a breakpoints mapping needs at least one threshold.
     if (thresholds.length === 0) {
       dynamicErrors.thresholds = THRESHOLDS_MIN_MESSAGE;
     } else if (
-      // Gap 5: thresholds must be strictly ascending, with no duplicates.
       thresholds.some(
         (threshold, index) =>
           index > 0 && threshold.value <= (thresholds[index - 1]?.value ?? 0),

--- a/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
@@ -39,11 +39,13 @@ import {
   createVariableAsync,
   updateVariableAsync,
 } from '~/ducks/modules/protocol/codebook';
+import { getFamilyPedigreeNodeTypeChangeBlock } from '~/ducks/modules/protocol/stages';
 import type { RootState } from '~/ducks/store';
 import {
   getVariableOptionsForSubject,
   makeGetVariable,
 } from '~/selectors/codebook';
+import { getProtocol } from '~/selectors/protocol';
 import { ensureError } from '~/utils/ensureError';
 import { optionsMatch } from '~/utils/variables';
 
@@ -139,6 +141,26 @@ const NodeConfigurationInner = ({
   const formValues = useSelector((state: RootState) =>
     getFormValues(form)(state),
   );
+  const stageId = useSelector(
+    (state: RootState) => formSelector(state, 'id') as string | undefined,
+  );
+  const stages = useSelector(
+    (state: RootState) => getProtocol(state)?.stages ?? [],
+  );
+  // A NarrativePedigree binds its diseases to variables on this stage's node
+  // type, so changing the node type would dangle those references. Block the
+  // change while such dependents exist, mirroring the deletion guard.
+  const dependentNarrativeStages = stageId
+    ? getFamilyPedigreeNodeTypeChangeBlock(stages, stageId)
+    : [];
+  const nodeTypeChangeBlockReason =
+    dependentNarrativeStages.length > 0
+      ? `This Family Pedigree stage's network is used by the following Narrative Pedigree stage(s): ${dependentNarrativeStages
+          .map((dependent) => `"${dependent.label || 'Untitled'}"`)
+          .join(
+            ', ',
+          )}. Change or remove those stage(s) before changing its node type.`
+      : null;
   const formFields = keys(formValues);
   const handleResetStage = useCallback(() => {
     const fieldsToReset = difference(formFields, PRESERVE_ON_NODE_TYPE_CHANGE);
@@ -229,6 +251,7 @@ const NodeConfigurationInner = ({
             name="nodeConfig.type"
             entityType="node"
             promptBeforeChange="You attempted to change the node type of a stage that you have already configured. Before you can proceed the stage must be reset, which will remove any existing configuration. Do you want to reset the stage now?"
+            blockChangeReason={nodeTypeChangeBlockReason}
             component={EntitySelectField}
             onChange={handleResetStage}
             validation={{ required: true }}

--- a/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/NodeConfiguration.tsx
@@ -147,9 +147,6 @@ const NodeConfigurationInner = ({
   const stages = useSelector(
     (state: RootState) => getProtocol(state)?.stages ?? [],
   );
-  // A NarrativePedigree binds its diseases to variables on this stage's node
-  // type, so changing the node type would dangle those references. Block the
-  // change while such dependents exist, mirroring the deletion guard.
   const dependentNarrativeStages = stageId
     ? getFamilyPedigreeNodeTypeChangeBlock(stages, stageId)
     : [];

--- a/apps/architect/src/components/sections/FamilyPedigree/__tests__/NodeConfigurationHandlers.test.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/__tests__/NodeConfigurationHandlers.test.tsx
@@ -48,6 +48,10 @@ vi.mock('~/selectors/codebook', () => ({
   makeGetVariable: () => () => undefined,
 }));
 
+vi.mock('~/selectors/protocol', () => ({
+  getProtocol: () => undefined,
+}));
+
 vi.mock('~/components/EditorLayout', () => ({
   Row: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   Section: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/apps/architect/src/components/sections/MapOptions.tsx
+++ b/apps/architect/src/components/sections/MapOptions.tsx
@@ -41,6 +41,14 @@ type MapOptionsProps = StageEditorSectionProps & {
   };
   disabled: boolean;
 };
+const NO_SELECTABLE_PROPERTIES_MESSAGE =
+  'The selected GeoJSON has no feature properties available for map selection. Choose a GeoJSON file whose features include properties.';
+
+// Always-failing validator used when the chosen GeoJSON exposes no feature
+// properties. Mounting a required control here blocks Save with an actionable
+// message instead of letting the opaque whole-protocol validation error fire.
+const noSelectablePropertiesGuard = () => NO_SELECTABLE_PROPERTIES_MESSAGE;
+
 const defaultMapOptions = {
   center: [0, 0],
   tokenAssetId: '',
@@ -56,11 +64,19 @@ const MapOptions = ({
   mapOptions = defaultMapOptions,
   disabled,
 }: MapOptionsProps) => {
-  const { variables: variableOptions } = useVariablesFromExternalData(
-    mapOptions?.dataSourceAssetId,
-    true,
-    'geojson',
-  );
+  const { variables: variableOptions, isVariablesLoading } =
+    useVariablesFromExternalData(
+      mapOptions?.dataSourceAssetId,
+      true,
+      'geojson',
+    );
+  const dataSourceAssetId = mapOptions?.dataSourceAssetId;
+  // A data source is chosen and its variables have finished loading, but no
+  // feature in the GeoJSON exposes any properties to select on.
+  const noSelectableProperties =
+    Boolean(dataSourceAssetId) &&
+    !isVariablesLoading &&
+    variableOptions.length === 0;
   const { paletteName, paletteSize } = {
     paletteName: 'ord-color-seq',
     paletteSize: 8,
@@ -107,16 +123,24 @@ const MapOptions = ({
             validation={{ required: true }}
           />
         </Row>
-        {variableOptions && variableOptions.length > 0 && (
+        {Boolean(dataSourceAssetId) && !isVariablesLoading && (
           <Row>
             <ValidatedField
               name="mapOptions.targetFeatureProperty"
               label="Which property should be used for map selection?"
               component={FrescoReduxField}
-              validation={{ required: true }}
+              validation={{
+                required: noSelectableProperties
+                  ? noSelectablePropertiesGuard
+                  : true,
+              }}
               componentProps={{
                 fieldComponent: FrescoNativeSelectField,
                 options: variableOptions,
+                disabled: noSelectableProperties,
+                hint: noSelectableProperties
+                  ? NO_SELECTABLE_PROPERTIES_MESSAGE
+                  : undefined,
               }}
             />
           </Row>

--- a/apps/architect/src/components/sections/MapOptions.tsx
+++ b/apps/architect/src/components/sections/MapOptions.tsx
@@ -44,9 +44,6 @@ type MapOptionsProps = StageEditorSectionProps & {
 const NO_SELECTABLE_PROPERTIES_MESSAGE =
   'The selected GeoJSON has no feature properties available for map selection. Choose a GeoJSON file whose features include properties.';
 
-// Always-failing validator used when the chosen GeoJSON exposes no feature
-// properties. Mounting a required control here blocks Save with an actionable
-// message instead of letting the opaque whole-protocol validation error fire.
 const noSelectablePropertiesGuard = () => NO_SELECTABLE_PROPERTIES_MESSAGE;
 
 const defaultMapOptions = {
@@ -71,8 +68,6 @@ const MapOptions = ({
       'geojson',
     );
   const dataSourceAssetId = mapOptions?.dataSourceAssetId;
-  // A data source is chosen and its variables have finished loading, but no
-  // feature in the GeoJSON exposes any properties to select on.
   const noSelectableProperties =
     Boolean(dataSourceAssetId) &&
     !isVariablesLoading &&

--- a/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.test.tsx
+++ b/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.test.tsx
@@ -5,9 +5,10 @@ import { Provider } from 'react-redux';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const confirm = vi.fn();
+const openDialog = vi.fn();
 
 vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
-  default: () => ({ confirm }),
+  default: () => ({ confirm, openDialog }),
 }));
 
 vi.mock('~/components/Dialog/NewTypeDialog', () => ({
@@ -76,6 +77,7 @@ const renderControl = (
 describe('EntitySelectControl', () => {
   beforeEach(() => {
     confirm.mockReset();
+    openDialog.mockReset();
   });
 
   it('exposes selectable entity types as a radio group', () => {
@@ -103,6 +105,25 @@ describe('EntitySelectControl', () => {
 
     expect(confirm).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith('place');
+  });
+
+  it('refuses a change and warns when blockChangeReason is set', () => {
+    const onChange = renderControl({
+      blockChangeReason: 'A Narrative Pedigree depends on this stage.',
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Place' }));
+
+    expect(openDialog).toHaveBeenCalledOnce();
+    expect(openDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'acknowledge',
+        intent: 'warning',
+        description: 'A Narrative Pedigree depends on this stage.',
+      }),
+    );
+    expect(confirm).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('creates and selects a new entity type', () => {

--- a/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -212,7 +212,10 @@ export const EntitySelectControl = ({
 
       <Button
         icon={<Plus />}
-        onClick={() => setShowNewTypeDialog(true)}
+        onClick={() => {
+          if (refuseBlockedChange()) return;
+          setShowNewTypeDialog(true);
+        }}
         color="primary"
         disabled={disabled || readOnly}
       >

--- a/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -40,6 +40,7 @@ type EntitySelectControlProps = {
   'onBlur'?: FocusEventHandler;
   'onFocus'?: FocusEventHandler;
   'promptBeforeChange'?: string | null;
+  'blockChangeReason'?: string | null;
   'disabled'?: boolean;
   'readOnly'?: boolean;
   'required'?: boolean;
@@ -58,6 +59,7 @@ export const EntitySelectControl = ({
   onBlur,
   onFocus,
   promptBeforeChange = null,
+  blockChangeReason = null,
   disabled = false,
   readOnly = false,
   required = false,
@@ -66,7 +68,7 @@ export const EntitySelectControl = ({
   'aria-labelledby': ariaLabelledBy,
   'aria-required': ariaRequired,
 }: EntitySelectControlProps) => {
-  const { confirm } = useDialog();
+  const { confirm, openDialog } = useDialog();
   const edgeOptions = useSelector(getEdgeOptions);
   const nodeOptions = useSelector(getNodeOptions);
   const [showNewTypeDialog, setShowNewTypeDialog] = useState(false);
@@ -75,9 +77,26 @@ export const EntitySelectControl = ({
     [entityType, edgeOptions, nodeOptions],
   );
 
+  // A dependent stage relies on the current type, so the change is refused
+  // outright (unlike promptBeforeChange, which lets the researcher proceed).
+  const refuseBlockedChange = useCallback(() => {
+    if (!value || !blockChangeReason) return false;
+
+    void openDialog({
+      type: 'acknowledge',
+      intent: 'warning',
+      title: `Cannot change ${entityType} type`,
+      description: blockChangeReason,
+      actions: { primary: { label: 'OK', value: true } },
+    });
+    return true;
+  }, [value, blockChangeReason, openDialog, entityType]);
+
   const handleSelectItem = useCallback(
     (selectedItem: string) => {
       if (disabled || readOnly || selectedItem === value) return;
+
+      if (refuseBlockedChange()) return;
 
       if (!value || !promptBeforeChange) {
         onChange?.(selectedItem);
@@ -97,6 +116,7 @@ export const EntitySelectControl = ({
       disabled,
       readOnly,
       value,
+      refuseBlockedChange,
       promptBeforeChange,
       confirm,
       entityType,
@@ -107,9 +127,11 @@ export const EntitySelectControl = ({
   const handleNewTypeComplete = useCallback(
     (newTypeId?: string) => {
       setShowNewTypeDialog(false);
-      if (newTypeId && !disabled && !readOnly) onChange?.(newTypeId);
+      if (!newTypeId || disabled || readOnly) return;
+      if (refuseBlockedChange()) return;
+      onChange?.(newTypeId);
     },
-    [disabled, onChange, readOnly],
+    [disabled, readOnly, refuseBlockedChange, onChange],
   );
 
   return (
@@ -212,6 +234,7 @@ type EntitySelectFieldProps = WrappedFieldProps & {
   entityType: 'node' | 'edge';
   label?: string | null;
   promptBeforeChange?: string | null;
+  blockChangeReason?: string | null;
   disabled?: boolean;
   readOnly?: boolean;
 };

--- a/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
+++ b/apps/architect/src/components/sections/fields/EntitySelectField/EntitySelectField.tsx
@@ -77,8 +77,6 @@ export const EntitySelectControl = ({
     [entityType, edgeOptions, nodeOptions],
   );
 
-  // A dependent stage relies on the current type, so the change is refused
-  // outright (unlike promptBeforeChange, which lets the researcher proceed).
   const refuseBlockedChange = useCallback(() => {
     if (!value || !blockChangeReason) return false;
 

--- a/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
+++ b/apps/architect/src/ducks/modules/protocol/__tests__/stages.test.ts
@@ -6,6 +6,7 @@ import type { AppDispatch } from '~/ducks/store';
 
 import reducer, {
   actionCreators,
+  getFamilyPedigreeNodeTypeChangeBlock,
   getInvalidSkipDestinationReferences,
   getSkipDestinationDependentStages,
   test,
@@ -164,6 +165,43 @@ describe('protocol.stages', () => {
         expect(violation?.sourceStage.id).toBe('source');
         expect(violation?.destinationStage).toBeUndefined();
         expect(violation?.destinationStageId).toBe('destination');
+      });
+    });
+
+    describe('getFamilyPedigreeNodeTypeChangeBlock', () => {
+      const familyPedigreeWithDependent = [
+        { id: 'fp', type: 'FamilyPedigree', label: 'Family Pedigree' },
+        {
+          id: 'np',
+          type: 'NarrativePedigree',
+          label: 'Narrative Pedigree',
+          sourceStageId: 'fp',
+        },
+      ] as Stage[];
+
+      it('returns dependent NarrativePedigree stages when present', () => {
+        expect(
+          getFamilyPedigreeNodeTypeChangeBlock(
+            familyPedigreeWithDependent,
+            'fp',
+          ).map((stage) => stage.id),
+        ).toEqual(['np']);
+      });
+
+      it('returns nothing when no NarrativePedigree sources the stage', () => {
+        const withoutDependent = [
+          { id: 'fp', type: 'FamilyPedigree', label: 'Family Pedigree' },
+          {
+            id: 'np',
+            type: 'NarrativePedigree',
+            label: 'Narrative Pedigree',
+            sourceStageId: 'other',
+          },
+        ] as Stage[];
+
+        expect(
+          getFamilyPedigreeNodeTypeChangeBlock(withoutDependent, 'fp'),
+        ).toEqual([]);
       });
     });
 

--- a/apps/architect/src/ducks/modules/protocol/stages.ts
+++ b/apps/architect/src/ducks/modules/protocol/stages.ts
@@ -61,6 +61,17 @@ export const getFamilyPedigreeDependentStages = <
       candidate.sourceStageId === stageId,
   );
 
+// A NarrativePedigree's diseases bind variables on the source FamilyPedigree
+// stage's nodeConfig.type, so changing that node type would leave those
+// references dangling against the new type. Returns the dependent stages that
+// block the change, mirroring the deletion guard above.
+export const getFamilyPedigreeNodeTypeChangeBlock = <
+  T extends StageDependencyCandidate,
+>(
+  stages: T[],
+  stageId: string,
+) => getFamilyPedigreeDependentStages(stages, stageId);
+
 export const getSkipDestinationDependentStages = <
   T extends StageDependencyCandidate,
 >(

--- a/apps/architect/src/ducks/modules/protocol/stages.ts
+++ b/apps/architect/src/ducks/modules/protocol/stages.ts
@@ -61,10 +61,6 @@ export const getFamilyPedigreeDependentStages = <
       candidate.sourceStageId === stageId,
   );
 
-// A NarrativePedigree's diseases bind variables on the source FamilyPedigree
-// stage's nodeConfig.type, so changing that node type would leave those
-// references dangling against the new type. Returns the dependent stages that
-// block the change, mirroring the deletion guard above.
 export const getFamilyPedigreeNodeTypeChangeBlock = <
   T extends StageDependencyCandidate,
 >(

--- a/apps/architect/src/utils/protocols/__tests__/assetTools.test.ts
+++ b/apps/architect/src/utils/protocols/__tests__/assetTools.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAssetById } from '~/utils/assetUtils';
+
+import { getGeoJsonVariables } from '../assetTools';
+
+vi.mock('~/utils/assetUtils', () => ({
+  getAssetById: vi.fn(),
+}));
+
+const mockedGetAssetById = vi.mocked(getAssetById);
+
+const asBlobAsset = (geoJson: unknown) =>
+  ({ data: new Blob([JSON.stringify(geoJson)]) }) as unknown as Awaited<
+    ReturnType<typeof getAssetById>
+  >;
+
+describe('getGeoJsonVariables', () => {
+  beforeEach(() => {
+    mockedGetAssetById.mockReset();
+  });
+
+  it('unions property keys across all features', async () => {
+    mockedGetAssetById.mockResolvedValue(
+      asBlobAsset({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', properties: { name: 'A' } },
+          { type: 'Feature', properties: { name: 'B', code: '02' } },
+        ],
+      }),
+    );
+
+    await expect(getGeoJsonVariables('asset-1')).resolves.toEqual([
+      'name',
+      'code',
+    ]);
+  });
+
+  it('returns keys even when only a later feature has properties', async () => {
+    mockedGetAssetById.mockResolvedValue(
+      asBlobAsset({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature' },
+          { type: 'Feature', properties: {} },
+          { type: 'Feature', properties: { region: 'north' } },
+        ],
+      }),
+    );
+
+    await expect(getGeoJsonVariables('asset-2')).resolves.toEqual(['region']);
+  });
+
+  it('returns an empty list when no feature has properties (degenerate case)', async () => {
+    mockedGetAssetById.mockResolvedValue(
+      asBlobAsset({
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature' }, { type: 'Feature', properties: {} }],
+      }),
+    );
+
+    await expect(getGeoJsonVariables('asset-3')).resolves.toEqual([]);
+  });
+});

--- a/apps/architect/src/utils/protocols/assetTools.ts
+++ b/apps/architect/src/utils/protocols/assetTools.ts
@@ -195,10 +195,6 @@ export const getGeoJsonVariables = async (assetId: string) => {
     features?: { properties?: Record<string, unknown> }[];
   };
 
-  // Union property keys across every feature. A GeoJSON feature may legitimately
-  // omit `properties` (RFC 7946), so inspecting only the first feature would
-  // miss keys that appear on later features and leave the map-selection control
-  // (and its required validator) unmounted.
   const keys = new Set<string>();
   for (const feature of geoJson?.features ?? []) {
     if (feature?.properties) {

--- a/apps/architect/src/utils/protocols/assetTools.ts
+++ b/apps/architect/src/utils/protocols/assetTools.ts
@@ -195,9 +195,18 @@ export const getGeoJsonVariables = async (assetId: string) => {
     features?: { properties?: Record<string, unknown> }[];
   };
 
-  if (geoJson?.features?.[0]?.properties) {
-    return Object.keys(geoJson.features[0].properties);
+  // Union property keys across every feature. A GeoJSON feature may legitimately
+  // omit `properties` (RFC 7946), so inspecting only the first feature would
+  // miss keys that appear on later features and leave the map-selection control
+  // (and its required validator) unmounted.
+  const keys = new Set<string>();
+  for (const feature of geoJson?.features ?? []) {
+    if (feature?.properties) {
+      for (const key of Object.keys(feature.properties)) {
+        keys.add(key);
+      }
+    }
   }
 
-  return [];
+  return Array.from(keys);
 };

--- a/packages/interview/src/selectors/__tests__/session.test.ts
+++ b/packages/interview/src/selectors/__tests__/session.test.ts
@@ -1,7 +1,10 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 
-import type { NodeDefinition } from '@codaco/protocol-validation';
+import {
+  asEntityAttributeReference,
+  type NodeDefinition,
+} from '@codaco/protocol-validation';
 import type { DyadCensusMetadataItem } from '@codaco/shared-consts';
 
 import { createInitialNetwork } from '../../contract/network';
@@ -73,7 +76,7 @@ describe('resolveNodeShape', () => {
     const shape: NodeDefinition['shape'] = {
       default: 'circle',
       dynamic: {
-        variable: 'ethnicity',
+        variable: asEntityAttributeReference('ethnicity'),
         type: 'discrete',
         map: [
           { value: 'asian', shape: 'square' },
@@ -89,7 +92,7 @@ describe('resolveNodeShape', () => {
     const shape: NodeDefinition['shape'] = {
       default: 'circle',
       dynamic: {
-        variable: 'role',
+        variable: asEntityAttributeReference('role'),
         type: 'discrete',
         map: [{ value: 'lead', shape: 'diamond' }],
       },
@@ -102,7 +105,7 @@ describe('resolveNodeShape', () => {
     const shape: NodeDefinition['shape'] = {
       default: 'square',
       dynamic: {
-        variable: 'is_person',
+        variable: asEntityAttributeReference('is_person'),
         type: 'discrete',
         map: [{ value: true, shape: 'circle' }],
       },

--- a/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
@@ -4101,6 +4101,81 @@ describe('Migration V7 to V8', () => {
       expect(migrated.stages.map((s) => s.id)).toEqual(['keep']);
       expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
     });
+
+    const buildWithSkipTo = (stageId: string) =>
+      ({
+        schemaVersion: 7 as const,
+        codebook: {
+          node: {
+            person: {
+              name: 'Person',
+              color: 'node-color-seq-1',
+              variables: {
+                name: { name: 'Name', type: 'text', component: 'Text' },
+              },
+            },
+          },
+          edge: {},
+          ego: {},
+        },
+        stages: [
+          {
+            id: 'src',
+            type: 'NameGenerator',
+            label: 'Generate',
+            subject: { entity: 'node', type: 'person' },
+            form: { title: 'Add', fields: [{ variable: 'name', prompt: 'N' }] },
+            prompts: [{ id: 'p1', text: 'Who?' }],
+            skipLogic: {
+              action: 'SKIP',
+              filter: {
+                join: 'OR',
+                rules: [
+                  {
+                    type: 'node',
+                    id: 'rule1',
+                    options: { type: 'person', operator: 'EXISTS' },
+                  },
+                ],
+              },
+              destination: { type: 'stage', stageId },
+            },
+          },
+          { id: 'empty', type: 'EgoForm', label: 'Ego', form: { fields: [] } },
+          {
+            id: 'keep',
+            type: 'Information',
+            label: 'Info',
+            items: [{ id: 'i1', type: 'text', content: 'Hello' }],
+          },
+        ],
+      }) as unknown as Protocol<7>;
+
+    type MigratedSkip = {
+      stages: { id?: string; skipLogic?: { destination?: unknown } }[];
+    };
+
+    it('clears a skip destination pointing at a dropped stage', () => {
+      const migrated = migrationV7toV8.migrate(buildWithSkipTo('empty'), {
+        name: 'Test Protocol',
+      }) as unknown as MigratedSkip;
+
+      expect(migrated.stages.map((s) => s.id)).toEqual(['src', 'keep']);
+      expect(migrated.stages[0]?.skipLogic?.destination).toBeUndefined();
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+
+    it('preserves a skip destination pointing at a surviving stage', () => {
+      const migrated = migrationV7toV8.migrate(buildWithSkipTo('keep'), {
+        name: 'Test Protocol',
+      }) as unknown as MigratedSkip;
+
+      expect(migrated.stages[0]?.skipLogic?.destination).toEqual({
+        type: 'stage',
+        stageId: 'keep',
+      });
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
   });
 
   describe('migration metadata', () => {

--- a/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
@@ -3732,6 +3732,377 @@ describe('Migration V7 to V8', () => {
     });
   });
 
+  describe('external-data panel edge-rule removal (ext-panel-edge-rule)', () => {
+    const buildV7 = (panel: Record<string, unknown>) =>
+      ({
+        schemaVersion: 7 as const,
+        codebook: {
+          node: {
+            person: {
+              name: 'Person',
+              color: 'node-color-seq-1',
+              variables: {
+                name: { name: 'Name', type: 'text', component: 'Text' },
+              },
+            },
+          },
+          edge: { knows: { name: 'Knows', color: 'edge-color-seq-1' } },
+          ego: {},
+        },
+        stages: [
+          {
+            id: 'stage1',
+            type: 'NameGenerator',
+            label: 'Generate',
+            subject: { entity: 'node', type: 'person' },
+            form: {
+              title: 'Add',
+              fields: [{ variable: 'name', prompt: 'Name' }],
+            },
+            prompts: [{ id: 'p1', text: 'Who?' }],
+            panels: [panel],
+          },
+        ],
+      }) as unknown as Protocol<7>;
+
+    const migratedPanel = (panel: Record<string, unknown>) => {
+      const migrated = migrationV7toV8.migrate(buildV7(panel), {
+        name: 'Test Protocol',
+      }) as unknown as {
+        stages: { panels?: { filter?: unknown }[] }[];
+      };
+      return migrated.stages[0]?.panels?.[0];
+    };
+
+    it('drops an edge rule from a non-existing panel filter but keeps node rules and join', () => {
+      const panel = migratedPanel({
+        id: 'panel1',
+        title: 'External',
+        dataSource: 'external1',
+        filter: {
+          join: 'AND',
+          rules: [
+            {
+              type: 'edge',
+              id: 'r1',
+              options: { type: 'knows', operator: 'EXISTS' },
+            },
+            {
+              type: 'alter',
+              id: 'r2',
+              options: { type: 'person', operator: 'EXISTS' },
+            },
+          ],
+        },
+      }) as { filter?: { join?: string; rules?: { type?: string }[] } };
+      expect(panel.filter?.rules).toHaveLength(1);
+      expect(panel.filter?.rules?.[0]?.type).toBe('node');
+      expect(panel.filter?.join).toBe('AND');
+    });
+
+    it('removes the filter entirely when only edge rules remain', () => {
+      const panel = migratedPanel({
+        id: 'panel1',
+        title: 'External',
+        dataSource: 'external1',
+        filter: {
+          rules: [
+            {
+              type: 'edge',
+              id: 'r1',
+              options: { type: 'knows', operator: 'EXISTS' },
+            },
+          ],
+        },
+      });
+      expect(panel).not.toHaveProperty('filter');
+    });
+
+    it('leaves edge rules on an existing-data panel untouched', () => {
+      const panel = migratedPanel({
+        id: 'panel1',
+        title: 'Existing',
+        dataSource: 'existing',
+        filter: {
+          rules: [
+            {
+              type: 'edge',
+              id: 'r1',
+              options: { type: 'knows', operator: 'EXISTS' },
+            },
+          ],
+        },
+      }) as { filter?: { rules?: { type?: string }[] } };
+      expect(panel.filter?.rules?.[0]?.type).toBe('edge');
+    });
+
+    it('migrates an external-panel edge-rule protocol to valid schema-8 output', () => {
+      const migratedRaw = migrationV7toV8.migrate(
+        buildV7({
+          id: 'panel1',
+          title: 'External',
+          dataSource: 'external1',
+          filter: {
+            rules: [
+              {
+                type: 'edge',
+                id: 'r1',
+                options: { type: 'knows', operator: 'EXISTS' },
+              },
+            ],
+          },
+        }),
+        { name: 'Test Protocol' },
+      );
+      expect(ProtocolSchemaV8.safeParse(migratedRaw).success).toBe(true);
+    });
+  });
+
+  describe('multi-rule filter join backfill (filter-rule-count)', () => {
+    const twoNodeRules = {
+      rules: [
+        {
+          type: 'alter',
+          id: 'r1',
+          options: { type: 'person', operator: 'EXISTS' },
+        },
+        {
+          type: 'alter',
+          id: 'r2',
+          options: { type: 'person', operator: 'NOT_EXISTS' },
+        },
+      ],
+    };
+
+    const buildV7 = (stage: Record<string, unknown>) =>
+      ({
+        schemaVersion: 7 as const,
+        codebook: {
+          node: {
+            person: {
+              name: 'Person',
+              color: 'node-color-seq-1',
+              variables: {
+                name: { name: 'Name', type: 'text', component: 'Text' },
+                pos: { name: 'Pos', type: 'layout' },
+              },
+            },
+          },
+          edge: {},
+          ego: {},
+        },
+        stages: [stage],
+      }) as unknown as Protocol<7>;
+
+    it('backfills join:OR on a multi-rule stage filter with no join', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildV7({
+          id: 'stage1',
+          type: 'Sociogram',
+          label: 'Sociogram',
+          subject: { entity: 'node', type: 'person' },
+          prompts: [
+            { id: 'p1', text: 'Position', layout: { layoutVariable: 'pos' } },
+          ],
+          filter: { ...twoNodeRules },
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as { stages: { filter?: { join?: string } }[] };
+      expect(migrated.stages[0]?.filter?.join).toBe('OR');
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+
+    it('backfills join:OR on a multi-rule skipLogic filter with no join', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildV7({
+          id: 'stage1',
+          type: 'Sociogram',
+          label: 'Sociogram',
+          subject: { entity: 'node', type: 'person' },
+          prompts: [
+            { id: 'p1', text: 'Position', layout: { layoutVariable: 'pos' } },
+          ],
+          skipLogic: { action: 'SKIP', filter: { ...twoNodeRules } },
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as {
+        stages: { skipLogic?: { filter?: { join?: string } } }[];
+      };
+      expect(migrated.stages[0]?.skipLogic?.filter?.join).toBe('OR');
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+
+    it('backfills join:OR on a multi-rule panel filter with no join', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildV7({
+          id: 'stage1',
+          type: 'NameGenerator',
+          label: 'Generate',
+          subject: { entity: 'node', type: 'person' },
+          form: {
+            title: 'Add',
+            fields: [{ variable: 'name', prompt: 'Name' }],
+          },
+          prompts: [{ id: 'p1', text: 'Who?' }],
+          panels: [
+            {
+              id: 'panel1',
+              title: 'Existing',
+              dataSource: 'existing',
+              filter: { ...twoNodeRules },
+            },
+          ],
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as {
+        stages: { panels?: { filter?: { join?: string } }[] }[];
+      };
+      expect(migrated.stages[0]?.panels?.[0]?.filter?.join).toBe('OR');
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+
+    it('leaves a single-rule filter join undefined', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildV7({
+          id: 'stage1',
+          type: 'Sociogram',
+          label: 'Sociogram',
+          subject: { entity: 'node', type: 'person' },
+          prompts: [
+            { id: 'p1', text: 'Position', layout: { layoutVariable: 'pos' } },
+          ],
+          filter: {
+            rules: [
+              {
+                type: 'alter',
+                id: 'r1',
+                options: { type: 'person', operator: 'EXISTS' },
+              },
+            ],
+          },
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as { stages: { filter?: { join?: string } }[] };
+      expect(migrated.stages[0]?.filter?.join).toBeUndefined();
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+  });
+
+  describe('non-renderable form-field removal (formfield-nonrenderable)', () => {
+    const buildAlterForm = (fields: Record<string, unknown>[]) =>
+      ({
+        schemaVersion: 7 as const,
+        codebook: {
+          node: {
+            person: {
+              name: 'Person',
+              color: 'node-color-seq-1',
+              variables: {
+                name: { name: 'Name', type: 'text', component: 'Text' },
+                homeLoc: { name: 'Home', type: 'location' },
+                pos: { name: 'Pos', type: 'layout' },
+              },
+            },
+          },
+          edge: {},
+          ego: {},
+        },
+        stages: [
+          {
+            id: 'stage1',
+            type: 'AlterForm',
+            label: 'About',
+            subject: { entity: 'node', type: 'person' },
+            form: { fields },
+            introductionPanel: { title: 'Intro', text: 'Welcome.' },
+          },
+        ],
+      }) as unknown as Protocol<7>;
+
+    it('drops layout/location fields but keeps renderable fields and validates', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildAlterForm([
+          { variable: 'name', prompt: 'Name' },
+          { variable: 'homeLoc', prompt: 'Home' },
+          { variable: 'pos', prompt: 'Pos' },
+        ]),
+        { name: 'Test Protocol' },
+      ) as unknown as {
+        stages: { form?: { fields?: { variable?: string }[] } }[];
+      };
+      const fields = migrated.stages[0]?.form?.fields;
+      expect(fields).toHaveLength(1);
+      expect(fields?.[0]?.variable).toBe('name');
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+  });
+
+  describe('empty-form stage removal (form-fields-min1)', () => {
+    const buildProtocol = (formStage: Record<string, unknown>) =>
+      ({
+        schemaVersion: 7 as const,
+        codebook: {
+          node: {
+            person: {
+              name: 'Person',
+              color: 'node-color-seq-1',
+              variables: {
+                name: { name: 'Name', type: 'text', component: 'Text' },
+                homeLoc: { name: 'Home', type: 'location' },
+              },
+            },
+          },
+          edge: {},
+          ego: {},
+        },
+        stages: [
+          formStage,
+          {
+            id: 'keep',
+            type: 'NameGenerator',
+            label: 'Generate',
+            subject: { entity: 'node', type: 'person' },
+            form: {
+              title: 'Add',
+              fields: [{ variable: 'name', prompt: 'Name' }],
+            },
+            prompts: [{ id: 'p1', text: 'Who?' }],
+          },
+        ],
+      }) as unknown as Protocol<7>;
+
+    it('drops an authored EgoForm with no fields and validates', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildProtocol({
+          id: 'empty',
+          type: 'EgoForm',
+          label: 'Ego',
+          form: { fields: [] },
+          introductionPanel: { title: 'Intro', text: 'Welcome.' },
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as { stages: { id?: string }[] };
+      expect(migrated.stages.map((s) => s.id)).toEqual(['keep']);
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+
+    it('drops an AlterForm emptied by non-renderable field removal (gap 9 -> gap 10)', () => {
+      const migrated = migrationV7toV8.migrate(
+        buildProtocol({
+          id: 'onlyLocation',
+          type: 'AlterForm',
+          label: 'About',
+          subject: { entity: 'node', type: 'person' },
+          form: { fields: [{ variable: 'homeLoc', prompt: 'Home' }] },
+          introductionPanel: { title: 'Intro', text: 'Welcome.' },
+        }),
+        { name: 'Test Protocol' },
+      ) as unknown as { stages: { id?: string }[] };
+      expect(migrated.stages.map((s) => s.id)).toEqual(['keep']);
+      expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
+    });
+  });
+
   describe('migration metadata', () => {
     it('has correct from and to versions', () => {
       expect(migrationV7toV8.from).toBe(7);

--- a/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/migration.test.ts
@@ -4086,7 +4086,7 @@ describe('Migration V7 to V8', () => {
       expect(ProtocolSchemaV8.safeParse(migrated).success).toBe(true);
     });
 
-    it('drops an AlterForm emptied by non-renderable field removal (gap 9 -> gap 10)', () => {
+    it('drops an AlterForm emptied by non-renderable field removal', () => {
       const migrated = migrationV7toV8.migrate(
         buildProtocol({
           id: 'onlyLocation',

--- a/packages/protocol-validation/src/schemas/8/__tests__/shape-mapping-validation.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/shape-mapping-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createBaseProtocol } from '../../../utils/test-utils.ts';
+import { asEntityAttributeReference } from '../entity-attribute-reference.ts';
 import ProtocolSchemaV8 from '../schema.ts';
 
 describe('Shape Mapping Validation', () => {
@@ -36,7 +37,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'category',
+        variable: asEntityAttributeReference('category'),
         type: 'discrete',
         map: [
           { value: 'friend', shape: 'circle' },
@@ -62,7 +63,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'square',
       dynamic: {
-        variable: 'is_person',
+        variable: asEntityAttributeReference('is_person'),
         type: 'discrete',
         map: [{ value: true, shape: 'circle' }],
       },
@@ -77,7 +78,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'age',
+        variable: asEntityAttributeReference('age'),
         type: 'breakpoints',
         thresholds: [{ value: 30, shape: 'square' }],
       },
@@ -92,7 +93,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'age',
+        variable: asEntityAttributeReference('age'),
         type: 'breakpoints',
         thresholds: [
           { value: 20, shape: 'square' },
@@ -110,7 +111,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'age',
+        variable: asEntityAttributeReference('age'),
         type: 'breakpoints',
         thresholds: [],
       },
@@ -125,7 +126,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'age',
+        variable: asEntityAttributeReference('age'),
         type: 'breakpoints',
         thresholds: [
           { value: 10, shape: 'circle' },
@@ -153,7 +154,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'category',
+        variable: asEntityAttributeReference('category'),
         type: 'discrete',
         map: [
           { value: 'friend', shape: 'circle' },
@@ -171,7 +172,7 @@ describe('Shape Mapping Validation', () => {
     protocol.codebook.node.person.shape = {
       default: 'circle',
       dynamic: {
-        variable: 'age',
+        variable: asEntityAttributeReference('age'),
         type: 'breakpoints',
         thresholds: [
           { value: 40, shape: 'square' },

--- a/packages/protocol-validation/src/schemas/8/codebook/definitions.ts
+++ b/packages/protocol-validation/src/schemas/8/codebook/definitions.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { entityAttributeReference } from '../entity-attribute-reference.ts';
 import {
   EdgeVariablesSchema,
   EgoVariablesSchema,
@@ -23,7 +24,7 @@ export const NodeShapes = ['circle', 'square', 'diamond'] as const;
 export type NodeShape = (typeof NodeShapes)[number];
 
 const DiscreteShapeMappingSchema = z.strictObject({
-  variable: z.string(),
+  variable: entityAttributeReference({ subject: 'owningVariable' }),
   type: z.literal('discrete'),
   map: z
     .array(
@@ -42,7 +43,7 @@ const DiscreteShapeMappingSchema = z.strictObject({
 });
 
 const BreakpointShapeMappingSchema = z.strictObject({
-  variable: z.string(),
+  variable: entityAttributeReference({ subject: 'owningVariable' }),
   type: z.literal('breakpoints'),
   thresholds: z
     .array(

--- a/packages/protocol-validation/src/schemas/8/migration.ts
+++ b/packages/protocol-validation/src/schemas/8/migration.ts
@@ -1050,6 +1050,7 @@ const migrationV7toV8 = createMigration({
         'AlterForm',
         'AlterEdgeForm',
       ]);
+      const removedStageIds = new Set<string>();
       result.stages = result.stages.filter((stage: unknown) => {
         const typedStage = asRecord(stage);
         if (
@@ -1060,8 +1061,27 @@ const migrationV7toV8 = createMigration({
           return true;
         }
         const fields = asRecord(typedStage.form)?.fields;
-        return Array.isArray(fields) && fields.length > 0;
+        if (Array.isArray(fields) && fields.length > 0) return true;
+        if (typeof typedStage.id === 'string') {
+          removedStageIds.add(typedStage.id);
+        }
+        return false;
       });
+
+      if (removedStageIds.size > 0) {
+        for (const stage of result.stages) {
+          const skipLogic = asRecord(asRecord(stage)?.skipLogic);
+          const destination = asRecord(skipLogic?.destination);
+          if (
+            skipLogic &&
+            destination?.type === 'stage' &&
+            typeof destination.stageId === 'string' &&
+            removedStageIds.has(destination.stageId)
+          ) {
+            delete skipLogic.destination;
+          }
+        }
+      }
     }
 
     // Backfill any missing, empty, or whitespace-only stage label with a

--- a/packages/protocol-validation/src/schemas/8/migration.ts
+++ b/packages/protocol-validation/src/schemas/8/migration.ts
@@ -494,11 +494,6 @@ const migrationV7toV8 = createMigration({
             typedStage.type === 'EgoForm'
               ? { entity: 'ego' }
               : typedStage.subject;
-          // Drop fields whose variable resolves to a non-renderable type
-          // (layout/location) before backfilling prompts — the v8 schema
-          // rejects such fields. The shared reject-list keeps this in step with
-          // the schema. A form emptied here is removed whole by the
-          // post-traverse form-fields-min1 pass below (which runs after this).
           const renderable = fields.filter((field) => {
             const type = codebookVariable(
               codebook,
@@ -763,11 +758,6 @@ const migrationV7toV8 = createMigration({
         },
       },
       {
-        // An external-data side panel contains only nodes, so an edge rule in
-        // its filter can never apply and v8 rejects it. Mirror the editor's
-        // stripEdgeRules: for every panel whose dataSource is not 'existing',
-        // drop edge rules, and remove the filter entirely when no rules remain
-        // (preserving filter.join when rules survive).
         paths: ['stages[]'],
         fn: <V>(stage: V) => {
           const typedStage = asRecord(stage);
@@ -836,12 +826,6 @@ const migrationV7toV8 = createMigration({
         },
       },
       {
-        // A filter with more than one rule requires an explicit `join` in v8
-        // (only the multi-rule union arm carries it). Legacy protocols relied on
-        // the runtime default of 'OR', so backfill it wherever a multi-rule
-        // filter has no join. Single-rule filters leave `join` legitimately
-        // optional. Runs after the empty-rules step so dropped filters are not
-        // considered.
         paths: ['stages[]'],
         fn: <V>(stage: V) => {
           const typedStage = asRecord(stage);
@@ -1060,13 +1044,6 @@ const migrationV7toV8 = createMigration({
     const result = transformed;
     result.name = deps.name;
 
-    // Drop Ego/Alter/AlterEdge form stages whose form has no fields — v8
-    // requires at least one. This post-traverse pass also removes any such form
-    // left empty by the non-renderable field drop above (traverseAndTransform
-    // element fns cannot remove array elements). NameGenerator is intentionally
-    // excluded. Safe from orphaning: nothing in v7 input references a stage id
-    // (skip-logic destinations are v8-only; filters reference codebook
-    // attributes, not stages).
     if (Array.isArray(result.stages)) {
       const droppableFormStageTypes = new Set([
         'EgoForm',

--- a/packages/protocol-validation/src/schemas/8/migration.ts
+++ b/packages/protocol-validation/src/schemas/8/migration.ts
@@ -4,6 +4,7 @@ import {
 } from '../../migration/index.ts';
 import { traverseAndTransform } from '../../utils/traverse-and-transform.ts';
 import { ordinalColorSequence } from './common/prompts.ts';
+import { NON_RENDERABLE_VARIABLE_TYPES } from './variables/types.ts';
 
 // Operators whose operand is a categorical option value (as opposed to a count,
 // like OPTIONS_*, or a regex). Their legacy scalar operands are wrapped in a
@@ -24,15 +25,15 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     ? (value as Record<string, unknown>)
     : null;
 
-const codebookVariableName = (
+const codebookVariable = (
   codebook: unknown,
   subject: unknown,
   variableId: unknown,
-): string | undefined => {
-  if (typeof variableId !== 'string') return undefined;
+): Record<string, unknown> | null => {
+  if (typeof variableId !== 'string') return null;
   const cb = asRecord(codebook);
   const subj = asRecord(subject);
-  if (!cb || !subj) return undefined;
+  if (!cb || !subj) return null;
   let variables: Record<string, unknown> | null = null;
   if (subj.entity === 'ego') {
     variables = asRecord(asRecord(cb.ego)?.variables);
@@ -44,7 +45,15 @@ const codebookVariableName = (
       asRecord(asRecord(cb[subj.entity])?.[subj.type])?.variables,
     );
   }
-  const name = variables ? asRecord(variables[variableId])?.name : undefined;
+  return variables ? asRecord(variables[variableId]) : null;
+};
+
+const codebookVariableName = (
+  codebook: unknown,
+  subject: unknown,
+  variableId: unknown,
+): string | undefined => {
+  const name = codebookVariable(codebook, subject, variableId)?.name;
   return typeof name === 'string' && name.trim() !== '' ? name : undefined;
 };
 
@@ -478,13 +487,31 @@ const migrationV7toV8 = createMigration({
         fn: <V>(stage: V) => {
           const typedStage = asRecord(stage);
           if (!typedStage) return stage;
-          const fields = asRecord(typedStage.form)?.fields;
-          if (!Array.isArray(fields)) return stage;
+          const form = asRecord(typedStage.form);
+          const fields = form?.fields;
+          if (!form || !Array.isArray(fields)) return stage;
           const subject =
             typedStage.type === 'EgoForm'
               ? { entity: 'ego' }
               : typedStage.subject;
-          for (const field of fields) {
+          // Drop fields whose variable resolves to a non-renderable type
+          // (layout/location) before backfilling prompts — the v8 schema
+          // rejects such fields. The shared reject-list keeps this in step with
+          // the schema. A form emptied here is removed whole by the
+          // post-traverse form-fields-min1 pass below (which runs after this).
+          const renderable = fields.filter((field) => {
+            const type = codebookVariable(
+              codebook,
+              subject,
+              asRecord(field)?.variable,
+            )?.type;
+            return (
+              typeof type !== 'string' ||
+              !NON_RENDERABLE_VARIABLE_TYPES.has(type)
+            );
+          });
+          form.fields = renderable;
+          for (const field of renderable) {
             const typedField = asRecord(field);
             if (!typedField) continue;
             if (
@@ -736,6 +763,33 @@ const migrationV7toV8 = createMigration({
         },
       },
       {
+        // An external-data side panel contains only nodes, so an edge rule in
+        // its filter can never apply and v8 rejects it. Mirror the editor's
+        // stripEdgeRules: for every panel whose dataSource is not 'existing',
+        // drop edge rules, and remove the filter entirely when no rules remain
+        // (preserving filter.join when rules survive).
+        paths: ['stages[]'],
+        fn: <V>(stage: V) => {
+          const typedStage = asRecord(stage);
+          if (!typedStage || !Array.isArray(typedStage.panels)) return stage;
+          for (const panel of typedStage.panels) {
+            const typedPanel = asRecord(panel);
+            if (!typedPanel || typedPanel.dataSource === 'existing') continue;
+            const filter = asRecord(typedPanel.filter);
+            if (!filter || !Array.isArray(filter.rules)) continue;
+            const remaining = filter.rules.filter(
+              (rule) => asRecord(rule)?.type !== 'edge',
+            );
+            if (remaining.length === 0) {
+              delete typedPanel.filter;
+            } else {
+              filter.rules = remaining;
+            }
+          }
+          return stage;
+        },
+      },
+      {
         // A filter whose rules array is empty empties (or inverts) the network
         // at runtime, and v8 requires at least one rule. Drop an empty stage or
         // panel filter; for skipLogic (whose filter is required) drop the whole
@@ -778,6 +832,37 @@ const migrationV7toV8 = createMigration({
             }
           }
 
+          return stage;
+        },
+      },
+      {
+        // A filter with more than one rule requires an explicit `join` in v8
+        // (only the multi-rule union arm carries it). Legacy protocols relied on
+        // the runtime default of 'OR', so backfill it wherever a multi-rule
+        // filter has no join. Single-rule filters leave `join` legitimately
+        // optional. Runs after the empty-rules step so dropped filters are not
+        // considered.
+        paths: ['stages[]'],
+        fn: <V>(stage: V) => {
+          const typedStage = asRecord(stage);
+          if (!typedStage) return stage;
+          const backfillJoin = (filter: unknown) => {
+            const typedFilter = asRecord(filter);
+            if (!typedFilter || !Array.isArray(typedFilter.rules)) return;
+            if (
+              typedFilter.rules.length > 1 &&
+              typedFilter.join === undefined
+            ) {
+              typedFilter.join = 'OR';
+            }
+          };
+          backfillJoin(typedStage.filter);
+          backfillJoin(asRecord(typedStage.skipLogic)?.filter);
+          if (Array.isArray(typedStage.panels)) {
+            for (const panel of typedStage.panels) {
+              backfillJoin(asRecord(panel)?.filter);
+            }
+          }
           return stage;
         },
       },
@@ -974,6 +1059,33 @@ const migrationV7toV8 = createMigration({
     // Set name from required dependency
     const result = transformed;
     result.name = deps.name;
+
+    // Drop Ego/Alter/AlterEdge form stages whose form has no fields — v8
+    // requires at least one. This post-traverse pass also removes any such form
+    // left empty by the non-renderable field drop above (traverseAndTransform
+    // element fns cannot remove array elements). NameGenerator is intentionally
+    // excluded. Safe from orphaning: nothing in v7 input references a stage id
+    // (skip-logic destinations are v8-only; filters reference codebook
+    // attributes, not stages).
+    if (Array.isArray(result.stages)) {
+      const droppableFormStageTypes = new Set([
+        'EgoForm',
+        'AlterForm',
+        'AlterEdgeForm',
+      ]);
+      result.stages = result.stages.filter((stage: unknown) => {
+        const typedStage = asRecord(stage);
+        if (
+          !typedStage ||
+          typeof typedStage.type !== 'string' ||
+          !droppableFormStageTypes.has(typedStage.type)
+        ) {
+          return true;
+        }
+        const fields = asRecord(typedStage.form)?.fields;
+        return Array.isArray(fields) && fields.length > 0;
+      });
+    }
 
     // Backfill any missing, empty, or whitespace-only stage label with a
     // one-based positional default ("Stage 1", "Stage 2", …) so the migrated

--- a/packages/protocol-validation/src/schemas/8/migration.ts
+++ b/packages/protocol-validation/src/schemas/8/migration.ts
@@ -1051,7 +1051,7 @@ const migrationV7toV8 = createMigration({
         'AlterEdgeForm',
       ]);
       const removedStageIds = new Set<string>();
-      result.stages = result.stages.filter((stage: unknown) => {
+      const keptStages = result.stages.filter((stage: unknown) => {
         const typedStage = asRecord(stage);
         if (
           !typedStage ||
@@ -1067,9 +1067,10 @@ const migrationV7toV8 = createMigration({
         }
         return false;
       });
+      result.stages = keptStages;
 
       if (removedStageIds.size > 0) {
-        for (const stage of result.stages) {
+        for (const stage of keptStages) {
           const skipLogic = asRecord(asRecord(stage)?.skipLogic);
           const destination = asRecord(skipLogic?.destination);
           if (

--- a/packages/protocol-validation/src/schemas/8/schema.ts
+++ b/packages/protocol-validation/src/schemas/8/schema.ts
@@ -41,10 +41,10 @@ import {
 } from './common/index.ts';
 import type { FilterRule } from './filters/index.ts';
 import { type Prompt, stageSchema } from './stages/index.ts';
-
-// Variable types that have no renderable form `component` and therefore
-// cannot be referenced by a form field.
-const NON_RENDERABLE_VARIABLE_TYPES = new Set(['layout', 'location']);
+// NON_RENDERABLE_VARIABLE_TYPES lives in the leaf variables/types module (and is
+// re-exported above via `export * from './variables/index.ts'`) so the v7→v8
+// migration can share the same reject-list without importing this heavy module.
+import { NON_RENDERABLE_VARIABLE_TYPES } from './variables/index.ts';
 
 // Operators that expect numeric values for comparison
 const NUMERIC_COMPARISON_OPERATORS = [

--- a/packages/protocol-validation/src/schemas/8/schema.ts
+++ b/packages/protocol-validation/src/schemas/8/schema.ts
@@ -41,9 +41,6 @@ import {
 } from './common/index.ts';
 import type { FilterRule } from './filters/index.ts';
 import { type Prompt, stageSchema } from './stages/index.ts';
-// NON_RENDERABLE_VARIABLE_TYPES lives in the leaf variables/types module (and is
-// re-exported above via `export * from './variables/index.ts'`) so the v7→v8
-// migration can share the same reject-list without importing this heavy module.
 import { NON_RENDERABLE_VARIABLE_TYPES } from './variables/index.ts';
 
 // Operators that expect numeric values for comparison

--- a/packages/protocol-validation/src/schemas/8/schema.ts
+++ b/packages/protocol-validation/src/schemas/8/schema.ts
@@ -938,35 +938,27 @@ const ProtocolSchema = z
           const { dynamic } = nodeDef.shape;
           const basePath = ['codebook', 'node', nodeType, 'shape', 'dynamic'];
 
-          if (!nodeDef.variables || !(dynamic.variable in nodeDef.variables)) {
-            ctx.addIssue({
-              code: 'custom' as const,
-              message: `Shape mapping variable "${dynamic.variable}" is not defined in this node type's variables`,
-              path: [...basePath, 'variable'],
-            });
-          } else {
-            const variable = nodeDef.variables[dynamic.variable];
-            if (variable) {
-              if (
-                dynamic.type === 'discrete' &&
-                !discreteEligibleTypes.has(variable.type)
-              ) {
-                ctx.addIssue({
-                  code: 'custom' as const,
-                  message: `Discrete shape mapping requires a categorical, ordinal, or boolean variable, but "${dynamic.variable}" is of type "${variable.type}"`,
-                  path: [...basePath, 'type'],
-                });
-              }
-              if (
-                dynamic.type === 'breakpoints' &&
-                !breakpointEligibleTypes.has(variable.type)
-              ) {
-                ctx.addIssue({
-                  code: 'custom' as const,
-                  message: `Breakpoint shape mapping requires a number or scalar variable, but "${dynamic.variable}" is of type "${variable.type}"`,
-                  path: [...basePath, 'type'],
-                });
-              }
+          const variable = nodeDef.variables?.[dynamic.variable];
+          if (variable) {
+            if (
+              dynamic.type === 'discrete' &&
+              !discreteEligibleTypes.has(variable.type)
+            ) {
+              ctx.addIssue({
+                code: 'custom' as const,
+                message: `Discrete shape mapping requires a categorical, ordinal, or boolean variable, but "${dynamic.variable}" is of type "${variable.type}"`,
+                path: [...basePath, 'type'],
+              });
+            }
+            if (
+              dynamic.type === 'breakpoints' &&
+              !breakpointEligibleTypes.has(variable.type)
+            ) {
+              ctx.addIssue({
+                code: 'custom' as const,
+                message: `Breakpoint shape mapping requires a number or scalar variable, but "${dynamic.variable}" is of type "${variable.type}"`,
+                path: [...basePath, 'type'],
+              });
             }
           }
         }

--- a/packages/protocol-validation/src/schemas/8/variables/types.ts
+++ b/packages/protocol-validation/src/schemas/8/variables/types.ts
@@ -25,10 +25,6 @@ export const VariableTypes = {
   location: 'location',
 } as const;
 
-// Variable types that have no renderable form `component` and therefore cannot
-// be referenced by a form field. Lives in this leaf module so both the schema's
-// form-field reject-list and the v7→v8 migration's field drop share one source
-// and cannot drift (importing it from schema.ts would create a module cycle).
 export const NON_RENDERABLE_VARIABLE_TYPES = new Set<string>([
   VariableTypes.layout,
   VariableTypes.location,

--- a/packages/protocol-validation/src/schemas/8/variables/types.ts
+++ b/packages/protocol-validation/src/schemas/8/variables/types.ts
@@ -25,6 +25,15 @@ export const VariableTypes = {
   location: 'location',
 } as const;
 
+// Variable types that have no renderable form `component` and therefore cannot
+// be referenced by a form field. Lives in this leaf module so both the schema's
+// form-field reject-list and the v7→v8 migration's field drop share one source
+// and cannot drift (importing it from schema.ts would create a module cycle).
+export const NON_RENDERABLE_VARIABLE_TYPES = new Set<string>([
+  VariableTypes.layout,
+  VariableTypes.location,
+]);
+
 export const ComponentTypesKeys = Object.keys(
   ComponentTypes,
 ) as (keyof typeof ComponentTypes)[];

--- a/packages/protocol-validation/src/utils/__tests__/entity-attribute-reference-coverage.test.ts
+++ b/packages/protocol-validation/src/utils/__tests__/entity-attribute-reference-coverage.test.ts
@@ -50,9 +50,10 @@ const countTagged = (
 // Update this number deliberately when adding/removing a tagged field.
 // Merged total: main's NetworkComposer reference fields, plus this branch's
 // pedigree fields — biologicalSexVariable (NodeConfigSchema), gameteRoleVariable
-// (EdgeConfigSchema), and NarrativePedigree diseases[].variable. The value is
-// verified against the runtime count computed below.
-const EXPECTED_TAGGED_FIELD_COUNT = 34;
+// (EdgeConfigSchema), and NarrativePedigree diseases[].variable — plus the two
+// node shape-mapping `variable` fields (discrete and breakpoints arms). The
+// value is verified against the runtime count computed below.
+const EXPECTED_TAGGED_FIELD_COUNT = 36;
 
 describe('entity-attribute reference coverage', () => {
   it('has tagged the expected number of reference fields', () => {


### PR DESCRIPTION
Protocols could end up in states that schema 8 rejects, from two directions:
the Architect editor let you save configurations the validator refuses, and
the v7→v8 migration passed through legacy shapes that schema 8 no longer
accepts.

## Architect — block the editor states that produce invalid protocols

- **Node shape mappings** now require a variable, and breakpoint mappings
  require at least one threshold with strictly increasing values. New
  thresholds seed above the previous one. An incomplete mapping blocks save
  with an explanation instead of reverting without warning.
- **Family Pedigree node type** can no longer be changed while a Narrative
  Pedigree stage depends on it, which previously left a reference to a
  variable that no longer existed on the new type.
- **Map stage** reads GeoJSON feature properties from every feature rather
  than only the first, so the property selector appears whenever any feature
  has properties. When none do, saving is blocked with a clear message
  instead of failing validation later.
- The codebook's "used in" display now names shape settings as a place a
  variable is used.

## protocol-validation — repair legacy shapes during v7→v8 migration

- Strip edge rules from external-data panel filters (they can never match on
  an external source).
- Backfill `join: 'OR'` on multi-rule filters that omit it, matching the
  query runtime's default.
- Drop form fields bound to non-renderable (layout/location) variables, and
  drop any form stage left with no fields.
- Record `shape.dynamic.variable` as an entity-attribute reference, so
  where-used reporting and dangling-reference validation account for shape
  mappings.

Also derives the shape-mapping editor types from the protocol schema rather
than hand-rolling parallel copies of them — no behaviour change.

## Test plan

- [x] New unit coverage for the migration repairs, the shape-mapping
      validator, the stage-dependency guard, and GeoJSON property collection
- [x] `pnpm --filter @codaco/protocol-validation test` — 729 passing
- [x] `pnpm --filter @codaco/architect test` — 940 passing
- [x] `pnpm knip` clean
- [x] Confirm in-app that an incomplete shape mapping blocks save with the
      intended message

## Notes

Two changesets, one per release lane (`@codaco/architect` and
`@codaco/protocol-validation`), both patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol editing now blocks invalid shape mappings and incomplete breakpoint thresholds instead of silently reverting, with clearer explanations.
  * Changing node types that impact dependent Family Pedigree stages is prevented with an acknowledgment message.
  * GeoJSON map selection now considers properties from all features, and when none are available the selection is disabled with a clear hint.
  * Schema 7 → 8 migration more reliably repairs legacy protocols (filter cleanup, form pruning, and dropped-stage skipLogic cleanup).

* **Validation**
  * Added entity/type validation for dynamic shape mappings used by inline editing, including required variable selection and strictly increasing, non-duplicate breakpoint thresholds.

* **Tests**
  * Expanded test coverage for migration guards, shape-mapping validation, and GeoJSON variable extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->