### PR TITLE
Refine website team and institution sections

### DIFF
--- a/.changeset/bright-website-partners.md
+++ b/.changeset/bright-website-partners.md
@@ -1,0 +1,5 @@
+---
+"networkcanvas.com": patch
+---
+
+Improve the homepage with a wider recent-publications grid, a compact scientific-advisors subsection, and larger, visually balanced institution logos.

--- a/apps/networkcanvas.com/app/[locale]/page.tsx
+++ b/apps/networkcanvas.com/app/[locale]/page.tsx
@@ -9,7 +9,6 @@ import { Grants } from '~/components/sections/Grants';
 import { HeroIntro } from '~/components/sections/HeroIntro';
 import { Institutions } from '~/components/sections/Institutions';
 import { Publications } from '~/components/sections/Publications';
-import { ScientificAdvisors } from '~/components/sections/ScientificAdvisors';
 import { Tools } from '~/components/sections/Tools';
 import { VideoSection } from '~/components/sections/VideoSection';
 import { WhatNext } from '~/components/sections/WhatNext';
@@ -43,7 +42,6 @@ export default async function HomePage({ params }: HomePageProps) {
         <Grants grants={grants} />
         <Publications publications={publications} />
         <CoreTeam members={coreTeam} />
-        <ScientificAdvisors />
         <Institutions />
         <WhatNext />
 

--- a/apps/networkcanvas.com/components/sections/CoreTeam.tsx
+++ b/apps/networkcanvas.com/components/sections/CoreTeam.tsx
@@ -6,11 +6,13 @@ import { Reveal } from '~/components/ui/Reveal';
 import { SectionHeading } from '~/components/ui/SectionHeading';
 import type { TeamMember } from '~/lib/siteContent';
 
+import { ScientificAdvisors } from './ScientificAdvisors';
+
 export function CoreTeam({ members }: { members: readonly TeamMember[] }) {
   const t = useTranslations('Team');
 
   return (
-    <Container className="tablet-landscape:py-28 py-20">
+    <Container as="section" className="tablet-landscape:py-28 py-20">
       <SectionHeading title={t('heading')}>{t('introduction')}</SectionHeading>
 
       <div className="tablet-portrait:grid-cols-3 tablet-landscape:grid-cols-4 mt-14 grid grid-cols-2 gap-x-6 gap-y-12">
@@ -38,6 +40,8 @@ export function CoreTeam({ members }: { members: readonly TeamMember[] }) {
           </Reveal>
         ))}
       </div>
+
+      <ScientificAdvisors />
     </Container>
   );
 }

--- a/apps/networkcanvas.com/components/sections/Institutions.tsx
+++ b/apps/networkcanvas.com/components/sections/Institutions.tsx
@@ -5,6 +5,7 @@ import { NativeLink } from '@codaco/fresco-ui/NativeLink';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { Container } from '~/components/ui/Container';
 import { SectionHeading } from '~/components/ui/SectionHeading';
