### PR TITLE
feat(synthetic): draw synthetic network nodes from roster data

### DIFF
--- a/.changeset/architect-roster-backed-previews.md
+++ b/.changeset/architect-roster-backed-previews.md
@@ -1,0 +1,9 @@
+---
+'@codaco/architect': minor
+---
+
+Synthetic preview sessions now draw roster-stage people from the protocol's
+actual roster assets instead of inventing them, so a preview lines up with the
+roster file the way a real interview would. A roster that is missing or
+unreadable — including a half-built draft stage — falls back to generated
+people, so a roster problem never blocks a preview.

--- a/.changeset/interviewer-synthetic-roster-data.md
+++ b/.changeset/interviewer-synthetic-roster-data.md
@@ -1,0 +1,11 @@
+---
+'@codaco/interviewer': minor
+---
+
+Synthetic sessions now pick people from a protocol's actual rosters. Previously,
+a roster screen generated invented people, so test data never lined up with the
+roster file and that mismatch carried into every later stage. Generated sessions
+now draw from the real roster rows, and a stage that also allows adding people
+manually gets a mix of both. Where a side panel filters its roster, generation
+draws only from the people that panel would actually show. Protocols whose
+roster files are missing or unreadable still generate as before.

--- a/.changeset/interviewer-synthetic-roster-data.md
+++ b/.changeset/interviewer-synthetic-roster-data.md
@@ -7,5 +7,7 @@ a roster screen generated invented people, so test data never lined up with the
 roster file and that mismatch carried into every later stage. Generated sessions
 now draw from the real roster rows, and a stage that also allows adding people
 manually gets a mix of both. Where a side panel filters its roster, generation
-draws only from the people that panel would actually show. Protocols whose
-roster files are missing or unreadable still generate as before.
+draws only from the people that panel would actually show. A roster that loads
+but has no rows — or whose panel filters out everyone — now generates an empty
+roster stage rather than inventing people. Protocols whose roster files are
+missing or unreadable still generate as before.

--- a/.changeset/roster-backed-synthetic-networks.md
+++ b/.changeset/roster-backed-synthetic-networks.md
@@ -1,16 +1,28 @@
 ---
-'@codaco/protocol-utilities': minor
+'@codaco/protocol-utilities': major
 '@codaco/interview': minor
+'@codaco/protocol-validation': minor
 ---
 
-`generateNetwork` can now build name generator stages from real roster data. Pass
-parsed roster nodes via the new `externalData` option, keyed by stage id, and
-roster and roster-panel stages draw their people from those rows — preserving
-each row's primary key and attributes — instead of inventing people from the
+`generateNetwork` now takes a single parameter object — call
+`generateNetwork({ codebook, stages, ...options })` instead of passing the
+codebook and stages as positional arguments. This is a breaking change.
+
+It can also build name generator stages from real roster data. Pass parsed
+roster nodes via the new `externalData` option, keyed by stage id, and roster
+and roster-panel stages draw their people from those rows — preserving each
+row's primary key and attributes — instead of inventing people from the
 codebook. Draws are without replacement across prompts and stages, mirroring the
 runtime's global exclusion of rows already in the network. A stage with no entry
-still falls back to codebook-generated people.
+still falls back to codebook-generated people. A new `config` option exposes the
+generation-tuning defaults (the roster-versus-fabricate ratio, node counts, edge
+probabilities, and so on) so callers can override them.
 
-`@codaco/interview` now exports `loadExternalData`, `makeVariableUUIDReplacer`,
-and `getVariableTypeReplacements` so hosts can parse roster assets the same way
-the interview runtime does.
+`@codaco/interview` now exposes its roster-parsing pipeline from the `./contract`
+entry: `collectRosterExternalData` gathers a protocol's roster nodes keyed by
+stage, and `parseExternalNetworkAsset` and `filterExternalPanelNodes` parse and
+filter individual roster assets. This is the exact code the interview runtime
+uses, so a host reads roster assets identically to a live interview.
+
+`@codaco/protocol-validation` now exports a `StructuralCodebook` type for
+consumers that assemble or receive a codebook before schema validation.

--- a/.changeset/roster-backed-synthetic-networks.md
+++ b/.changeset/roster-backed-synthetic-networks.md
@@ -16,7 +16,9 @@ codebook. Draws are without replacement across prompts and stages, mirroring the
 runtime's global exclusion of rows already in the network. A stage with no entry
 still falls back to codebook-generated people. A new `config` option exposes the
 generation-tuning defaults (the roster-versus-fabricate ratio, node counts, edge
-probabilities, and so on) so callers can override them.
+probabilities, and so on) so callers can override them. FamilyPedigree stages
+now mark exactly one generated node as ego, matching the runtime convention,
+instead of randomising the ego flag across every node.
 
 `@codaco/interview` now exposes its roster-parsing pipeline from the `./contract`
 entry: `collectRosterExternalData` gathers a protocol's roster nodes keyed by

--- a/.changeset/roster-backed-synthetic-networks.md
+++ b/.changeset/roster-backed-synthetic-networks.md
@@ -1,0 +1,16 @@
+---
+'@codaco/protocol-utilities': minor
+'@codaco/interview': minor
+---
+
+`generateNetwork` can now build name generator stages from real roster data. Pass
+parsed roster nodes via the new `externalData` option, keyed by stage id, and
+roster and roster-panel stages draw their people from those rows — preserving
+each row's primary key and attributes — instead of inventing people from the
+codebook. Draws are without replacement across prompts and stages, mirroring the
+runtime's global exclusion of rows already in the network. A stage with no entry
+still falls back to codebook-generated people.
+
+`@codaco/interview` now exports `loadExternalData`, `makeVariableUUIDReplacer`,
+and `getVariableTypeReplacements` so hosts can parse roster assets the same way
+the interview runtime does.

--- a/.changeset/roster-backed-synthetic-networks.md
+++ b/.changeset/roster-backed-synthetic-networks.md
@@ -1,6 +1,6 @@
 ---
 '@codaco/protocol-utilities': major
-'@codaco/interview': minor
+'@codaco/interview': major
 '@codaco/protocol-validation': minor
 ---
 
@@ -28,3 +28,11 @@ uses, so a host reads roster assets identically to a live interview.
 
 `@codaco/protocol-validation` now exports a `StructuralCodebook` type for
 consumers that assemble or receive a codebook before schema validation.
+
+Roster rows parsed by `@codaco/interview` are now identified as
+`subjectType_contentHash` instead of a bare content hash. A roster file that
+backs more than one node type (say, a shared address book used by both a
+person stage and a place stage) previously produced the same primary key for
+matching rows under each type, an invariant violation once both ended up in
+the same network. This is a breaking change: sessions saved by earlier
+versions will not re-associate their roster people after upgrading.

--- a/.changeset/roster-backed-synthetic-networks.md
+++ b/.changeset/roster-backed-synthetic-networks.md
@@ -14,7 +14,10 @@ and roster-panel stages draw their people from those rows — preserving each
 row's primary key and attributes — instead of inventing people from the
 codebook. Draws are without replacement across prompts and stages, mirroring the
 runtime's global exclusion of rows already in the network. A stage with no entry
-still falls back to codebook-generated people. A new `config` option exposes the
+still falls back to codebook-generated people. A roster that loads but contains
+no rows — or whose panel filters out every row — now generates an empty roster
+stage instead of inventing people, matching a live interview that would offer
+nobody to add; only a missing or unreadable roster falls back to fabrication. A new `config` option exposes the
 generation-tuning defaults (the roster-versus-fabricate ratio, node counts, edge
 probabilities, and so on) so callers can override them. FamilyPedigree stages
 now mark exactly one generated node as ego, matching the runtime convention,

--- a/apps/architect/src/components/PreviewHost/PreviewHost.tsx
+++ b/apps/architect/src/components/PreviewHost/PreviewHost.tsx
@@ -19,11 +19,12 @@ import { hydrateMemoryAsset } from '~/utils/inMemoryAssetStore';
 
 import { currentProtocolToPayload } from './currentProtocolToPayload';
 import { isPreviewMessage, type PreviewPayload } from './messages';
+import { collectPreviewRosterData } from './previewRosterData';
 import { useAssetResolver } from './useAssetResolver';
 const PAYLOAD_TIMEOUT_MS = 5000;
 const noopSync = async () => {};
 const noopFinish = async () => {};
