### PR TITLE
Fix documentation search crash and add fallback

### DIFF
--- a/.changeset/calm-docs-search.md
+++ b/.changeset/calm-docs-search.md
@@ -1,0 +1,5 @@
+---
+'@codaco/documentation': patch
+---
+
+Keep documentation search available in deploy previews and show recovery actions when an unexpected error interrupts the app.

--- a/apps/documentation/README.md
+++ b/apps/documentation/README.md
@@ -25,7 +25,7 @@ To run the app locally:
 
 Effortlessly find the information you need with the top-level search bar. Instantly locate relevant documentation, making navigation and discovery a breeze.
 
-Search is powered by Algolia DocSearch (`@docsearch/react`) in `components/DocSearchComponent.tsx`, configured via the `NEXT_PUBLIC_ALGOLIA_*` env vars in `env.js`. Results are made section-aware in two ways:
+Search is powered by Algolia DocSearch (`@docsearch/react`) in `components/DocSearchComponent.tsx`, configured via the `NEXT_PUBLIC_ALGOLIA_*` env vars in `env.js`. Production receives these values from GitHub Actions secrets, while the `documentation-dev` Netlify site provides them to Git-integrated deploy previews. Results are made section-aware in two ways:
 
 - **Section badge** — each result shows a coloured pill naming its workflow section (Get Started, Design Protocols, …), matching the homepage colours. The section slug is derived purely client-side from the hit's URL (the first path segment after the locale), so no Algolia-side data is required for the badge. Colours and labels come from `lib/sections.ts` and the `SectionSwitcher` translation namespace.
 - **Current-section boost** — results from the section the reader is currently in are boosted (via Algolia `optionalFilters`) so same-section pages rank higher, while every section still appears.

--- a/apps/documentation/components/DocSearchComponent.tsx
+++ b/apps/documentation/components/DocSearchComponent.tsx
@@ -10,8 +10,15 @@ import { usePageBackgroundTargetRef } from '@codaco/art';
 import { inputFieldControlVariants } from '@codaco/fresco-ui/form/fields/InputField';
 import { cx } from '@codaco/fresco-ui/utils/cva';
 import { env } from '~/env';
+import { getDocSearchConfig } from '~/lib/docSearchConfig';
 import { getSectionColorClass } from '~/lib/sections';
 import { usePathname } from '~/navigation';
+
+const docSearchConfig = getDocSearchConfig({
+  appId: env.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID,
+  indexName: env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME,
+  apiKey: env.NEXT_PUBLIC_ALGOLIA_API_KEY,
+});
 
 // Pulls the workflow-section slug out of a result's URL. Sections are the first
 // path segment after the locale (e.g. /en/design-protocols/...); we match the
