### PR TITLE
feat(architect): open protocol preview in a dedicated window

### DIFF
--- a/.changeset/architect-preview-popup-window.md
+++ b/.changeset/architect-preview-popup-window.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': minor
+---
+
+Open protocol previews in a dedicated window instead of a browser tab. When Architect is installed as an app, the preview opens in its own app window.

--- a/apps/architect/src/components/PreviewHost/__tests__/launchPreview.test.ts
+++ b/apps/architect/src/components/PreviewHost/__tests__/launchPreview.test.ts
@@ -67,7 +67,11 @@ describe('launchPreview', () => {
       skipLogicBypassed: false,
     });
 
-    expect(openSpy).toHaveBeenCalledWith('/preview/', '_blank');
+    expect(openSpy).toHaveBeenCalledWith(
+      '/preview/',
+      '_blank',
+      'popup,width=1280,height=800',
+    );
 
     postReadyFromSource(popup);
     await promise;

--- a/apps/architect/src/components/PreviewHost/launchPreview.ts
+++ b/apps/architect/src/components/PreviewHost/launchPreview.ts
@@ -41,8 +41,15 @@ export function launchPreview({
 
   // Trailing slash is required: a bare '/preview' hits Vite's SPA html fallback
   // (and equivalent static-host fallbacks) and serves the main app's index.html
-  // instead of the preview entry, leaving a blank tab.
-  const popup = window.open('/preview/', '_blank');
+  // instead of the preview entry, leaving a blank window.
+  // The features string makes browsers open a separate popup window rather than
+  // a tab (and an app window when Architect runs as an installed PWA); the
+  // handshake below needs window.opener, so 'noopener' must never be added.
+  const popup = window.open(
+    '/preview/',
+    '_blank',
+    'popup,width=1280,height=800',
+  );
   if (!popup) {
     return Promise.resolve({ kind: 'popup-blocked' });
   }
@@ -55,7 +62,7 @@ export function launchPreview({
   });
 
   const expectedOrigin = window.location.origin;
-  // Ferry any Safari-private in-memory fallback assets to the preview tab: the
+  // Ferry any Safari-private in-memory fallback assets to the preview window: the
   // durable IndexedDB store is shared across tabs, but the in-memory map is
   // per-realm, so the preview context would otherwise resolve nothing. Blobs
   // survive structured clone over postMessage.
@@ -76,7 +83,7 @@ export function launchPreview({
 
   return new Promise<LaunchPreviewResult>((resolve, reject) => {
     // The listener stays registered for the popup's lifetime so a reloaded
-    // preview tab can re-request the payload. Cleanup happens when the popup
+    // preview window can re-request the payload. Cleanup happens when the popup
     // closes or when the initial handshake times out.
     let initialDelivered = false;
 
@@ -104,14 +111,16 @@ export function launchPreview({
       if (initialDelivered) return;
       cleanup();
       reject(
-        new Error("Preview tab didn't load in time. Close it and try again."),
+        new Error(
+          "Preview window didn't load in time. Close it and try again.",
+        ),
       );
     }, HANDSHAKE_TIMEOUT_MS);
 
     const closedPollId = setInterval(() => {
       if (!popup.closed) return;
       cleanup();
-      // Closing the tab before the handshake would otherwise leave the promise
+      // Closing the window before the handshake would otherwise leave the promise
       // pending forever, stranding the Preview button in its disabled state.
       if (!initialDelivered) {
         resolve({ kind: 'popup-closed' });


### PR DESCRIPTION
## Summary
- Pass a window-features string (`popup,width=1280,height=800`) to the preview `window.open` call so the protocol preview opens as a separate popup window instead of a browser tab in both Chrome and Safari.
- When Architect is running as an installed PWA in a Chromium browser, the child of the standalone app window opens as an app window, so installed users get a native-feeling preview window with no browser chrome.
- Deliberately keeps the `'_blank'` target and omits `noopener`: the payload handshake in `PreviewHost` depends on `window.opener`, and a named/reused window would let stale payload listeners from earlier launches fire into the reused window.
- Updates the user-facing timeout message and comments from "tab" to "window", and adds an Architect-lane changeset.

## Test plan
- [x] `vitest run src/components/PreviewHost/__tests__/launchPreview.test.ts` — 9/9 pass (window.open assertion updated)
- [x] `pnpm --filter @codaco/architect typecheck`
- [x] `oxlint` / `oxfmt` on modified files
- [x] `pnpm knip` (pre-existing config hints only)
- [x] `pnpm check:changesets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)