-function buildSession(payload: PreviewPayload): SessionPayload {
+async function buildSession(payload: PreviewPayload): Promise<SessionPayload> {
   const now = new Date().toISOString();
   const base: SessionPayload = {
     id: uuid(),
@@ -36,16 +37,22 @@ function buildSession(payload: PreviewPayload): SessionPayload {
   if (!payload.useSyntheticData) {
     return base;
   }
-  const generated = generateNetwork(
-    payload.protocol.codebook,
-    payload.protocol.stages,
-    {
-      // Leave the previewed stage partially complete so interaction-driven
-      // interfaces (ordinal/categorical bins, sociogram) still have
-      // unplaced nodes to work with.
-      inProgressStageIndex: payload.startStage,
-    },
+  // Draw roster-stage people from the protocol's real roster assets. Failures
+  // are isolated per-asset and never throw, so a roster problem degrades to
+  // fabricated people rather than blocking the preview.
+  const externalData = await collectPreviewRosterData(
+    payload.protocol,
+    payload.protocolId,
   );
+  const generated = generateNetwork({
+    codebook: payload.protocol.codebook,
+    stages: payload.protocol.stages,
+    externalData,
+    // Leave the previewed stage partially complete so interaction-driven
+    // interfaces (ordinal/categorical bins, sociogram) still have
+    // unplaced nodes to work with.
+    inProgressStageIndex: payload.startStage,
+  });
   // Stages that record a finalized state (e.g. a FamilyPedigree's committed
   // network) do so via stageMetadata; without it they preview as never
   // finalized. Parse each entry independently so a single malformed entry is
@@ -90,6 +97,33 @@ export function PreviewHost() {
     if (!opener) return;
     const expectedOrigin = window.location.origin;
     let received = false;
+    let cancelled = false;
+    const processPayload = async (previewPayload: PreviewPayload) => {
+      let nextPayload: InterviewPayload;
+      try {
+        // Resolve the protocol payload first (a throw here means an invalid
+        // protocol shape), then build the session, which is async because
+        // synthetic previews fetch and parse the protocol's roster assets.
+        const protocol = currentProtocolToPayload(previewPayload.protocol);
+        const session = await buildSession(previewPayload);
+        if (cancelled) return;
+        nextPayload = { protocol, session };
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Failed to build preview payload', error);
+        setProcessingFailed(true);
+        return;
+      }
+      setProcessingFailed(false);
+      setInterviewPayload(nextPayload);
+      setProtocolId(previewPayload.protocolId);
+      setCurrentStep(previewPayload.startStage);
+      setBypassedStageIndex(
+        previewPayload.skipLogicBypassed ? previewPayload.startStage : null,
+      );
+      setSkipLogicNoticeDismissed(false);
+      setTimedOut(false);
+    };
     const onMessage = (event: MessageEvent) => {
       if (event.source !== opener) return;
       if (event.origin !== expectedOrigin) return;
@@ -108,31 +142,11 @@ export function PreviewHost() {
           data: asset.data,
         });
       }
-      let nextPayload: InterviewPayload;
-      try {
-        // Build the payload before marking the handshake received: a throw here
-        // (invalid protocol shape, synthetic-network generation) must surface an
-        // error rather than leave the loader stuck forever.
-        nextPayload = {
-          protocol: currentProtocolToPayload(previewPayload.protocol),
-          session: buildSession(previewPayload),
-        };
-      } catch (error) {
-        console.error('Failed to build preview payload', error);
-        received = true;
-        setProcessingFailed(true);
-        return;
-      }
+      // The payload message arrived — the handshake succeeded, so disarm the
+      // "couldn't reach Architect" timeout regardless of how the async build
+      // resolves. A build failure surfaces the processing-failed screen.
       received = true;
-      setProcessingFailed(false);
-      setInterviewPayload(nextPayload);
-      setProtocolId(previewPayload.protocolId);
-      setCurrentStep(previewPayload.startStage);
-      setBypassedStageIndex(
-        previewPayload.skipLogicBypassed ? previewPayload.startStage : null,
-      );
-      setSkipLogicNoticeDismissed(false);
-      setTimedOut(false);
+      void processPayload(previewPayload);
     };
     window.addEventListener('message', onMessage);
     opener.postMessage({ type: 'preview:ready' }, expectedOrigin);
@@ -140,6 +154,7 @@ export function PreviewHost() {
       if (!received) setTimedOut(true);
     }, PAYLOAD_TIMEOUT_MS);
     return () => {
+      cancelled = true;
       window.removeEventListener('message', onMessage);
       clearTimeout(timeoutId);
     };

--- a/apps/architect/src/components/PreviewHost/__tests__/PreviewHost.test.tsx
+++ b/apps/architect/src/components/PreviewHost/__tests__/PreviewHost.test.tsx
@@ -102,11 +102,11 @@ describe('PreviewHost', () => {
     );
   });
 
-  it('mounts Shell with the payload after receiving preview:payload', () => {
+  it('mounts Shell with the payload after receiving preview:payload', async () => {
     render(<PreviewHost />);
     postPayload(openerStub, makePayload());
 
-    expect(screen.getByTestId('shell-mounted')).toBeInTheDocument();
+    expect(await screen.findByTestId('shell-mounted')).toBeInTheDocument();
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       payload: InterviewPayload;
       currentStep: number;
@@ -119,25 +119,27 @@ describe('PreviewHost', () => {
     expect(typeof call.onStepChange).toBe('function');
   });
 
-  it('always enables stage navigation in Architect preview', () => {
+  it('always enables stage navigation in Architect preview', async () => {
     render(<PreviewHost />);
     postPayload(openerStub, makePayload());
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       allowStageNavigation: boolean;
     };
     expect(call.allowStageNavigation).toBe(true);
   });
 
-  it('initialises currentStep from payload.startStage', () => {
+  it('initialises currentStep from payload.startStage', async () => {
     render(<PreviewHost />);
     postPayload(openerStub, makePayload({ startStage: 3 }));
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as { currentStep: number };
     expect(call.currentStep).toBe(3);
   });
 
-  it('passes a one-stage initial override without removing skip logic', () => {
+  it('passes a one-stage initial override without removing skip logic', async () => {
     render(<PreviewHost />);
     const baseProtocol = makeProtocol();
     const protocol = {
@@ -157,6 +159,7 @@ describe('PreviewHost', () => {
       makePayload({ protocol, startStage: 0, skipLogicBypassed: true }),
     );
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       payload: InterviewPayload;
       initialStageOverrideIndex?: number;
@@ -165,20 +168,22 @@ describe('PreviewHost', () => {
     expect(call.payload.protocol.stages[0]).toHaveProperty('skipLogic');
   });
 
-  it('omits the initial override when preview skip logic is active', () => {
+  it('omits the initial override when preview skip logic is active', async () => {
     render(<PreviewHost />);
     postPayload(openerStub, makePayload({ skipLogicBypassed: false }));
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       initialStageOverrideIndex?: number;
     };
     expect(call.initialStageOverrideIndex).toBeUndefined();
   });
 
-  it('seeds a synthetic network when useSyntheticData is true', () => {
+  it('seeds a synthetic network when useSyntheticData is true', async () => {
     render(<PreviewHost />);
     postPayload(openerStub, makePayload({ useSyntheticData: true }));
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       payload: InterviewPayload;
       currentStep: number;
@@ -186,7 +191,7 @@ describe('PreviewHost', () => {
     expect(call.currentStep).toBe(0);
   });
 
-  it('leaves the previewed stage partially complete in synthetic data', () => {
+  it('leaves the previewed stage partially complete in synthetic data', async () => {
     render(<PreviewHost />);
     const protocol = {
       name: 'T',
@@ -234,6 +239,7 @@ describe('PreviewHost', () => {
       makePayload({ protocol, startStage: 1, useSyntheticData: true }),
     );
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       payload: InterviewPayload;
     };
@@ -249,7 +255,7 @@ describe('PreviewHost', () => {
     expect(placed.length).toBeGreaterThan(0);
   });
 
-  it('seeds finalized stageMetadata for a synthetic FamilyPedigree', () => {
+  it('seeds finalized stageMetadata for a synthetic FamilyPedigree', async () => {
     render(<PreviewHost />);
     const protocol = {
       name: 'T',
@@ -276,6 +282,7 @@ describe('PreviewHost', () => {
       makePayload({ protocol, startStage: 0, useSyntheticData: true }),
     );
 
+    await screen.findByTestId('shell-mounted');
     const call = shellMock.mock.calls.at(-1)?.[0] as {
       payload: InterviewPayload;
     };
@@ -284,7 +291,7 @@ describe('PreviewHost', () => {
     });
   });
 
-  it('shows an error fallback when payload processing throws', () => {
+  it('shows an error fallback when payload processing throws', async () => {
     render(<PreviewHost />);
     const protocol = {
       name: 'T',
@@ -297,7 +304,9 @@ describe('PreviewHost', () => {
     };
     postPayload(openerStub, makePayload({ protocol, useSyntheticData: true }));
 
-    expect(screen.getByText(/couldn't build the preview/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/couldn't build the preview/i),
+    ).toBeInTheDocument();
     expect(shellMock).not.toHaveBeenCalled();
   });
 

--- a/apps/architect/src/components/PreviewHost/__tests__/previewRosterData.test.ts
+++ b/apps/architect/src/components/PreviewHost/__tests__/previewRosterData.test.ts
@@ -194,4 +194,28 @@ describe('collectPreviewRosterData', () => {
 
     expect(result).toEqual({});
   });
+
+  it('fails soft to {} and logs when collection itself throws', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    // A draft stage engineered to throw the moment collection reads its `type`,
+    // standing in for the half-built shapes previews can produce.
+    const explodingStage = {
+      id: 'boom',
+      label: 'Boom',
+      get type(): string {
+        throw new Error('stage read failed');
+      },
+    };
+    const protocol = makeProtocol({
+      stages: [explodingStage],
+    } as unknown as Partial<CurrentProtocol>);
+
+    const result = await collectPreviewRosterData(protocol, PROTOCOL_ID);
+
+    expect(result).toEqual({});
+    expect(consoleError).toHaveBeenCalled();
+  });
 });

--- a/apps/architect/src/components/PreviewHost/__tests__/previewRosterData.test.ts
+++ b/apps/architect/src/components/PreviewHost/__tests__/previewRosterData.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CurrentProtocol } from '@codaco/protocol-validation';
+import { entityAttributesProperty } from '@codaco/shared-consts';
+
+const getAssetById = vi.fn();
+vi.mock('~/utils/assetUtils', () => ({
+  getAssetById: (...args: unknown[]) => getAssetById(...args),
+}));
+
+const { collectPreviewRosterData, makeRosterAssetResolver } =
+  await import('../previewRosterData');
+
+const PROTOCOL_ID = 'protocol-1';
+const PEOPLE_CSV = 'Name,Age\nAda,36\nGrace,45\nAlan,41\n';
+
+const createObjectURL = vi.fn((_blob: unknown) => 'blob:roster');
+const revokeObjectURL = vi.fn();
+
+function csvBlob(): Blob {
+  return new Blob([PEOPLE_CSV], { type: 'text/csv' });
+}
+
+function makeProtocol(
+  overrides: Partial<CurrentProtocol> = {},
+): CurrentProtocol {
+  return {
+    name: 'T',
+    description: '',
+    schemaVersion: 8,
+    stages: [],
+    codebook: {
+      node: {
+        person: {
+          variables: {
+            'var-name': { name: 'Name', type: 'text' },
+            'var-age': { name: 'Age', type: 'number' },
+          },
+        },
+      },
+      edge: {},
+      ego: {},
+    },
+    assetManifest: {
+      roster: {
+        id: 'roster',
+        type: 'network',
+        name: 'People',
+        source: 'people.csv',
+      },
+    },
+    ...overrides,
+  } as unknown as CurrentProtocol;
+}
+
+const rosterStage = {
+  id: 'stage-ngr',
+  label: 'Roster',
+  type: 'NameGeneratorRoster',
+  subject: { entity: 'node', type: 'person' },
+  dataSource: 'roster',
+  prompts: [{ id: 'p1', text: 'Pick people' }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createObjectURL.mockReturnValue('blob:roster');
+  // Subclass rather than spread so URL stays constructible (jsdom builds
+  // `new URL(...)` internally); vi.unstubAllGlobals then restores it.
+  class StubURL extends URL {}
+  vi.stubGlobal(
+    'URL',
+    Object.assign(StubURL, { createObjectURL, revokeObjectURL }),
+  );
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(PEOPLE_CSV))),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('makeRosterAssetResolver', () => {
+  it('resolves a network asset to an object URL with the manifest source filename', async () => {
+    getAssetById.mockResolvedValue({
+      id: 'roster',
+      name: 'People',
+      data: csvBlob(),
+    });
+
+    const resolve = makeRosterAssetResolver(makeProtocol(), PROTOCOL_ID);
+    const resolved = await resolve('roster');
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.url).toBe('blob:roster');
+    expect(resolved!.sourceFileName).toBe('people.csv');
+    expect(getAssetById).toHaveBeenCalledWith('roster', PROTOCOL_ID);
+
+    resolved!.cleanup?.();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:roster');
+  });
+
+  it('returns null for a non-network manifest entry without touching the store', async () => {
+    const protocol = makeProtocol({
+      assetManifest: {
+        roster: {
+          id: 'roster',
+          type: 'image',
+          name: 'Logo',
+          source: 'logo.png',
+        },
+      },
+    } as unknown as Partial<CurrentProtocol>);
+
+    const resolve = makeRosterAssetResolver(protocol, PROTOCOL_ID);
+
+    expect(await resolve('roster')).toBeNull();
+    expect(getAssetById).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the manifest has no entry for the asset', async () => {
+    const protocol = makeProtocol({
+      assetManifest: {},
+    } as unknown as Partial<CurrentProtocol>);
+
+    const resolve = makeRosterAssetResolver(protocol, PROTOCOL_ID);
+
+    expect(await resolve('roster')).toBeNull();
+    expect(getAssetById).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the asset is missing from the store', async () => {
+    getAssetById.mockResolvedValue(undefined);
+
+    const resolve = makeRosterAssetResolver(makeProtocol(), PROTOCOL_ID);
+
+    expect(await resolve('roster')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the stored asset data is a string rather than a blob', async () => {
+    getAssetById.mockResolvedValue({
+      id: 'roster',
+      name: 'People',
+      data: 'inline-data',
+    });
+
+    const resolve = makeRosterAssetResolver(makeProtocol(), PROTOCOL_ID);
+
+    expect(await resolve('roster')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('fails soft to null when the store lookup throws', async () => {
+    getAssetById.mockRejectedValue(new Error('storage unavailable'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const resolve = makeRosterAssetResolver(makeProtocol(), PROTOCOL_ID);
+
+    expect(await resolve('roster')).toBeNull();
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
+describe('collectPreviewRosterData', () => {
+  it('builds external data keyed by stage from the protocol rosters', async () => {
+    getAssetById.mockResolvedValue({
+      id: 'roster',
+      name: 'People',
+      data: csvBlob(),
+    });
+
+    const protocol = makeProtocol({
+      stages: [rosterStage],
+    } as unknown as Partial<CurrentProtocol>);
+    const result = await collectPreviewRosterData(protocol, PROTOCOL_ID);
+
+    expect(result['stage-ngr']).toHaveLength(3);
+    const [first] = result['stage-ngr']!;
+    expect(first!.type).toBe('person');
+    expect(first![entityAttributesProperty]['var-name']).toBe('Ada');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:roster');
+  });
+
+  it('returns {} when a roster asset cannot be resolved', async () => {
+    getAssetById.mockResolvedValue(undefined);
+
+    const protocol = makeProtocol({
+      stages: [rosterStage],
+    } as unknown as Partial<CurrentProtocol>);
+    const result = await collectPreviewRosterData(protocol, PROTOCOL_ID);
+
+    expect(result).toEqual({});
+  });
+});

--- a/apps/architect/src/components/PreviewHost/previewRosterData.ts
+++ b/apps/architect/src/components/PreviewHost/previewRosterData.ts
@@ -1,0 +1,68 @@
+import {
+  collectRosterExternalData,
+  type ResolveRosterAsset,
+} from '@codaco/interview/contract';
+import type { CurrentProtocol } from '@codaco/protocol-validation';
+import type { NcNode } from '@codaco/shared-consts';
+import { getAssetById } from '~/utils/assetUtils';
+
+/**
+ * Resolves a protocol asset id to a fetchable roster asset for synthetic
+ * preview generation, reusing the editor's own asset store (IndexedDB, then
+ * the Safari-private in-memory fallback). Previews run on draft protocols, so
+ * an asset may not be a roster, may lack a source, or may not exist yet — every
+ * unresolvable case returns null and any error is swallowed, so a roster
+ * problem can never break a preview. The worst case is that a roster stage
+ * falls back to fabricated people, exactly as before roster data was wired in.
+ */
+export function makeRosterAssetResolver(
+  protocol: CurrentProtocol,
+  protocolId: string,
+): ResolveRosterAsset {
+  return async (assetId) => {
+    try {
+      const manifestEntry = protocol.assetManifest?.[assetId];
+      if (
+        !manifestEntry ||
+        manifestEntry.type !== 'network' ||
+        !manifestEntry.source
+      ) {
+        return null;
+      }
+
+      const asset = await getAssetById(assetId, protocolId);
+      if (!asset || typeof asset.data === 'string') {
+        return null;
+      }
+
+      const url = URL.createObjectURL(asset.data);
+      return {
+        url,
+        sourceFileName: manifestEntry.source,
+        cleanup: () => URL.revokeObjectURL(url),
+      };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Could not resolve roster asset "${assetId}" for preview`,
+        error,
+      );
+      return null;
+    }
+  };
+}
+
+/**
+ * Roster node pools (keyed by stage id) for a preview's synthetic session,
+ * drawn from the protocol's actual roster assets.
+ */
+export function collectPreviewRosterData(
+  protocol: CurrentProtocol,
+  protocolId: string,
+): Promise<Record<string, NcNode[]>> {
+  return collectRosterExternalData({
+    stages: protocol.stages,
+    codebook: protocol.codebook,
+    resolveAsset: makeRosterAssetResolver(protocol, protocolId),
+  });
+}

--- a/apps/architect/src/components/PreviewHost/previewRosterData.ts
+++ b/apps/architect/src/components/PreviewHost/previewRosterData.ts
@@ -56,13 +56,23 @@ export function makeRosterAssetResolver(
  * Roster node pools (keyed by stage id) for a preview's synthetic session,
  * drawn from the protocol's actual roster assets.
  */
-export function collectPreviewRosterData(
+export async function collectPreviewRosterData(
   protocol: CurrentProtocol,
   protocolId: string,
 ): Promise<Record<string, NcNode[]>> {
-  return collectRosterExternalData({
-    stages: protocol.stages,
-    codebook: protocol.codebook,
-    resolveAsset: makeRosterAssetResolver(protocol, protocolId),
-  });
+  // Load-bearing soft-fail: previews run on draft protocols, so collection can
+  // throw on half-built shapes that per-asset error isolation can't anticipate
+  // (e.g. a malformed panel filter throwing inside network-query). Any failure
+  // returns {} so the preview still renders, falling back to fabricated people.
+  try {
+    return await collectRosterExternalData({
+      stages: protocol.stages,
+      codebook: protocol.codebook,
+      resolveAsset: makeRosterAssetResolver(protocol, protocolId),
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Could not collect roster data for preview', error);
+    return {};
+  }
 }

--- a/apps/interviewer/package.json
+++ b/apps/interviewer/package.json
@@ -31,6 +31,7 @@
     "@codaco/fresco-ui": "workspace:^",
     "@codaco/interview": "workspace:^",
     "@codaco/network-exporters": "workspace:^",
+    "@codaco/network-query": "workspace:^",
     "@codaco/protocol-utilities": "workspace:^",
     "@codaco/protocol-validation": "workspace:^",
     "@codaco/protocols": "workspace:^",

--- a/apps/interviewer/package.json
+++ b/apps/interviewer/package.json
@@ -31,7 +31,6 @@
     "@codaco/fresco-ui": "workspace:^",
     "@codaco/interview": "workspace:^",
     "@codaco/network-exporters": "workspace:^",
-    "@codaco/network-query": "workspace:^",
     "@codaco/protocol-utilities": "workspace:^",
     "@codaco/protocol-validation": "workspace:^",
     "@codaco/protocols": "workspace:^",

--- a/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { entityAttributesProperty } from '@codaco/shared-consts';
 
@@ -79,13 +79,23 @@ const MANIFEST = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  Object.assign(URL, { createObjectURL, revokeObjectURL });
   createObjectURL.mockReturnValue('blob:roster');
+  // Subclass rather than spread so URL stays constructible (jsdom builds
+  // `new URL(...)` internally); vi.unstubAllGlobals then restores it.
+  class StubURL extends URL {}
+  vi.stubGlobal(
+    'URL',
+    Object.assign(StubURL, { createObjectURL, revokeObjectURL }),
+  );
   vi.stubGlobal(
     'fetch',
     vi.fn(() => Promise.resolve(new Response(PEOPLE_CSV))),
   );
   getProtocolAssets.mockResolvedValue([storedAsset({})]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('loadRosterNodesForStages', () => {

--- a/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { entityAttributesProperty } from '@codaco/shared-consts';
+
+import type { StoredAsset, StoredProtocol } from '../../db/types';
+
+const getProtocolAssets = vi.fn();
+
+vi.mock('../../db/api', () => ({
+  getProtocolAssets: (...args: unknown[]) => getProtocolAssets(...args),
+}));
+
+const { loadRosterNodesForStages } = await import('../loadRosterData');
+
+const HASH = 'protocol-hash';
+
+const createObjectURL = vi.fn((_blob: unknown) => 'blob:roster');
+const revokeObjectURL = vi.fn();
+
+function csvBlob(body: string): Blob {
+  return new Blob([body], { type: 'text/csv' });
+}
+
+const PEOPLE_CSV = 'Name,Age\nAda,36\nGrace,45\nAlan,41\n';
+
+function storedAsset(partial: Partial<StoredAsset>): StoredAsset {
+  return {
+    id: `${HASH}::${partial.assetId ?? 'roster'}`,
+    protocolHash: HASH,
+    assetId: partial.assetId ?? 'roster',
+    name: partial.name ?? 'People',
+    type: partial.type ?? 'network',
+    data: partial.data ?? csvBlob(PEOPLE_CSV),
+  };
+}
+
+function storedProtocol(
+  stages: unknown[],
+  manifest: Record<string, { type: string; name: string; source?: string }>,
+): StoredProtocol {
+  return {
+    id: HASH,
+    hash: HASH,
+    name: 'Test',
+    schemaVersion: 8,
+    importedAt: new Date().toISOString(),
+    codebook: {
+      node: {
+        person: {
+          variables: {
+            'var-name': { name: 'Name', type: 'text' },
+            'var-age': { name: 'Age', type: 'number' },
+          },
+        },
+        place: {
+          variables: { 'var-place-name': { name: 'Name', type: 'text' } },
+        },
+      },
+    },
+    protocol: { stages, assetManifest: manifest },
+  } as unknown as StoredProtocol;
+}
+
+function rosterStage(overrides?: Record<string, unknown>) {
+  return {
+    id: 'stage-ngr',
+    label: 'Roster',
+    type: 'NameGeneratorRoster',
+    subject: { entity: 'node', type: 'person' },
+    dataSource: 'roster',
+    prompts: [{ id: 'p1', text: 'Pick people' }],
+    ...overrides,
+  };
+}
+
+const MANIFEST = {
+  roster: { type: 'network', name: 'People', source: 'people.csv' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(URL, { createObjectURL, revokeObjectURL });
+  createObjectURL.mockReturnValue('blob:roster');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(PEOPLE_CSV))),
+  );
+  getProtocolAssets.mockResolvedValue([storedAsset({})]);
+});
+
+describe('loadRosterNodesForStages', () => {
+  it('parses a CSV roster into nodes of the stage subject type', async () => {
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
+    );
+
+    expect(result['stage-ngr']).toHaveLength(3);
+    const [first] = result['stage-ngr']!;
+    expect(first!.type).toBe('person');
+    expect(first![entityAttributesProperty]['var-name']).toBe('Ada');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:roster');
+  });
+
+  it('collects external data panels on a name generator', async () => {
+    getProtocolAssets.mockResolvedValue([storedAsset({ assetId: 'panel' })]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol(
+        [
+          {
+            id: 'stage-ng',
+            label: 'Name Generator',
+            type: 'NameGenerator',
+            subject: { entity: 'node', type: 'person' },
+            prompts: [{ id: 'p1', text: 'Add people' }],
+            panels: [
+              { id: 'a', title: 'Previously', dataSource: 'existing' },
+              { id: 'b', title: 'Roster', dataSource: 'panel' },
+            ],
+          },
+        ],
+        { panel: { type: 'network', name: 'People', source: 'people.csv' } },
+      ),
+    );
+
+    expect(result['stage-ng']).toHaveLength(3);
+  });
+
+  it('offers only the rows a filtered panel would show', async () => {
+    getProtocolAssets.mockResolvedValue([storedAsset({ assetId: 'panel' })]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol(
+        [
+          {
+            id: 'stage-ng',
+            label: 'Name Generator',
+            type: 'NameGenerator',
+            subject: { entity: 'node', type: 'person' },
+            prompts: [{ id: 'p1', text: 'Add people' }],
+            panels: [
+              {
+                id: 'b',
+                title: 'Older people',
+                dataSource: 'panel',
+                filter: {
+                  join: 'AND',
+                  rules: [
+                    {
+                      id: 'r1',
+                      type: 'node',
+                      options: {
+                        type: 'person',
+                        attribute: 'var-age',
+                        operator: 'GREATER_THAN',
+                        value: 40,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        { panel: { type: 'network', name: 'People', source: 'people.csv' } },
+      ),
+    );
+
+    expect(result['stage-ng']).toHaveLength(2);
+    const names = result['stage-ng']!.map(
+      (n) => n[entityAttributesProperty]['var-name'],
+    );
+    expect(names).not.toContain('Ada');
+  });
+
+  it('still generates when the whole asset read fails', async () => {
+    getProtocolAssets.mockRejectedValue(new Error('undecryptable asset'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('omits a stage whose roster asset is missing', async () => {
+    getProtocolAssets.mockResolvedValue([]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it('keeps readable rosters when a sibling asset fails, and revokes its url', async () => {
+    const exploding = storedAsset({ assetId: 'broken' });
+    createObjectURL.mockImplementation((blob: unknown) =>
+      blob === exploding.data ? 'blob:broken' : 'blob:roster',
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        url === 'blob:broken'
+          ? Promise.reject(new Error('unreadable'))
+          : Promise.resolve(new Response(PEOPLE_CSV)),
+      ),
+    );
+    getProtocolAssets.mockResolvedValue([storedAsset({}), exploding]);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol(
+        [
+          rosterStage({ id: 'ok' }),
+          rosterStage({ id: 'bad', dataSource: 'broken' }),
+        ],
+        {
+          ...MANIFEST,
+          broken: { type: 'network', name: 'Broken', source: 'broken.csv' },
+        },
+      ),
+    );
+
+    expect(result.ok).toHaveLength(3);
+    expect(result.bad).toBeUndefined();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:broken');
+  });
+
+  it('parses the same asset separately for each subject type', async () => {
+    const protocol = storedProtocol(
+      [
+        rosterStage({ id: 'as-person' }),
+        rosterStage({
+          id: 'as-place',
+          subject: { entity: 'node', type: 'place' },
+        }),
+      ],
+      MANIFEST,
+    );
+    const result = await loadRosterNodesForStages(protocol);
+
+    expect(result['as-person']![0]!.type).toBe('person');
+    expect(result['as-place']![0]!.type).toBe('place');
+    expect(result['as-person']![0]![entityAttributesProperty]['var-name']).toBe(
+      'Ada',
+    );
+    expect(
+      result['as-place']![0]![entityAttributesProperty]['var-place-name'],
+    ).toBe('Ada');
+  });
+
+  it('does nothing when no stage uses a roster', async () => {
+    const result = await loadRosterNodesForStages(
+      storedProtocol(
+        [{ id: 'info', label: 'Info', type: 'Information', items: [] }],
+        {},
+      ),
+    );
+
+    expect(result).toEqual({});
+    expect(getProtocolAssets).not.toHaveBeenCalled();
+  });
+});

--- a/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/loadRosterData.test.ts
@@ -52,9 +52,6 @@ function storedProtocol(
             'var-age': { name: 'Age', type: 'number' },
           },
         },
-        place: {
-          variables: { 'var-place-name': { name: 'Name', type: 'text' } },
-        },
       },
     },
     protocol: { stages, assetManifest: manifest },
@@ -98,8 +95,12 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// These tests cover only the adapter's own responsibilities — joining stored
+// assets to roster sources, gating on asset type/shape, the object-URL
+// create/revoke lifecycle, and the source-filename choice. The parse, merge,
+// and panel-filter semantics live in @codaco/interview and are tested there.
 describe('loadRosterNodesForStages', () => {
-  it('parses a CSV roster into nodes of the stage subject type', async () => {
+  it('resolves a roster asset to an object URL and revokes it once parsed', async () => {
     const result = await loadRosterNodesForStages(
       storedProtocol([rosterStage()], MANIFEST),
     );
@@ -108,90 +109,30 @@ describe('loadRosterNodesForStages', () => {
     const [first] = result['stage-ngr']!;
     expect(first!.type).toBe('person');
     expect(first![entityAttributesProperty]['var-name']).toBe('Ada');
+    expect(createObjectURL).toHaveBeenCalledOnce();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:roster');
   });
 
-  it('collects external data panels on a name generator', async () => {
-    getProtocolAssets.mockResolvedValue([storedAsset({ assetId: 'panel' })]);
-
-    const result = await loadRosterNodesForStages(
-      storedProtocol(
-        [
-          {
-            id: 'stage-ng',
-            label: 'Name Generator',
-            type: 'NameGenerator',
-            subject: { entity: 'node', type: 'person' },
-            prompts: [{ id: 'p1', text: 'Add people' }],
-            panels: [
-              { id: 'a', title: 'Previously', dataSource: 'existing' },
-              { id: 'b', title: 'Roster', dataSource: 'panel' },
-            ],
-          },
-        ],
-        { panel: { type: 'network', name: 'People', source: 'people.csv' } },
-      ),
-    );
-
-    expect(result['stage-ng']).toHaveLength(3);
-  });
-
-  it('offers only the rows a filtered panel would show', async () => {
-    getProtocolAssets.mockResolvedValue([storedAsset({ assetId: 'panel' })]);
-
-    const result = await loadRosterNodesForStages(
-      storedProtocol(
-        [
-          {
-            id: 'stage-ng',
-            label: 'Name Generator',
-            type: 'NameGenerator',
-            subject: { entity: 'node', type: 'person' },
-            prompts: [{ id: 'p1', text: 'Add people' }],
-            panels: [
-              {
-                id: 'b',
-                title: 'Older people',
-                dataSource: 'panel',
-                filter: {
-                  join: 'AND',
-                  rules: [
-                    {
-                      id: 'r1',
-                      type: 'node',
-                      options: {
-                        type: 'person',
-                        attribute: 'var-age',
-                        operator: 'GREATER_THAN',
-                        value: 40,
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        ],
-        { panel: { type: 'network', name: 'People', source: 'people.csv' } },
-      ),
-    );
-
-    expect(result['stage-ng']).toHaveLength(2);
-    const names = result['stage-ng']!.map(
-      (n) => n[entityAttributesProperty]['var-name'],
-    );
-    expect(names).not.toContain('Ada');
-  });
-
-  it('still generates when the whole asset read fails', async () => {
-    getProtocolAssets.mockRejectedValue(new Error('undecryptable asset'));
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('prefers the manifest source over the stored asset name as the parse filename', async () => {
+    // The stored asset name would parse as JSON; only the manifest's
+    // `people.csv` source yields the CSV parse that produces rows.
+    getProtocolAssets.mockResolvedValue([storedAsset({ name: 'roster.json' })]);
 
     const result = await loadRosterNodesForStages(
       storedProtocol([rosterStage()], MANIFEST),
     );
 
-    expect(result).toEqual({});
+    expect(result['stage-ngr']).toHaveLength(3);
+  });
+
+  it('falls back to the stored asset name when the manifest has no source', async () => {
+    getProtocolAssets.mockResolvedValue([storedAsset({ name: 'people.csv' })]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], {}),
+    );
+
+    expect(result['stage-ngr']).toHaveLength(3);
   });
 
   it('omits a stage whose roster asset is missing', async () => {
@@ -202,66 +143,58 @@ describe('loadRosterNodesForStages', () => {
     );
 
     expect(result).toEqual({});
+    expect(createObjectURL).not.toHaveBeenCalled();
   });
 
-  it('keeps readable rosters when a sibling asset fails, and revokes its url', async () => {
-    const exploding = storedAsset({ assetId: 'broken' });
-    createObjectURL.mockImplementation((blob: unknown) =>
-      blob === exploding.data ? 'blob:broken' : 'blob:roster',
+  it('omits a stage whose asset is not a network asset', async () => {
+    getProtocolAssets.mockResolvedValue([storedAsset({ type: 'image' })]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
     );
+
+    expect(result).toEqual({});
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('omits a stage whose asset data is a string rather than a blob', async () => {
+    getProtocolAssets.mockResolvedValue([storedAsset({ data: 'inline-data' })]);
+
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
+    );
+
+    expect(result).toEqual({});
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('revokes the object URL even when parsing the asset fails', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn((url: string) =>
-        url === 'blob:broken'
-          ? Promise.reject(new Error('unreadable'))
-          : Promise.resolve(new Response(PEOPLE_CSV)),
-      ),
+      vi.fn(() => Promise.reject(new Error('unreadable'))),
     );
-    getProtocolAssets.mockResolvedValue([storedAsset({}), exploding]);
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = await loadRosterNodesForStages(
-      storedProtocol(
-        [
-          rosterStage({ id: 'ok' }),
-          rosterStage({ id: 'bad', dataSource: 'broken' }),
-        ],
-        {
-          ...MANIFEST,
-          broken: { type: 'network', name: 'Broken', source: 'broken.csv' },
-        },
-      ),
+      storedProtocol([rosterStage()], MANIFEST),
     );
 
-    expect(result.ok).toHaveLength(3);
-    expect(result.bad).toBeUndefined();
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:broken');
+    expect(result).toEqual({});
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:roster');
   });
 
-  it('parses the same asset separately for each subject type', async () => {
-    const protocol = storedProtocol(
-      [
-        rosterStage({ id: 'as-person' }),
-        rosterStage({
-          id: 'as-place',
-          subject: { entity: 'node', type: 'place' },
-        }),
-      ],
-      MANIFEST,
-    );
-    const result = await loadRosterNodesForStages(protocol);
+  it('still resolves to {} when the whole asset read fails', async () => {
+    getProtocolAssets.mockRejectedValue(new Error('undecryptable asset'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(result['as-person']![0]!.type).toBe('person');
-    expect(result['as-place']![0]!.type).toBe('place');
-    expect(result['as-person']![0]![entityAttributesProperty]['var-name']).toBe(
-      'Ada',
+    const result = await loadRosterNodesForStages(
+      storedProtocol([rosterStage()], MANIFEST),
     );
-    expect(
-      result['as-place']![0]![entityAttributesProperty]['var-place-name'],
-    ).toBe('Ada');
+
+    expect(result).toEqual({});
   });
 
-  it('does nothing when no stage uses a roster', async () => {
+  it('never reads protocol assets when no stage uses a roster', async () => {
     const result = await loadRosterNodesForStages(
       storedProtocol(
         [{ id: 'info', label: 'Info', type: 'Information', items: [] }],

--- a/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { generateNetwork } from '@codaco/protocol-utilities';
 import developmentProtocol from '@codaco/protocols/development';
@@ -21,8 +21,8 @@ vi.mock('../../db/api', () => ({
 const { loadRosterNodesForStages } = await import('../loadRosterData');
 
 const ASSET_DIR = resolve(
-  process.cwd(),
-  '../../packages/protocols/development/assets/',
+  import.meta.dirname,
+  '../../../../../../packages/protocols/development/assets/',
 );
 
 const HASH = 'development-hash';
@@ -63,10 +63,16 @@ beforeAll(() => {
   const urlByBlob = new Map<unknown, string>();
   assets.forEach((a, i) => urlByBlob.set(a.data, [...bytesByUrl.keys()][i]!));
 
-  Object.assign(URL, {
-    createObjectURL: (blob: unknown) => urlByBlob.get(blob) ?? 'blob:unknown',
-    revokeObjectURL: () => undefined,
-  });
+  // Subclass rather than spread so URL stays constructible (jsdom builds
+  // `new URL(...)` internally); vi.unstubAllGlobals then restores it.
+  class StubURL extends URL {}
+  vi.stubGlobal(
+    'URL',
+    Object.assign(StubURL, {
+      createObjectURL: (blob: unknown) => urlByBlob.get(blob) ?? 'blob:unknown',
+      revokeObjectURL: () => undefined,
+    }),
+  );
   vi.stubGlobal('fetch', (url: string) => {
     const bytes = bytesByUrl.get(url);
     if (!bytes) return Promise.reject(new Error(`No bytes for ${url}`));
@@ -74,6 +80,10 @@ beforeAll(() => {
   });
 
   getProtocolAssets.mockResolvedValue(assets);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('synthetic generation over the real Development Protocol', () => {

--- a/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { generateNetwork } from '@codaco/protocol-utilities';
+import developmentProtocol from '@codaco/protocols/development';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+} from '@codaco/shared-consts';
+
+import type { StoredAsset, StoredProtocol } from '../../db/types';
+
+const getProtocolAssets = vi.fn();
+
+vi.mock('../../db/api', () => ({
+  getProtocolAssets: (...args: unknown[]) => getProtocolAssets(...args),
+}));
+
+const { loadRosterNodesForStages } = await import('../loadRosterData');
+
+const ASSET_DIR = resolve(
+  process.cwd(),
+  '../../packages/protocols/development/assets/',
+);
+
+const HASH = 'development-hash';
+
+const bytesByUrl = new Map<string, Buffer>();
+
+function storedProtocol(): StoredProtocol {
+  return {
+    id: HASH,
+    hash: HASH,
+    name: 'Development Protocol',
+    schemaVersion: 8,
+    importedAt: new Date().toISOString(),
+    codebook: developmentProtocol.codebook,
+    protocol: developmentProtocol,
+  } as unknown as StoredProtocol;
+}
+
+beforeAll(() => {
+  const manifest = developmentProtocol.assetManifest ?? {};
+  const assets: StoredAsset[] = [];
+
+  for (const [assetId, entry] of Object.entries(manifest)) {
+    if (entry.type !== 'network' || !('source' in entry)) continue;
+    const bytes = readFileSync(resolve(ASSET_DIR, entry.source));
+    const url = `blob:${assetId}`;
+    bytesByUrl.set(url, bytes);
+    assets.push({
+      id: `${HASH}::${assetId}`,
+      protocolHash: HASH,
+      assetId,
+      name: entry.name,
+      type: 'network',
+      data: new Blob([new Uint8Array(bytes)]),
+    });
+  }
+
+  const urlByBlob = new Map<unknown, string>();
+  assets.forEach((a, i) => urlByBlob.set(a.data, [...bytesByUrl.keys()][i]!));
+
+  Object.assign(URL, {
+    createObjectURL: (blob: unknown) => urlByBlob.get(blob) ?? 'blob:unknown',
+    revokeObjectURL: () => undefined,
+  });
+  vi.stubGlobal('fetch', (url: string) => {
+    const bytes = bytesByUrl.get(url);
+    if (!bytes) return Promise.reject(new Error(`No bytes for ${url}`));
+    return Promise.resolve(new Response(bytes.toString('utf8')));
+  });
+
+  getProtocolAssets.mockResolvedValue(assets);
+});
+
+describe('synthetic generation over the real Development Protocol', () => {
+  it('parses every roster-backed stage from the real asset files', async () => {
+    const externalData = await loadRosterNodesForStages(storedProtocol());
+
+    expect(Object.keys(externalData).toSorted()).toEqual([
+      'namegen1',
+      'namegen1a',
+      'namegenroster1',
+      'namegenroster2',
+      'namegenroster2a',
+      'namegenroster3',
+    ]);
+
+    expect(externalData.namegenroster1).toHaveLength(6);
+    expect(externalData.namegenroster2a!.length).toBeGreaterThan(200);
+
+    expect(externalData.namegen1).toHaveLength(1);
+  });
+
+  it('maps roster columns onto real codebook variable ids', async () => {
+    const externalData = await loadRosterNodesForStages(storedProtocol());
+
+    const person = externalData.namegenroster1![0]!;
+    expect(person.type).toBe('person_node_type');
+
+    const nameVariable = Object.entries(
+      developmentProtocol.codebook.node!.person_node_type!.variables!,
+    ).find(([, v]) => v.name === 'nickname')![0];
+
+    const attributes = person[entityAttributesProperty];
+    expect(Object.keys(attributes)).toContain(nameVariable);
+  });
+
+  it('builds a network whose roster people come from the real rosters', async () => {
+    const protocol = storedProtocol();
+    const externalData = await loadRosterNodesForStages(protocol);
+
+    const { network } = generateNetwork(
+      protocol.codebook,
+      protocol.protocol.stages,
+      { seed: 42, externalData },
+    );
+
+    const rosterKeys = new Set(
+      Object.values(externalData)
+        .flat()
+        .map((n) => n[entityPrimaryKeyProperty]),
+    );
+
+    const venueNodes = network.nodes.filter(
+      (n) => n.type === 'venue_node_type' && n.stageId === 'namegenroster2a',
+    );
+    expect(venueNodes.length).toBeGreaterThan(0);
+    for (const node of venueNodes) {
+      expect(rosterKeys.has(node[entityPrimaryKeyProperty])).toBe(true);
+    }
+  });
+
+  it('never reuses one person across the stages sharing a roster', async () => {
+    const protocol = storedProtocol();
+    const externalData = await loadRosterNodesForStages(protocol);
+
+    const { network } = generateNetwork(
+      protocol.codebook,
+      protocol.protocol.stages,
+      { seed: 7, externalData },
+    );
+
+    const shared = new Set(
+      externalData.namegenroster1!.map((n) => n[entityPrimaryKeyProperty]),
+    );
+    const drawn = network.nodes
+      .map((n) => n[entityPrimaryKeyProperty])
+      .filter((key) => shared.has(key));
+
+    expect(drawn.length).toBeGreaterThan(0);
+    expect(new Set(drawn).size).toBe(drawn.length);
+    expect(drawn.length).toBeLessThanOrEqual(6);
+  });
+
+  it('still generates when the protocol has no rosters at hand', async () => {
+    getProtocolAssets.mockResolvedValueOnce([]);
+    const protocol = storedProtocol();
+
+    const externalData = await loadRosterNodesForStages(protocol);
+    expect(externalData).toEqual({});
+
+    const { network } = generateNetwork(
+      protocol.codebook,
+      protocol.protocol.stages,
+      { seed: 42, externalData },
+    );
+
+    expect(network.nodes.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
+++ b/apps/interviewer/src/lib/synthetic/__tests__/rosterIntegration.test.ts
@@ -123,11 +123,12 @@ describe('synthetic generation over the real Development Protocol', () => {
     const protocol = storedProtocol();
     const externalData = await loadRosterNodesForStages(protocol);
 
-    const { network } = generateNetwork(
-      protocol.codebook,
-      protocol.protocol.stages,
-      { seed: 42, externalData },
-    );
+    const { network } = generateNetwork({
+      codebook: protocol.codebook,
+      stages: protocol.protocol.stages,
+      seed: 42,
+      externalData,
+    });
 
     const rosterKeys = new Set(
       Object.values(externalData)
@@ -148,11 +149,12 @@ describe('synthetic generation over the real Development Protocol', () => {
     const protocol = storedProtocol();
     const externalData = await loadRosterNodesForStages(protocol);
 
-    const { network } = generateNetwork(
-      protocol.codebook,
-      protocol.protocol.stages,
-      { seed: 7, externalData },
-    );
+    const { network } = generateNetwork({
+      codebook: protocol.codebook,
+      stages: protocol.protocol.stages,
+      seed: 7,
+      externalData,
+    });
 
     const shared = new Set(
       externalData.namegenroster1!.map((n) => n[entityPrimaryKeyProperty]),
@@ -173,11 +175,12 @@ describe('synthetic generation over the real Development Protocol', () => {
     const externalData = await loadRosterNodesForStages(protocol);
     expect(externalData).toEqual({});
 
-    const { network } = generateNetwork(
-      protocol.codebook,
-      protocol.protocol.stages,
-      { seed: 42, externalData },
-    );
+    const { network } = generateNetwork({
+      codebook: protocol.codebook,
+      stages: protocol.protocol.stages,
+      seed: 42,
+      externalData,
+    });
 
     expect(network.nodes.length).toBeGreaterThan(0);
   });

--- a/apps/interviewer/src/lib/synthetic/generate.ts
+++ b/apps/interviewer/src/lib/synthetic/generate.ts
@@ -4,6 +4,8 @@ import { getInterviewProgress } from '@codaco/interview';
 import { generateNetwork } from '@codaco/protocol-utilities';
 import { createSession, getProtocolByHash, updateSession } from '~/lib/db/api';
 
+import { loadRosterNodesForStages } from './loadRosterData';
+
 type GenerateOptions = {
   protocolHash: string;
   count: number;
@@ -33,7 +35,13 @@ export async function generateSyntheticSessions(
     throw new Error(`Protocol not found for hash "${protocolHash}".`);
   }
 
-  const genOptions = { simulateDropOut, respectSkipLogicAndFiltering };
+  const externalData = await loadRosterNodesForStages(protocol);
+
+  const genOptions = {
+    simulateDropOut,
+    respectSkipLogicAndFiltering,
+    externalData,
+  };
   const generated: GeneratedRow[] = [];
   let completedCount = 0;
 

--- a/apps/interviewer/src/lib/synthetic/generate.ts
+++ b/apps/interviewer/src/lib/synthetic/generate.ts
@@ -38,6 +38,8 @@ export async function generateSyntheticSessions(
   const externalData = await loadRosterNodesForStages(protocol);
 
   const genOptions = {
+    codebook: protocol.codebook,
+    stages: protocol.protocol.stages,
     simulateDropOut,
     respectSkipLogicAndFiltering,
     externalData,
@@ -46,11 +48,8 @@ export async function generateSyntheticSessions(
   let completedCount = 0;
 
   for (let i = 0; i < count; i++) {
-    const { network, stageMetadata, currentStep, droppedOut } = generateNetwork(
-      protocol.codebook,
-      protocol.protocol.stages,
-      genOptions,
-    );
+    const { network, stageMetadata, currentStep, droppedOut } =
+      generateNetwork(genOptions);
 
     const session = await createSession({
       protocolHash,
@@ -82,11 +81,10 @@ export async function generateSyntheticSessions(
       const toFix = generated.filter((g) => g.droppedOut).slice(0, deficit);
 
       for (const row of toFix) {
-        const { network, stageMetadata, currentStep } = generateNetwork(
-          protocol.codebook,
-          protocol.protocol.stages,
-          { ...genOptions, simulateDropOut: false },
-        );
+        const { network, stageMetadata, currentStep } = generateNetwork({
+          ...genOptions,
+          simulateDropOut: false,
+        });
         await updateSession(row.sessionId, {
           network,
           currentStep,

--- a/apps/interviewer/src/lib/synthetic/loadRosterData.ts
+++ b/apps/interviewer/src/lib/synthetic/loadRosterData.ts
@@ -1,0 +1,140 @@
+import {
+  getVariableTypeReplacements,
+  loadExternalData,
+  makeVariableUUIDReplacer,
+} from '@codaco/interview';
+import { filter as customFilter } from '@codaco/network-query';
+import type { Filter, Stage } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcNode,
+} from '@codaco/shared-consts';
+import { getProtocolAssets } from '~/lib/db/api';
+import type { StoredAsset, StoredProtocol } from '~/lib/db/types';
+
+type RosterSource = {
+  assetId: string;
+  filter?: Filter;
+};
+
+type RosterStage = {
+  stageId: string;
+  subjectType: string;
+  sources: RosterSource[];
+};
+
+function getRosterStage(stage: Stage): RosterStage | null {
+  const sources: RosterSource[] = [];
+
+  if (stage.type === 'NameGeneratorRoster') {
+    sources.push({ assetId: stage.dataSource });
+  } else if (
+    stage.type === 'NameGenerator' ||
+    stage.type === 'NameGeneratorQuickAdd'
+  ) {
+    for (const panel of stage.panels ?? []) {
+      if (panel.dataSource !== 'existing') {
+        sources.push({ assetId: panel.dataSource, filter: panel.filter });
+      }
+    }
+  } else {
+    return null;
+  }
+
+  if (sources.length === 0) return null;
+  if (stage.subject.entity !== 'node') return null;
+
+  return { stageId: stage.id, subjectType: stage.subject.type, sources };
+}
+
+function applyPanelFilter(nodes: NcNode[], panelFilter?: Filter): NcNode[] {
+  if (!panelFilter) return nodes;
+  return customFilter(panelFilter)({
+    nodes,
+    edges: [],
+    ego: { [entityPrimaryKeyProperty]: '', [entityAttributesProperty]: {} },
+  }).nodes;
+}
+
+async function parseAsset(
+  asset: StoredAsset,
+  source: string | undefined,
+  subjectType: string,
+  codebook: StoredProtocol['codebook'],
+): Promise<NcNode[]> {
+  if (typeof asset.data === 'string') return [];
+
+  const url = URL.createObjectURL(asset.data);
+  try {
+    const sourceFileName = source ?? asset.name;
+    const { nodes } = await loadExternalData(sourceFileName, url);
+    const uuidData = nodes.map(makeVariableUUIDReplacer(codebook, subjectType));
+    return getVariableTypeReplacements(sourceFileName, uuidData, codebook, {
+      entity: 'node',
+      type: subjectType,
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export async function loadRosterNodesForStages(
+  protocol: StoredProtocol,
+): Promise<Record<string, NcNode[]>> {
+  const rosterStages = protocol.protocol.stages
+    .map(getRosterStage)
+    .filter((s): s is RosterStage => s !== null);
+
+  if (rosterStages.length === 0) return {};
+
+  const records = await getProtocolAssets(protocol.hash).catch((e: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error('Could not read protocol assets for roster data', e);
+    return [];
+  });
+  const assetsById = new Map(records.map((r) => [r.assetId, r]));
+  const manifest = protocol.protocol.assetManifest;
+
+  const parseCache = new Map<string, Promise<NcNode[]>>();
+
+  const result: Record<string, NcNode[]> = {};
+
+  for (const { stageId, subjectType, sources } of rosterStages) {
+    const byPrimaryKey = new Map<string, NcNode>();
+
+    for (const { assetId, filter: panelFilter } of sources) {
+      const asset = assetsById.get(assetId);
+      if (!asset || asset.type !== 'network') continue;
+
+      const cacheKey = `${assetId}::${subjectType}`;
+      let parsed = parseCache.get(cacheKey);
+      if (!parsed) {
+        const manifestEntry = manifest?.[assetId];
+        const source =
+          manifestEntry && 'source' in manifestEntry
+            ? manifestEntry.source
+            : undefined;
+        parsed = parseAsset(
+          asset,
+          source,
+          subjectType,
+          protocol.codebook,
+        ).catch((e: unknown) => {
+          // eslint-disable-next-line no-console
+          console.error(`Could not read roster asset "${assetId}"`, e);
+          return [];
+        });
+        parseCache.set(cacheKey, parsed);
+      }
+
+      for (const node of applyPanelFilter(await parsed, panelFilter)) {
+        byPrimaryKey.set(node[entityPrimaryKeyProperty], node);
+      }
+    }
+
+    if (byPrimaryKey.size > 0) result[stageId] = [...byPrimaryKey.values()];
+  }
+
+  return result;
+}

--- a/apps/interviewer/src/lib/synthetic/loadRosterData.ts
+++ b/apps/interviewer/src/lib/synthetic/loadRosterData.ts
@@ -4,7 +4,7 @@ import {
   makeVariableUUIDReplacer,
 } from '@codaco/interview';
 import { filter as customFilter } from '@codaco/network-query';
-import type { Filter, Stage } from '@codaco/protocol-validation';
+import type { Filter, Stage, StageSubject } from '@codaco/protocol-validation';
 import {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
@@ -13,6 +13,8 @@ import {
 import { getProtocolAssets } from '~/lib/db/api';
 import type { StoredAsset, StoredProtocol } from '~/lib/db/types';
 
+type NodeSubject = Extract<StageSubject, { entity: 'node' }>;
+
 type RosterSource = {
   assetId: string;
   filter?: Filter;
@@ -20,7 +22,7 @@ type RosterSource = {
 
 type RosterStage = {
   stageId: string;
-  subjectType: string;
+  subject: NodeSubject;
   sources: RosterSource[];
 };
 
@@ -45,7 +47,7 @@ function getRosterStage(stage: Stage): RosterStage | null {
   if (sources.length === 0) return null;
   if (stage.subject.entity !== 'node') return null;
 
-  return { stageId: stage.id, subjectType: stage.subject.type, sources };
+  return { stageId: stage.id, subject: stage.subject, sources };
 }
 
 function applyPanelFilter(nodes: NcNode[], panelFilter?: Filter): NcNode[] {
@@ -60,7 +62,7 @@ function applyPanelFilter(nodes: NcNode[], panelFilter?: Filter): NcNode[] {
 async function parseAsset(
   asset: StoredAsset,
   source: string | undefined,
-  subjectType: string,
+  subject: NodeSubject,
   codebook: StoredProtocol['codebook'],
 ): Promise<NcNode[]> {
   if (typeof asset.data === 'string') return [];
@@ -69,11 +71,15 @@ async function parseAsset(
   try {
     const sourceFileName = source ?? asset.name;
     const { nodes } = await loadExternalData(sourceFileName, url);
-    const uuidData = nodes.map(makeVariableUUIDReplacer(codebook, subjectType));
-    return getVariableTypeReplacements(sourceFileName, uuidData, codebook, {
-      entity: 'node',
-      type: subjectType,
-    });
+    const uuidData = nodes.map(
+      makeVariableUUIDReplacer(codebook, subject.type),
+    );
+    return getVariableTypeReplacements(
+      sourceFileName,
+      uuidData,
+      codebook,
+      subject,
+    );
   } finally {
     URL.revokeObjectURL(url);
   }
@@ -100,14 +106,14 @@ export async function loadRosterNodesForStages(
 
   const result: Record<string, NcNode[]> = {};
 
-  for (const { stageId, subjectType, sources } of rosterStages) {
+  for (const { stageId, subject, sources } of rosterStages) {
     const byPrimaryKey = new Map<string, NcNode>();
 
     for (const { assetId, filter: panelFilter } of sources) {
       const asset = assetsById.get(assetId);
       if (!asset || asset.type !== 'network') continue;
 
-      const cacheKey = `${assetId}::${subjectType}`;
+      const cacheKey = `${assetId}::${subject.type}`;
       let parsed = parseCache.get(cacheKey);
       if (!parsed) {
         const manifestEntry = manifest?.[assetId];
@@ -115,16 +121,13 @@ export async function loadRosterNodesForStages(
           manifestEntry && 'source' in manifestEntry
             ? manifestEntry.source
             : undefined;
-        parsed = parseAsset(
-          asset,
-          source,
-          subjectType,
-          protocol.codebook,
-        ).catch((e: unknown) => {
-          // eslint-disable-next-line no-console
-          console.error(`Could not read roster asset "${assetId}"`, e);
-          return [];
-        });
+        parsed = parseAsset(asset, source, subject, protocol.codebook).catch(
+          (e: unknown) => {
+            // eslint-disable-next-line no-console
+            console.error(`Could not read roster asset "${assetId}"`, e);
+            return [];
+          },
+        );
         parseCache.set(cacheKey, parsed);
       }
 

--- a/apps/interviewer/src/lib/synthetic/loadRosterData.ts
+++ b/apps/interviewer/src/lib/synthetic/loadRosterData.ts
@@ -1,143 +1,54 @@
 import {
-  getVariableTypeReplacements,
-  loadExternalData,
-  makeVariableUUIDReplacer,
-} from '@codaco/interview';
-import { filter as customFilter } from '@codaco/network-query';
-import type { Filter, Stage, StageSubject } from '@codaco/protocol-validation';
-import {
-  entityAttributesProperty,
-  entityPrimaryKeyProperty,
-  type NcNode,
-} from '@codaco/shared-consts';
+  collectRosterExternalData,
+  type ResolveRosterAsset,
+} from '@codaco/interview/contract';
+import type { NcNode } from '@codaco/shared-consts';
 import { getProtocolAssets } from '~/lib/db/api';
 import type { StoredAsset, StoredProtocol } from '~/lib/db/types';
 
-type NodeSubject = Extract<StageSubject, { entity: 'node' }>;
-
-type RosterSource = {
-  assetId: string;
-  filter?: Filter;
-};
-
-type RosterStage = {
-  stageId: string;
-  subject: NodeSubject;
-  sources: RosterSource[];
-};
-
-function getRosterStage(stage: Stage): RosterStage | null {
-  const sources: RosterSource[] = [];
-
-  if (stage.type === 'NameGeneratorRoster') {
-    sources.push({ assetId: stage.dataSource });
-  } else if (
-    stage.type === 'NameGenerator' ||
-    stage.type === 'NameGeneratorQuickAdd'
-  ) {
-    for (const panel of stage.panels ?? []) {
-      if (panel.dataSource !== 'existing') {
-        sources.push({ assetId: panel.dataSource, filter: panel.filter });
-      }
-    }
-  } else {
-    return null;
-  }
-
-  if (sources.length === 0) return null;
-  if (stage.subject.entity !== 'node') return null;
-
-  return { stageId: stage.id, subject: stage.subject, sources };
-}
-
-function applyPanelFilter(nodes: NcNode[], panelFilter?: Filter): NcNode[] {
-  if (!panelFilter) return nodes;
-  return customFilter(panelFilter)({
-    nodes,
-    edges: [],
-    ego: { [entityPrimaryKeyProperty]: '', [entityAttributesProperty]: {} },
-  }).nodes;
-}
-
-async function parseAsset(
-  asset: StoredAsset,
-  source: string | undefined,
-  subject: NodeSubject,
-  codebook: StoredProtocol['codebook'],
-): Promise<NcNode[]> {
-  if (typeof asset.data === 'string') return [];
-
-  const url = URL.createObjectURL(asset.data);
-  try {
-    const sourceFileName = source ?? asset.name;
-    const { nodes } = await loadExternalData(sourceFileName, url);
-    const uuidData = nodes.map(
-      makeVariableUUIDReplacer(codebook, subject.type),
-    );
-    return getVariableTypeReplacements(
-      sourceFileName,
-      uuidData,
-      codebook,
-      subject,
-    );
-  } finally {
-    URL.revokeObjectURL(url);
-  }
-}
-
+/**
+ * Host adapter for the shared roster-collection pipeline: reads this protocol's
+ * stored (decrypted) assets and resolves each roster asset id to a fetchable
+ * object URL, then delegates the parse/merge/filter work to
+ * `collectRosterExternalData`. The stored assets are fetched lazily on first
+ * resolve so a protocol with no roster stages never triggers an asset read.
+ */
 export async function loadRosterNodesForStages(
   protocol: StoredProtocol,
 ): Promise<Record<string, NcNode[]>> {
-  const rosterStages = protocol.protocol.stages
-    .map(getRosterStage)
-    .filter((s): s is RosterStage => s !== null);
+  let assetsByIdPromise: Promise<Map<string, StoredAsset>> | undefined;
+  const getAssetsById = () => {
+    assetsByIdPromise ??= getProtocolAssets(protocol.hash)
+      .catch((error: unknown): StoredAsset[] => {
+        // eslint-disable-next-line no-console
+        console.error('Could not read protocol assets for roster data', error);
+        return [];
+      })
+      .then(
+        (records) => new Map(records.map((record) => [record.assetId, record])),
+      );
+    return assetsByIdPromise;
+  };
 
-  if (rosterStages.length === 0) return {};
-
-  const records = await getProtocolAssets(protocol.hash).catch((e: unknown) => {
-    // eslint-disable-next-line no-console
-    console.error('Could not read protocol assets for roster data', e);
-    return [];
-  });
-  const assetsById = new Map(records.map((r) => [r.assetId, r]));
-  const manifest = protocol.protocol.assetManifest;
-
-  const parseCache = new Map<string, Promise<NcNode[]>>();
-
-  const result: Record<string, NcNode[]> = {};
-
-  for (const { stageId, subject, sources } of rosterStages) {
-    const byPrimaryKey = new Map<string, NcNode>();
-
-    for (const { assetId, filter: panelFilter } of sources) {
-      const asset = assetsById.get(assetId);
-      if (!asset || asset.type !== 'network') continue;
-
-      const cacheKey = `${assetId}::${subject.type}`;
-      let parsed = parseCache.get(cacheKey);
-      if (!parsed) {
-        const manifestEntry = manifest?.[assetId];
-        const source =
-          manifestEntry && 'source' in manifestEntry
-            ? manifestEntry.source
-            : undefined;
-        parsed = parseAsset(asset, source, subject, protocol.codebook).catch(
-          (e: unknown) => {
-            // eslint-disable-next-line no-console
-            console.error(`Could not read roster asset "${assetId}"`, e);
-            return [];
-          },
-        );
-        parseCache.set(cacheKey, parsed);
-      }
-
-      for (const node of applyPanelFilter(await parsed, panelFilter)) {
-        byPrimaryKey.set(node[entityPrimaryKeyProperty], node);
-      }
+  const resolveAsset: ResolveRosterAsset = async (assetId) => {
+    const asset = (await getAssetsById()).get(assetId);
+    if (!asset || asset.type !== 'network' || typeof asset.data === 'string') {
+      return null;
     }
 
-    if (byPrimaryKey.size > 0) result[stageId] = [...byPrimaryKey.values()];
-  }
+    const url = URL.createObjectURL(asset.data);
+    const manifestEntry = protocol.protocol.assetManifest?.[assetId];
+    const sourceFileName =
+      manifestEntry && 'source' in manifestEntry
+        ? manifestEntry.source
+        : asset.name;
 
-  return result;
+    return { url, sourceFileName, cleanup: () => URL.revokeObjectURL(url) };
+  };
+
+  return collectRosterExternalData({
+    stages: protocol.protocol.stages,
+    codebook: protocol.codebook,
+    resolveAsset,
+  });
 }

--- a/packages/interview/src/contract/__tests__/rosterData.test.ts
+++ b/packages/interview/src/contract/__tests__/rosterData.test.ts
@@ -22,6 +22,8 @@ import {
 
 const PEOPLE_CSV = 'Name,Age\nAda,36\nGrace,45\nAlan,41\n';
 const PLACES_CSV = 'Name\nOffice\nHome\n';
+// Header row only: a roster asset that resolves and parses but has no rows.
+const EMPTY_CSV = 'Name,Age\n';
 
 const codebook: Codebook = {
   node: {
@@ -88,6 +90,23 @@ const ageFilter: Filter = {
         attribute: asEntityAttributeReference('var-age'),
         operator: 'GREATER_THAN',
         value: 40,
+      },
+    },
+  ],
+};
+
+// Keeps nobody: no roster person is older than 200.
+const impossibleAgeFilter: Filter = {
+  join: 'AND',
+  rules: [
+    {
+      id: 'r1',
+      type: 'node',
+      options: {
+        type: 'person',
+        attribute: asEntityAttributeReference('var-age'),
+        operator: 'GREATER_THAN',
+        value: 200,
       },
     },
   ],
@@ -376,6 +395,65 @@ describe('collectRosterExternalData', () => {
     expect(result['stage-ng']).toHaveLength(3);
     const keys = result['stage-ng']!.map((n) => n[entityPrimaryKeyProperty]);
     expect(new Set(keys).size).toBe(3);
+  });
+
+  it('emits an empty pool for a roster that resolves but has no rows', async () => {
+    stubFetch({ 'stub://empty': EMPTY_CSV });
+    const cleanup = vi.fn();
+    const resolveAsset: ResolveRosterAsset = vi
+      .fn()
+      .mockResolvedValue(resolved('empty', { cleanup }));
+
+    const result = await collectRosterExternalData({
+      stages: [rosterStage('stage-ngr', 'empty')],
+      codebook,
+      resolveAsset,
+    });
+
+    // Key present (a resolvable but empty roster), distinct from an absent key.
+    expect('stage-ngr' in result).toBe(true);
+    expect(result['stage-ngr']).toEqual([]);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits an empty pool when a panel filter removes every row', async () => {
+    stubFetch({ 'stub://panel': PEOPLE_CSV });
+    const resolveAsset: ResolveRosterAsset = vi
+      .fn()
+      .mockResolvedValue(resolved('panel'));
+
+    const panels: Panel[] = [
+      {
+        id: 'b',
+        title: 'Nobody',
+        dataSource: 'panel',
+        filter: impossibleAgeFilter,
+      },
+    ];
+
+    const result = await collectRosterExternalData({
+      stages: [nameGeneratorStage('stage-ng', panels)],
+      codebook,
+      resolveAsset,
+    });
+
+    expect('stage-ng' in result).toBe(true);
+    expect(result['stage-ng']).toEqual([]);
+  });
+
+  it('omits a stage whose only source cannot be resolved', async () => {
+    const resolveAsset: ResolveRosterAsset = vi.fn().mockResolvedValue(null);
+
+    const result = await collectRosterExternalData({
+      stages: [rosterStage('all-failed', 'missing')],
+      codebook,
+      resolveAsset,
+    });
+
+    // Every source failed, so the stage is absent — generation falls back to
+    // fabrication rather than treating this as a known-empty roster.
+    expect('all-failed' in result).toBe(false);
+    expect(result).toEqual({});
   });
 
   it('returns {} and never calls resolveAsset when no stage has a roster data source', async () => {

--- a/packages/interview/src/contract/__tests__/rosterData.test.ts
+++ b/packages/interview/src/contract/__tests__/rosterData.test.ts
@@ -8,7 +8,10 @@ import {
   type Panel,
   type Stage,
 } from '@codaco/protocol-validation';
-import { entityAttributesProperty } from '@codaco/shared-consts';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+} from '@codaco/shared-consts';
 
 import {
   collectRosterExternalData,
@@ -297,6 +300,82 @@ describe('collectRosterExternalData', () => {
       expect.stringContaining('"unreadable"'),
       expect.any(Error),
     );
+  });
+
+  it('drops draft roster stages missing subject or dataSource, leaving siblings intact', async () => {
+    stubFetch({ 'stub://roster': PEOPLE_CSV });
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) => {
+      if (assetId === 'roster') {
+        return Promise.resolve(resolved('roster'));
+      }
+      return Promise.resolve(null);
+    });
+
+    // Draft/unvalidated stages the host may feed in: `subject` or `dataSource`
+    // absent despite the schema types marking them required.
+    const draftMissingSubject = {
+      id: 'draft-no-subject',
+      label: 'Roster',
+      type: 'NameGeneratorRoster',
+      dataSource: 'draft-roster',
+      prompts: [{ id: 'p1', text: 'Pick people' }],
+    } as unknown as Stage;
+    const draftMissingDataSource = {
+      id: 'draft-no-source',
+      label: 'Roster',
+      type: 'NameGeneratorRoster',
+      subject: { entity: 'node', type: 'person' },
+      prompts: [{ id: 'p1', text: 'Pick people' }],
+    } as unknown as Stage;
+
+    // A throw would reject this await and fail the test.
+    const result = await collectRosterExternalData({
+      stages: [
+        draftMissingSubject,
+        draftMissingDataSource,
+        rosterStage('ok', 'roster'),
+      ],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result.ok).toHaveLength(3);
+    expect(result['draft-no-subject']).toBeUndefined();
+    expect(result['draft-no-source']).toBeUndefined();
+    // The dropped stages never reach asset resolution.
+    expect(resolveAsset).not.toHaveBeenCalledWith('draft-roster');
+    expect(resolveAsset).toHaveBeenCalledWith('roster');
+  });
+
+  it('collapses byte-identical rows from two panels to one entry per content hash', async () => {
+    stubFetch({
+      'stub://panel-a': PEOPLE_CSV,
+      'stub://panel-b': PEOPLE_CSV,
+    });
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) => {
+      if (assetId === 'panel-a' || assetId === 'panel-b') {
+        return Promise.resolve(resolved(assetId));
+      }
+      return Promise.resolve(null);
+    });
+
+    const panels: Panel[] = [
+      { id: 'a', title: 'First', dataSource: 'panel-a' },
+      { id: 'b', title: 'Second', dataSource: 'panel-b' },
+    ];
+
+    const result = await collectRosterExternalData({
+      stages: [nameGeneratorStage('stage-ng', panels)],
+      codebook,
+      resolveAsset,
+    });
+
+    // Both panels parse independently, but byte-identical content yields
+    // identical content-hash primary keys, so the later source overwrites the
+    // earlier one in the merge map: three rows in, three entries out (not six).
+    expect(result['stage-ng']).toHaveLength(3);
+    const keys = result['stage-ng']!.map((n) => n[entityPrimaryKeyProperty]);
+    expect(new Set(keys).size).toBe(3);
   });
 
   it('returns {} and never calls resolveAsset when no stage has a roster data source', async () => {

--- a/packages/interview/src/contract/__tests__/rosterData.test.ts
+++ b/packages/interview/src/contract/__tests__/rosterData.test.ts
@@ -456,6 +456,35 @@ describe('collectRosterExternalData', () => {
     expect(result).toEqual({});
   });
 
+  it('emits an empty pool when one source fails but another succeeds with no rows', async () => {
+    stubFetch({ 'stub://empty': EMPTY_CSV });
+    // spyOn returns the file's already-installed spy; clear its accumulated
+    // calls so the count below is scoped to this test.
+    vi.spyOn(console, 'error')
+      .mockImplementation(() => {})
+      .mockClear();
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) =>
+      Promise.resolve(resolved(assetId)),
+    );
+
+    const panels: Panel[] = [
+      { id: 'a', title: 'Broken', dataSource: 'broken' },
+      { id: 'b', title: 'Empty', dataSource: 'empty' },
+    ];
+
+    const result = await collectRosterExternalData({
+      stages: [nameGeneratorStage('stage-ng', panels)],
+      codebook,
+      resolveAsset,
+    });
+
+    // One source parsed successfully (with zero rows), so the roster is known
+    // empty — key present with [] — despite the sibling source failing.
+    expect('stage-ng' in result).toBe(true);
+    expect(result['stage-ng']).toEqual([]);
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
   it('returns {} and never calls resolveAsset when no stage has a roster data source', async () => {
     const resolveAsset: ResolveRosterAsset = vi.fn();
 

--- a/packages/interview/src/contract/__tests__/rosterData.test.ts
+++ b/packages/interview/src/contract/__tests__/rosterData.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  asEntityAttributeReference,
+  type Codebook,
+  type Filter,
+  type FormField,
+  type Panel,
+  type Stage,
+} from '@codaco/protocol-validation';
+import { entityAttributesProperty } from '@codaco/shared-consts';
+
+import {
+  collectRosterExternalData,
+  filterExternalPanelNodes,
+  type ResolvedRosterAsset,
+  type ResolveRosterAsset,
+} from '../rosterData';
+
+const PEOPLE_CSV = 'Name,Age\nAda,36\nGrace,45\nAlan,41\n';
+const PLACES_CSV = 'Name\nOffice\nHome\n';
+
+const codebook: Codebook = {
+  node: {
+    person: {
+      name: 'Person',
+      color: 'node-color-seq-1',
+      shape: { default: 'circle' },
+      variables: {
+        'var-name': { name: 'Name', type: 'text' },
+        'var-age': { name: 'Age', type: 'number' },
+      },
+    },
+    place: {
+      name: 'Place',
+      color: 'node-color-seq-2',
+      shape: { default: 'square' },
+      variables: {
+        'var-place-name': { name: 'Name', type: 'text' },
+      },
+    },
+  },
+};
+
+const nameField: FormField = {
+  variable: asEntityAttributeReference('var-name'),
+  prompt: 'Name',
+};
+
+function rosterStage(id: string, dataSource: string): Stage {
+  return {
+    id,
+    label: 'Roster',
+    type: 'NameGeneratorRoster',
+    subject: { entity: 'node', type: 'person' },
+    dataSource,
+    prompts: [{ id: 'p1', text: 'Pick people' }],
+  };
+}
+
+function nameGeneratorStage(
+  id: string,
+  panels: Panel[],
+  subjectType = 'person',
+): Stage {
+  return {
+    id,
+    label: 'Name Generator',
+    type: 'NameGenerator',
+    form: { title: 'Add people', fields: [nameField] },
+    subject: { entity: 'node', type: subjectType },
+    panels,
+    prompts: [{ id: 'p1', text: 'Add people' }],
+  };
+}
+
+const ageFilter: Filter = {
+  join: 'AND',
+  rules: [
+    {
+      id: 'r1',
+      type: 'node',
+      options: {
+        type: 'person',
+        attribute: asEntityAttributeReference('var-age'),
+        operator: 'GREATER_THAN',
+        value: 40,
+      },
+    },
+  ],
+};
+
+// Maps stub URLs to CSV bodies so the stubbed `fetch` can serve distinct
+// content per asset without a real network.
+function stubFetch(bodiesByUrl: Record<string, string>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === 'stub://broken') {
+        return Promise.reject(new Error('unreachable'));
+      }
+      const body = bodiesByUrl[url];
+      if (body === undefined) {
+        return Promise.reject(new Error(`no stub body for ${url}`));
+      }
+      return Promise.resolve(new Response(body));
+    }),
+  );
+}
+
+function resolved(
+  assetId: string,
+  overrides?: Partial<ResolvedRosterAsset>,
+): ResolvedRosterAsset {
+  return {
+    url: `stub://${assetId}`,
+    sourceFileName: `${assetId}.csv`,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('collectRosterExternalData', () => {
+  it('parses a CSV roster into nodes of the stage subject type', async () => {
+    stubFetch({ 'stub://roster': PEOPLE_CSV });
+    const cleanup = vi.fn();
+    const resolveAsset: ResolveRosterAsset = vi
+      .fn()
+      .mockResolvedValue(resolved('roster', { cleanup }));
+
+    const result = await collectRosterExternalData({
+      stages: [rosterStage('stage-ngr', 'roster')],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result['stage-ngr']).toHaveLength(3);
+    const [first] = result['stage-ngr']!;
+    expect(first!.type).toBe('person');
+    expect(first![entityAttributesProperty]['var-name']).toBe('Ada');
+    // cleanup runs after a successful parse too, not only on failure.
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers only the rows a filtered panel would show', async () => {
+    stubFetch({ 'stub://panel': PEOPLE_CSV });
+    const resolveAsset: ResolveRosterAsset = vi
+      .fn()
+      .mockResolvedValue(resolved('panel'));
+
+    const panels: Panel[] = [
+      {
+        id: 'b',
+        title: 'Older people',
+        dataSource: 'panel',
+        filter: ageFilter,
+      },
+    ];
+
+    const result = await collectRosterExternalData({
+      stages: [nameGeneratorStage('stage-ng', panels)],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result['stage-ng']).toHaveLength(2);
+    const names = result['stage-ng']!.map(
+      (n) => n[entityAttributesProperty]['var-name'],
+    );
+    expect(names).not.toContain('Ada');
+  });
+
+  it('merges multiple panels by primary key and ignores existing-dataSource panels', async () => {
+    stubFetch({
+      'stub://panel-people': PEOPLE_CSV,
+      'stub://panel-places': PLACES_CSV,
+    });
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) => {
+      if (assetId === 'panel-people' || assetId === 'panel-places') {
+        return Promise.resolve(resolved(assetId));
+      }
+      return Promise.resolve(null);
+    });
+
+    const panels: Panel[] = [
+      { id: 'a', title: 'Previously', dataSource: 'existing' },
+      { id: 'b', title: 'People', dataSource: 'panel-people' },
+      { id: 'c', title: 'Places', dataSource: 'panel-places' },
+    ];
+
+    const result = await collectRosterExternalData({
+      stages: [nameGeneratorStage('stage-ng', panels)],
+      codebook,
+      resolveAsset,
+    });
+
+    // 3 people + 2 places, with the "existing" panel contributing nothing.
+    expect(result['stage-ng']).toHaveLength(5);
+    expect(resolveAsset).not.toHaveBeenCalledWith('existing');
+  });
+
+  it('parses the same asset once per assetId::subjectType and produces per-type pools', async () => {
+    stubFetch({ 'stub://roster': PEOPLE_CSV });
+    const resolveAsset: ResolveRosterAsset = vi
+      .fn()
+      .mockResolvedValue(resolved('roster'));
+
+    const result = await collectRosterExternalData({
+      stages: [
+        rosterStage('as-person-a', 'roster'),
+        rosterStage('as-person-b', 'roster'),
+        {
+          id: 'as-place',
+          label: 'Roster',
+          type: 'NameGeneratorRoster',
+          subject: { entity: 'node', type: 'place' },
+          dataSource: 'roster',
+          prompts: [{ id: 'p1', text: 'Pick places' }],
+        },
+      ],
+      codebook,
+      resolveAsset,
+    });
+
+    // Same assetId + same subject type (person) is parsed once and reused.
+    // A different subject type (place) triggers a second, separate parse.
+    expect(resolveAsset).toHaveBeenCalledTimes(2);
+    expect(result['as-person-a']![0]!.type).toBe('person');
+    expect(result['as-person-b']![0]!.type).toBe('person');
+    expect(result['as-place']![0]!.type).toBe('place');
+    expect(
+      result['as-place']![0]![entityAttributesProperty]['var-place-name'],
+    ).toBe('Ada');
+  });
+
+  it('isolates a failing parse: sibling stages keep their pools, console.error fires, cleanup still runs', async () => {
+    stubFetch({ 'stub://roster': PEOPLE_CSV });
+    const okCleanup = vi.fn();
+    const brokenCleanup = vi.fn();
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) => {
+      if (assetId === 'roster') {
+        return Promise.resolve(resolved('roster', { cleanup: okCleanup }));
+      }
+      if (assetId === 'broken') {
+        return Promise.resolve(
+          resolved('broken', {
+            url: 'stub://broken',
+            cleanup: brokenCleanup,
+          }),
+        );
+      }
+      return Promise.resolve(null);
+    });
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await collectRosterExternalData({
+      stages: [rosterStage('ok', 'roster'), rosterStage('bad', 'broken')],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result.ok).toHaveLength(3);
+    expect(result.bad).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"broken"'),
+      expect.any(Error),
+    );
+    expect(brokenCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates a failing resolveAsset the same way, without calling cleanup', async () => {
+    stubFetch({ 'stub://roster': PEOPLE_CSV });
+    const resolveAsset: ResolveRosterAsset = vi.fn((assetId: string) => {
+      if (assetId === 'roster') {
+        return Promise.resolve(resolved('roster'));
+      }
+      return Promise.reject(new Error('could not decrypt asset'));
+    });
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await collectRosterExternalData({
+      stages: [rosterStage('ok', 'roster'), rosterStage('bad', 'unreadable')],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result.ok).toHaveLength(3);
+    expect(result.bad).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"unreadable"'),
+      expect.any(Error),
+    );
+  });
+
+  it('returns {} and never calls resolveAsset when no stage has a roster data source', async () => {
+    const resolveAsset: ResolveRosterAsset = vi.fn();
+
+    const result = await collectRosterExternalData({
+      stages: [
+        {
+          id: 'info',
+          label: 'Info',
+          type: 'Information',
+          title: 'Info',
+          items: [],
+        },
+      ],
+      codebook,
+      resolveAsset,
+    });
+
+    expect(result).toEqual({});
+    expect(resolveAsset).not.toHaveBeenCalled();
+  });
+});
+
+describe('filterExternalPanelNodes', () => {
+  it('returns the input array unchanged when no filter is given', () => {
+    const nodes = [
+      {
+        _uid: 'n1',
+        type: 'person',
+        [entityAttributesProperty]: { 'var-name': 'Ada' },
+      },
+    ];
+
+    expect(filterExternalPanelNodes(nodes)).toBe(nodes);
+  });
+});

--- a/packages/interview/src/contract/index.ts
+++ b/packages/interview/src/contract/index.ts
@@ -10,6 +10,11 @@
 
 export { isValidAssetType } from './assets';
 export { createInitialNetwork } from './network';
+export {
+  collectRosterExternalData,
+  filterExternalPanelNodes,
+  parseExternalNetworkAsset,
+} from './rosterData';
 
 export type {
   AssetRequestHandler,
@@ -24,3 +29,4 @@ export type {
   StepChangeMeta,
   SyncHandler,
 } from './types';
+export type { ResolvedRosterAsset, ResolveRosterAsset } from './rosterData';

--- a/packages/interview/src/contract/rosterData.ts
+++ b/packages/interview/src/contract/rosterData.ts
@@ -1,0 +1,211 @@
+import { filter as customFilter } from '@codaco/network-query';
+import type {
+  Codebook,
+  Filter,
+  Stage,
+  StageSubject,
+} from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import { getVariableTypeReplacements } from '../utils/externalData';
+import loadExternalData, {
+  makeVariableUUIDReplacer,
+} from '../utils/loadExternalData';
+
+type NodeSubject = Extract<StageSubject, { entity: 'node' }>;
+
+/**
+ * A roster/panel asset resolved by the host: a fetchable URL, the filename
+ * that drives the CSV-vs-JSON decision, and an optional cleanup callback
+ * (e.g. `URL.revokeObjectURL`) invoked once parsing settles, whether it
+ * succeeded or failed.
+ */
+export type ResolvedRosterAsset = {
+  url: string;
+  sourceFileName: string;
+  cleanup?: () => void;
+};
+
+/**
+ * Host hook resolving a protocol asset-manifest id to a fetchable asset.
+ * Returns null when the asset is missing or isn't a network asset, in which
+ * case that source is skipped.
+ */
+export type ResolveRosterAsset = (
+  assetId: string,
+) => Promise<ResolvedRosterAsset | null>;
+
+/**
+ * The runtime's external-data parse pipeline (single source of truth):
+ * fetch → uuid-replace → type-replace. Mirrors `useExternalData`.
+ *
+ * `subject` accepts any non-ego stage subject (node or edge) because the
+ * hook this backs (`useExternalData`) is typed against the shared
+ * `getStageSubject` selector, which spans every stage type; in practice only
+ * node subjects reach it, since only node-collecting stages (NameGenerator,
+ * NameGeneratorRoster, NameGeneratorQuickAdd) carry external data sources.
+ */
+export async function parseExternalNetworkAsset({
+  sourceFileName,
+  url,
+  codebook,
+  subject,
+}: {
+  sourceFileName: string;
+  url: string;
+  codebook: Codebook;
+  subject: Exclude<StageSubject, { entity: 'ego' }>;
+}): Promise<NcNode[]> {
+  const { nodes } = await loadExternalData(sourceFileName, url);
+  const uuidData = nodes.map(makeVariableUUIDReplacer(codebook, subject.type));
+  return getVariableTypeReplacements(
+    sourceFileName,
+    uuidData,
+    codebook,
+    subject,
+  );
+}
+
+/**
+ * The runtime's external-panel filter semantics (`getPanelNodes`, external
+ * branch). `defaultEgo` deliberately mirrors that selector's shape exactly —
+ * it stands in for a real ego so ego-scoped filter rules have something to
+ * read, it is not meant to represent an actual participant.
+ */
+export function filterExternalPanelNodes(
+  nodes: NcNode[],
+  filter?: Filter,
+): NcNode[] {
+  if (!filter) {
+    return nodes;
+  }
+
+  const defaultEgo = { _uid: '', [entityAttributesProperty]: {} };
+  return customFilter(filter)({
+    nodes,
+    edges: [],
+    ego: defaultEgo,
+  }).nodes;
+}
+
+type RosterSource = {
+  assetId: string;
+  filter?: Filter;
+};
+
+type RosterStage = {
+  stageId: string;
+  subject: NodeSubject;
+  sources: RosterSource[];
+};
+
+function getRosterStage(stage: Stage): RosterStage | null {
+  const sources: RosterSource[] = [];
+
+  if (stage.type === 'NameGeneratorRoster') {
+    sources.push({ assetId: stage.dataSource });
+  } else if (
+    stage.type === 'NameGenerator' ||
+    stage.type === 'NameGeneratorQuickAdd'
+  ) {
+    for (const panel of stage.panels ?? []) {
+      if (panel.dataSource !== 'existing') {
+        sources.push({ assetId: panel.dataSource, filter: panel.filter });
+      }
+    }
+  } else {
+    return null;
+  }
+
+  if (sources.length === 0) return null;
+  if (stage.subject.entity !== 'node') return null;
+
+  return { stageId: stage.id, subject: stage.subject, sources };
+}
+
+async function parseRosterSource(
+  assetId: string,
+  subject: NodeSubject,
+  codebook: Codebook,
+  resolveAsset: ResolveRosterAsset,
+): Promise<NcNode[]> {
+  const resolved = await resolveAsset(assetId);
+  if (!resolved) {
+    return [];
+  }
+
+  try {
+    return await parseExternalNetworkAsset({
+      sourceFileName: resolved.sourceFileName,
+      url: resolved.url,
+      codebook,
+      subject,
+    });
+  } finally {
+    resolved.cleanup?.();
+  }
+}
+
+/**
+ * Host-agnostic roster collection for synthetic generation: per-stage node
+ * pools keyed by stage id, built from each stage's `NameGeneratorRoster`
+ * data source, or `NameGenerator`/`NameGeneratorQuickAdd` panel data sources.
+ */
+export async function collectRosterExternalData({
+  stages,
+  codebook,
+  resolveAsset,
+}: {
+  stages: Stage[];
+  codebook: Codebook;
+  resolveAsset: ResolveRosterAsset;
+}): Promise<Record<string, NcNode[]>> {
+  const rosterStages = stages
+    .map(getRosterStage)
+    .filter((stage): stage is RosterStage => stage !== null);
+
+  if (rosterStages.length === 0) {
+    return {};
+  }
+
+  // Cache parses per invocation so an asset shared by several stages (or
+  // panels) is only fetched and parsed once per subject type.
+  const parseCache = new Map<string, Promise<NcNode[]>>();
+  const result: Record<string, NcNode[]> = {};
+
+  for (const { stageId, subject, sources } of rosterStages) {
+    const byPrimaryKey = new Map<string, NcNode>();
+
+    for (const { assetId, filter } of sources) {
+      const cacheKey = `${assetId}::${subject.type}`;
+      let parsed = parseCache.get(cacheKey);
+      if (!parsed) {
+        parsed = parseRosterSource(
+          assetId,
+          subject,
+          codebook,
+          resolveAsset,
+        ).catch((error: unknown) => {
+          // eslint-disable-next-line no-console
+          console.error(`Could not read roster asset "${assetId}"`, error);
+          return [];
+        });
+        parseCache.set(cacheKey, parsed);
+      }
+
+      for (const node of filterExternalPanelNodes(await parsed, filter)) {
+        byPrimaryKey.set(node[entityPrimaryKeyProperty], node);
+      }
+    }
+
+    if (byPrimaryKey.size > 0) {
+      result[stageId] = [...byPrimaryKey.values()];
+    }
+  }
+
+  return result;
+}

--- a/packages/interview/src/contract/rosterData.ts
+++ b/packages/interview/src/contract/rosterData.ts
@@ -104,17 +104,26 @@ type RosterStage = {
 };
 
 function getRosterStage(stage: Stage): RosterStage | null {
+  // Hosts pass draft/unvalidated stages (Architect previews the protocol being
+  // edited), so `dataSource`, `subject`, and panel fields can be absent even
+  // though the schema types mark them required. Every field is re-checked at
+  // runtime and the stage is skipped on a mismatch rather than throwing — the
+  // same widening-without-assertion posture as generateNetwork's subject.ts.
   const sources: RosterSource[] = [];
 
   if (stage.type === 'NameGeneratorRoster') {
-    sources.push({ assetId: stage.dataSource });
+    const dataSource: string | undefined = stage.dataSource;
+    if (typeof dataSource === 'string') {
+      sources.push({ assetId: dataSource });
+    }
   } else if (
     stage.type === 'NameGenerator' ||
     stage.type === 'NameGeneratorQuickAdd'
   ) {
     for (const panel of stage.panels ?? []) {
-      if (panel.dataSource !== 'existing') {
-        sources.push({ assetId: panel.dataSource, filter: panel.filter });
+      const dataSource: string | undefined = panel.dataSource;
+      if (typeof dataSource === 'string' && dataSource !== 'existing') {
+        sources.push({ assetId: dataSource, filter: panel.filter });
       }
     }
   } else {
@@ -122,7 +131,11 @@ function getRosterStage(stage: Stage): RosterStage | null {
   }
 
   if (sources.length === 0) return null;
-  if (stage.subject.entity !== 'node') return null;
+
+  const subject: { entity?: string; type?: string } | undefined = stage.subject;
+  if (subject?.entity !== 'node' || typeof subject.type !== 'string') {
+    return null;
+  }
 
   return { stageId: stage.id, subject: stage.subject, sources };
 }

--- a/packages/interview/src/contract/rosterData.ts
+++ b/packages/interview/src/contract/rosterData.ts
@@ -140,24 +140,33 @@ function getRosterStage(stage: Stage): RosterStage | null {
   return { stageId: stage.id, subject: stage.subject, sources };
 }
 
+/**
+ * A source that resolved and parsed successfully (`nodes` may be empty — a
+ * readable roster with no rows), versus one that failed (the asset was missing
+ * or unreadable). The distinction lets a stage emit an empty pool for a
+ * genuinely empty roster while omitting a stage whose every source failed.
+ */
+type SourceOutcome = { resolved: true; nodes: NcNode[] } | { resolved: false };
+
 async function parseRosterSource(
   assetId: string,
   subject: NodeSubject,
   codebook: Codebook,
   resolveAsset: ResolveRosterAsset,
-): Promise<NcNode[]> {
+): Promise<SourceOutcome> {
   const resolved = await resolveAsset(assetId);
   if (!resolved) {
-    return [];
+    return { resolved: false };
   }
 
   try {
-    return await parseExternalNetworkAsset({
+    const nodes = await parseExternalNetworkAsset({
       sourceFileName: resolved.sourceFileName,
       url: resolved.url,
       codebook,
       subject,
     });
+    return { resolved: true, nodes };
   } finally {
     resolved.cleanup?.();
   }
@@ -167,6 +176,12 @@ async function parseRosterSource(
  * Host-agnostic roster collection for synthetic generation: per-stage node
  * pools keyed by stage id, built from each stage's `NameGeneratorRoster`
  * data source, or `NameGenerator`/`NameGeneratorQuickAdd` panel data sources.
+ *
+ * A stage's key is emitted (with an array that may be empty) whenever at least
+ * one of its sources resolved and parsed successfully — an empty array means
+ * "roster known to be empty", distinct from an absent key. A stage whose every
+ * source failed (missing asset, or a resolve/parse error) is omitted, so
+ * downstream generation still falls back to fabrication for it.
  */
 export async function collectRosterExternalData({
   stages,
@@ -187,11 +202,12 @@ export async function collectRosterExternalData({
 
   // Cache parses per invocation so an asset shared by several stages (or
   // panels) is only fetched and parsed once per subject type.
-  const parseCache = new Map<string, Promise<NcNode[]>>();
+  const parseCache = new Map<string, Promise<SourceOutcome>>();
   const result: Record<string, NcNode[]> = {};
 
   for (const { stageId, subject, sources } of rosterStages) {
     const byPrimaryKey = new Map<string, NcNode>();
+    let anySourceResolved = false;
 
     for (const { assetId, filter } of sources) {
       const cacheKey = `${assetId}::${subject.type}`;
@@ -202,20 +218,26 @@ export async function collectRosterExternalData({
           subject,
           codebook,
           resolveAsset,
-        ).catch((error: unknown) => {
+        ).catch((error: unknown): SourceOutcome => {
           // eslint-disable-next-line no-console
           console.error(`Could not read roster asset "${assetId}"`, error);
-          return [];
+          return { resolved: false };
         });
         parseCache.set(cacheKey, parsed);
       }
 
-      for (const node of filterExternalPanelNodes(await parsed, filter)) {
+      const outcome = await parsed;
+      if (!outcome.resolved) continue;
+      anySourceResolved = true;
+
+      for (const node of filterExternalPanelNodes(outcome.nodes, filter)) {
         byPrimaryKey.set(node[entityPrimaryKeyProperty], node);
       }
     }
 
-    if (byPrimaryKey.size > 0) {
+    // Emit an (possibly empty) pool once any source resolved; omit the stage
+    // entirely when every source failed so generation falls back to fabrication.
+    if (anySourceResolved) {
       result[stageId] = [...byPrimaryKey.values()];
     }
   }

--- a/packages/interview/src/hooks/useExternalData.tsx
+++ b/packages/interview/src/hooks/useExternalData.tsx
@@ -6,12 +6,9 @@ import type { NcNode } from '@codaco/shared-consts';
 
 import { useCaptureException } from '../analytics/useTrack';
 import { useContractHandlers } from '../contract/context';
+import { parseExternalNetworkAsset } from '../contract/rosterData';
 import { getAssetManifest, getCodebook } from '../store/modules/protocol';
 import { ensureError } from '../utils/ensureError';
-import { getVariableTypeReplacements } from '../utils/externalData';
-import loadExternalData, {
-  makeVariableUUIDReplacer,
-} from '../utils/loadExternalData';
 
 const useExternalData = (
   dataSource: Panel['dataSource'],
@@ -60,15 +57,12 @@ const useExternalData = (
         // Prefer the original source filename for the CSV-vs-JSON decision; the
         // display `name` may lack an extension on hand-edited protocols.
         const sourceFileName = asset.source ?? asset.name;
-        const { nodes } = await loadExternalData(sourceFileName, url);
-        const replacer = makeVariableUUIDReplacer(codebook, subject.type);
-        const uuidData = nodes.map(replacer);
-        const formatted = getVariableTypeReplacements(
+        const formatted = await parseExternalNetworkAsset({
           sourceFileName,
-          uuidData,
+          url,
           codebook,
           subject,
-        );
+        });
         if (!cancelled) {
           setExternalData(formatted);
           setStatus({ isLoading: false, error: null });

--- a/packages/interview/src/index.ts
+++ b/packages/interview/src/index.ts
@@ -25,9 +25,4 @@ export { default as Shell, type NavigationOrientation } from './Shell';
 export { createInitialNetwork } from './contract/network';
 // Public utilities (consumed by sibling monorepo packages, e.g. network-exporters)
 export { getInterviewProgress } from './selectors/utils';
-export { getVariableTypeReplacements } from './utils/externalData';
 export { getNodeLabelAttribute } from './utils/getNodeLabelAttribute';
-export {
-  default as loadExternalData,
-  makeVariableUUIDReplacer,
-} from './utils/loadExternalData';

--- a/packages/interview/src/index.ts
+++ b/packages/interview/src/index.ts
@@ -25,4 +25,9 @@ export { default as Shell, type NavigationOrientation } from './Shell';
 export { createInitialNetwork } from './contract/network';
 // Public utilities (consumed by sibling monorepo packages, e.g. network-exporters)
 export { getInterviewProgress } from './selectors/utils';
+export { getVariableTypeReplacements } from './utils/externalData';
 export { getNodeLabelAttribute } from './utils/getNodeLabelAttribute';
+export {
+  default as loadExternalData,
+  makeVariableUUIDReplacer,
+} from './utils/loadExternalData';

--- a/packages/interview/src/selectors/name-generator.ts
+++ b/packages/interview/src/selectors/name-generator.ts
@@ -8,6 +8,7 @@ import {
   type NcNode,
 } from '@codaco/shared-consts';
 
+import { filterExternalPanelNodes } from '../contract/rosterData';
 import { getCodebook } from '../store/modules/protocol';
 import type { RootState } from '../store/store';
 import {
@@ -92,36 +93,34 @@ export const getPanelNodes = (
         ),
       };
 
-      let nodes: NcNode[] = [];
-
-      // For current network nodes, we filter out any nodes that are already in the prompt
       if (panelConfig.dataSource === 'existing') {
-        nodes = nodesForOtherPrompts.filter(notInSet(new Set(nodeIds.prompt)));
-      } else {
-        // For external data nodes, we filter out any nodes that are already in the prompt
-        nodes =
-          externalData?.filter(
-            notInSet(new Set([...nodeIds.prompt, ...nodeIds.other])),
-          ) ?? ([] as NcNode[]);
+        // For current network nodes, we filter out any nodes that are already in the prompt
+        const nodes = nodesForOtherPrompts.filter(
+          notInSet(new Set(nodeIds.prompt)),
+        );
+
+        if (!panelConfig.filter) {
+          return nodes;
+        }
+
+        // If a filter is provided, we apply it to the nodes
+        const filterFunction = customFilter(panelConfig.filter);
+
+        const filteredNetwork = filterFunction({
+          nodes,
+          edges: networkEdges,
+          ego: networkEgo ?? { _uid: '', [entityAttributesProperty]: {} },
+        });
+
+        return filteredNetwork.nodes;
       }
 
-      if (!panelConfig.filter) {
-        return nodes;
-      }
+      // For external data nodes, we filter out any nodes that are already in the prompt
+      const nodes =
+        externalData?.filter(
+          notInSet(new Set([...nodeIds.prompt, ...nodeIds.other])),
+        ) ?? ([] as NcNode[]);
 
-      // If a filter is provided, we apply it to the nodes
-      const filterFunction = customFilter(panelConfig.filter);
-
-      const defaultEgo = { _uid: '', [entityAttributesProperty]: {} };
-      const filteredNetwork = filterFunction({
-        nodes,
-        edges: panelConfig.dataSource === 'existing' ? networkEdges : [],
-        ego:
-          panelConfig.dataSource === 'existing' && networkEgo
-            ? networkEgo
-            : defaultEgo,
-      });
-
-      return filteredNetwork.nodes;
+      return filterExternalPanelNodes(nodes, panelConfig.filter);
     },
   );

--- a/packages/interview/src/utils/__tests__/loadExternalData.test.ts
+++ b/packages/interview/src/utils/__tests__/loadExternalData.test.ts
@@ -19,6 +19,12 @@ const codebook: Codebook = {
       shape: { default: 'circle' },
       variables: {},
     },
+    place: {
+      name: 'Place',
+      color: 'node-color-seq-2',
+      shape: { default: 'square' },
+      variables: {},
+    },
   },
 };
 
@@ -50,6 +56,34 @@ describe('makeVariableUUIDReplacer primary-key salt', () => {
     const b = replacer(row, 3);
 
     expect(a[entityPrimaryKeyProperty]).toBe(b[entityPrimaryKeyProperty]);
+  });
+
+  it('prefixes the primary key with the stage subject type', () => {
+    const row: Partial<NcNode> = {
+      [entityAttributesProperty]: { name: 'Carol', age: '50' },
+    };
+
+    const replacer = makeVariableUUIDReplacer(codebook, 'person');
+
+    const node = replacer(row, 0);
+
+    expect(node[entityPrimaryKeyProperty]).toMatch(/^person_/);
+  });
+
+  it('gives the same row parsed under two subject types different primary keys', () => {
+    const row: Partial<NcNode> = {
+      [entityAttributesProperty]: { name: 'Dana', age: '29' },
+    };
+
+    // Same asset row, same index, parsed for two different node types (e.g.
+    // one roster shared by a person stage and a place stage) — this is the
+    // invariant the subject-type prefix exists to guarantee.
+    const asPerson = makeVariableUUIDReplacer(codebook, 'person')(row, 0);
+    const asPlace = makeVariableUUIDReplacer(codebook, 'place')(row, 0);
+
+    expect(asPerson[entityPrimaryKeyProperty]).not.toBe(
+      asPlace[entityPrimaryKeyProperty],
+    );
   });
 });
 

--- a/packages/interview/src/utils/loadExternalData.ts
+++ b/packages/interview/src/utils/loadExternalData.ts
@@ -83,7 +83,10 @@ export const makeVariableUUIDReplacer =
     // Salt the content hash with the row's data-file position so byte-identical
     // rows receive distinct (but deterministic) primary keys. Without the index
     // the Collection keyExtractor dedupes identical rows to a single card.
-    const uuid = hash({ node, index });
+    // Prefix with the subject type so the same asset parsed for two different
+    // node types can never collide: a row's identity is scoped to the subject
+    // it was parsed for, keeping primary keys unique within a single network.
+    const uuid = `${subjectType}_${hash({ node, index })}`;
 
     const attributes = mapKeys(
       node[entityAttributesProperty] ?? {},

--- a/packages/protocol-utilities/src/ValueGenerator.ts
+++ b/packages/protocol-utilities/src/ValueGenerator.ts
@@ -1,5 +1,7 @@
 import { en, Faker } from '@faker-js/faker';
 
+import type { VariableValue } from '@codaco/shared-consts';
+
 import type { VariableEntry } from './types';
 
 export class ValueGenerator {
@@ -10,7 +12,7 @@ export class ValueGenerator {
     this.faker.seed(seed);
   }
 
-  generateForVariable(variable: VariableEntry, index: number): unknown {
+  generateForVariable(variable: VariableEntry, index: number): VariableValue {
     switch (variable.type) {
       case 'text':
         return this.faker.person.firstName();

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -757,6 +757,59 @@ describe('generateNetwork', () => {
         }),
       ).not.toThrow();
     });
+
+    // markStageInProgress runs on the stage being edited, so in Architect
+    // previews its prompts are the most likely to be half-built.
+    it('does not throw when an in-progress Sociogram prompt lacks layout', () => {
+      const codebook = makeCodebook();
+      const stages = [
+        makeNameGeneratorStage(),
+        {
+          id: 'stage-soc-draft',
+          label: 'Sociogram',
+          type: 'Sociogram',
+          subject: { entity: 'node', type: 'node-type-1' },
+          prompts: [{ id: 'prompt-soc', text: 'Place people' }],
+        } as unknown as Stage,
+      ];
+
+      expect(() =>
+        generateNetwork({
+          codebook,
+          stages,
+          seed: 42,
+          inProgressStageIndex: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it('never writes an "undefined" key when an in-progress OrdinalBin prompt lacks a variable', () => {
+      const codebook = makeBinCodebook();
+      const stages = [
+        makeNameGeneratorStage(),
+        {
+          id: 'stage-ob-draft',
+          label: 'Ordinal Bin',
+          type: 'OrdinalBin',
+          subject: { entity: 'node', type: 'node-type-1' },
+          prompts: [{ id: 'prompt-ob', text: 'How close?' }],
+        } as unknown as Stage,
+      ];
+
+      let result: ReturnType<typeof generateNetwork> | undefined;
+      expect(() => {
+        result = generateNetwork({
+          codebook,
+          stages,
+          seed: 42,
+          inProgressStageIndex: 1,
+        });
+      }).not.toThrow();
+
+      for (const node of result!.network.nodes) {
+        expect(node[entityAttributesProperty]).not.toHaveProperty('undefined');
+      }
+    });
   });
 
   describe('roster-backed generation', () => {

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -910,7 +910,7 @@ describe('generateNetwork', () => {
       }
     });
 
-    it('lets prompt attributes win over a colliding roster column', () => {
+    it('lets the roster value win a collision on a roster interface stage', () => {
       const stage = makeRosterStage({
         prompts: [
           {
@@ -930,6 +930,34 @@ describe('generateNetwork', () => {
       expect(network.nodes).toHaveLength(2);
       for (const node of network.nodes) {
         expect(isRosterUid(node[entityPrimaryKeyProperty])).toBe(true);
+        expect(node[entityAttributesProperty]['var-name']).toBe(
+          rosterNameFor(node[entityPrimaryKeyProperty]),
+        );
+      }
+    });
+
+    it('lets the prompt attribute win a collision on a name generator panel', () => {
+      const stage = makeNameGeneratorStage({
+        prompts: [
+          {
+            id: 'prompt-1',
+            text: 'Prompt one',
+            additionalAttributes: [{ variable: 'var-name', value: true }],
+          },
+        ],
+        behaviours: { minNodes: 2, maxNodes: 2 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(5) },
+      });
+
+      const fromRoster = network.nodes.filter((n) =>
+        isRosterUid(n[entityPrimaryKeyProperty]),
+      );
+      expect(fromRoster.length).toBeGreaterThan(0);
+      for (const node of fromRoster) {
         expect(node[entityAttributesProperty]['var-name']).toBe(true);
       }
     });

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   entityAttributesProperty,
   entityPrimaryKeyProperty,
+  type NcNode,
   StageMetadataSchema,
 } from '@codaco/shared-consts';
 
@@ -65,6 +66,56 @@ function makeNameGeneratorStage(overrides?: Record<string, unknown>): Stage {
     behaviours: { minNodes: 5, maxNodes: 8 },
     ...overrides,
   } as Stage;
+}
+
+function makeRosterStage(overrides?: Record<string, unknown>): Stage {
+  return {
+    id: 'stage-ngr',
+    label: 'Roster',
+    type: 'NameGeneratorRoster',
+    subject: { entity: 'node', type: 'node-type-1' },
+    dataSource: 'roster-asset',
+    prompts: [{ id: 'prompt-ngr', text: 'Pick people' }],
+    behaviours: { minNodes: 1, maxNodes: 8 },
+    ...overrides,
+  } as Stage;
+}
+
+const ROSTER_UID_PREFIX = 'roster-row-';
+
+function rosterNameFor(primaryKey: string): string {
+  return `Roster person ${primaryKey.slice(ROSTER_UID_PREFIX.length)}`;
+}
+
+function isRosterUid(primaryKey: string): boolean {
+  return primaryKey.startsWith(ROSTER_UID_PREFIX);
+}
+
+function makeRosterPool(count: number): NcNode[] {
+  return Array.from({ length: count }, (_, i) => {
+    const primaryKey = `${ROSTER_UID_PREFIX}${i}`;
+    return {
+      [entityPrimaryKeyProperty]: primaryKey,
+      type: 'node-type-1',
+      [entityAttributesProperty]: { 'var-name': rosterNameFor(primaryKey) },
+    } as NcNode;
+  });
+}
+
+function uniquePrimaryKeys(network: { nodes: NcNode[] }): number {
+  return new Set(network.nodes.map((n) => n[entityPrimaryKeyProperty])).size;
+}
+
+function stripUnstableIds(network: { nodes: NcNode[]; edges: unknown[] }) {
+  return {
+    nodes: network.nodes.map((n) => ({
+      ...n,
+      [entityPrimaryKeyProperty]: isRosterUid(n[entityPrimaryKeyProperty])
+        ? n[entityPrimaryKeyProperty]
+        : 'fabricated',
+    })),
+    edgeCount: network.edges.length,
+  };
 }
 
 function makeDyadCensusStage(overrides?: Record<string, unknown>): Stage {
@@ -681,6 +732,226 @@ describe('generateNetwork', () => {
           inProgressStageIndex: 99,
         }),
       ).not.toThrow();
+    });
+  });
+
+  describe('roster-backed generation', () => {
+    it('draws every node on a roster stage from the roster, keeping ids and values', () => {
+      const stage = makeRosterStage({
+        behaviours: { minNodes: 3, maxNodes: 3 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ngr': makeRosterPool(5) },
+      });
+
+      expect(network.nodes).toHaveLength(3);
+      for (const node of network.nodes) {
+        expect(isRosterUid(node[entityPrimaryKeyProperty])).toBe(true);
+        expect(node[entityAttributesProperty]['var-name']).toBe(
+          rosterNameFor(node[entityPrimaryKeyProperty]),
+        );
+      }
+    });
+
+    it('never draws the same roster row twice across prompts', () => {
+      const stage = makeRosterStage({
+        prompts: [
+          { id: 'prompt-1', text: 'Prompt one' },
+          { id: 'prompt-2', text: 'Prompt two' },
+        ],
+        behaviours: { minNodes: 4, maxNodes: 8 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 7,
+        externalData: { 'stage-ngr': makeRosterPool(10) },
+      });
+
+      expect(network.nodes.length).toBeGreaterThan(1);
+      expect(uniquePrimaryKeys(network)).toBe(network.nodes.length);
+      expect(network.nodes.length).toBeLessThanOrEqual(8);
+    });
+
+    it('never draws the same roster row twice across stages sharing a roster', () => {
+      const pool = makeRosterPool(4);
+      const stages = [
+        makeRosterStage({
+          id: 'stage-a',
+          behaviours: { minNodes: 2, maxNodes: 2 },
+        }),
+        makeRosterStage({
+          id: 'stage-b',
+          behaviours: { minNodes: 2, maxNodes: 2 },
+        }),
+      ];
+
+      const { network } = generateNetwork(makeCodebook(), stages, {
+        seed: 42,
+        externalData: { 'stage-a': pool, 'stage-b': pool },
+      });
+
+      expect(network.nodes).toHaveLength(4);
+      expect(uniquePrimaryKeys(network)).toBe(4);
+    });
+
+    it('stops at the roster size on a roster stage, even below minNodes', () => {
+      const stage = makeRosterStage({
+        behaviours: { minNodes: 5, maxNodes: 8 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ngr': makeRosterPool(2) },
+      });
+
+      expect(network.nodes).toHaveLength(2);
+    });
+
+    it.each([
+      ['no entry for the stage', undefined],
+      ['an empty entry for the stage', { 'stage-ngr': [] }],
+    ])('fabricates people given %s', (_label, externalData) => {
+      const stage = makeRosterStage({
+        behaviours: { minNodes: 3, maxNodes: 3 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData,
+      });
+
+      expect(network.nodes).toHaveLength(3);
+      expect(
+        network.nodes.every((n) => !isRosterUid(n[entityPrimaryKeyProperty])),
+      ).toBe(true);
+    });
+
+    it('tops up from the codebook when a stage also offers a manual add path', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 8, maxNodes: 8 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(2) },
+      });
+
+      expect(network.nodes).toHaveLength(8);
+      const fromRoster = network.nodes.filter((n) =>
+        isRosterUid(n[entityPrimaryKeyProperty]),
+      );
+      expect(fromRoster).toHaveLength(2);
+    });
+
+    it('mixes roster and fabricated people when the roster is ample', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 20, maxNodes: 20 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(50) },
+      });
+
+      const fromRoster = network.nodes.filter((n) =>
+        isRosterUid(n[entityPrimaryKeyProperty]),
+      );
+      expect(fromRoster.length).toBeGreaterThan(0);
+      expect(fromRoster.length).toBeLessThan(network.nodes.length);
+    });
+
+    it('adds nobody once an earlier stage exhausts a shared roster', () => {
+      const pool = makeRosterPool(3);
+      const stages = [
+        makeRosterStage({
+          id: 'stage-a',
+          behaviours: { minNodes: 3, maxNodes: 3 },
+        }),
+        makeRosterStage({
+          id: 'stage-b',
+          behaviours: { minNodes: 2, maxNodes: 2 },
+        }),
+      ];
+
+      const { network } = generateNetwork(makeCodebook(), stages, {
+        seed: 42,
+        externalData: { 'stage-a': pool, 'stage-b': pool },
+      });
+
+      expect(network.nodes.filter((n) => n.stageId === 'stage-a')).toHaveLength(
+        3,
+      );
+      expect(network.nodes.filter((n) => n.stageId === 'stage-b')).toHaveLength(
+        0,
+      );
+    });
+
+    it('keeps roster values through the form field pass', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 3, maxNodes: 3 },
+        form: { fields: [{ variable: 'var-name', prompt: 'Their name' }] },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(5) },
+      });
+
+      const fromRoster = network.nodes.filter((n) =>
+        isRosterUid(n[entityPrimaryKeyProperty]),
+      );
+      expect(fromRoster.length).toBeGreaterThan(0);
+      for (const node of fromRoster) {
+        expect(node[entityAttributesProperty]['var-name']).toBe(
+          rosterNameFor(node[entityPrimaryKeyProperty]),
+        );
+      }
+    });
+
+    it('lets prompt attributes win over a colliding roster column', () => {
+      const stage = makeRosterStage({
+        prompts: [
+          {
+            id: 'prompt-1',
+            text: 'Prompt one',
+            additionalAttributes: [{ variable: 'var-name', value: true }],
+          },
+        ],
+        behaviours: { minNodes: 2, maxNodes: 2 },
+      });
+
+      const { network } = generateNetwork(makeCodebook(), [stage], {
+        seed: 42,
+        externalData: { 'stage-ngr': makeRosterPool(5) },
+      });
+
+      expect(network.nodes).toHaveLength(2);
+      for (const node of network.nodes) {
+        expect(isRosterUid(node[entityPrimaryKeyProperty])).toBe(true);
+        expect(node[entityAttributesProperty]['var-name']).toBe(true);
+      }
+    });
+
+    it('stays reproducible for a given seed', () => {
+      const stages = [
+        makeRosterStage({ behaviours: { minNodes: 2, maxNodes: 6 } }),
+      ];
+      const externalData = { 'stage-ngr': makeRosterPool(8) };
+
+      const first = generateNetwork(makeCodebook(), stages, {
+        seed: 99,
+        externalData,
+      });
+      const second = generateNetwork(makeCodebook(), stages, {
+        seed: 99,
+        externalData,
+      });
+
+      expect(stripUnstableIds(first.network)).toEqual(
+        stripUnstableIds(second.network),
+      );
     });
   });
 

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -859,6 +859,39 @@ describe('generateNetwork', () => {
         expect(node[entityAttributesProperty]).not.toHaveProperty('undefined');
       }
     });
+
+    // A draft stage can carry a `subject` key whose value is unset (Architect's
+    // in-memory draft state), which passes an `'subject' in stage` type check
+    // but would throw on a direct `.entity` dereference.
+    it('does not throw when an in-progress OrdinalBin has an unset subject', () => {
+      const codebook = makeBinCodebook();
+      const stages = [
+        makeNameGeneratorStage(),
+        {
+          id: 'stage-ob-draft',
+          label: 'Ordinal Bin',
+          type: 'OrdinalBin',
+          subject: undefined,
+          prompts: [
+            { id: 'prompt-ob', text: 'How close?', variable: 'var-ordinal' },
+          ],
+        } as unknown as Stage,
+      ];
+
+      let result: ReturnType<typeof generateNetwork> | undefined;
+      expect(() => {
+        result = generateNetwork({
+          codebook,
+          stages,
+          seed: 42,
+          inProgressStageIndex: 1,
+        });
+      }).not.toThrow();
+
+      for (const node of result!.network.nodes) {
+        expect(node[entityAttributesProperty]).not.toHaveProperty('undefined');
+      }
+    });
   });
 
   describe('roster-backed generation', () => {

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -419,6 +419,53 @@ describe('generateNetwork', () => {
       expect(network.nodes.length).toBe(0);
       expect(network.edges.length).toBe(0);
     });
+
+    it('marks exactly one node as ego, and false on every other node', () => {
+      const codebook = makeCodebook({
+        node: {
+          'node-type-1': {
+            color: 'node-color-seq-1',
+            variables: {
+              'var-name': { name: 'Name', type: 'text' },
+              'var-ego': { name: 'Is ego', type: 'boolean' },
+            },
+          },
+        },
+      });
+      const stages = [makeFamilyPedigreeStage()];
+
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
+
+      expect(network.nodes.length).toBeGreaterThan(1);
+
+      const egoNodes = network.nodes.filter(
+        (node) => node[entityAttributesProperty]['var-ego'] === true,
+      );
+      expect(egoNodes).toHaveLength(1);
+      expect(egoNodes[0]).toBe(network.nodes[0]);
+
+      for (const node of network.nodes.slice(1)) {
+        expect(node[entityAttributesProperty]['var-ego']).toBe(false);
+      }
+    });
+
+    it('does not throw and skips ego marking when nodeConfig has no egoVariable', () => {
+      const codebook = makeCodebook();
+      const stages = [
+        makeFamilyPedigreeStage({
+          nodeConfig: {
+            type: 'node-type-1',
+            nodeLabelVariable: 'var-name',
+            biologicalSexVariable: 'var-sex',
+            relationshipVariable: 'var-rel',
+          },
+        }),
+      ];
+
+      expect(() =>
+        generateNetwork({ codebook, stages, seed: 42 }),
+      ).not.toThrow();
+    });
   });
 
   describe('all node types match codebook', () => {

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -820,14 +820,16 @@ describe('generateNetwork', () => {
         } as unknown as Stage,
       ];
 
-      expect(() =>
-        generateNetwork({
-          codebook,
-          stages,
-          seed: 42,
-          inProgressStageIndex: 1,
-        }),
-      ).not.toThrow();
+      const { network } = generateNetwork({
+        codebook,
+        stages,
+        seed: 42,
+        inProgressStageIndex: 1,
+      });
+
+      for (const node of network.nodes) {
+        expect(node[entityAttributesProperty]).not.toHaveProperty('undefined');
+      }
     });
 
     it('never writes an "undefined" key when an in-progress OrdinalBin prompt lacks a variable', () => {

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -1087,6 +1087,115 @@ describe('generateNetwork', () => {
     });
   });
 
+  describe('draft protocol input (missing subject)', () => {
+    // generateNetwork also runs on unvalidated draft state (e.g. Architect's
+    // live preview of a protocol still being edited), where a subject-bearing
+    // stage can be missing `subject` entirely even though the schema types mark
+    // it required. Every handler must skip such a stage rather than throw.
+    it('skips a node-subject handler (Sociogram) without throwing when subject is missing', () => {
+      const codebook = makeCodebook();
+      const stages = [
+        makeNameGeneratorStage({ behaviours: { minNodes: 4, maxNodes: 4 } }),
+        {
+          id: 'stage-soc-draft',
+          label: 'Sociogram',
+          type: 'Sociogram',
+          prompts: [
+            {
+              id: 'prompt-soc',
+              text: 'Connect people',
+              edges: { create: 'edge-type-1' },
+            },
+          ],
+        } as unknown as Stage,
+      ];
+
+      expect(() =>
+        generateNetwork({ codebook, stages, seed: 42 }),
+      ).not.toThrow();
+
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
+      expect(network.nodes).toHaveLength(4);
+      expect(network.edges).toHaveLength(0);
+    });
+
+    it('skips AlterEdgeForm without throwing when subject is missing, leaving edge attributes exactly as created', () => {
+      // Edge creation (DyadCensus) already populates every codebook variable
+      // for the edge type, so a working guard must leave those values
+      // untouched rather than merely "absent" — compare against the same
+      // protocol with the malformed stage omitted entirely.
+      const codebook = makeCodebook({
+        edge: {
+          'edge-type-1': {
+            color: 'edge-color-seq-1',
+            variables: {
+              'var-strength': { name: 'Strength', type: 'text' },
+            },
+          },
+        },
+      });
+      const baseStages = [
+        makeNameGeneratorStage({ behaviours: { minNodes: 4, maxNodes: 4 } }),
+        makeDyadCensusStage(),
+      ];
+      const draftStage = {
+        id: 'stage-aef-draft',
+        label: 'Alter Edge Form',
+        type: 'AlterEdgeForm',
+        form: { fields: [{ variable: 'var-strength', prompt: 'Strength' }] },
+      } as unknown as Stage;
+
+      const withoutDraft = generateNetwork({
+        codebook,
+        stages: baseStages,
+        seed: 42,
+      });
+
+      const runWithDraft = () =>
+        generateNetwork({
+          codebook,
+          stages: [...baseStages, draftStage],
+          seed: 42,
+        });
+
+      expect(runWithDraft).not.toThrow();
+      const withDraft = runWithDraft();
+
+      expect(withDraft.network.edges.length).toBe(
+        withoutDraft.network.edges.length,
+      );
+      expect(withDraft.network.edges.length).toBeGreaterThan(0);
+      expect(
+        withDraft.network.edges.map((e) => e[entityAttributesProperty]),
+      ).toEqual(
+        withoutDraft.network.edges.map((e) => e[entityAttributesProperty]),
+      );
+    });
+
+    it('contributes no nodes when a NameGenerator-family stage is missing subject', () => {
+      const codebook = makeCodebook();
+      const stage = {
+        id: 'stage-ng-draft',
+        label: 'Name Generator',
+        type: 'NameGenerator',
+        prompts: [{ id: 'prompt-ng', text: 'Add people' }],
+        behaviours: { minNodes: 5, maxNodes: 8 },
+      } as unknown as Stage;
+
+      expect(() =>
+        generateNetwork({ codebook, stages: [stage], seed: 42 }),
+      ).not.toThrow();
+
+      const { network } = generateNetwork({
+        codebook,
+        stages: [stage],
+        seed: 42,
+      });
+      expect(network.nodes).toHaveLength(0);
+      expect(network.edges).toHaveLength(0);
+    });
+  });
+
   describe('generation config overrides', () => {
     it('rosterDrawRatio: 1 draws every node on a mixed stage from the roster while it lasts', () => {
       const stage = makeNameGeneratorStage({

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -976,10 +976,7 @@ describe('generateNetwork', () => {
       expect(network.nodes).toHaveLength(2);
     });
 
-    it.each([
-      ['no entry for the stage', undefined],
-      ['an empty entry for the stage', { 'stage-ngr': [] }],
-    ])('fabricates people given %s', (_label, externalData) => {
+    it('fabricates people on a roster stage with no external-data entry', () => {
       const stage = makeRosterStage({
         behaviours: { minNodes: 3, maxNodes: 3 },
       });
@@ -988,10 +985,50 @@ describe('generateNetwork', () => {
         codebook: makeCodebook(),
         stages: [stage],
         seed: 42,
-        externalData,
+        externalData: undefined,
       });
 
       expect(network.nodes).toHaveLength(3);
+      expect(
+        network.nodes.every((n) => !isRosterUid(n[entityPrimaryKeyProperty])),
+      ).toBe(true);
+    });
+
+    // Inverts the earlier "empty entry fabricates" behaviour: a resolvable but
+    // empty roster now means "roster known to be empty", not "no roster". A live
+    // interview would offer nobody to add, so a roster stage with an empty entry
+    // adds nobody rather than inventing people.
+    it('adds nobody on a roster stage whose external-data entry is empty', () => {
+      const stage = makeRosterStage({
+        behaviours: { minNodes: 3, maxNodes: 3 },
+      });
+
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
+        seed: 42,
+        externalData: { 'stage-ngr': [] },
+      });
+
+      expect(network.nodes).toHaveLength(0);
+    });
+
+    // The empty-roster rule suppresses fabrication only on pure roster stages. A
+    // name generator with a manual-add path still fabricates to its node counts
+    // when its roster entry is empty.
+    it('still fabricates to minNodes on a mixed name generator with an empty entry', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 5, maxNodes: 5 },
+      });
+
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
+        seed: 42,
+        externalData: { 'stage-ng': [] },
+      });
+
+      expect(network.nodes).toHaveLength(5);
       expect(
         network.nodes.every((n) => !isRosterUid(n[entityPrimaryKeyProperty])),
       ).toBe(true);

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.test.ts
@@ -16,7 +16,7 @@ import {
 
 import { generateNetwork } from '../generateNetwork';
 
-type Codebook = Parameters<typeof generateNetwork>[0];
+type Codebook = Parameters<typeof generateNetwork>[0]['codebook'];
 
 type ZodLiteralDef = { _zod: { def: { values: string[] } } };
 type ZodOptionShape = { shape: { type: ZodLiteralDef } };
@@ -214,7 +214,7 @@ function makeHiddenSkipLogic(
 }
 
 function makeSkipRoutingCodebook(): Codebook {
-  const nodeDefinition = {
+  const nodeDefinition: NonNullable<Codebook['node']>[string] = {
     color: 'node-color-seq-1',
     variables: { 'var-name': { name: 'Name', type: 'text' } },
   };
@@ -245,7 +245,9 @@ describe('generateNetwork', () => {
         skipLogic: makeHiddenSkipLogic(),
       } as Stage;
 
-      const { network } = generateNetwork(makeSkipRoutingCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeSkipRoutingCodebook(),
+        stages,
         seed: 42,
         respectSkipLogicAndFiltering: true,
       });
@@ -266,7 +268,9 @@ describe('generateNetwork', () => {
         makeTypedNameGeneratorStage('target', 'destination'),
       ];
 
-      const { network } = generateNetwork(makeSkipRoutingCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeSkipRoutingCodebook(),
+        stages,
         seed: 42,
         respectSkipLogicAndFiltering: true,
       });
@@ -286,7 +290,9 @@ describe('generateNetwork', () => {
         makeTypedNameGeneratorStage('unreachable', 'bypassed'),
       ];
 
-      const { network } = generateNetwork(makeSkipRoutingCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeSkipRoutingCodebook(),
+        stages,
         seed: 42,
         respectSkipLogicAndFiltering: true,
       });
@@ -309,7 +315,9 @@ describe('generateNetwork', () => {
         makeTypedNameGeneratorStage('target', 'final'),
       ];
 
-      const { network } = generateNetwork(makeSkipRoutingCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeSkipRoutingCodebook(),
+        stages,
         seed: 42,
         respectSkipLogicAndFiltering: true,
       });
@@ -331,7 +339,9 @@ describe('generateNetwork', () => {
         makeTypedNameGeneratorStage('target', 'destination'),
       ];
 
-      const { network } = generateNetwork(makeSkipRoutingCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeSkipRoutingCodebook(),
+        stages,
         seed: 42,
         respectSkipLogicAndFiltering: true,
       });
@@ -348,7 +358,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThan(0);
 
@@ -361,7 +371,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.edges.length).toBeGreaterThan(0);
 
@@ -374,7 +384,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       const codebookNodeTypes = new Set(Object.keys(codebook.node ?? {}));
 
@@ -387,7 +397,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       for (const node of network.nodes) {
         const attrs = node[entityAttributesProperty];
@@ -404,7 +414,7 @@ describe('generateNetwork', () => {
         }),
       ];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.nodes.length).toBe(0);
       expect(network.edges.length).toBe(0);
@@ -426,7 +436,7 @@ describe('generateNetwork', () => {
         makeFamilyPedigreeStage(),
       ];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       for (const node of network.nodes) {
         expect(node.type).not.toBe('person');
@@ -441,7 +451,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeNameGeneratorStage({ behaviours: { minNodes: 9 } })];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThanOrEqual(9);
       for (const node of network.nodes) {
@@ -455,7 +465,7 @@ describe('generateNetwork', () => {
         makeNameGeneratorStage({ behaviours: { minNodes: 6, maxNodes: 3 } }),
       ];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThanOrEqual(6);
     });
@@ -466,7 +476,7 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeFamilyPedigreeStage()];
 
-      const { stageMetadata } = generateNetwork(codebook, stages, { seed: 42 });
+      const { stageMetadata } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(stageMetadata).toEqual({ 0: { isNetworkCommitted: true } });
       expect(StageMetadataSchema.safeParse(stageMetadata).success).toBe(true);
@@ -476,7 +486,9 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeNameGeneratorStage(), makeDyadCensusStage()];
 
-      const { stageMetadata, network } = generateNetwork(codebook, stages, {
+      const { stageMetadata, network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
       });
 
@@ -506,7 +518,9 @@ describe('generateNetwork', () => {
       const codebook = makeCodebook();
       const stages = [makeNameGeneratorStage(), makeTieStrengthCensusStage()];
 
-      const { stageMetadata, network } = generateNetwork(codebook, stages, {
+      const { stageMetadata, network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
       });
 
@@ -536,7 +550,7 @@ describe('generateNetwork', () => {
         makeFamilyPedigreeStage({ id: 'stage-fp-2' }),
       ];
 
-      const { stageMetadata } = generateNetwork(codebook, stages, { seed: 42 });
+      const { stageMetadata } = generateNetwork({ codebook, stages, seed: 42 });
 
       const result = StageMetadataSchema.safeParse(stageMetadata);
       expect(result.success).toBe(true);
@@ -609,7 +623,7 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, { seed: 42 });
+      const { network } = generateNetwork({ codebook, stages, seed: 42 });
 
       expect(network.nodes.length).toBeGreaterThan(0);
       for (const node of network.nodes) {
@@ -621,7 +635,9 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, {
+      const { network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
         inProgressStageIndex: 1,
       });
@@ -651,7 +667,9 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeCategoricalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, {
+      const { network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
         inProgressStageIndex: 1,
       });
@@ -695,7 +713,9 @@ describe('generateNetwork', () => {
         } as Stage,
       ];
 
-      const { network } = generateNetwork(codebook, stages, {
+      const { network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
         inProgressStageIndex: 1,
       });
@@ -712,7 +732,9 @@ describe('generateNetwork', () => {
       const codebook = makeBinCodebook();
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
-      const { network } = generateNetwork(codebook, stages, {
+      const { network } = generateNetwork({
+        codebook,
+        stages,
         seed: 42,
         inProgressStageIndex: 0,
       });
@@ -727,7 +749,9 @@ describe('generateNetwork', () => {
       const stages = [makeNameGeneratorStage(), makeOrdinalBinStage()];
 
       expect(() =>
-        generateNetwork(codebook, stages, {
+        generateNetwork({
+          codebook,
+          stages,
           seed: 42,
           inProgressStageIndex: 99,
         }),
@@ -741,7 +765,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 3, maxNodes: 3 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ngr': makeRosterPool(5) },
       });
@@ -764,7 +790,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 4, maxNodes: 8 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 7,
         externalData: { 'stage-ngr': makeRosterPool(10) },
       });
@@ -787,7 +815,9 @@ describe('generateNetwork', () => {
         }),
       ];
 
-      const { network } = generateNetwork(makeCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
         seed: 42,
         externalData: { 'stage-a': pool, 'stage-b': pool },
       });
@@ -801,7 +831,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 5, maxNodes: 8 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ngr': makeRosterPool(2) },
       });
@@ -817,7 +849,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 3, maxNodes: 3 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData,
       });
@@ -833,7 +867,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 8, maxNodes: 8 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ng': makeRosterPool(2) },
       });
@@ -850,7 +886,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 20, maxNodes: 20 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ng': makeRosterPool(50) },
       });
@@ -875,7 +913,9 @@ describe('generateNetwork', () => {
         }),
       ];
 
-      const { network } = generateNetwork(makeCodebook(), stages, {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
         seed: 42,
         externalData: { 'stage-a': pool, 'stage-b': pool },
       });
@@ -894,7 +934,9 @@ describe('generateNetwork', () => {
         form: { fields: [{ variable: 'var-name', prompt: 'Their name' }] },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ng': makeRosterPool(5) },
       });
@@ -922,7 +964,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 2, maxNodes: 2 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ngr': makeRosterPool(5) },
       });
@@ -948,7 +992,9 @@ describe('generateNetwork', () => {
         behaviours: { minNodes: 2, maxNodes: 2 },
       });
 
-      const { network } = generateNetwork(makeCodebook(), [stage], {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
         seed: 42,
         externalData: { 'stage-ng': makeRosterPool(5) },
       });
@@ -968,11 +1014,15 @@ describe('generateNetwork', () => {
       ];
       const externalData = { 'stage-ngr': makeRosterPool(8) };
 
-      const first = generateNetwork(makeCodebook(), stages, {
+      const first = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
         seed: 99,
         externalData,
       });
-      const second = generateNetwork(makeCodebook(), stages, {
+      const second = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
         seed: 99,
         externalData,
       });
@@ -1017,7 +1067,7 @@ describe('generateNetwork', () => {
         } as unknown as Stage;
 
         expect(
-          () => generateNetwork(codebook, [stage], { seed: 42 }),
+          () => generateNetwork({ codebook, stages: [stage], seed: 42 }),
           `Stage type "${stageType}" is not handled by generateNetwork`,
         ).not.toThrow();
       }
@@ -1031,9 +1081,107 @@ describe('generateNetwork', () => {
         type: 'SomeNewStageType',
       } as unknown as Stage;
 
-      expect(() => generateNetwork(codebook, [stage], { seed: 42 })).toThrow(
-        /Unsupported stage type "SomeNewStageType"/,
+      expect(() =>
+        generateNetwork({ codebook, stages: [stage], seed: 42 }),
+      ).toThrow(/Unsupported stage type "SomeNewStageType"/);
+    });
+  });
+
+  describe('generation config overrides', () => {
+    it('rosterDrawRatio: 1 draws every node on a mixed stage from the roster while it lasts', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 5, maxNodes: 5 },
+      });
+
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(5) },
+        config: { rosterDrawRatio: 1 },
+      });
+
+      expect(network.nodes).toHaveLength(5);
+      expect(
+        network.nodes.every((n) => isRosterUid(n[entityPrimaryKeyProperty])),
+      ).toBe(true);
+    });
+
+    it('rosterDrawRatio: 0 draws nobody from the roster on a mixed stage', () => {
+      const stage = makeNameGeneratorStage({
+        behaviours: { minNodes: 5, maxNodes: 5 },
+      });
+
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
+        seed: 42,
+        externalData: { 'stage-ng': makeRosterPool(5) },
+        config: { rosterDrawRatio: 0 },
+      });
+
+      expect(network.nodes).toHaveLength(5);
+      expect(
+        network.nodes.every((n) => !isRosterUid(n[entityPrimaryKeyProperty])),
+      ).toBe(true);
+    });
+
+    it('nodeCount overrides the default bounds when a stage omits behaviours', () => {
+      const stage = makeNameGeneratorStage({ behaviours: undefined });
+
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [stage],
+        seed: 42,
+        config: { nodeCount: { min: 3, max: 3 } },
+      });
+
+      expect(network.nodes).toHaveLength(3);
+    });
+
+    it('dropOutFactor: 0 never triggers drop-out', () => {
+      const stages = Array.from({ length: 20 }, (_, i) =>
+        makeTypedNameGeneratorStage(`ng-${i}`, 'node-type-1'),
       );
+
+      const { droppedOut, currentStep } = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
+        seed: 42,
+        simulateDropOut: true,
+        config: { dropOutFactor: 0 },
+      });
+
+      expect(droppedOut).toBe(false);
+      expect(currentStep).toBe(stages.length);
+    });
+
+    it('a large dropOutFactor forces an early drop-out', () => {
+      const stages = Array.from({ length: 20 }, (_, i) =>
+        makeTypedNameGeneratorStage(`ng-${i}`, 'node-type-1'),
+      );
+
+      const { droppedOut, currentStep } = generateNetwork({
+        codebook: makeCodebook(),
+        stages,
+        seed: 42,
+        simulateDropOut: true,
+        config: { dropOutFactor: 100 },
+      });
+
+      expect(droppedOut).toBe(true);
+      expect(currentStep).toBe(0);
+    });
+
+    it('familyPedigreeNodeCount with a fixed range produces exactly that many nodes', () => {
+      const { network } = generateNetwork({
+        codebook: makeCodebook(),
+        stages: [makeFamilyPedigreeStage()],
+        seed: 42,
+        config: { familyPedigreeNodeCount: { min: 6, max: 6 } },
+      });
+
+      expect(network.nodes).toHaveLength(6);
     });
   });
 });

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -74,6 +74,7 @@ export type GenerateNetworkOptions = {
    * effect on stage types where complete data is preferable (e.g. forms).
    */
   inProgressStageIndex?: number;
+  externalData?: Record<string, NcNode[]>;
 };
 
 export type GenerateNetworkResult = {
@@ -146,6 +147,14 @@ function getPromptAdditionalAttributes(
   );
 }
 
+const ROSTER_DRAW_RATIO = 0.7;
+
+type RosterDraw = {
+  pool: NcNode[] | undefined;
+  used: Set<string>;
+  allowFabrication: boolean;
+};
+
 function createNodesForStage(
   codebook: Codebook,
   stage: Stage,
@@ -153,6 +162,7 @@ function createNodesForStage(
   valueGen: ValueGenerator,
   existingNodeCount: number,
   stageNodeCount: number,
+  roster: RosterDraw,
 ): NcNode[] {
   const stageRecord = stage as Record<string, unknown>;
   const subject = stageRecord.subject as
@@ -172,10 +182,22 @@ function createNodesForStage(
   const remaining = maxNodes - stageNodeCount;
   if (remaining <= 0) return [];
 
-  const count = Math.min(valueGen.randomInt(minNodes, maxNodes), remaining);
+  const hasRoster = (roster.pool?.length ?? 0) > 0;
+
+  const pool = roster.pool
+    ? roster.pool.filter((n) => !roster.used.has(n[entityPrimaryKeyProperty]))
+    : [];
+
+  const requested = Math.min(valueGen.randomInt(minNodes, maxNodes), remaining);
+  const count =
+    hasRoster && !roster.allowFabrication
+      ? Math.min(requested, pool.length)
+      : requested;
+
   const promptId = (prompt.id as string) ?? uuid();
   const additionalAttrs = getPromptAdditionalAttributes(prompt);
   const newNodes: NcNode[] = [];
+  let drawn = 0;
 
   for (let i = 0; i < count; i++) {
     const nodeIndex = existingNodeCount + i;
@@ -185,10 +207,29 @@ function createNodesForStage(
       nodeIndex,
     );
 
+    const takeFromRoster =
+      drawn < pool.length &&
+      (!roster.allowFabrication ||
+        valueGen.randomFloat(0, 1) < ROSTER_DRAW_RATIO);
+
+    let primaryKey = uuid();
+
+    if (takeFromRoster) {
+      const swapIndex = valueGen.randomInt(drawn, pool.length - 1);
+      const picked = pool[swapIndex]!;
+      pool[swapIndex] = pool[drawn]!;
+      pool[drawn] = picked;
+      drawn += 1;
+
+      primaryKey = picked[entityPrimaryKeyProperty];
+      roster.used.add(primaryKey);
+      Object.assign(attrs, picked[entityAttributesProperty]);
+    }
+
     Object.assign(attrs, additionalAttrs);
 
     newNodes.push({
-      [entityPrimaryKeyProperty]: uuid(),
+      [entityPrimaryKeyProperty]: primaryKey,
       type: nodeType,
       [entityAttributesProperty]: attrs,
       stageId: stageRecord.id as string,
@@ -421,6 +462,7 @@ export function generateNetwork(
     simulateDropOut = false,
     respectSkipLogicAndFiltering = false,
     inProgressStageIndex,
+    externalData,
   } = options;
 
   const valueGen = new ValueGenerator(
@@ -431,6 +473,7 @@ export function generateNetwork(
   const egoAttributes: Record<string, unknown> = {};
   const stageMetadata: Record<string, unknown> = {};
   const egoUid = uuid();
+  const usedRosterUids = new Set<string>();
   const totalStages = stages.length;
   let currentStep = 0;
   let droppedOut = false;
@@ -485,6 +528,11 @@ export function generateNetwork(
       case 'NameGenerator':
       case 'NameGeneratorQuickAdd':
       case 'NameGeneratorRoster': {
+        const rosterDraw: RosterDraw = {
+          pool: externalData?.[stageId],
+          used: usedRosterUids,
+          allowFabrication: stageType !== 'NameGeneratorRoster',
+        };
         let stageNodeCount = 0;
         for (const prompt of prompts) {
           const newNodes = createNodesForStage(
@@ -494,6 +542,7 @@ export function generateNetwork(
             valueGen,
             nodes.length,
             stageNodeCount,
+            rosterDraw,
           );
           stageNodeCount += newNodes.length;
 
@@ -947,6 +996,7 @@ export function generateNetwork(
           valueGen,
           nodes.length,
           0,
+          { pool: undefined, used: usedRosterUids, allowFabrication: true },
         );
         nodes.push(...newNodes);
 

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -42,8 +42,14 @@ export type GenerateNetworkParams = {
    * (`NameGeneratorRoster`) and name generators with roster panels. Rows are
    * drawn **without replacement across all prompts and stages** via a shared
    * used-set, mirroring the runtime's exclusion of rows already in the network.
-   * A stage with no entry (or an empty/exhausted pool) falls back per stage
-   * type: a roster stage adds nobody, while a name generator fabricates people.
+   *
+   * A key's presence is three-way. An **absent** key means "no roster known":
+   * a roster stage fabricates people, a name generator fabricates as usual. An
+   * **empty array** means "roster known to be empty" (the asset resolved but had
+   * no rows, or a panel filtered them all out): a roster stage adds nobody,
+   * while a name generator still fabricates to its node counts via its manual
+   * add path. A **non-empty** array draws from those rows (a roster stage only
+   * from them; a name generator mixes them with fabricated people).
    */
   externalData?: Record<string, NcNode[]>;
   /** Seed for deterministic output. A random seed is used when omitted. */

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -1,80 +1,65 @@
 import { v4 as uuid } from 'uuid';
 
 import {
-  filter as getFilter,
   isStageSkipped,
   resolveSkipLogicDestinationIndex,
 } from '@codaco/network-query';
-import type { Filter, SkipLogic, Stage } from '@codaco/protocol-validation';
-import {
-  type DyadCensusMetadataItem,
-  entityAttributesProperty,
-  entityPrimaryKeyProperty,
-  type NcEdge,
-  type NcNetwork,
-  type NcNode,
-} from '@codaco/shared-consts';
+import type { Stage, StructuralCodebook } from '@codaco/protocol-validation';
+import type { NcNetwork, NcNode } from '@codaco/shared-consts';
 
-import type { VariableEntry } from './types';
+import {
+  type GenerationConfig,
+  resolveGenerationConfig,
+} from './generateNetwork/config';
+import type {
+  GenerationContext,
+  NetworkDraft,
+} from './generateNetwork/context';
+import { buildCurrentNetwork } from './generateNetwork/filtering';
+import { markStageInProgress } from './generateNetwork/inProgress';
+import {
+  handleAlterEdgeForm,
+  handleAlterForm,
+  handleCategoricalBin,
+  handleDyadCensus,
+  handleEgoForm,
+  handleFamilyPedigree,
+  handleGeospatial,
+  handleNameGenerators,
+  handleNetworkComposer,
+  handleOrdinalBin,
+  handleSociogram,
+  handleTieStrengthCensus,
+} from './generateNetwork/stageHandlers';
 import { ValueGenerator } from './ValueGenerator';
 
-type NcAttributeValue =
-  | string
-  | boolean
-  | number
-  | number[]
-  | (string | number | boolean)[]
-  | { x: number; y: number }
-  | null;
-
-type VariableDefinition = {
-  name: string;
-  type: string;
-  // Any codebook variable's options: categorical/ordinal (string/number) or
-  // boolean variables (boolean value). Narrower codebook types (e.g.
-  // VariableOptions, which excludes boolean) are accepted structurally.
-  options?: { label: string; value: string | number | boolean }[];
-  validation?: Record<string, unknown>;
-  component?: string;
-};
-
-type Codebook = {
-  node?: Record<
-    string,
-    {
-      displayVariable?: string;
-      color?: string;
-      variables?: Record<string, VariableDefinition>;
-    }
-  >;
-  edge?: Record<
-    string,
-    {
-      color?: string;
-      variables?: Record<string, VariableDefinition>;
-    }
-  >;
-  ego?: {
-    variables?: Record<string, VariableDefinition>;
-  };
-};
-
-export type GenerateNetworkOptions = {
+export type GenerateNetworkParams = {
+  codebook: StructuralCodebook;
+  stages: Stage[];
   /**
-   * Seed for deterministic output. A random seed is used when omitted.
+   * Pre-parsed roster rows keyed by **stage id**. Applies to node-subject
+   * name-generator stages that source people from external data — roster stages
+   * (`NameGeneratorRoster`) and name generators with roster panels. Rows are
+   * drawn **without replacement across all prompts and stages** via a shared
+   * used-set, mirroring the runtime's exclusion of rows already in the network.
+   * A stage with no entry (or an empty/exhausted pool) falls back per stage
+   * type: a roster stage adds nobody, while a name generator fabricates people.
    */
+  externalData?: Record<string, NcNode[]>;
+  /** Seed for deterministic output. A random seed is used when omitted. */
   seed?: number;
   simulateDropOut?: boolean;
   respectSkipLogicAndFiltering?: boolean;
   /**
    * Index of a stage to treat as in progress rather than complete. For
-   * interaction-driven stages (OrdinalBin, CategoricalBin, Sociogram), a
-   * subset of subject nodes is left without a value for the stage's prompt
-   * variables, so the stage's interaction can still be exercised. Has no
-   * effect on stage types where complete data is preferable (e.g. forms).
+   * interaction-driven stages (OrdinalBin, CategoricalBin, Sociogram), a subset
+   * of subject nodes is left without a value for the stage's prompt variables,
+   * so the stage's interaction can still be exercised. Has no effect on stage
+   * types where complete data is preferable (e.g. forms).
    */
   inProgressStageIndex?: number;
-  externalData?: Record<string, NcNode[]>;
+  /** Overrides for generation tuning constants. See {@link GenerationConfig}. */
+  config?: Partial<GenerationConfig>;
 };
 
 export type GenerateNetworkResult = {
@@ -84,447 +69,71 @@ export type GenerateNetworkResult = {
   droppedOut: boolean;
 };
 
-function toVariableEntry(
-  id: string,
-  variable: VariableDefinition,
-): VariableEntry {
-  return {
-    id,
-    name: variable.name,
-    type: variable.type as VariableEntry['type'],
-    component: variable.component as VariableEntry['component'],
-    options: variable.options?.filter(
-      (o): o is { label: string; value: string | number } =>
-        typeof o.value !== 'boolean',
-    ),
-    validation: variable.validation,
-  };
-}
-
-function generateValue(
-  valueGen: ValueGenerator,
-  entry: VariableEntry,
-  index: number,
-): NcAttributeValue {
-  return valueGen.generateForVariable(entry, index) as NcAttributeValue;
-}
-
-function generateAttributes(
-  variables: Record<string, VariableDefinition> | undefined,
-  valueGen: ValueGenerator,
-  index: number,
-): Record<string, NcAttributeValue> {
-  if (!variables) return {};
-  const attrs: Record<string, NcAttributeValue> = {};
-  for (const [varId, variable] of Object.entries(variables)) {
-    const entry = toVariableEntry(varId, variable);
-    attrs[varId] = generateValue(valueGen, entry, index);
-  }
-  return attrs;
-}
-
-function getStageBehaviours(
-  stage: Stage,
-): { minNodes?: number; maxNodes?: number } | undefined {
-  const stageRecord = stage as Record<string, unknown>;
-  return stageRecord.behaviours as
-    | { minNodes?: number; maxNodes?: number }
-    | undefined;
-}
-
-type AdditionalAttribute = { variable: string; value: boolean };
-
-function getPromptAdditionalAttributes(
-  prompt: Record<string, unknown>,
-): Record<string, boolean> {
-  const additional = prompt.additionalAttributes as
-    | AdditionalAttribute[]
-    | undefined;
-  if (!additional) return {};
-  return additional.reduce(
-    (acc, { variable, value }) => ({ ...acc, [variable]: value }),
-    {} as Record<string, boolean>,
-  );
-}
-
-const ROSTER_DRAW_RATIO = 0.7;
-
-type RosterDraw = {
-  pool: NcNode[] | undefined;
-  used: Set<string>;
-  allowFabrication: boolean;
-};
-
-function createNodesForStage(
-  codebook: Codebook,
-  stage: Stage,
-  prompt: Record<string, unknown>,
-  valueGen: ValueGenerator,
-  existingNodeCount: number,
-  stageNodeCount: number,
-  roster: RosterDraw,
-): NcNode[] {
-  const stageRecord = stage as Record<string, unknown>;
-  const subject = stageRecord.subject as
-    | { entity: string; type: string }
-    | undefined;
-  if (subject?.entity !== 'node') return [];
-
-  const nodeType = subject.type;
-  const nodeTypeDef = codebook.node?.[nodeType];
-  if (!nodeTypeDef) return [];
-
-  const behaviours = getStageBehaviours(stage);
-  const minNodes = behaviours?.minNodes ?? 1;
-  // A configured minNodes above the default max (or above an explicit maxNodes)
-  // must not invert the range, or randomInt(min,max) throws and the preview hangs.
-  const maxNodes = Math.max(behaviours?.maxNodes ?? 8, minNodes);
-  const remaining = maxNodes - stageNodeCount;
-  if (remaining <= 0) return [];
-
-  const hasRoster = (roster.pool?.length ?? 0) > 0;
-
-  const pool = roster.pool
-    ? roster.pool.filter((n) => !roster.used.has(n[entityPrimaryKeyProperty]))
-    : [];
-
-  const requested = Math.min(valueGen.randomInt(minNodes, maxNodes), remaining);
-  const count =
-    hasRoster && !roster.allowFabrication
-      ? Math.min(requested, pool.length)
-      : requested;
-
-  const promptId = (prompt.id as string) ?? uuid();
-  const additionalAttrs = getPromptAdditionalAttributes(prompt);
-  const newNodes: NcNode[] = [];
-  let drawn = 0;
-
-  for (let i = 0; i < count; i++) {
-    const nodeIndex = existingNodeCount + i;
-    const attrs = generateAttributes(
-      nodeTypeDef.variables,
-      valueGen,
-      nodeIndex,
-    );
-
-    const takeFromRoster =
-      drawn < pool.length &&
-      (!roster.allowFabrication ||
-        valueGen.randomFloat(0, 1) < ROSTER_DRAW_RATIO);
-
-    let primaryKey = uuid();
-
-    if (takeFromRoster) {
-      const swapIndex = valueGen.randomInt(drawn, pool.length - 1);
-      const picked = pool[swapIndex]!;
-      pool[swapIndex] = pool[drawn]!;
-      pool[drawn] = picked;
-      drawn += 1;
-
-      primaryKey = picked[entityPrimaryKeyProperty];
-      roster.used.add(primaryKey);
-
-      const rosterValues = picked[entityAttributesProperty];
-      // The roster interface lets the roster value win a collision with a
-      // prompt attribute, while a name generator panel lets the prompt win.
-      if (roster.allowFabrication) {
-        Object.assign(attrs, rosterValues, additionalAttrs);
-      } else {
-        Object.assign(attrs, additionalAttrs, rosterValues);
-      }
-    } else {
-      Object.assign(attrs, additionalAttrs);
-    }
-
-    newNodes.push({
-      [entityPrimaryKeyProperty]: primaryKey,
-      type: nodeType,
-      [entityAttributesProperty]: attrs,
-      stageId: stageRecord.id as string,
-      promptIDs: [promptId],
-    } as NcNode);
-  }
-
-  return newNodes;
-}
-
-function createEdgesForPairs(
-  nodes: NcNode[],
-  edgeType: string,
-  probability: number,
-  valueGen: ValueGenerator,
-  edgeVariables?: Record<string, VariableDefinition>,
-): { edges: NcEdge[]; negativeIndices: [number, number][] } {
-  const edges: NcEdge[] = [];
-  const negativeIndices: [number, number][] = [];
-
-  for (let i = 0; i < nodes.length; i++) {
-    for (let j = i + 1; j < nodes.length; j++) {
-      if (valueGen.randomFloat(0, 1) < probability) {
-        const attrs = edgeVariables
-          ? generateAttributes(edgeVariables, valueGen, edges.length)
-          : {};
-
-        edges.push({
-          [entityPrimaryKeyProperty]: uuid(),
-          type: edgeType,
-          from: nodes[i]![entityPrimaryKeyProperty],
-          to: nodes[j]![entityPrimaryKeyProperty],
-          [entityAttributesProperty]: attrs,
-        } as NcEdge);
-      } else {
-        negativeIndices.push([i, j]);
-      }
-    }
-  }
-
-  return { edges, negativeIndices };
-}
-
-function getNodesOfType(nodes: NcNode[], nodeType: string): NcNode[] {
-  return nodes.filter((n) => n.type === nodeType);
-}
-
-function getEdgesOfType(edges: NcEdge[], edgeType: string): NcEdge[] {
-  return edges.filter((e) => e.type === edgeType);
-}
-
-function getStageSubject(
-  stage: Stage,
-): { entity: string; type: string } | undefined {
-  const stageRecord = stage as Record<string, unknown>;
-  return stageRecord.subject as { entity: string; type: string } | undefined;
-}
-
-function getStagePrompts(stage: Stage): Record<string, unknown>[] {
-  const stageRecord = stage as Record<string, unknown>;
-  const prompts = stageRecord.prompts as Record<string, unknown>[] | undefined;
-  return prompts ?? [];
-}
-
-function getStageType(stage: Stage): string {
-  return (stage as Record<string, unknown>).type as string;
-}
-
-function getStageId(stage: Stage): string {
-  return (stage as Record<string, unknown>).id as string;
-}
-
-function getStageForm(
-  stage: Stage,
-): { fields: { variable: string }[] } | undefined {
-  return (stage as Record<string, unknown>).form as
-    | { fields: { variable: string }[] }
-    | undefined;
-}
-
-function buildCurrentNetwork(
-  egoUid: string,
-  egoAttributes: Record<string, unknown>,
-  nodes: NcNode[],
-  edges: NcEdge[],
-): NcNetwork {
-  return {
-    ego: {
-      [entityPrimaryKeyProperty]: egoUid,
-      [entityAttributesProperty]: egoAttributes,
-    } as NcNetwork['ego'],
-    nodes,
-    edges,
-  };
-}
-
-function getStageFilteredNodes(
-  nodes: NcNode[],
-  edges: NcEdge[],
-  egoUid: string,
-  egoAttributes: Record<string, unknown>,
-  stage: Stage,
-  nodeType: string,
-  respectFiltering: boolean,
-): NcNode[] {
-  if (!respectFiltering) return getNodesOfType(nodes, nodeType);
-
-  const stageRecord = stage as Record<string, unknown>;
-  const stageFilter = stageRecord.filter as Filter | undefined;
-  if (!stageFilter) return getNodesOfType(nodes, nodeType);
-
-  const currentNetwork = buildCurrentNetwork(
-    egoUid,
-    egoAttributes,
-    nodes,
-    edges,
-  );
-  const filtered = getFilter(stageFilter)(currentNetwork);
-  return getNodesOfType(filtered.nodes, nodeType);
-}
-
-function getStageFilteredEdges(
-  nodes: NcNode[],
-  edges: NcEdge[],
-  egoUid: string,
-  egoAttributes: Record<string, unknown>,
-  stage: Stage,
-  edgeType: string,
-  respectFiltering: boolean,
-): NcEdge[] {
-  if (!respectFiltering) return getEdgesOfType(edges, edgeType);
-
-  const stageRecord = stage as Record<string, unknown>;
-  const stageFilter = stageRecord.filter as Filter | undefined;
-  if (!stageFilter) return getEdgesOfType(edges, edgeType);
-
-  const currentNetwork = buildCurrentNetwork(
-    egoUid,
-    egoAttributes,
-    nodes,
-    edges,
-  );
-  const filtered = getFilter(stageFilter)(currentNetwork);
-  return getEdgesOfType(filtered.edges, edgeType);
-}
-
-/**
- * Variables an in-progress stage would not yet have written for unvisited
- * nodes. Clearing these returns a node to the stage's "unplaced" bucket.
- */
-function getInProgressClearableVariables(stage: Stage): string[] {
-  const prompts = getStagePrompts(stage);
-
-  switch (getStageType(stage)) {
-    case 'OrdinalBin':
-      return prompts.flatMap((p) =>
-        typeof p.variable === 'string' ? [p.variable] : [],
-      );
-    case 'CategoricalBin':
-      // A node only counts as uncategorised when both the prompt variable
-      // and any "other" variable are nil.
-      return prompts.flatMap((p) =>
-        [p.variable, p.otherVariable].filter(
-          (v): v is string => typeof v === 'string',
-        ),
-      );
-    case 'Sociogram':
-      return prompts.flatMap((p) => {
-        const layout = p.layout as { layoutVariable?: string } | undefined;
-        return layout?.layoutVariable ? [layout.layoutVariable] : [];
-      });
-    default:
-      return [];
-  }
-}
-
-/**
- * Clears the stage's prompt variables on roughly half of its subject nodes
- * (always at least one) so the stage presents as partially complete: some
- * nodes already placed, others still awaiting interaction.
- */
-function markStageInProgress(
-  stage: Stage,
-  nodes: NcNode[],
-  edges: NcEdge[],
-  egoUid: string,
-  egoAttributes: Record<string, unknown>,
-  valueGen: ValueGenerator,
-  respectFiltering: boolean,
-): void {
-  const variables = getInProgressClearableVariables(stage);
-  if (variables.length === 0) return;
-
-  const subject = getStageSubject(stage);
-  if (subject?.entity !== 'node') return;
-
-  const subjectNodes = getStageFilteredNodes(
-    nodes,
-    edges,
-    egoUid,
-    egoAttributes,
-    stage,
-    subject.type,
-    respectFiltering,
-  );
-  if (subjectNodes.length === 0) return;
-
-  const indices = subjectNodes.map((_, idx) => idx);
-  for (let i = indices.length - 1; i > 0; i--) {
-    const j = valueGen.randomInt(0, i);
-    [indices[i], indices[j]] = [indices[j]!, indices[i]!];
-  }
-
-  const clearCount = Math.max(1, Math.floor(subjectNodes.length / 2));
-  for (const idx of indices.slice(0, clearCount)) {
-    const attrs = subjectNodes[idx]![entityAttributesProperty];
-    for (const varId of variables) {
-      attrs[varId] = null;
-    }
-  }
-}
-
 export function generateNetwork(
-  codebook: Codebook,
-  stages: Stage[],
-  options: GenerateNetworkOptions = {},
+  params: GenerateNetworkParams,
 ): GenerateNetworkResult {
   const {
+    codebook,
+    stages,
+    externalData,
     seed,
     simulateDropOut = false,
     respectSkipLogicAndFiltering = false,
     inProgressStageIndex,
-    externalData,
-  } = options;
+    config,
+  } = params;
 
   const valueGen = new ValueGenerator(
     seed ?? Math.floor(Math.random() * 100000),
   );
-  const nodes: NcNode[] = [];
-  const edges: NcEdge[] = [];
-  const egoAttributes: Record<string, unknown> = {};
-  const stageMetadata: Record<string, unknown> = {};
-  const egoUid = uuid();
-  const usedRosterUids = new Set<string>();
+
+  const ctx: GenerationContext = {
+    codebook,
+    valueGen,
+    config: resolveGenerationConfig(config),
+    usedRosterUids: new Set<string>(),
+    externalData,
+    respectSkipLogicAndFiltering,
+  };
+
+  const draft: NetworkDraft = {
+    egoUid: uuid(),
+    egoAttributes: {},
+    nodes: [],
+    edges: [],
+    stageMetadata: {},
+  };
+
   const totalStages = stages.length;
   let currentStep = 0;
   let droppedOut = false;
 
   for (let i = 0; i < stages.length; i++) {
     const stage = stages[i]!;
-    const stageType = getStageType(stage);
-    const stageId = getStageId(stage);
-    const prompts = getStagePrompts(stage);
+    // Captured before the switch narrows `stage`, so the exhaustive-default
+    // branch can still name an unsupported runtime type.
+    const stageType = stage.type;
 
-    if (respectSkipLogicAndFiltering) {
-      const stageRecord = stage as Record<string, unknown>;
-      const skipLogic = stageRecord.skipLogic as SkipLogic | undefined;
-
-      if (skipLogic) {
-        const currentNetwork = buildCurrentNetwork(
-          egoUid,
-          egoAttributes,
-          nodes,
-          edges,
-        );
-        if (isStageSkipped(skipLogic, currentNetwork)) {
-          const destination = skipLogic.destination;
-
-          if (destination) {
-            const destinationIndex = resolveSkipLogicDestinationIndex(
-              destination,
-              stages,
-              i,
-            );
-
-            if (destinationIndex !== undefined) {
-              i = destinationIndex - 1;
-            }
+    if (respectSkipLogicAndFiltering && stage.skipLogic) {
+      const { skipLogic } = stage;
+      if (isStageSkipped(skipLogic, buildCurrentNetwork(draft))) {
+        const { destination } = skipLogic;
+        if (destination) {
+          const destinationIndex = resolveSkipLogicDestinationIndex(
+            destination,
+            stages,
+            i,
+          );
+          if (destinationIndex !== undefined) {
+            i = destinationIndex - 1;
           }
-
-          continue;
         }
+        continue;
       }
     }
 
     if (simulateDropOut) {
-      const dropOutChance = ((i + 1) / totalStages) * 0.15;
+      const dropOutChance = ((i + 1) / totalStages) * ctx.config.dropOutFactor;
       if (valueGen.randomFloat(0, 1) < dropOutChance) {
         droppedOut = true;
         currentStep = i;
@@ -532,511 +141,53 @@ export function generateNetwork(
       }
     }
 
-    switch (stageType) {
+    switch (stage.type) {
       case 'NameGenerator':
       case 'NameGeneratorQuickAdd':
-      case 'NameGeneratorRoster': {
-        const rosterDraw: RosterDraw = {
-          pool: externalData?.[stageId],
-          used: usedRosterUids,
-          allowFabrication: stageType !== 'NameGeneratorRoster',
-        };
-        let stageNodeCount = 0;
-        for (const prompt of prompts) {
-          const newNodes = createNodesForStage(
-            codebook,
-            stage,
-            prompt,
-            valueGen,
-            nodes.length,
-            stageNodeCount,
-            rosterDraw,
-          );
-          stageNodeCount += newNodes.length;
-
-          const form = getStageForm(stage);
-          if (form) {
-            const subject = getStageSubject(stage);
-            if (subject?.entity === 'node') {
-              const nodeTypeDef = codebook.node?.[subject.type];
-              if (nodeTypeDef?.variables) {
-                const formVarIds = new Set(form.fields.map((f) => f.variable));
-                for (const node of newNodes) {
-                  const attrs = node[entityAttributesProperty];
-                  for (const varId of formVarIds) {
-                    const varDef = nodeTypeDef.variables[varId];
-                    if (varDef && !(varId in attrs)) {
-                      const entry = toVariableEntry(varId, varDef);
-                      attrs[varId] = generateValue(
-                        valueGen,
-                        entry,
-                        nodes.length,
-                      );
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          nodes.push(...newNodes);
-        }
+      case 'NameGeneratorRoster':
+        handleNameGenerators(ctx, draft, stage);
         break;
-      }
-
-      case 'Sociogram': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-
-        for (const prompt of prompts) {
-          const promptEdges = prompt.edges as
-            | { create?: string; display?: string[] }
-            | undefined;
-          if (promptEdges?.create) {
-            const { edges: newEdges } = createEdgesForPairs(
-              subjectNodes,
-              promptEdges.create,
-              valueGen.randomFloat(0.3, 0.5),
-              valueGen,
-              codebook.edge?.[promptEdges.create]?.variables,
-            );
-            edges.push(...newEdges);
-          }
-
-          const layout = prompt.layout as
-            | { layoutVariable?: string }
-            | undefined;
-          if (layout?.layoutVariable) {
-            for (const node of subjectNodes) {
-              node[entityAttributesProperty][layout.layoutVariable] = {
-                x: valueGen.randomFloat(0.1, 0.9),
-                y: valueGen.randomFloat(0.1, 0.9),
-              };
-            }
-          }
-        }
+      case 'Sociogram':
+        handleSociogram(ctx, draft, stage);
         break;
-      }
-
       case 'DyadCensus':
-      case 'OneToManyDyadCensus': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-
-        const negativeResponses: DyadCensusMetadataItem[] = [];
-        for (let promptIndex = 0; promptIndex < prompts.length; promptIndex++) {
-          const prompt = prompts[promptIndex]!;
-          const createEdgeType = prompt.createEdge as string | undefined;
-          if (!createEdgeType) continue;
-
-          const probability = valueGen.randomFloat(0.4, 0.6);
-          const { edges: newEdges, negativeIndices } = createEdgesForPairs(
-            subjectNodes,
-            createEdgeType,
-            probability,
-            valueGen,
-            codebook.edge?.[createEdgeType]?.variables,
-          );
-          edges.push(...newEdges);
-
-          for (const [a, b] of negativeIndices) {
-            negativeResponses.push([
-              promptIndex,
-              subjectNodes[a]![entityPrimaryKeyProperty],
-              subjectNodes[b]![entityPrimaryKeyProperty],
-              false,
-            ]);
-          }
-        }
-
-        if (negativeResponses.length > 0) {
-          stageMetadata[i] = negativeResponses;
-        }
+      case 'OneToManyDyadCensus':
+        handleDyadCensus(ctx, draft, stage, i);
         break;
-      }
-
-      case 'TieStrengthCensus': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-
-        const negativeResponses: DyadCensusMetadataItem[] = [];
-        for (let promptIndex = 0; promptIndex < prompts.length; promptIndex++) {
-          const prompt = prompts[promptIndex]!;
-          const createEdgeType = prompt.createEdge as string | undefined;
-          const edgeVariable = prompt.edgeVariable as string | undefined;
-          if (!createEdgeType) continue;
-
-          const probability = valueGen.randomFloat(0.4, 0.6);
-          const edgeTypeDef = codebook.edge?.[createEdgeType];
-          const { edges: newEdges, negativeIndices } = createEdgesForPairs(
-            subjectNodes,
-            createEdgeType,
-            probability,
-            valueGen,
-            edgeTypeDef?.variables,
-          );
-
-          if (edgeVariable && edgeTypeDef?.variables?.[edgeVariable]) {
-            const varDef = edgeTypeDef.variables[edgeVariable];
-            for (let edgeIdx = 0; edgeIdx < newEdges.length; edgeIdx++) {
-              const entry = toVariableEntry(edgeVariable, varDef);
-              newEdges[edgeIdx]![entityAttributesProperty][edgeVariable] =
-                generateValue(valueGen, entry, edgeIdx);
-            }
-          }
-
-          edges.push(...newEdges);
-
-          for (const [a, b] of negativeIndices) {
-            negativeResponses.push([
-              promptIndex,
-              subjectNodes[a]![entityPrimaryKeyProperty],
-              subjectNodes[b]![entityPrimaryKeyProperty],
-              false,
-            ]);
-          }
-        }
-
-        if (negativeResponses.length > 0) {
-          stageMetadata[i] = negativeResponses;
-        }
+      case 'TieStrengthCensus':
+        handleTieStrengthCensus(ctx, draft, stage, i);
         break;
-      }
-
-      case 'OrdinalBin': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-        const nodeTypeDef = codebook.node?.[subject.type];
-
-        for (const prompt of prompts) {
-          const varId = prompt.variable as string | undefined;
-          if (!varId || !nodeTypeDef?.variables?.[varId]) continue;
-
-          const varDef = nodeTypeDef.variables[varId];
-          const variableOptions = varDef.options ?? [];
-          if (variableOptions.length === 0) continue;
-
-          for (const node of subjectNodes) {
-            const optionIndex = valueGen.randomInt(
-              0,
-              variableOptions.length - 1,
-            );
-            node[entityAttributesProperty][varId] =
-              variableOptions[optionIndex]!.value;
-          }
-        }
+      case 'OrdinalBin':
+        handleOrdinalBin(ctx, draft, stage);
         break;
-      }
-
-      case 'CategoricalBin': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-        const nodeTypeDef = codebook.node?.[subject.type];
-
-        for (const prompt of prompts) {
-          const varId = prompt.variable as string | undefined;
-          if (!varId || !nodeTypeDef?.variables?.[varId]) continue;
-
-          const varDef = nodeTypeDef.variables[varId];
-          const variableOptions =
-            varDef.options?.filter((o) => typeof o.value !== 'boolean') ?? [];
-          if (variableOptions.length === 0) continue;
-
-          for (const node of subjectNodes) {
-            const count = valueGen.randomInt(
-              1,
-              Math.min(2, variableOptions.length),
-            );
-            const picked: (number | string | boolean)[] = [];
-            const startIdx = valueGen.randomInt(0, variableOptions.length - 1);
-            for (let c = 0; c < count; c++) {
-              picked.push(
-                variableOptions[(startIdx + c) % variableOptions.length]!.value,
-              );
-            }
-            node[entityAttributesProperty][varId] = picked;
-          }
-        }
+      case 'CategoricalBin':
+        handleCategoricalBin(ctx, draft, stage);
         break;
-      }
-
-      case 'EgoForm': {
-        const egoVars = codebook.ego?.variables;
-        if (egoVars) {
-          const attrs = generateAttributes(egoVars, valueGen, 0);
-          Object.assign(egoAttributes, attrs);
-        }
+      case 'EgoForm':
+        handleEgoForm(ctx, draft);
         break;
-      }
-
-      case 'AlterForm': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-        const form = getStageForm(stage);
-        if (!form) break;
-
-        const nodeTypeDef = codebook.node?.[subject.type];
-        if (!nodeTypeDef?.variables) break;
-
-        const formVarIds = form.fields.map((f) => f.variable);
-
-        for (let nodeIndex = 0; nodeIndex < subjectNodes.length; nodeIndex++) {
-          const node = subjectNodes[nodeIndex]!;
-          for (const varId of formVarIds) {
-            const varDef = nodeTypeDef.variables[varId];
-            if (varDef) {
-              const entry = toVariableEntry(varId, varDef);
-              node[entityAttributesProperty][varId] = generateValue(
-                valueGen,
-                entry,
-                nodeIndex,
-              );
-            }
-          }
-        }
+      case 'AlterForm':
+        handleAlterForm(ctx, draft, stage);
         break;
-      }
-
-      case 'AlterEdgeForm': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'edge') break;
-
-        const subjectEdges = getStageFilteredEdges(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-        const form = getStageForm(stage);
-        if (!form) break;
-
-        const edgeTypeDef = codebook.edge?.[subject.type];
-        if (!edgeTypeDef?.variables) break;
-
-        const formVarIds = form.fields.map((f) => f.variable);
-
-        for (let edgeIndex = 0; edgeIndex < subjectEdges.length; edgeIndex++) {
-          const edge = subjectEdges[edgeIndex]!;
-          for (const varId of formVarIds) {
-            const varDef = edgeTypeDef.variables[varId];
-            if (varDef) {
-              const entry = toVariableEntry(varId, varDef);
-              edge[entityAttributesProperty][varId] = generateValue(
-                valueGen,
-                entry,
-                edgeIndex,
-              );
-            }
-          }
-        }
+      case 'AlterEdgeForm':
+        handleAlterEdgeForm(ctx, draft, stage);
         break;
-      }
-
-      case 'FamilyPedigree': {
-        const stageRecord = stage as Record<string, unknown>;
-        const nodeCount = valueGen.randomInt(4, 10);
-
-        const nodeConfig = stageRecord.nodeConfig as
-          | { type: string }
-          | undefined;
-        const nodeType = nodeConfig?.type;
-        const nodeTypeDef = nodeType ? codebook.node?.[nodeType] : undefined;
-
-        const edgeConfig = stageRecord.edgeConfig as
-          | { type: string }
-          | undefined;
-        const edgeType = edgeConfig?.type;
-
-        if (!nodeType) break;
-
-        const familyNodes: NcNode[] = [];
-        for (let nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
-          const attrs = generateAttributes(
-            nodeTypeDef?.variables,
-            valueGen,
-            nodes.length + nodeIndex,
-          );
-
-          const nodeIsEgoVar = stageRecord.nodeIsEgoVariable as
-            | string
-            | undefined;
-          if (nodeIsEgoVar && nodeIndex === 0) {
-            attrs[nodeIsEgoVar] = true;
-          }
-
-          familyNodes.push({
-            [entityPrimaryKeyProperty]: uuid(),
-            type: nodeType,
-            [entityAttributesProperty]: attrs,
-            stageId,
-          } as NcNode);
-        }
-
-        nodes.push(...familyNodes);
-
-        if (edgeType && familyNodes.length > 1) {
-          for (
-            let childIndex = 1;
-            childIndex < familyNodes.length;
-            childIndex++
-          ) {
-            const parentIdx = valueGen.randomInt(
-              0,
-              Math.min(childIndex - 1, familyNodes.length - 1),
-            );
-            edges.push({
-              [entityPrimaryKeyProperty]: uuid(),
-              type: edgeType,
-              from: familyNodes[parentIdx]![entityPrimaryKeyProperty],
-              to: familyNodes[childIndex]![entityPrimaryKeyProperty],
-              [entityAttributesProperty]: {},
-            } as NcEdge);
-          }
-        }
-
-        stageMetadata[i] = { isNetworkCommitted: true };
+      case 'FamilyPedigree':
+        handleFamilyPedigree(ctx, draft, stage, i);
         break;
-      }
-
-      case 'Geospatial': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        const subjectNodes = getStageFilteredNodes(
-          nodes,
-          edges,
-          egoUid,
-          egoAttributes,
-          stage,
-          subject.type,
-          respectSkipLogicAndFiltering,
-        );
-
-        for (const prompt of prompts) {
-          const varId = prompt.variable as string | undefined;
-          if (!varId) continue;
-
-          for (const node of subjectNodes) {
-            node[entityAttributesProperty][varId] = {
-              x: valueGen.randomFloat(-180, 180),
-              y: valueGen.randomFloat(-90, 90),
-            };
-          }
-        }
+      case 'Geospatial':
+        handleGeospatial(ctx, draft, stage);
         break;
-      }
-
-      case 'NetworkComposer': {
-        const subject = getStageSubject(stage);
-        if (subject?.entity !== 'node') break;
-
-        // Network Composer builds the network from scratch: create nodes of the
-        // subject type (populating their codebook attributes — quickAdd, layout,
-        // and node-form variables) and draw edges of each configured edge type
-        // among them. It is promptless, so a synthetic prompt id seeds creation.
-        const newNodes = createNodesForStage(
-          codebook,
-          stage,
-          { id: stageId },
-          valueGen,
-          nodes.length,
-          0,
-          { pool: undefined, used: usedRosterUids, allowFabrication: true },
-        );
-        nodes.push(...newNodes);
-
-        const composerEdges = (stage as Record<string, unknown>).edges as
-          | { subject?: { type?: string } }[]
-          | undefined;
-        for (const edgeDef of composerEdges ?? []) {
-          const edgeType = edgeDef.subject?.type;
-          if (!edgeType) continue;
-          const { edges: newEdges } = createEdgesForPairs(
-            newNodes,
-            edgeType,
-            // Network Composer is a from-scratch builder rendered across several
-            // edge types at once; a per-pair 30-50% probability produced a
-            // near-complete graph in the preview. Keep it sparse and readable.
-            valueGen.randomFloat(0.05, 0.1),
-            valueGen,
-            codebook.edge?.[edgeType]?.variables,
-          );
-          edges.push(...newEdges);
-        }
+      case 'NetworkComposer':
+        handleNetworkComposer(ctx, draft, stage);
         break;
-      }
-
       case 'Information':
       case 'Anonymisation':
       case 'Narrative':
       case 'NarrativePedigree':
-        // NarrativePedigree is read-only and never adds nodes or edges —
-        // it reads the shared network written by its source FamilyPedigree stage.
+        // Read-only / content stages add no nodes or edges. NarrativePedigree
+        // reads the shared network written by its source FamilyPedigree stage.
         break;
-
       default:
         throw new Error(
           `Unsupported stage type "${stageType}". ` +
@@ -1045,23 +196,15 @@ export function generateNetwork(
     }
   }
 
-  // Applied as a post-pass: node creation populates every codebook variable,
-  // and later stages may rewrite the same variable, so values must be cleared
-  // after all stages have run.
+  // Applied as a post-pass: node creation populates every codebook variable, and
+  // later stages may rewrite the same variable, so values must be cleared after
+  // all stages have run.
   const inProgressStage =
     inProgressStageIndex !== undefined
       ? stages[inProgressStageIndex]
       : undefined;
   if (inProgressStage) {
-    markStageInProgress(
-      inProgressStage,
-      nodes,
-      edges,
-      egoUid,
-      egoAttributes,
-      valueGen,
-      respectSkipLogicAndFiltering,
-    );
+    markStageInProgress(ctx, draft, inProgressStage);
   }
 
   if (!droppedOut) {
@@ -1069,15 +212,9 @@ export function generateNetwork(
   }
 
   return {
-    network: {
-      ego: {
-        [entityPrimaryKeyProperty]: egoUid,
-        [entityAttributesProperty]: egoAttributes,
-      } as NcNetwork['ego'],
-      nodes,
-      edges,
-    },
-    stageMetadata: Object.keys(stageMetadata).length > 0 ? stageMetadata : null,
+    network: buildCurrentNetwork(draft),
+    stageMetadata:
+      Object.keys(draft.stageMetadata).length > 0 ? draft.stageMetadata : null,
     currentStep,
     droppedOut,
   };

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -223,10 +223,18 @@ function createNodesForStage(
 
       primaryKey = picked[entityPrimaryKeyProperty];
       roster.used.add(primaryKey);
-      Object.assign(attrs, picked[entityAttributesProperty]);
-    }
 
-    Object.assign(attrs, additionalAttrs);
+      const rosterValues = picked[entityAttributesProperty];
+      // The roster interface lets the roster value win a collision with a
+      // prompt attribute, while a name generator panel lets the prompt win.
+      if (roster.allowFabrication) {
+        Object.assign(attrs, rosterValues, additionalAttrs);
+      } else {
+        Object.assign(attrs, additionalAttrs, rosterValues);
+      }
+    } else {
+      Object.assign(attrs, additionalAttrs);
+    }
 
     newNodes.push({
       [entityPrimaryKeyProperty]: primaryKey,

--- a/packages/protocol-utilities/src/generateNetwork/attributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/attributes.ts
@@ -1,0 +1,38 @@
+import type { Variable, Variables } from '@codaco/protocol-validation';
+import type { VariableValue } from '@codaco/shared-consts';
+
+import type { VariableEntry } from '../types';
+import type { ValueGenerator } from '../ValueGenerator';
+
+export function toVariableEntry(id: string, variable: Variable): VariableEntry {
+  const options =
+    'options' in variable
+      ? variable.options?.filter(
+          (o): o is { label: string; value: string | number } =>
+            typeof o.value !== 'boolean',
+        )
+      : undefined;
+
+  return {
+    id,
+    name: variable.name,
+    type: variable.type,
+    component: 'component' in variable ? variable.component : undefined,
+    options,
+    validation: 'validation' in variable ? variable.validation : undefined,
+  };
+}
+
+export function generateAttributes(
+  variables: Variables | undefined,
+  valueGen: ValueGenerator,
+  index: number,
+): Record<string, VariableValue> {
+  if (!variables) return {};
+  const attrs: Record<string, VariableValue> = {};
+  for (const [varId, variable] of Object.entries(variables)) {
+    const entry = toVariableEntry(varId, variable);
+    attrs[varId] = valueGen.generateForVariable(entry, index);
+  }
+  return attrs;
+}

--- a/packages/protocol-utilities/src/generateNetwork/config.ts
+++ b/packages/protocol-utilities/src/generateNetwork/config.ts
@@ -1,0 +1,60 @@
+/**
+ * A closed `[min, max]` numeric range a random draw is sampled from.
+ */
+type Range = { min: number; max: number };
+
+/**
+ * Tuning constants for synthetic network generation. Every value is an
+ * assumption about how much data a stage should fabricate; exposing them as
+ * config (resolved over {@link DEFAULT_GENERATION_CONFIG}) keeps them visible
+ * and overridable instead of buried as literals. Callers pass a `Partial` of
+ * this and the defaults fill the rest.
+ */
+export type GenerationConfig = {
+  /**
+   * Probability that a node on a mixed name-generator stage (one that can both
+   * draw from a roster and fabricate) is drawn from the roster rather than
+   * fabricated, while roster rows remain.
+   */
+  rosterDrawRatio: number;
+  /** Node-count window used when a name-generator stage omits `behaviours`. */
+  nodeCount: Range;
+  /**
+   * Scales the per-stage drop-out probability, which grows across the protocol
+   * as `((stageIndex + 1) / stageCount) * dropOutFactor`.
+   */
+  dropOutFactor: number;
+  /** Per-pair edge probability for Sociogram prompts. */
+  sociogramEdgeProbability: Range;
+  /** {x, y} position range for Sociogram layout variables (unit-square inset). */
+  sociogramLayoutRange: Range;
+  /** Per-pair edge probability for DyadCensus and TieStrengthCensus prompts. */
+  censusEdgeProbability: Range;
+  /** Per-pair edge probability for NetworkComposer edge types. */
+  networkComposerEdgeProbability: Range;
+  /** Node-count range for a FamilyPedigree stage. */
+  familyPedigreeNodeCount: Range;
+  /**
+   * Fraction of an in-progress stage's subject nodes left unplaced (always at
+   * least one node), so the stage presents as partially complete.
+   */
+  inProgressClearRatio: number;
+};
+
+const DEFAULT_GENERATION_CONFIG: GenerationConfig = {
+  rosterDrawRatio: 0.7,
+  nodeCount: { min: 1, max: 8 },
+  dropOutFactor: 0.15,
+  sociogramEdgeProbability: { min: 0.3, max: 0.5 },
+  sociogramLayoutRange: { min: 0.1, max: 0.9 },
+  censusEdgeProbability: { min: 0.4, max: 0.6 },
+  networkComposerEdgeProbability: { min: 0.05, max: 0.1 },
+  familyPedigreeNodeCount: { min: 4, max: 10 },
+  inProgressClearRatio: 0.5,
+};
+
+export function resolveGenerationConfig(
+  overrides?: Partial<GenerationConfig>,
+): GenerationConfig {
+  return { ...DEFAULT_GENERATION_CONFIG, ...overrides };
+}

--- a/packages/protocol-utilities/src/generateNetwork/context.ts
+++ b/packages/protocol-utilities/src/generateNetwork/context.ts
@@ -1,0 +1,39 @@
+import type { Stage, StructuralCodebook } from '@codaco/protocol-validation';
+import type { NcEdge, NcNode, VariableValue } from '@codaco/shared-consts';
+
+import type { ValueGenerator } from '../ValueGenerator';
+import type { GenerationConfig } from './config';
+
+/**
+ * The concrete member of the {@link Stage} discriminated union for a given
+ * `type` literal (or union of literals), for typing per-stage handlers.
+ */
+export type StageOfType<T extends Stage['type']> = Extract<Stage, { type: T }>;
+
+/**
+ * Read-mostly inputs threaded through every generation helper, so utility
+ * functions read the resolved config and shared roster state without long
+ * positional parameter lists.
+ */
+export type GenerationContext = {
+  codebook: StructuralCodebook;
+  valueGen: ValueGenerator;
+  config: GenerationConfig;
+  /** Roster rows already drawn into the network, shared across stages. */
+  usedRosterUids: Set<string>;
+  /** Pre-parsed roster rows keyed by stage id (see `generateNetwork`). */
+  externalData: Record<string, NcNode[]> | undefined;
+  respectSkipLogicAndFiltering: boolean;
+};
+
+/**
+ * The network accumulated as stages run. Handlers mutate it in place.
+ */
+export type NetworkDraft = {
+  egoUid: string;
+  egoAttributes: Record<string, VariableValue>;
+  nodes: NcNode[];
+  edges: NcEdge[];
+  /** Stage metadata keyed by stage index. */
+  stageMetadata: Record<string, unknown>;
+};

--- a/packages/protocol-utilities/src/generateNetwork/edges.ts
+++ b/packages/protocol-utilities/src/generateNetwork/edges.ts
@@ -1,0 +1,59 @@
+import { v4 as uuid } from 'uuid';
+
+import type { Variables } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcEdge,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import { generateAttributes } from './attributes';
+import type { GenerationContext } from './context';
+
+export function getNodesOfType(nodes: NcNode[], nodeType: string): NcNode[] {
+  return nodes.filter((n) => n.type === nodeType);
+}
+
+export function getEdgesOfType(edges: NcEdge[], edgeType: string): NcEdge[] {
+  return edges.filter((e) => e.type === edgeType);
+}
+
+/**
+ * Considers every unordered pair of nodes, creating an edge of `edgeType` with
+ * the given per-pair `probability`. Pairs left unconnected are returned as
+ * `negativeIndices` so census stages can record explicit "no" responses.
+ */
+export function createEdgesForPairs(
+  ctx: GenerationContext,
+  nodes: NcNode[],
+  edgeType: string,
+  probability: number,
+  edgeVariables?: Variables,
+): { edges: NcEdge[]; negativeIndices: [number, number][] } {
+  const edges: NcEdge[] = [];
+  const negativeIndices: [number, number][] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      if (ctx.valueGen.randomFloat(0, 1) < probability) {
+        const attrs = edgeVariables
+          ? generateAttributes(edgeVariables, ctx.valueGen, edges.length)
+          : {};
+
+        const edge: NcEdge = {
+          [entityPrimaryKeyProperty]: uuid(),
+          type: edgeType,
+          from: nodes[i]![entityPrimaryKeyProperty],
+          to: nodes[j]![entityPrimaryKeyProperty],
+          [entityAttributesProperty]: attrs,
+        };
+        edges.push(edge);
+      } else {
+        negativeIndices.push([i, j]);
+      }
+    }
+  }
+
+  return { edges, negativeIndices };
+}

--- a/packages/protocol-utilities/src/generateNetwork/filtering.ts
+++ b/packages/protocol-utilities/src/generateNetwork/filtering.ts
@@ -1,0 +1,61 @@
+import { filter as getFilter } from '@codaco/network-query';
+import type { Filter, Stage } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcEdge,
+  type NcNetwork,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import type { GenerationContext, NetworkDraft } from './context';
+import { getEdgesOfType, getNodesOfType } from './edges';
+
+export function buildCurrentNetwork(draft: NetworkDraft): NcNetwork {
+  return {
+    ego: {
+      [entityPrimaryKeyProperty]: draft.egoUid,
+      [entityAttributesProperty]: draft.egoAttributes,
+    },
+    nodes: draft.nodes,
+    edges: draft.edges,
+  };
+}
+
+function getStageFilter(stage: Stage): Filter | undefined {
+  return 'filter' in stage ? stage.filter : undefined;
+}
+
+export function getStageFilteredNodes(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: Stage,
+  nodeType: string,
+): NcNode[] {
+  if (!ctx.respectSkipLogicAndFiltering) {
+    return getNodesOfType(draft.nodes, nodeType);
+  }
+
+  const stageFilter = getStageFilter(stage);
+  if (!stageFilter) return getNodesOfType(draft.nodes, nodeType);
+
+  const filtered = getFilter(stageFilter)(buildCurrentNetwork(draft));
+  return getNodesOfType(filtered.nodes, nodeType);
+}
+
+export function getStageFilteredEdges(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: Stage,
+  edgeType: string,
+): NcEdge[] {
+  if (!ctx.respectSkipLogicAndFiltering) {
+    return getEdgesOfType(draft.edges, edgeType);
+  }
+
+  const stageFilter = getStageFilter(stage);
+  if (!stageFilter) return getEdgesOfType(draft.edges, edgeType);
+
+  const filtered = getFilter(stageFilter)(buildCurrentNetwork(draft));
+  return getEdgesOfType(filtered.edges, edgeType);
+}

--- a/packages/protocol-utilities/src/generateNetwork/inProgress.ts
+++ b/packages/protocol-utilities/src/generateNetwork/inProgress.ts
@@ -3,6 +3,7 @@ import { entityAttributesProperty } from '@codaco/shared-consts';
 
 import type { GenerationContext, NetworkDraft } from './context';
 import { getStageFilteredNodes } from './filtering';
+import { getSubjectType } from './subject';
 
 /** Keep only string entries, dropping the `undefined` a half-built prompt yields. */
 function onlyStrings(values: (string | undefined)[]): string[] {
@@ -47,10 +48,9 @@ function getInProgressClearableVariables(stage: Stage): string[] {
 }
 
 function getNodeSubjectType(stage: Stage): string | undefined {
-  if (!('subject' in stage) || stage.subject.entity !== 'node') {
-    return undefined;
-  }
-  return stage.subject.type;
+  if (!('subject' in stage)) return undefined;
+  const subject: { entity?: string; type?: string } | undefined = stage.subject;
+  return getSubjectType(subject, 'node');
 }
 
 /**

--- a/packages/protocol-utilities/src/generateNetwork/inProgress.ts
+++ b/packages/protocol-utilities/src/generateNetwork/inProgress.ts
@@ -4,23 +4,44 @@ import { entityAttributesProperty } from '@codaco/shared-consts';
 import type { GenerationContext, NetworkDraft } from './context';
 import { getStageFilteredNodes } from './filtering';
 
+/** Keep only string entries, dropping the `undefined` a half-built prompt yields. */
+function onlyStrings(values: (string | undefined)[]): string[] {
+  return values.filter((value): value is string => typeof value === 'string');
+}
+
 /**
  * Variables an in-progress stage would not yet have written for unvisited
  * nodes. Clearing these returns a node to the stage's "unplaced" bucket.
+ *
+ * markStageInProgress runs on the in-progress stage — in Architect previews the
+ * stage being edited, so its prompts can be half-built (missing `variable` or
+ * `layout`) even though the schema types mark those fields required. Each field
+ * is re-derived at runtime and non-strings are filtered out, so no `undefined`
+ * key ever reaches the attribute object.
  */
 function getInProgressClearableVariables(stage: Stage): string[] {
   if (stage.type === 'OrdinalBin') {
-    return stage.prompts.map((p) => p.variable);
+    return onlyStrings(
+      (stage.prompts ?? []).map((p): string | undefined => p.variable),
+    );
   }
   if (stage.type === 'CategoricalBin') {
     // A node only counts as uncategorised when both the prompt variable and any
     // "other" variable are nil, so both are cleared together.
-    return stage.prompts.flatMap((p) =>
-      p.otherVariable ? [p.variable, p.otherVariable] : [p.variable],
+    return onlyStrings(
+      (stage.prompts ?? []).flatMap((p): (string | undefined)[] => [
+        p.variable,
+        p.otherVariable,
+      ]),
     );
   }
   if (stage.type === 'Sociogram') {
-    return stage.prompts.map((p) => p.layout.layoutVariable);
+    return onlyStrings(
+      (stage.prompts ?? []).map((p): string | undefined => {
+        const layout: { layoutVariable?: string } | undefined = p.layout;
+        return layout?.layoutVariable;
+      }),
+    );
   }
   return [];
 }

--- a/packages/protocol-utilities/src/generateNetwork/inProgress.ts
+++ b/packages/protocol-utilities/src/generateNetwork/inProgress.ts
@@ -1,0 +1,70 @@
+import type { Stage } from '@codaco/protocol-validation';
+import { entityAttributesProperty } from '@codaco/shared-consts';
+
+import type { GenerationContext, NetworkDraft } from './context';
+import { getStageFilteredNodes } from './filtering';
+
+/**
+ * Variables an in-progress stage would not yet have written for unvisited
+ * nodes. Clearing these returns a node to the stage's "unplaced" bucket.
+ */
+function getInProgressClearableVariables(stage: Stage): string[] {
+  if (stage.type === 'OrdinalBin') {
+    return stage.prompts.map((p) => p.variable);
+  }
+  if (stage.type === 'CategoricalBin') {
+    // A node only counts as uncategorised when both the prompt variable and any
+    // "other" variable are nil, so both are cleared together.
+    return stage.prompts.flatMap((p) =>
+      p.otherVariable ? [p.variable, p.otherVariable] : [p.variable],
+    );
+  }
+  if (stage.type === 'Sociogram') {
+    return stage.prompts.map((p) => p.layout.layoutVariable);
+  }
+  return [];
+}
+
+function getNodeSubjectType(stage: Stage): string | undefined {
+  if (!('subject' in stage) || stage.subject.entity !== 'node') {
+    return undefined;
+  }
+  return stage.subject.type;
+}
+
+/**
+ * Clears the stage's prompt variables on a fraction of its subject nodes
+ * (always at least one) so the stage presents as partially complete: some
+ * nodes already placed, others still awaiting interaction.
+ */
+export function markStageInProgress(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: Stage,
+): void {
+  const variables = getInProgressClearableVariables(stage);
+  if (variables.length === 0) return;
+
+  const nodeType = getNodeSubjectType(stage);
+  if (nodeType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, nodeType);
+  if (subjectNodes.length === 0) return;
+
+  const indices = subjectNodes.map((_, idx) => idx);
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = ctx.valueGen.randomInt(0, i);
+    [indices[i], indices[j]] = [indices[j]!, indices[i]!];
+  }
+
+  const clearCount = Math.max(
+    1,
+    Math.floor(subjectNodes.length * ctx.config.inProgressClearRatio),
+  );
+  for (const idx of indices.slice(0, clearCount)) {
+    const attrs = subjectNodes[idx]![entityAttributesProperty];
+    for (const varId of variables) {
+      attrs[varId] = null;
+    }
+  }
+}

--- a/packages/protocol-utilities/src/generateNetwork/nodes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/nodes.ts
@@ -10,6 +10,7 @@ import {
 import { generateAttributes } from './attributes';
 import type { GenerationConfig } from './config';
 import type { GenerationContext, StageOfType } from './context';
+import { getSubjectType } from './subject';
 
 /**
  * Node-subject stages that fabricate nodes: the three name-generator variants
@@ -86,7 +87,9 @@ export function createNodesForStage(
   stageNodeCount: number,
   roster: RosterDraw,
 ): NcNode[] {
-  const nodeType = stage.subject.type;
+  const nodeType = getSubjectType(stage.subject, 'node');
+  if (nodeType === undefined) return [];
+
   const nodeTypeDef = ctx.codebook.node?.[nodeType];
   if (!nodeTypeDef) return [];
 

--- a/packages/protocol-utilities/src/generateNetwork/nodes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/nodes.ts
@@ -1,0 +1,170 @@
+import { v4 as uuid } from 'uuid';
+
+import type { AdditionalAttributes } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import { generateAttributes } from './attributes';
+import type { GenerationConfig } from './config';
+import type { GenerationContext, StageOfType } from './context';
+
+/**
+ * Node-subject stages that fabricate nodes: the three name-generator variants
+ * and NetworkComposer (a from-scratch builder).
+ */
+type NodeCreationStage = StageOfType<
+  | 'NameGenerator'
+  | 'NameGeneratorQuickAdd'
+  | 'NameGeneratorRoster'
+  | 'NetworkComposer'
+>;
+
+/**
+ * Minimal prompt shape node creation needs: an id (for `promptIDs`) and any
+ * additional attributes to stamp onto created nodes. NetworkComposer, which is
+ * promptless, passes a synthetic `{ id }`.
+ */
+type NodeDrawPrompt = {
+  id?: string;
+  additionalAttributes?: AdditionalAttributes;
+};
+
+/**
+ * Roster state for a name-generator stage.
+ *
+ * `pool` is the stage's unfiltered roster rows; the drawable rows are those in
+ * `pool` not already in `used`. That distinction is load-bearing: "has a
+ * roster" is decided from the unfiltered `pool`, so a `NameGeneratorRoster`
+ * stage whose roster is exhausted by an earlier stage produces zero nodes
+ * (roster present but nothing drawable), while a stage with no roster at all
+ * fabricates. See `createNodesForStage`.
+ */
+export type RosterDraw = {
+  pool?: NcNode[];
+  /** Roster rows already drawn, shared across all prompts and stages. */
+  used: Set<string>;
+  /** Whether the stage may fabricate nodes beyond the roster. */
+  allowFabrication: boolean;
+};
+
+function getPromptAdditionalAttributes(
+  additional: AdditionalAttributes | undefined,
+): Record<string, boolean> {
+  if (!additional) return {};
+  return additional.reduce<Record<string, boolean>>(
+    (acc, { variable, value }) => ({ ...acc, [variable]: value }),
+    {},
+  );
+}
+
+function getNodeCountBounds(
+  stage: NodeCreationStage,
+  config: GenerationConfig,
+): { minNodes: number; maxNodes: number } {
+  const behaviours = 'behaviours' in stage ? stage.behaviours : undefined;
+  const minNodes =
+    behaviours && 'minNodes' in behaviours && behaviours.minNodes !== undefined
+      ? behaviours.minNodes
+      : config.nodeCount.min;
+  const maxNodes =
+    behaviours && 'maxNodes' in behaviours && behaviours.maxNodes !== undefined
+      ? behaviours.maxNodes
+      : config.nodeCount.max;
+  // A configured minNodes above the max (or above an explicit maxNodes) must not
+  // invert the range, or randomInt(min, max) throws and the preview hangs.
+  return { minNodes, maxNodes: Math.max(maxNodes, minNodes) };
+}
+
+export function createNodesForStage(
+  ctx: GenerationContext,
+  stage: NodeCreationStage,
+  prompt: NodeDrawPrompt,
+  existingNodeCount: number,
+  stageNodeCount: number,
+  roster: RosterDraw,
+): NcNode[] {
+  const nodeType = stage.subject.type;
+  const nodeTypeDef = ctx.codebook.node?.[nodeType];
+  if (!nodeTypeDef) return [];
+
+  const { minNodes, maxNodes } = getNodeCountBounds(stage, ctx.config);
+  const remaining = maxNodes - stageNodeCount;
+  if (remaining <= 0) return [];
+
+  // "Has a roster" is read from the UNFILTERED pool; the drawable pool excludes
+  // rows already used. This is what distinguishes "no roster data → fabricate"
+  // from "roster exhausted → produce zero nodes" on NameGeneratorRoster stages.
+  const hasRoster = (roster.pool?.length ?? 0) > 0;
+
+  const pool = roster.pool
+    ? roster.pool.filter((n) => !roster.used.has(n[entityPrimaryKeyProperty]))
+    : [];
+
+  const requested = Math.min(
+    ctx.valueGen.randomInt(minNodes, maxNodes),
+    remaining,
+  );
+  const count =
+    hasRoster && !roster.allowFabrication
+      ? Math.min(requested, pool.length)
+      : requested;
+
+  const promptId = prompt.id ?? uuid();
+  const additionalAttrs = getPromptAdditionalAttributes(
+    prompt.additionalAttributes,
+  );
+  const newNodes: NcNode[] = [];
+  let drawn = 0;
+
+  for (let i = 0; i < count; i++) {
+    const nodeIndex = existingNodeCount + i;
+    const attrs = generateAttributes(
+      nodeTypeDef.variables,
+      ctx.valueGen,
+      nodeIndex,
+    );
+
+    const takeFromRoster =
+      drawn < pool.length &&
+      (!roster.allowFabrication ||
+        ctx.valueGen.randomFloat(0, 1) < ctx.config.rosterDrawRatio);
+
+    let primaryKey = uuid();
+
+    if (takeFromRoster) {
+      const swapIndex = ctx.valueGen.randomInt(drawn, pool.length - 1);
+      const picked = pool[swapIndex]!;
+      pool[swapIndex] = pool[drawn]!;
+      pool[drawn] = picked;
+      drawn += 1;
+
+      primaryKey = picked[entityPrimaryKeyProperty];
+      roster.used.add(primaryKey);
+
+      const rosterValues = picked[entityAttributesProperty];
+      // The roster interface lets the roster value win a collision with a
+      // prompt attribute, while a name generator panel lets the prompt win.
+      if (roster.allowFabrication) {
+        Object.assign(attrs, rosterValues, additionalAttrs);
+      } else {
+        Object.assign(attrs, additionalAttrs, rosterValues);
+      }
+    } else {
+      Object.assign(attrs, additionalAttrs);
+    }
+
+    const node: NcNode = {
+      [entityPrimaryKeyProperty]: primaryKey,
+      type: nodeType,
+      [entityAttributesProperty]: attrs,
+      stageId: stage.id,
+      promptIDs: [promptId],
+    };
+    newNodes.push(node);
+  }
+
+  return newNodes;
+}

--- a/packages/protocol-utilities/src/generateNetwork/nodes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/nodes.ts
@@ -37,11 +37,13 @@ type NodeDrawPrompt = {
  * Roster state for a name-generator stage.
  *
  * `pool` is the stage's unfiltered roster rows; the drawable rows are those in
- * `pool` not already in `used`. That distinction is load-bearing: "has a
- * roster" is decided from the unfiltered `pool`, so a `NameGeneratorRoster`
- * stage whose roster is exhausted by an earlier stage produces zero nodes
- * (roster present but nothing drawable), while a stage with no roster at all
- * fabricates. See `createNodesForStage`.
+ * `pool` not already in `used`. Presence of `pool` is load-bearing and
+ * three-way: `undefined` means "no roster known" (the stage had no external
+ * data entry), an empty array means "roster known to be empty" (the asset
+ * resolved and parsed but yielded no rows, or a panel filtered them all out),
+ * and a non-empty array is a roster with rows. A `NameGeneratorRoster` stage
+ * fabricates only in the first case; a known-empty or exhausted roster produces
+ * zero nodes. See `createNodesForStage`.
  */
 export type RosterDraw = {
   pool?: NcNode[];
@@ -97,10 +99,13 @@ export function createNodesForStage(
   const remaining = maxNodes - stageNodeCount;
   if (remaining <= 0) return [];
 
-  // "Has a roster" is read from the UNFILTERED pool; the drawable pool excludes
-  // rows already used. This is what distinguishes "no roster data → fabricate"
-  // from "roster exhausted → produce zero nodes" on NameGeneratorRoster stages.
-  const hasRoster = (roster.pool?.length ?? 0) > 0;
+  // "Has a roster" means the stage was given a roster entry at all — the key is
+  // present — regardless of how many rows it holds. This three-way distinction
+  // drives NameGeneratorRoster fallback: no entry (`pool` undefined) fabricates;
+  // an entry that is empty (roster known empty) or exhausted by an earlier stage
+  // (drawable pool empty) produces zero nodes. The drawable pool below excludes
+  // rows already used.
+  const hasRoster = roster.pool !== undefined;
 
   const pool = roster.pool
     ? roster.pool.filter((n) => !roster.used.has(n[entityPrimaryKeyProperty]))

--- a/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
+++ b/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
@@ -13,6 +13,7 @@ import type { GenerationContext, NetworkDraft, StageOfType } from './context';
 import { createEdgesForPairs } from './edges';
 import { getStageFilteredEdges, getStageFilteredNodes } from './filtering';
 import { createNodesForStage, type RosterDraw } from './nodes';
+import { getSubjectType } from './subject';
 
 export function handleNameGenerators(
   ctx: GenerationContext,
@@ -27,7 +28,9 @@ export function handleNameGenerators(
     allowFabrication: stage.type !== 'NameGeneratorRoster',
   };
   const form = 'form' in stage ? stage.form : undefined;
-  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+  const subjectType = getSubjectType(stage.subject, 'node');
+  const nodeTypeDef =
+    subjectType !== undefined ? ctx.codebook.node?.[subjectType] : undefined;
 
   let stageNodeCount = 0;
   for (const prompt of stage.prompts) {
@@ -69,12 +72,10 @@ export function handleSociogram(
   draft: NetworkDraft,
   stage: StageOfType<'Sociogram'>,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
 
   for (const prompt of stage.prompts) {
     const createEdge = prompt.edges?.create;
@@ -116,12 +117,10 @@ export function handleDyadCensus(
   stage: StageOfType<'DyadCensus' | 'OneToManyDyadCensus'>,
   stageIndex: number,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
 
   const negativeResponses: DyadCensusMetadataItem[] = [];
   for (let promptIndex = 0; promptIndex < stage.prompts.length; promptIndex++) {
@@ -162,12 +161,10 @@ export function handleTieStrengthCensus(
   stage: StageOfType<'TieStrengthCensus'>,
   stageIndex: number,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
 
   const negativeResponses: DyadCensusMetadataItem[] = [];
   for (let promptIndex = 0; promptIndex < stage.prompts.length; promptIndex++) {
@@ -222,13 +219,11 @@ export function handleOrdinalBin(
   draft: NetworkDraft,
   stage: StageOfType<'OrdinalBin'>,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
-  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
+  const nodeTypeDef = ctx.codebook.node?.[subjectType];
 
   for (const prompt of stage.prompts) {
     const varDef = nodeTypeDef?.variables?.[prompt.variable];
@@ -250,13 +245,11 @@ export function handleCategoricalBin(
   draft: NetworkDraft,
   stage: StageOfType<'CategoricalBin'>,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
-  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
+  const nodeTypeDef = ctx.codebook.node?.[subjectType];
 
   for (const prompt of stage.prompts) {
     const varDef = nodeTypeDef?.variables?.[prompt.variable];
@@ -306,13 +299,11 @@ export function handleAlterForm(
   const form = stage.form;
   if (!form) return;
 
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
-  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
+  const nodeTypeDef = ctx.codebook.node?.[subjectType];
   if (!nodeTypeDef?.variables) return;
 
   const formVarIds = form.fields.map((f) => f.variable);
@@ -338,13 +329,11 @@ export function handleAlterEdgeForm(
   const form = stage.form;
   if (!form) return;
 
-  const subjectEdges = getStageFilteredEdges(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
-  const edgeTypeDef = ctx.codebook.edge?.[stage.subject.type];
+  const subjectType = getSubjectType(stage.subject, 'edge');
+  if (subjectType === undefined) return;
+
+  const subjectEdges = getStageFilteredEdges(ctx, draft, stage, subjectType);
+  const edgeTypeDef = ctx.codebook.edge?.[subjectType];
   if (!edgeTypeDef?.variables) return;
 
   const formVarIds = form.fields.map((f) => f.variable);
@@ -422,12 +411,10 @@ export function handleGeospatial(
   draft: NetworkDraft,
   stage: StageOfType<'Geospatial'>,
 ): void {
-  const subjectNodes = getStageFilteredNodes(
-    ctx,
-    draft,
-    stage,
-    stage.subject.type,
-  );
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
+  const subjectNodes = getStageFilteredNodes(ctx, draft, stage, subjectType);
 
   for (const prompt of stage.prompts) {
     const varId = prompt.variable;
@@ -449,6 +436,9 @@ export function handleNetworkComposer(
   draft: NetworkDraft,
   stage: StageOfType<'NetworkComposer'>,
 ): void {
+  const subjectType = getSubjectType(stage.subject, 'node');
+  if (subjectType === undefined) return;
+
   // Network Composer builds the network from scratch: create nodes of the
   // subject type (populating their codebook attributes) and draw edges of each
   // configured edge type among them. It is promptless, so a synthetic prompt id

--- a/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
+++ b/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
@@ -1,0 +1,484 @@
+import { v4 as uuid } from 'uuid';
+
+import {
+  type DyadCensusMetadataItem,
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+  type NcEdge,
+  type NcNode,
+} from '@codaco/shared-consts';
+
+import { generateAttributes, toVariableEntry } from './attributes';
+import type { GenerationContext, NetworkDraft, StageOfType } from './context';
+import { createEdgesForPairs } from './edges';
+import { getStageFilteredEdges, getStageFilteredNodes } from './filtering';
+import { createNodesForStage, type RosterDraw } from './nodes';
+
+export function handleNameGenerators(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<
+    'NameGenerator' | 'NameGeneratorQuickAdd' | 'NameGeneratorRoster'
+  >,
+): void {
+  const roster: RosterDraw = {
+    pool: ctx.externalData?.[stage.id],
+    used: ctx.usedRosterUids,
+    allowFabrication: stage.type !== 'NameGeneratorRoster',
+  };
+  const form = 'form' in stage ? stage.form : undefined;
+  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+
+  let stageNodeCount = 0;
+  for (const prompt of stage.prompts) {
+    const newNodes = createNodesForStage(
+      ctx,
+      stage,
+      prompt,
+      draft.nodes.length,
+      stageNodeCount,
+      roster,
+    );
+    stageNodeCount += newNodes.length;
+
+    // A stage form fills any codebook variables a drawn node does not yet have.
+    // Values are indexed by the running node total (before these nodes are added).
+    if (form && nodeTypeDef?.variables) {
+      const formVarIds = new Set(form.fields.map((f) => f.variable));
+      for (const node of newNodes) {
+        const attrs = node[entityAttributesProperty];
+        for (const varId of formVarIds) {
+          const varDef = nodeTypeDef.variables[varId];
+          if (varDef && !(varId in attrs)) {
+            const entry = toVariableEntry(varId, varDef);
+            attrs[varId] = ctx.valueGen.generateForVariable(
+              entry,
+              draft.nodes.length,
+            );
+          }
+        }
+      }
+    }
+
+    draft.nodes.push(...newNodes);
+  }
+}
+
+export function handleSociogram(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'Sociogram'>,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+
+  for (const prompt of stage.prompts) {
+    const createEdge = prompt.edges?.create;
+    if (createEdge) {
+      const { edges: newEdges } = createEdgesForPairs(
+        ctx,
+        subjectNodes,
+        createEdge,
+        ctx.valueGen.randomFloat(
+          ctx.config.sociogramEdgeProbability.min,
+          ctx.config.sociogramEdgeProbability.max,
+        ),
+        ctx.codebook.edge?.[createEdge]?.variables,
+      );
+      draft.edges.push(...newEdges);
+    }
+
+    const layoutVariable = prompt.layout?.layoutVariable;
+    if (layoutVariable) {
+      for (const node of subjectNodes) {
+        node[entityAttributesProperty][layoutVariable] = {
+          x: ctx.valueGen.randomFloat(
+            ctx.config.sociogramLayoutRange.min,
+            ctx.config.sociogramLayoutRange.max,
+          ),
+          y: ctx.valueGen.randomFloat(
+            ctx.config.sociogramLayoutRange.min,
+            ctx.config.sociogramLayoutRange.max,
+          ),
+        };
+      }
+    }
+  }
+}
+
+export function handleDyadCensus(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'DyadCensus' | 'OneToManyDyadCensus'>,
+  stageIndex: number,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+
+  const negativeResponses: DyadCensusMetadataItem[] = [];
+  for (let promptIndex = 0; promptIndex < stage.prompts.length; promptIndex++) {
+    const createEdgeType = stage.prompts[promptIndex]!.createEdge;
+    if (!createEdgeType) continue;
+
+    const probability = ctx.valueGen.randomFloat(
+      ctx.config.censusEdgeProbability.min,
+      ctx.config.censusEdgeProbability.max,
+    );
+    const { edges: newEdges, negativeIndices } = createEdgesForPairs(
+      ctx,
+      subjectNodes,
+      createEdgeType,
+      probability,
+      ctx.codebook.edge?.[createEdgeType]?.variables,
+    );
+    draft.edges.push(...newEdges);
+
+    for (const [a, b] of negativeIndices) {
+      negativeResponses.push([
+        promptIndex,
+        subjectNodes[a]![entityPrimaryKeyProperty],
+        subjectNodes[b]![entityPrimaryKeyProperty],
+        false,
+      ]);
+    }
+  }
+
+  if (negativeResponses.length > 0) {
+    draft.stageMetadata[stageIndex] = negativeResponses;
+  }
+}
+
+export function handleTieStrengthCensus(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'TieStrengthCensus'>,
+  stageIndex: number,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+
+  const negativeResponses: DyadCensusMetadataItem[] = [];
+  for (let promptIndex = 0; promptIndex < stage.prompts.length; promptIndex++) {
+    const prompt = stage.prompts[promptIndex]!;
+    const createEdgeType = prompt.createEdge;
+    const edgeVariable = prompt.edgeVariable;
+    if (!createEdgeType) continue;
+
+    const probability = ctx.valueGen.randomFloat(
+      ctx.config.censusEdgeProbability.min,
+      ctx.config.censusEdgeProbability.max,
+    );
+    const edgeTypeDef = ctx.codebook.edge?.[createEdgeType];
+    const { edges: newEdges, negativeIndices } = createEdgesForPairs(
+      ctx,
+      subjectNodes,
+      createEdgeType,
+      probability,
+      edgeTypeDef?.variables,
+    );
+
+    const edgeVarDef = edgeVariable
+      ? edgeTypeDef?.variables?.[edgeVariable]
+      : undefined;
+    if (edgeVariable && edgeVarDef) {
+      for (let edgeIdx = 0; edgeIdx < newEdges.length; edgeIdx++) {
+        const entry = toVariableEntry(edgeVariable, edgeVarDef);
+        newEdges[edgeIdx]![entityAttributesProperty][edgeVariable] =
+          ctx.valueGen.generateForVariable(entry, edgeIdx);
+      }
+    }
+
+    draft.edges.push(...newEdges);
+
+    for (const [a, b] of negativeIndices) {
+      negativeResponses.push([
+        promptIndex,
+        subjectNodes[a]![entityPrimaryKeyProperty],
+        subjectNodes[b]![entityPrimaryKeyProperty],
+        false,
+      ]);
+    }
+  }
+
+  if (negativeResponses.length > 0) {
+    draft.stageMetadata[stageIndex] = negativeResponses;
+  }
+}
+
+export function handleOrdinalBin(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'OrdinalBin'>,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+
+  for (const prompt of stage.prompts) {
+    const varDef = nodeTypeDef?.variables?.[prompt.variable];
+    if (!varDef) continue;
+
+    const variableOptions = 'options' in varDef ? (varDef.options ?? []) : [];
+    if (variableOptions.length === 0) continue;
+
+    for (const node of subjectNodes) {
+      const optionIndex = ctx.valueGen.randomInt(0, variableOptions.length - 1);
+      node[entityAttributesProperty][prompt.variable] =
+        variableOptions[optionIndex]!.value;
+    }
+  }
+}
+
+export function handleCategoricalBin(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'CategoricalBin'>,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+
+  for (const prompt of stage.prompts) {
+    const varDef = nodeTypeDef?.variables?.[prompt.variable];
+    if (!varDef) continue;
+
+    const variableOptions =
+      'options' in varDef
+        ? (varDef.options?.filter((o) => typeof o.value !== 'boolean') ?? [])
+        : [];
+    if (variableOptions.length === 0) continue;
+
+    for (const node of subjectNodes) {
+      const count = ctx.valueGen.randomInt(
+        1,
+        Math.min(2, variableOptions.length),
+      );
+      const picked: (string | number)[] = [];
+      const startIdx = ctx.valueGen.randomInt(0, variableOptions.length - 1);
+      for (let c = 0; c < count; c++) {
+        picked.push(
+          variableOptions[(startIdx + c) % variableOptions.length]!.value,
+        );
+      }
+      node[entityAttributesProperty][prompt.variable] = picked;
+    }
+  }
+}
+
+export function handleEgoForm(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+): void {
+  const egoVars = ctx.codebook.ego?.variables;
+  if (egoVars) {
+    Object.assign(
+      draft.egoAttributes,
+      generateAttributes(egoVars, ctx.valueGen, 0),
+    );
+  }
+}
+
+export function handleAlterForm(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'AlterForm'>,
+): void {
+  const form = stage.form;
+  if (!form) return;
+
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+  const nodeTypeDef = ctx.codebook.node?.[stage.subject.type];
+  if (!nodeTypeDef?.variables) return;
+
+  const formVarIds = form.fields.map((f) => f.variable);
+
+  for (let nodeIndex = 0; nodeIndex < subjectNodes.length; nodeIndex++) {
+    const node = subjectNodes[nodeIndex]!;
+    for (const varId of formVarIds) {
+      const varDef = nodeTypeDef.variables[varId];
+      if (varDef) {
+        const entry = toVariableEntry(varId, varDef);
+        node[entityAttributesProperty][varId] =
+          ctx.valueGen.generateForVariable(entry, nodeIndex);
+      }
+    }
+  }
+}
+
+export function handleAlterEdgeForm(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'AlterEdgeForm'>,
+): void {
+  const form = stage.form;
+  if (!form) return;
+
+  const subjectEdges = getStageFilteredEdges(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+  const edgeTypeDef = ctx.codebook.edge?.[stage.subject.type];
+  if (!edgeTypeDef?.variables) return;
+
+  const formVarIds = form.fields.map((f) => f.variable);
+
+  for (let edgeIndex = 0; edgeIndex < subjectEdges.length; edgeIndex++) {
+    const edge = subjectEdges[edgeIndex]!;
+    for (const varId of formVarIds) {
+      const varDef = edgeTypeDef.variables[varId];
+      if (varDef) {
+        const entry = toVariableEntry(varId, varDef);
+        edge[entityAttributesProperty][varId] =
+          ctx.valueGen.generateForVariable(entry, edgeIndex);
+      }
+    }
+  }
+}
+
+export function handleFamilyPedigree(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'FamilyPedigree'>,
+  stageIndex: number,
+): void {
+  const nodeCount = ctx.valueGen.randomInt(
+    ctx.config.familyPedigreeNodeCount.min,
+    ctx.config.familyPedigreeNodeCount.max,
+  );
+
+  const nodeType = stage.nodeConfig?.type;
+  const nodeTypeDef = nodeType ? ctx.codebook.node?.[nodeType] : undefined;
+  const edgeType = stage.edgeConfig?.type;
+
+  if (!nodeType) return;
+
+  const familyNodes: NcNode[] = [];
+  for (let nodeIndex = 0; nodeIndex < nodeCount; nodeIndex++) {
+    const attrs = generateAttributes(
+      nodeTypeDef?.variables,
+      ctx.valueGen,
+      draft.nodes.length + nodeIndex,
+    );
+
+    familyNodes.push({
+      [entityPrimaryKeyProperty]: uuid(),
+      type: nodeType,
+      [entityAttributesProperty]: attrs,
+      stageId: stage.id,
+    });
+  }
+
+  draft.nodes.push(...familyNodes);
+
+  if (edgeType && familyNodes.length > 1) {
+    for (let childIndex = 1; childIndex < familyNodes.length; childIndex++) {
+      const parentIdx = ctx.valueGen.randomInt(
+        0,
+        Math.min(childIndex - 1, familyNodes.length - 1),
+      );
+      const edge: NcEdge = {
+        [entityPrimaryKeyProperty]: uuid(),
+        type: edgeType,
+        from: familyNodes[parentIdx]![entityPrimaryKeyProperty],
+        to: familyNodes[childIndex]![entityPrimaryKeyProperty],
+        [entityAttributesProperty]: {},
+      };
+      draft.edges.push(edge);
+    }
+  }
+
+  draft.stageMetadata[stageIndex] = { isNetworkCommitted: true };
+}
+
+export function handleGeospatial(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'Geospatial'>,
+): void {
+  const subjectNodes = getStageFilteredNodes(
+    ctx,
+    draft,
+    stage,
+    stage.subject.type,
+  );
+
+  for (const prompt of stage.prompts) {
+    const varId = prompt.variable;
+    if (!varId) continue;
+
+    for (const node of subjectNodes) {
+      // ±180/±90 are the world-coordinate bounds (the coordinate space), not a
+      // tuning knob, so they stay as literals.
+      node[entityAttributesProperty][varId] = {
+        x: ctx.valueGen.randomFloat(-180, 180),
+        y: ctx.valueGen.randomFloat(-90, 90),
+      };
+    }
+  }
+}
+
+export function handleNetworkComposer(
+  ctx: GenerationContext,
+  draft: NetworkDraft,
+  stage: StageOfType<'NetworkComposer'>,
+): void {
+  // Network Composer builds the network from scratch: create nodes of the
+  // subject type (populating their codebook attributes) and draw edges of each
+  // configured edge type among them. It is promptless, so a synthetic prompt id
+  // seeds creation, and it never draws from a roster.
+  const newNodes = createNodesForStage(
+    ctx,
+    stage,
+    { id: stage.id },
+    draft.nodes.length,
+    0,
+    { used: ctx.usedRosterUids, allowFabrication: true },
+  );
+  draft.nodes.push(...newNodes);
+
+  for (const edgeDef of stage.edges ?? []) {
+    const edgeType = edgeDef.subject?.type;
+    if (!edgeType) continue;
+    const { edges: newEdges } = createEdgesForPairs(
+      ctx,
+      newNodes,
+      edgeType,
+      // A from-scratch builder rendered across several edge types at once; a
+      // per-pair 30-50% probability produced a near-complete graph in the
+      // preview, so this range keeps it sparse and readable.
+      ctx.valueGen.randomFloat(
+        ctx.config.networkComposerEdgeProbability.min,
+        ctx.config.networkComposerEdgeProbability.max,
+      ),
+      ctx.codebook.edge?.[edgeType]?.variables,
+    );
+    draft.edges.push(...newEdges);
+  }
+}

--- a/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
+++ b/packages/protocol-utilities/src/generateNetwork/stageHandlers.ts
@@ -365,6 +365,7 @@ export function handleFamilyPedigree(
   const nodeType = stage.nodeConfig?.type;
   const nodeTypeDef = nodeType ? ctx.codebook.node?.[nodeType] : undefined;
   const edgeType = stage.edgeConfig?.type;
+  const egoVariable = stage.nodeConfig?.egoVariable;
 
   if (!nodeType) return;
 
@@ -381,6 +382,18 @@ export function handleFamilyPedigree(
       type: nodeType,
       [entityAttributesProperty]: attrs,
       stageId: stage.id,
+    });
+  }
+
+  // generateAttributes randomises egoVariable per node like any other boolean
+  // codebook variable, but the runtime marks exactly one pedigree node as ego
+  // (FamilyPedigree's egoCellTransform sets true on the proband and explicit
+  // false on every other alter/partner/child). Pin that here, after
+  // generation, so overwriting the attribute costs no RNG draws and the rest
+  // of the stage's random stream is undisturbed.
+  if (egoVariable) {
+    familyNodes.forEach((node, index) => {
+      node[entityAttributesProperty][egoVariable] = index === 0;
     });
   }
 

--- a/packages/protocol-utilities/src/generateNetwork/subject.ts
+++ b/packages/protocol-utilities/src/generateNetwork/subject.ts
@@ -1,0 +1,18 @@
+/**
+ * `generateNetwork` runs on unvalidated, possibly in-progress protocol state —
+ * Architect's live preview feeds it a draft protocol as it is being edited, and
+ * the package's own tests construct stages via `as unknown as Stage` — so a
+ * stage's `subject` can be absent, or carry the wrong `entity`, even though the
+ * schema types mark it required. Every subject-bearing handler re-derives the
+ * subject type at runtime instead of trusting the static type, and skips
+ * (returns `undefined`, never throws) on a mismatch or missing subject.
+ */
+export function getSubjectType(
+  subject: { entity?: string; type?: string } | undefined,
+  entity: 'node' | 'edge',
+): string | undefined {
+  if (subject?.entity !== entity || typeof subject.type !== 'string') {
+    return undefined;
+  }
+  return subject.type;
+}

--- a/packages/protocol-utilities/src/index.ts
+++ b/packages/protocol-utilities/src/index.ts
@@ -1,5 +1,6 @@
+export type { GenerationConfig } from './generateNetwork/config';
 export type {
-  GenerateNetworkOptions,
+  GenerateNetworkParams,
   GenerateNetworkResult,
 } from './generateNetwork';
 export { generateNetwork } from './generateNetwork';

--- a/packages/protocol-validation/src/schemas/8/codebook/codebook.ts
+++ b/packages/protocol-validation/src/schemas/8/codebook/codebook.ts
@@ -7,8 +7,11 @@ import {
   getAllEntityNames,
 } from '../../../utils/validation-helpers.ts';
 import {
+  type EdgeDefinition,
   EdgeDefinitionSchema,
+  type EgoDefinition,
   EgoDefinitionSchema,
+  type NodeDefinition,
   NodeDefinitionSchema,
 } from './definitions.ts';
 
@@ -61,3 +64,20 @@ export const CodebookSchema = z
   });
 
 export type Codebook = z.infer<typeof CodebookSchema>;
+
+/**
+ * A structural view of {@link Codebook} that relaxes each entity definition's
+ * strict requirements (a node's `name`/`color`/`shape`, an edge's `name`).
+ *
+ * Consumers that assemble or receive a codebook before it is schema-validated —
+ * e.g. synthetic network generation, which only ever reads each entity's
+ * `variables` — need to accept these partially-populated codebooks. Deriving the
+ * per-entity shapes from the canonical definitions with `Partial` (rather than
+ * re-describing them structurally) keeps the `variables` typing in lock-step
+ * with the schema.
+ */
+export type StructuralCodebook = {
+  node?: Record<string, Partial<NodeDefinition>>;
+  edge?: Record<string, Partial<EdgeDefinition>>;
+  ego?: Partial<EgoDefinition>;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,9 +859,6 @@ importers:
       '@codaco/network-exporters':
         specifier: workspace:^
         version: link:../../packages/network-exporters
-      '@codaco/network-query':
-        specifier: workspace:^
-        version: link:../../packages/network-query
       '@codaco/protocol-utilities':
         specifier: workspace:^
         version: link:../../packages/protocol-utilities

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,9 @@ importers:
       '@codaco/network-exporters':
         specifier: workspace:^
         version: link:../../packages/network-exporters
+      '@codaco/network-query':
+        specifier: workspace:^
+        version: link:../../packages/network-query
       '@codaco/protocol-utilities':
         specifier: workspace:^
         version: link:../../packages/protocol-utilities


### PR DESCRIPTION
## Summary

Synthetic sessions with a roster-backed name generator used to invent people from the codebook, so their identities never matched the roster file — and that mismatch propagated into every downstream stage. They now draw from the **actual roster rows**, preserving each row's primary key and attributes, so generated data matches what a real interview produces.

- New `externalData` option on `generateNetwork` (`@codaco/protocol-utilities`), keyed by **stage id** — roster/roster-panel stages draw from these rows instead of fabricating; draws are without replacement across prompts and across stages sharing a roster.
- A filtered side panel draws **only the rows that panel would show** (mirrors the runtime's `getPanelNodes`).
- Missing / unreadable / empty rosters fall back to fabrication, so generation never fails on a roster problem.
- Exposes `loadExternalData`, `makeVariableUUIDReplacer`, `getVariableTypeReplacements` from `@codaco/interview` so the app can parse roster assets the same way the runtime does.
- App-layer `loadRosterNodesForStages` (Interviewer) resolves + parses each stage's roster assets.

## Scope & known limitations

- **Interviewer only.** Architect's preview still fabricates roster people (its `buildSession` is synchronous inside a postMessage handshake — a separate change).
- Roster nodes carry codebook-generated values for variables the roster leaves blank, where a real session would have `null` — pre-existing `generateNetwork` behaviour, kept as-is.
- Nodes never accumulate multiple `promptIDs`.

## Test plan

- [x] `@codaco/protocol-utilities` unit — 103 pass (roster draw, without-replacement, cross-stage exhaustion, seeded determinism, fallback)
- [x] `@codaco/interviewer` unit — 442 pass (incl. `loadRosterData` asset join, filtered panel, per-asset + whole-read error isolation, real-protocol integration)
- [x] `@codaco/interview` unit — 1172 pass
- [x] lint, knip, changeset lanes
- [ ] Manual: import a roster protocol, generate synthetic sessions, confirm generated people show as already-added (excluded from the source panel, not duplicated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic sessions now use people from the protocol’s roster data.
  * Roster filters are respected when selecting people.
  * Roster attributes and identifiers are preserved in generated networks.
  * People are not reused across prompts or stages sharing a roster.
  * Stages may combine roster-based and manually generated people when applicable.
  * Added support for externally supplied roster data during network generation.

* **Bug Fixes**
  * Synthetic generation continues to work when roster files are missing, unreadable, or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->