@@ -101,6 +108,7 @@ const DocSearchComponent = ({
   const translations = useDocSearchTranslations();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const backgroundTargetRef = usePageBackgroundTargetRef();
+  const isSearchAvailable = docSearchConfig !== null;
 
   const selectVisibleSearchAsBackgroundTarget = useCallback(() => {
     const button = buttonRef.current;
@@ -157,13 +165,24 @@ const DocSearchComponent = ({
           size: large ? 'lg' : 'md',
           state: 'normal',
           className: cx(
-            'pointer-events-auto w-full shrink cursor-pointer',
+            'pointer-events-auto w-full shrink',
+            isSearchAvailable
+              ? 'cursor-pointer'
+              : 'cursor-not-allowed opacity-50',
             className,
           ),
         })}
         onClick={openDocSearch}
-        aria-label={t('button.buttonAriaLabel')}
-        aria-haspopup="dialog"
+        disabled={!isSearchAvailable}
+        aria-label={
+          isSearchAvailable
+            ? t('button.buttonAriaLabel')
+            : t('button.buttonUnavailableText')
+        }
+        aria-haspopup={isSearchAvailable ? 'dialog' : undefined}
+        title={
+          isSearchAvailable ? undefined : t('button.buttonUnavailableText')
+        }
       >
         <Search aria-hidden />
         <span
@@ -193,49 +212,51 @@ const DocSearchComponent = ({
           <span className="text-sm">⌘</span>K
         </kbd>
       </button>
-      <div className="hidden">
-        <DocSearch
-          translations={translations}
-          appId={env.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID}
-          indices={[
-            {
-              name: env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME,
-              searchParameters: {
-                filters: `lang:${locale}`,
-                // Boost (not restrict) results from the section the reader is
-                // currently in, so same-section pages rank higher while every
-                // section still appears. Relies on the crawler-populated,
-                // facetable `section` attribute on each record.
-                ...(boostSection
-                  ? { optionalFilters: [`section:${boostSection}`] }
-                  : {}),
+      {docSearchConfig ? (
+        <div className="hidden">
+          <DocSearch
+            translations={translations}
+            appId={docSearchConfig.appId}
+            indices={[
+              {
+                name: docSearchConfig.indexName,
+                searchParameters: {
+                  filters: `lang:${locale}`,
+                  // Boost (not restrict) results from the section the reader is
+                  // currently in, so same-section pages rank higher while every
+                  // section still appears. Relies on the crawler-populated,
+                  // facetable `section` attribute on each record.
+                  ...(boostSection
+                    ? { optionalFilters: [`section:${boostSection}`] }
+                    : {}),
+                },
               },
-            },
-          ]}
-          apiKey={env.NEXT_PUBLIC_ALGOLIA_API_KEY}
-          insights={true}
-          placeholder="Search documentation"
-          hitComponent={({ hit, children }) => {
-            const slug = getSectionSlug(hit.url);
-            const colorClass = slug ? getSectionColorClass(slug) : undefined;
-            return (
-              <a href={hit.url}>
-                {slug && colorClass ? (
-                  <span
-                    className={cx(
-                      'mr-2 shrink-0 self-center rounded-full px-2 py-0.5 text-[0.625rem] font-semibold tracking-wide text-white uppercase',
-                      colorClass,
-                    )}
-                  >
-                    {sectionLabel(slug)}
-                  </span>
-                ) : null}
-                {children}
-              </a>
-            );
-          }}
-        />
-      </div>
+            ]}
+            apiKey={docSearchConfig.apiKey}
+            insights={true}
+            placeholder="Search documentation"
+            hitComponent={({ hit, children }) => {
+              const slug = getSectionSlug(hit.url);
+              const colorClass = slug ? getSectionColorClass(slug) : undefined;
+              return (
+                <a href={hit.url}>
+                  {slug && colorClass ? (
+                    <span
+                      className={cx(
+                        'mr-2 shrink-0 self-center rounded-full px-2 py-0.5 text-[0.625rem] font-semibold tracking-wide text-white uppercase',
+                        colorClass,
+                      )}
+                    >
+                      {sectionLabel(slug)}
+                    </span>
+                  ) : null}
+                  {children}
+                </a>
+              );
+            }}
+          />
+        </div>
+      ) : null}
     </>
   );
 };

--- a/apps/documentation/components/Providers/__tests__/posthog-provider.test.tsx
+++ b/apps/documentation/components/Providers/__tests__/posthog-provider.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PostHogClientProvider } from '../posthog-provider';
+
+const { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('posthog-js', () => ({
+  default: { captureException },
+}));
+
+function Thrower(): never {
+  throw new Error('boom');
+}
+
+describe('PostHogClientProvider', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    captureException.mockClear();
+  });
+
+  it('renders children while the app is healthy', () => {
+    render(
+      <PostHogClientProvider>
+        <p>Documentation content</p>
+      </PostHogClientProvider>,
+    );
+
+    expect(screen.getByText('Documentation content')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows recovery actions and reports unexpected render errors', () => {
+    render(
+      <PostHogClientProvider>
+        <Thrower />
+      </PostHogClientProvider>,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Something went wrong' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Reload page' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Documentation home' }),
+    ).toBeInTheDocument();
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'boom' }),
+      { feature: 'app-error-boundary' },
+    );
+  });
+});

--- a/apps/documentation/components/Providers/posthog-provider.tsx
+++ b/apps/documentation/components/Providers/posthog-provider.tsx
@@ -4,10 +4,51 @@ import { PostHogErrorBoundary, PostHogProvider } from '@posthog/react';
 import posthog from 'posthog-js';
 import type { ReactNode } from 'react';
 