+import { cn } from '~/lib/cn';
 import { institutions } from '~/lib/content';
 
 function renderPriorLink(chunks: ReactNode) {
@@ -37,7 +38,7 @@ export function Institutions() {
   const t = useTranslations('Institutions');
 
   return (
-    <Container className="tablet-landscape:py-24 py-20">
+    <Container maxWidth="full" className="tablet-landscape:py-24 py-20">
       <SectionHeading title={t('heading')}>
         <Paragraph margin="none">
           {t.rich('paragraph1', {
@@ -53,7 +54,7 @@ export function Institutions() {
       <div
         data-homepage-weave-target
         data-homepage-weave-moving-target
-        className="mt-14 flex flex-wrap items-center justify-center gap-x-16 gap-y-10"
+        className="laptop:gap-x-12 mx-auto mt-14 flex max-w-[1500px] flex-wrap items-center justify-center gap-x-10 gap-y-10"
       >
         {institutions.map((inst) => (
           // Partner logos are fixed-colour brand assets. In dark mode they sit on
@@ -61,13 +62,32 @@ export function Institutions() {
           // in light mode the plate is absent and the logos render as before.
           <div
             key={inst.name}
-            className="[[data-theme=dark]_&]:rounded [[data-theme=dark]_&]:bg-white/90 [[data-theme=dark]_&]:px-5 [[data-theme=dark]_&]:py-3"
+            className="flex max-w-full items-center justify-center [[data-theme=dark]_&]:rounded [[data-theme=dark]_&]:bg-white/90 [[data-theme=dark]_&]:px-3 [[data-theme=dark]_&]:py-2"
           >
-            <img
-              src={inst.logo}
-              alt={inst.name}
-              className="tablet-landscape:h-20 h-16 w-auto object-contain"
-            />
+            <div
+              className={cn(
+                'tablet-portrait:h-20 laptop:h-28 relative h-16 max-w-full overflow-hidden',
+                inst.name === 'University of Oxford' &&
+                  'tablet-portrait:w-40 laptop:w-56 w-32',
+                inst.name === 'Northwestern University' &&
+                  'tablet-portrait:w-[21rem] laptop:w-[29rem] w-72',
+                inst.name === 'Complex Data Collective' &&
+                  'tablet-portrait:w-[21.5rem] laptop:w-[30rem] w-72',
+              )}
+            >
+              <img
+                src={inst.logo}
+                alt={inst.name}
+                className={cn(
+                  'absolute left-1/2 h-full w-auto max-w-none -translate-x-1/2 -translate-y-1/2 object-contain',
+                  inst.name === 'Northwestern University' && 'top-1/2',
+                  inst.name === 'University of Oxford' &&
+                    'top-[42.5%] scale-[1.3]',
+                  inst.name === 'Complex Data Collective' &&
+                    'top-[42.5%] scale-[3.2]',
+                )}
+              />
+            </div>
           </div>
         ))}
       </div>

--- a/apps/networkcanvas.com/components/sections/Publications.tsx
+++ b/apps/networkcanvas.com/components/sections/Publications.tsx
@@ -54,7 +54,7 @@ export function Publications({
         </Paragraph>
       </SectionHeading>
 
-      <div className="tablet-portrait:grid-cols-2 tablet-landscape:grid-cols-3 laptop:grid-cols-4 mx-auto mt-14 grid w-full max-w-[1200px] grid-cols-1 gap-5">
+      <div className="tablet-portrait:grid-cols-2 tablet-landscape:grid-cols-3 laptop:grid-cols-4 mx-auto mt-14 grid w-full max-w-[1600px] grid-cols-1 gap-5">
         {publications.map((pub, i) => (
           <Reveal key={pub.id} delay={(i % 4) * 0.04}>
             <a

--- a/apps/networkcanvas.com/components/sections/ScientificAdvisors.tsx
+++ b/apps/networkcanvas.com/components/sections/ScientificAdvisors.tsx
@@ -1,26 +1,27 @@
 import { useTranslations } from 'next-intl';
 
+import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
-import { Container } from '~/components/ui/Container';
-import { SectionHeading } from '~/components/ui/SectionHeading';
 import { scientificAdvisors } from '~/lib/content';
 
 export function ScientificAdvisors() {
   const t = useTranslations('ScientificAdvisors');
 
   return (
-    <Container
+    <div
       data-homepage-weave-target
-      className="tablet-landscape:py-28 py-20"
+      className="mx-auto mt-16 max-w-3xl text-center"
     >
-      <SectionHeading title={t('heading')}>
-        <Paragraph
-          margin="none"
-          className="text-text/80 tablet-landscape:text-lg text-base"
-        >
-          {scientificAdvisors.join(', ')}
-        </Paragraph>
-      </SectionHeading>
-    </Container>
+      <Heading
+        level="h3"
+        margin="none"
+        className="font-heading text-text text-xl font-bold"
+      >
+        {t('heading')}
+      </Heading>
+      <Paragraph margin="none" className="text-text/70 mt-3 text-base">
+        {scientificAdvisors.join(', ')}
+      </Paragraph>
+    </div>
   );
 }

--- a/apps/networkcanvas.com/components/sections/__tests__/LocalizedSections.test.tsx
+++ b/apps/networkcanvas.com/components/sections/__tests__/LocalizedSections.test.tsx
@@ -9,7 +9,6 @@ import { CoreTeam } from '../CoreTeam';
 import { DesignPrinciples } from '../DesignPrinciples';
 import { Institutions } from '../Institutions';
 import { Publications } from '../Publications';
-import { ScientificAdvisors } from '../ScientificAdvisors';
 import { VideoSection } from '../VideoSection';
 import { WhatNext } from '../WhatNext';
 
@@ -59,7 +58,6 @@ describe('localized home sections', () => {
       <>
         <DesignPrinciples />
         <CoreTeam members={members} />
-        <ScientificAdvisors />
       </>,
       'es',
     );
@@ -137,7 +135,7 @@ describe('localized home sections', () => {
       'laptop:grid-cols-4',
       'grid-cols-1',
       'w-full',
-      'max-w-[1200px]',
+      'max-w-[1600px]',
       'mx-auto',
     );
     expect(publicationCard?.closest('.max-w-none')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- widen the recent publications grid to a 1600px maximum
- move Scientific Advisors into a compact subsection beneath Core Team
- enlarge institution logos while normalizing their visible height and preserving intrinsic width
- add a Website-only patch changeset

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm --filter networkcanvas.com test`
- [x] `pnpm --filter networkcanvas.com build`
- [x] `pnpm check:changesets`
- [x] visually verified at 1440px and 390px widths