### PR TITLE
ci: make rate-limited services opt-in

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,10 @@
 # can touch hundreds of them, which pushes PRs past CodeRabbit's 150-file review
 # limit and drowns out the reviewable harness/source changes.
 reviews:
+  # Reviews are opt-in. Request an incremental review with
+  # `@coderabbitai review`, or a complete review with `@coderabbitai full review`.
+  auto_review:
+    enabled: false
   path_filters:
     - '!packages/interview/e2e/aria-snapshots/**'
     - '!packages/interview/e2e/visual-snapshots/**'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,7 @@
 reviews:
   # Reviews are opt-in. Request an incremental review with
   # `@coderabbitai review`, or a complete review with `@coderabbitai full review`.
+  commit_status: false
   auto_review:
     enabled: false
   path_filters:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,7 +2,20 @@ name: Chromatic
 
 on:
   push:
+    branches:
+      - 'changeset-release/**'
   workflow_dispatch:
+    inputs:
+      project:
+        description: Storybook project to publish
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - fresco-ui
+          - interview
+          - interviewer
 
 permissions:
   contents: read
@@ -26,12 +39,40 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.before }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REQUESTED_PROJECT: ${{ inputs.project }}
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            case "$REQUESTED_PROJECT" in
+              all)
+                fresco_ui=true
+                interview=true
+                interviewer=true
+                ;;
+              fresco-ui)
+                fresco_ui=true
+                interview=false
+                interviewer=false
+                ;;
+              interview)
+                fresco_ui=false
+                interview=true
+                interviewer=false
+                ;;
+              interviewer)
+                fresco_ui=false
+                interview=false
+                interviewer=true
+                ;;
+              *)
+                echo "Unknown Storybook project: $REQUESTED_PROJECT" >&2
+                exit 1
+                ;;
+            esac
+
             {
-              echo "fresco_ui=true"
-              echo "interview=true"
-              echo "interviewer=true"
+              echo "fresco_ui=$fresco_ui"
+              echo "interview=$interview"
+              echo "interviewer=$interviewer"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- disable automatic CodeRabbit reviews and skipped-review commit statuses while retaining comment-triggered reviews
- limit automatic Chromatic runs to generated changeset release branches
- let manual Chromatic runs target one Storybook project or all projects

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `actionlint .github/workflows/chromatic.yml`
- [x] `pnpm exec oxfmt --check .github/workflows/chromatic.yml .coderabbit.yaml`
- [x] `git diff --check`