+import Button from '@codaco/fresco-ui/Button';
+import Heading from '@codaco/fresco-ui/typography/Heading';
+import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
+
+function AppErrorFallback() {
+  return (
+    <main
+      role="alert"
+      aria-labelledby="app-error-title"
+      className="publish-colors bg-background text-text flex min-h-dvh items-center justify-center p-4"
+    >
+      <div className="w-full max-w-lg">
+        <Heading id="app-error-title" level="h1">
+          Something went wrong
+        </Heading>
+        <Paragraph>
+          The documentation could not continue. Reload the page to try again, or
+          return to the documentation home page.
+        </Paragraph>
+        <div className="flex flex-wrap gap-3">
+          <Button color="primary" onClick={() => window.location.reload()}>
+            Reload page
+          </Button>
+          <Button
+            color="primary"
+            variant="outline"
+            onClick={() => window.location.assign('/en')}
+          >
+            Documentation home
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}
+
 export function PostHogClientProvider({ children }: { children: ReactNode }) {
   return (
     <PostHogProvider client={posthog}>
-      <PostHogErrorBoundary>{children}</PostHogErrorBoundary>
+      <PostHogErrorBoundary
+        fallback={AppErrorFallback}
+        additionalProperties={{ feature: 'app-error-boundary' }}
+      >
+        {children}
+      </PostHogErrorBoundary>
     </PostHogProvider>
   );
 }

--- a/apps/documentation/docs/design-protocols/key-concepts/responsive-svg-backgrounds.en.mdx
+++ b/apps/documentation/docs/design-protocols/key-concepts/responsive-svg-backgrounds.en.mdx
@@ -56,7 +56,7 @@ study.
 
 The template uses a contextual name-generator example. [Bidart and Charbonneau
 describe a contextual name
-generator](https://journals.sagepub.com/doi/10.1177/1525822X11408513) for
+generator](https://espace.inrs.ca/id/eprint/9280/) for
 building a broad view of someone's network from the social contexts of everyday
 life.
 

--- a/apps/documentation/lib/__tests__/docSearchConfig.test.ts
+++ b/apps/documentation/lib/__tests__/docSearchConfig.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDocSearchConfig } from '../docSearchConfig';
+
+describe('getDocSearchConfig', () => {
+  it.each([
+    {},
+    { appId: '', indexName: 'index', apiKey: 'key' },
+    { appId: 'app', indexName: ' ', apiKey: 'key' },
+    { appId: 'app', indexName: 'index', apiKey: undefined },
+  ])('rejects incomplete browser configuration', (candidate) => {
+    expect(getDocSearchConfig(candidate)).toBeNull();
+  });
+
+  it('normalizes complete browser configuration', () => {
+    expect(
+      getDocSearchConfig({
+        appId: ' app ',
+        indexName: ' index ',
+        apiKey: ' key ',
+      }),
+    ).toEqual({ appId: 'app', indexName: 'index', apiKey: 'key' });
+  });
+});

--- a/apps/documentation/lib/docSearchConfig.ts
+++ b/apps/documentation/lib/docSearchConfig.ts
@@ -1,0 +1,25 @@
+type DocSearchConfigCandidate = {
+  appId?: string;
+  indexName?: string;
+  apiKey?: string;
+};
+
+type DocSearchConfig = {
+  appId: string;
+  indexName: string;
+  apiKey: string;
+};
+
+export function getDocSearchConfig({
+  appId: candidateAppId,
+  indexName: candidateIndexName,
+  apiKey: candidateApiKey,
+}: DocSearchConfigCandidate): DocSearchConfig | null {
+  const appId = candidateAppId?.trim();
+  const indexName = candidateIndexName?.trim();
+  const apiKey = candidateApiKey?.trim();
+
+  if (!appId || !indexName || !apiKey) return null;
+
+  return { appId, indexName, apiKey };
+}

--- a/apps/documentation/messages/en.json
+++ b/apps/documentation/messages/en.json
@@ -100,7 +100,7 @@
     "system": "System"
   },
   "Hero": {
-    "title": "Documentation for every stage\nof your workflow",
+    "title": "Documentation for every stage\nof your research",
     "tagline": "Guides and reference material for planning studies, designing protocols, collecting data, and analyzing results."
   },
   "Home": {

--- a/apps/documentation/messages/en.json
+++ b/apps/documentation/messages/en.json
@@ -36,7 +36,8 @@
     "button": {
       "buttonText": "Search documentation",
       "buttonTextMobile": "Search docs",
-      "buttonAriaLabel": "Open search modal"
+      "buttonAriaLabel": "Open search modal",
+      "buttonUnavailableText": "Search is temporarily unavailable"
     },
     "modal": {
       "searchBox": {

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -13,6 +13,7 @@
     "generateProtocols": "tsx ./scripts/generateSampleProtocol.ts",
     "optimize-images": "node ./scripts/optimize-images.mjs",
     "start": "pnpm next start",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "validate-redirects": "tsx ./scripts/validate-redirects.ts",
     "test-redirects": "tsx ./scripts/test-redirects.ts"
@@ -48,14 +49,18 @@
     "@microflash/rehype-figure": "^2.1.4",
     "@tailwindcss/postcss": "catalog:",
     "@tailwindcss/typography": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/hast": "^3.0.4",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/unist": "^3.0.3",
+    "@vitejs/plugin-react": "catalog:",
     "gray-matter": "^4.0.3",
     "hast-util-heading-rank": "^3.0.0",
     "hast-util-to-string": "^3.0.1",
+    "jsdom": "catalog:",
     "jszip": "catalog:",
     "mdast-util-to-string": "^4.0.0",
     "next-sitemap": "^4.2.3",
@@ -75,6 +80,7 @@
     "unist-util-visit": "^5.1.0",
     "vfile": "^6.0.3",
     "vfile-matter": "^5.0.1",
+    "vitest": "catalog:",
     "zod": "catalog:"
   }
 }

--- a/apps/documentation/vitest.config.ts
+++ b/apps/documentation/vitest.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: [
+      'components/**/__tests__/**/*.{ts,tsx}',
+      'lib/**/__tests__/**/*.{ts,tsx}',
+    ],
+  },
+});

--- a/apps/documentation/vitest.setup.ts
+++ b/apps/documentation/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -757,6 +757,12 @@ importers:
       '@tailwindcss/typography':
         specifier: 'catalog:'
         version: 0.5.20(tailwindcss@4.3.2)
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -772,6 +778,9 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -781,6 +790,9 @@ importers:
       hast-util-to-string:
         specifier: ^3.0.1
         version: 3.0.1
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1(@noble/hashes@2.2.0)
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -838,6 +850,9 @@ importers:
       vfile-matter:
         specifier: ^5.0.1
         version: 5.0.1
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/turbo.json
+++ b/turbo.json
@@ -64,6 +64,24 @@
       ],
       "outputs": ["out/**", ".next/**", "!.next/cache/**"]
     },
+    "@codaco/documentation#test": {
+      "dependsOn": ["^topo"],
+      "inputs": [
+        "app/**",
+        "components/**",
+        "hooks/**",
+        "lib/**",
+        "messages/**",
+        "env.js",
+        "navigation.ts",
+        "vitest.config.*",
+        "vitest.setup.*",
+        "tsconfig*.json",
+        "package.json",
+        ".env"
+      ],
+      "outputs": []
+    },
     "@codaco/architect#build": {
       "dependsOn": ["^topo"],
       "inputs": [


### PR DESCRIPTION
## Summary
- validate Algolia browser configuration before rendering DocSearch so incomplete deploy-preview configuration cannot crash the app
- add a full-page PostHog error-boundary fallback with reload and documentation-home recovery actions
- add focused Vitest coverage and document where production and deploy-preview search variables are configured
- update the documentation homepage hero to describe support for every stage of the reader's research
- repair an existing contextual name-generator citation whose publisher response blocked the documentation link check
- ensure Turbo invalidates documentation tests when their app source or co-located tests change

## Test plan
- [x] `CI=true pnpm --filter @codaco/documentation test`
- [x] `CI=true pnpm --filter @codaco/documentation typecheck`
- [x] `CI=true pnpm typecheck`
- [x] `CI=true pnpm lint`
- [x] `CI=true pnpm knip`
- [x] `CI=true pnpm check:changesets`
- [x] configured and empty-config production builds
- [x] browser smoke checks for working search and unavailable-search fallback
- [x] replacement citation responds successfully
- [x] Turbo dry run includes documentation app source and co-located test inputs