### PR TITLE
Fix: interview stage jump navigation

### DIFF
--- a/.changeset/interview-stage-jump-navigation.md
+++ b/.changeset/interview-stage-jump-navigation.md
@@ -1,0 +1,10 @@
+---
+'@codaco/interview': patch
+---
+
+Go to the chosen screen when picking one from the navigation bar. Screens that
+have their own internal steps previously ignored the choice — picking a later
+screen from an alter form moved to the next person's form and stayed put.
+Picking a screen now saves the current form if it can, asks before discarding
+changes that cannot be saved, and otherwise moves straight there without
+requiring the form to be completed first.

--- a/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
+++ b/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
@@ -582,6 +582,40 @@ describe('useInterviewNavigation goToStage (progress-bar jump)', () => {
     expect(onStepChange).not.toHaveBeenCalled();
   });
 
+  it('does not run beforeNext handlers when an unavailable target is declined', async () => {
+    const stages = makeStages(4);
+    stages[2]!.skipLogic = ALWAYS_SKIPPED;
+    const { result, onStepChange } = renderStatefulNavigation(stages, 0);
+
+    const beforeNext = vi.fn(() => true);
+    act(() => {
+      result.current.registerBeforeNext(beforeNext);
+    });
+
+    const confirmSkip = vi.fn().mockResolvedValue(false);
+    await act(async () => {
+      await result.current.goToStage(2, confirmSkip);
+    });
+
+    expect(confirmSkip).toHaveBeenCalledTimes(1);
+    expect(beforeNext).not.toHaveBeenCalled();
+    expect(onStepChange).not.toHaveBeenCalled();
+  });
+
+  it('confirms an unavailable target once when it is already unavailable', async () => {
+    const stages = makeStages(4);
+    stages[2]!.skipLogic = ALWAYS_SKIPPED;
+    const { result, onStepChange } = renderStatefulNavigation(stages, 0);
+
+    const confirmSkip = vi.fn().mockResolvedValue(true);
+    await act(async () => {
+      await result.current.goToStage(2, confirmSkip);
+    });
+
+    expect(confirmSkip).toHaveBeenCalledTimes(1);
+    expect(onStepChange).toHaveBeenCalledWith(2, expect.anything());
+  });
+
   it('lands on a confirmed skipped stage without being bounced by recovery', async () => {
     const stages = makeStages(4);
     stages[2]!.skipLogic = ALWAYS_SKIPPED;

--- a/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
+++ b/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
@@ -469,6 +469,87 @@ describe('useInterviewNavigation goToStage (progress-bar jump)', () => {
     expect(directions).toEqual(['forwards', 'backwards']);
   });
 
+  it("passes intent 'jump' to beforeNext, and 'step' for button navigation", async () => {
+    const intents: string[] = [];
+    const record = (_direction: string, intent: string) => {
+      intents.push(intent);
+      return true;
+    };
+
+    const jumped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      jumped.result.current.registerBeforeNext(record);
+    });
+    await act(async () => {
+      await jumped.result.current.goToStage(4);
+    });
+
+    const stepped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      stepped.result.current.registerBeforeNext(record);
+    });
+    await act(async () => {
+      await stepped.result.current.moveForward();
+    });
+    act(() => {
+      stepped.result.current.registerBeforeNext(record);
+    });
+    await act(async () => {
+      await stepped.result.current.moveBackward();
+    });
+
+    expect(intents).toEqual(['jump', 'step', 'step']);
+  });
+
+  it('lets a handler deny a jump while still allowing a step', async () => {
+    const denyJumps = (_direction: string, intent: string) => intent !== 'jump';
+
+    const jumped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      jumped.result.current.registerBeforeNext(denyJumps);
+    });
+    await act(async () => {
+      await jumped.result.current.goToStage(4);
+    });
+
+    expect(jumped.onStepChange).not.toHaveBeenCalled();
+
+    const stepped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      stepped.result.current.registerBeforeNext(denyJumps);
+    });
+    await act(async () => {
+      await stepped.result.current.moveForward();
+    });
+
+    expect(stepped.onStepChange).toHaveBeenCalledWith(3, expect.anything());
+  });
+
+  it('lets a handler allow a jump while still blocking a step', async () => {
+    const allowOnlyJumps = (_direction: string, intent: string) =>
+      intent === 'jump';
+
+    const jumped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      jumped.result.current.registerBeforeNext(allowOnlyJumps);
+    });
+    await act(async () => {
+      await jumped.result.current.goToStage(4);
+    });
+
+    expect(jumped.onStepChange).toHaveBeenCalledWith(4, expect.anything());
+
+    const stepped = renderStatefulNavigation(makeStages(5), 2);
+    act(() => {
+      stepped.result.current.registerBeforeNext(allowOnlyJumps);
+    });
+    await act(async () => {
+      await stepped.result.current.moveForward();
+    });
+
+    expect(stepped.onStepChange).not.toHaveBeenCalled();
+  });
+
   it('still navigates when a beforeNext handler returns FORCE', async () => {
     const { result, onStepChange } = renderStatefulNavigation(makeStages(4), 0);
 

--- a/packages/interview/src/hooks/useBeforeNext.ts
+++ b/packages/interview/src/hooks/useBeforeNext.ts
@@ -12,7 +12,9 @@ export default function useBeforeNext(handler: BeforeNextFunction) {
   const key = useId();
 
   useEffect(() => {
-    registerBeforeNext(key, (direction) => handlerRef.current(direction));
+    registerBeforeNext(key, (direction, intent) =>
+      handlerRef.current(direction, intent),
+    );
     return () => registerBeforeNext(key, null);
   }, [registerBeforeNext, key]);
 }

--- a/packages/interview/src/hooks/useInterviewNavigation.ts
+++ b/packages/interview/src/hooks/useInterviewNavigation.ts
@@ -265,6 +265,20 @@ export default function useInterviewNavigation(
         const direction: Direction =
           targetIndex > currentStep ? 'forwards' : 'backwards';
 
+        // Confirm before running beforeNext handlers, so declining leaves the
+        // current screen untouched rather than saving or resetting it first.
+        const initialAvailability = getStageAvailabilityMap(
+          interviewStore.getState(),
+        )[targetIndex];
+        let confirmedUnavailable = false;
+        if (initialAvailability && initialAvailability.kind !== 'available') {
+          confirmedUnavailable =
+            (await confirmUnavailable?.(initialAvailability)) ?? false;
+          if (!confirmedUnavailable) {
+            return;
+          }
+        }
+
         const stageAllowsNavigation = await canNavigate(direction, 'jump');
         if (!stageAllowsNavigation) {
           return;
@@ -277,7 +291,8 @@ export default function useInterviewNavigation(
         )[targetIndex];
         if (targetAvailability && targetAvailability.kind !== 'available') {
           const confirmed =
-            (await confirmUnavailable?.(targetAvailability)) ?? false;
+            confirmedUnavailable ||
+            ((await confirmUnavailable?.(targetAvailability)) ?? false);
           if (!confirmed) {
             return;
           }

--- a/packages/interview/src/hooks/useInterviewNavigation.ts
+++ b/packages/interview/src/hooks/useInterviewNavigation.ts
@@ -31,6 +31,7 @@ import type { RootState } from '../store/store';
 import type {
   BeforeNextFunction,
   Direction,
+  NavigationIntent,
   RegisterBeforeNext,
   StageProps,
 } from '../types';
@@ -139,7 +140,10 @@ export default function useInterviewNavigation(
    * in insertion order. If any returns false, navigation is blocked. If any
    * returns 'FORCE' (and none returned false), the prompt boundary is skipped.
    */
-  const canNavigate = async (direction: Direction) => {
+  const canNavigate = async (
+    direction: Direction,
+    intent: NavigationIntent,
+  ) => {
     const handlers = beforeNextHandlers.current;
     if (handlers.size === 0) {
       return true;
@@ -147,7 +151,7 @@ export default function useInterviewNavigation(
 
     let hasForce = false;
     for (const fn of handlers.values()) {
-      const result = await fn(direction);
+      const result = await fn(direction, intent);
 
       invariant(
         result === true || result === false || result === 'FORCE',
@@ -169,7 +173,7 @@ export default function useInterviewNavigation(
     setForceNavigationDisabled(true);
 
     try {
-      const stageAllowsNavigation = await canNavigate('forwards');
+      const stageAllowsNavigation = await canNavigate('forwards', 'step');
 
       if (!stageAllowsNavigation) {
         return;
@@ -212,7 +216,7 @@ export default function useInterviewNavigation(
     setForceNavigationDisabled(true);
 
     try {
-      const stageAllowsNavigation = await canNavigate('backwards');
+      const stageAllowsNavigation = await canNavigate('backwards', 'step');
 
       if (!stageAllowsNavigation) {
         return;
@@ -261,7 +265,7 @@ export default function useInterviewNavigation(
         const direction: Direction =
           targetIndex > currentStep ? 'forwards' : 'backwards';
 
-        const stageAllowsNavigation = await canNavigate(direction);
+        const stageAllowsNavigation = await canNavigate(direction, 'jump');
         if (!stageAllowsNavigation) {
           return;
         }

--- a/packages/interview/src/hooks/useStageValidation.ts
+++ b/packages/interview/src/hooks/useStageValidation.ts
@@ -14,7 +14,7 @@ import { useTrack } from '../analytics/useTrack';
 import { StageMetadataContext } from '../contexts/StageMetadataContext';
 import { useInterviewToastContext } from '../toast/InterviewToast';
 import { interviewToastManager } from '../toast/interviewToastManager';
-import type { Direction } from '../types';
+import type { Direction, NavigationIntent } from '../types';
 
 type StageConstraint = {
   direction: 'forwards' | 'backwards' | 'both';
@@ -115,7 +115,11 @@ function useStageValidation({ constraints }: UseStageValidationOptions) {
 
   // Register the keyed beforeNext handler
   useEffect(() => {
-    const handler = (direction: Direction) => {
+    const handler = (direction: Direction, intent: NavigationIntent) => {
+      if (intent === 'jump') {
+        return true;
+      }
+
       const currentConstraints = constraintsRef.current;
       const activeToasts = activeToastsRef.current;
 

--- a/packages/interview/src/interfaces/AlterEdgeForm/AlterEdgeForm.tsx
+++ b/packages/interview/src/interfaces/AlterEdgeForm/AlterEdgeForm.tsx
@@ -85,8 +85,8 @@ const AlterEdgeForm = (props: StageProps<'AlterEdgeForm'>) => {
 
   const { moveForward } = props.getNavigationHelpers();
 
-  useBeforeNext((direction) => {
-    if (mode === 'intro' && direction === 'forwards') {
+  useBeforeNext((direction, intent) => {
+    if (mode === 'intro' && direction === 'forwards' && intent === 'step') {
       setMode('form');
       return false;
     }

--- a/packages/interview/src/interfaces/AlterForm/AlterForm.tsx
+++ b/packages/interview/src/interfaces/AlterForm/AlterForm.tsx
@@ -61,8 +61,8 @@ const AlterForm = (props: StageProps<'AlterForm'>) => {
   // Intro state owns the forward-nav signal: pressing next dismisses the intro
   // instead of leaving the stage. Once in form mode, SlidesForm's own
   // useBeforeNext takes over. Backwards always passes through.
-  useBeforeNext((direction) => {
-    if (mode === 'intro' && direction === 'forwards') {
+  useBeforeNext((direction, intent) => {
+    if (mode === 'intro' && direction === 'forwards' && intent === 'step') {
       setMode('form');
       return false;
     }

--- a/packages/interview/src/interfaces/DyadCensus/DyadCensus.tsx
+++ b/packages/interview/src/interfaces/DyadCensus/DyadCensus.tsx
@@ -139,7 +139,12 @@ export default function DyadCensus(props: DyadCensusProps) {
   });
 
   // Navigation
-  useBeforeNext((direction) => {
+  useBeforeNext((direction, intent) => {
+    if (intent === 'jump') {
+      setPairIndex(0);
+      return true;
+    }
+
     if (direction === 'forwards') {
       setIsForwards(true);
 

--- a/packages/interview/src/interfaces/DyadCensus/__tests__/DyadCensus.test.tsx
+++ b/packages/interview/src/interfaces/DyadCensus/__tests__/DyadCensus.test.tsx
@@ -129,10 +129,13 @@ function renderInterface(
     }
   };
 
-  const runValidation = async (direction: 'forwards' | 'backwards') => {
+  const runValidation = async (
+    direction: 'forwards' | 'backwards',
+    intent: 'step' | 'jump' = 'step',
+  ) => {
     let result: boolean | 'FORCE' | undefined;
     await act(async () => {
-      result = await handlers.get('stageValidation')?.(direction, 'step');
+      result = await handlers.get('stageValidation')?.(direction, intent);
     });
     return result;
   };
@@ -186,6 +189,14 @@ function renderInterface(
 }
 
 describe('DyadCensus interface', () => {
+  it('blocks stepping forwards on an unanswered pair but allows a direct jump', async () => {
+    const { advancePastIntro, runValidation } = renderInterface(onePromptStage);
+    await advancePastIntro();
+
+    expect(await runValidation('forwards')).toBe(false);
+    expect(await runValidation('forwards', 'jump')).toBe(true);
+  });
+
   it('reflects a shared-graph edge on a later prompt but still requires a per-prompt answer', async () => {
     const { store, advancePastIntro, runValidation, yesButton } =
       renderInterface(twoPromptStage);

--- a/packages/interview/src/interfaces/DyadCensus/__tests__/DyadCensus.test.tsx
+++ b/packages/interview/src/interfaces/DyadCensus/__tests__/DyadCensus.test.tsx
@@ -132,7 +132,7 @@ function renderInterface(
   const runValidation = async (direction: 'forwards' | 'backwards') => {
     let result: boolean | 'FORCE' | undefined;
     await act(async () => {
-      result = await handlers.get('stageValidation')?.(direction);
+      result = await handlers.get('stageValidation')?.(direction, 'step');
     });
     return result;
   };
@@ -141,7 +141,7 @@ function renderInterface(
     await act(async () => {
       for (const [key, fn] of handlers) {
         if (key === 'stageValidation') continue;
-        await fn(direction);
+        await fn(direction, 'step');
       }
     });
   };

--- a/packages/interview/src/interfaces/EgoForm/EgoForm.tsx
+++ b/packages/interview/src/interfaces/EgoForm/EgoForm.tsx
@@ -95,16 +95,16 @@ const EgoFormInner = (props: EgoFormProps) => {
     ) as Record<string, FieldValue>,
   });
 
-  const beforeNext: BeforeNextFunction = async (direction) => {
+  const beforeNext: BeforeNextFunction = async (direction, intent) => {
     // If direction is backwards, and the form is invalid, check if the user
     // wants to proceed anyway (causing the form to be reset)
-    if (direction === 'backwards') {
+    if (direction === 'backwards' || intent === 'jump') {
       if (isFormDirty && !isFormValid) {
         const result = await openDialog({
           type: 'choice',
           title: 'Discard changes?',
           description:
-            'This form contains invalid data, so it cannot be saved. If you continue it will be reset and your changes will be lost. Do you want to discard your changes?',
+            'This form contains invalid data, so it cannot be saved. If you continue it will be reset, and your changes will be lost. Do you want to discard your changes?',
           intent: 'destructive',
           actions: {
             primary: { label: 'Discard changes', value: true },

--- a/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.tsx
+++ b/packages/interview/src/interfaces/FamilyPedigree/FamilyPedigree.tsx
@@ -242,7 +242,7 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
     setActiveNominationVariable(prompt?.variable ?? null);
   };
 
-  useBeforeNext((direction) => {
+  useBeforeNext((direction, intent) => {
     if (direction === 'forwards') {
       // Step 0 → finalize before advancing
       if (currentStepIndex === 0) {
@@ -254,7 +254,7 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
         }
 
         if (isNetworkCommitted) {
-          if (hasNominationPrompts) {
+          if (hasNominationPrompts && intent === 'step') {
             // Already finalized (revisiting) — skip straight to nomination
             setCurrentStepIndex(1);
             updateNominationVariable(1);
@@ -284,7 +284,7 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
       }
 
       const isLastStep = currentStepIndex === allPrompts.length - 1;
-      if (isLastStep) {
+      if (intent === 'jump' || isLastStep) {
         syncMetadata();
         return true;
       }
@@ -296,6 +296,11 @@ const FamilyPedigree = (props: StageProps<'FamilyPedigree'>) => {
     }
     if (direction === 'backwards') {
       if (currentStepIndex === 0) {
+        return true;
+      }
+
+      if (intent === 'jump') {
+        syncMetadata();
         return true;
       }
 

--- a/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
+++ b/packages/interview/src/interfaces/Geospatial/Geospatial.tsx
@@ -32,7 +32,7 @@ import { useStageSelector } from '../../hooks/useStageSelector';
 import { getNetworkNodesForType } from '../../selectors/session';
 import { updateNode as updateNodeAction } from '../../store/modules/session';
 import type { RootState } from '../../store/store';
-import type { Direction, StageProps } from '../../types';
+import type { Direction, NavigationIntent, StageProps } from '../../types';
 import CollapsablePrompts from '../Sociogram/CollapsablePrompts';
 import { isMapboxStubBrowser } from './isMapboxStubBrowser';
 import { useMapbox } from './useMapbox';
@@ -325,9 +325,14 @@ export default function GeospatialInterface({
     handleResetSelection();
   }, [handleResetSelection, navState.activeIndex]);
 
-  const beforeNext = (direction: Direction) => {
+  const beforeNext = (direction: Direction, intent: NavigationIntent) => {
     // Leave the stage if there are no nodes
     if (stageNodes.length === 0) {
+      return true;
+    }
+
+    if (intent === 'jump') {
+      handleResetSelection();
       return true;
     }
 

--- a/packages/interview/src/interfaces/OneToManyDyadCensus/OneToManyDyadCensus.tsx
+++ b/packages/interview/src/interfaces/OneToManyDyadCensus/OneToManyDyadCensus.tsx
@@ -96,7 +96,12 @@ function OneToManyDyadCensus(props: OneToManyDyadCensusProps) {
    * - If we are moving backward, decrement the step until we reach 0
    * - If we are moving backward and on step 0, allow navigation
    */
-  useBeforeNext((direction) => {
+  useBeforeNext((direction, intent) => {
+    if (intent === 'jump') {
+      crossingDirection.current = direction;
+      return true;
+    }
+
     if (direction === 'forwards') {
       if (currentStep + 1 <= numberOfSteps) {
         setCurrentStep((prev) => prev + 1);

--- a/packages/interview/src/interfaces/OneToManyDyadCensus/__tests__/OneToManyDyadCensus.test.tsx
+++ b/packages/interview/src/interfaces/OneToManyDyadCensus/__tests__/OneToManyDyadCensus.test.tsx
@@ -143,7 +143,7 @@ function renderInterface(edges: NcEdge[] = []) {
   const navigate = async (direction: 'forwards' | 'backwards') => {
     let allowed = false;
     await act(async () => {
-      allowed = (await beforeNext?.(direction)) === true;
+      allowed = (await beforeNext?.(direction, 'step')) === true;
     });
     if (allowed) {
       const current = store.getState().session?.promptIndex ?? 0;

--- a/packages/interview/src/interfaces/SlidesForm/SlidesForm.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/SlidesForm.tsx
@@ -324,7 +324,7 @@ export default function SlidesForm({
     setIsReadyForNext(slideReady);
   }, [setIsReadyForNext, slideReady]);
 
-  const beforeNext: BeforeNextFunction = async (direction: Direction) => {
+  const beforeNext: BeforeNextFunction = async (direction, intent) => {
     if (items.length === 0) {
       return true;
     }
@@ -333,7 +333,7 @@ export default function SlidesForm({
 
     if (direction === 'backwards') {
       if (activeIndex === 0) {
-        if (onNavigateBack) {
+        if (onNavigateBack && intent === 'step') {
           onNavigateBack();
           return false;
         }
@@ -343,7 +343,7 @@ export default function SlidesForm({
       const formIsValid = await slideRef.current?.validate();
 
       if (!formIsValid && slideRef.current?.isDirty()) {
-        await confirm({
+        const discarded = await confirm({
           title: 'Discard changes?',
           description:
             'This form contains invalid data, so it cannot be saved. If you continue it will be reset, and your changes will be lost. Do you want to discard your changes?',
@@ -352,14 +352,20 @@ export default function SlidesForm({
           intent: 'destructive',
           onConfirm: () => {
             track('form_dismissed_without_save', { form_kind });
-            setActiveIndex((prev) => prev - 1);
+            if (intent === 'step') {
+              setActiveIndex((prev) => prev - 1);
+            }
           },
         });
-        return false;
+        return intent === 'jump' && discarded === true;
       }
 
       if (formIsValid) {
         await slideRef.current?.submit();
+      }
+
+      if (intent === 'jump') {
+        return true;
       }
 
       setActiveIndex((prev) => prev - 1);
@@ -378,7 +384,7 @@ export default function SlidesForm({
 
     await slideRef.current?.submit();
 
-    if (activeIndex >= items.length - 1) {
+    if (intent === 'jump' || activeIndex >= items.length - 1) {
       return true;
     }
 

--- a/packages/interview/src/interfaces/SlidesForm/SlidesForm.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/SlidesForm.tsx
@@ -106,6 +106,15 @@ const slideTransition = {
   damping: 15,
 };
 
+const discardChangesDialog = {
+  title: 'Discard changes?',
+  description:
+    'This form contains invalid data, so it cannot be saved. If you continue it will be reset, and your changes will be lost. Do you want to discard your changes?',
+  confirmLabel: 'Discard changes',
+  cancelLabel: 'Keep changes',
+  intent: 'destructive' as const,
+};
+
 type SlideHandle = {
   validate: () => Promise<boolean>;
   submit: () => Promise<void>;
@@ -331,9 +340,31 @@ export default function SlidesForm({
 
     setPendingDirection(direction);
 
+    if (intent === 'jump') {
+      const formIsValid = await slideRef.current?.validate();
+
+      if (formIsValid) {
+        await slideRef.current?.submit();
+        return true;
+      }
+
+      if (!slideRef.current?.isDirty()) {
+        return true;
+      }
+
+      const discarded = await confirm({
+        ...discardChangesDialog,
+        onConfirm: () => {
+          track('form_dismissed_without_save', { form_kind });
+        },
+      });
+
+      return discarded === true;
+    }
+
     if (direction === 'backwards') {
       if (activeIndex === 0) {
-        if (onNavigateBack && intent === 'step') {
+        if (onNavigateBack) {
           onNavigateBack();
           return false;
         }
@@ -343,29 +374,18 @@ export default function SlidesForm({
       const formIsValid = await slideRef.current?.validate();
 
       if (!formIsValid && slideRef.current?.isDirty()) {
-        const discarded = await confirm({
-          title: 'Discard changes?',
-          description:
-            'This form contains invalid data, so it cannot be saved. If you continue it will be reset, and your changes will be lost. Do you want to discard your changes?',
-          confirmLabel: 'Discard changes',
-          cancelLabel: 'Cancel',
-          intent: 'destructive',
+        await confirm({
+          ...discardChangesDialog,
           onConfirm: () => {
             track('form_dismissed_without_save', { form_kind });
-            if (intent === 'step') {
-              setActiveIndex((prev) => prev - 1);
-            }
+            setActiveIndex((prev) => prev - 1);
           },
         });
-        return intent === 'jump' && discarded === true;
+        return false;
       }
 
       if (formIsValid) {
         await slideRef.current?.submit();
-      }
-
-      if (intent === 'jump') {
-        return true;
       }
 
       setActiveIndex((prev) => prev - 1);
@@ -384,7 +404,7 @@ export default function SlidesForm({
 
     await slideRef.current?.submit();
 
-    if (intent === 'jump' || activeIndex >= items.length - 1) {
+    if (activeIndex >= items.length - 1) {
       return true;
     }
 

--- a/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
@@ -470,4 +470,96 @@ describe('SlidesForm navigation ownership', () => {
 
     expect(onStepChange).not.toHaveBeenCalled();
   });
+
+  it('leaves the stage on a jump once discarding unsaved changes is confirmed', async () => {
+    const store = configureStore({
+      reducer: { session, protocol, ui },
+      preloadedState: {
+        session: {
+          id: 'session',
+          network: {
+            ego: { [entityAttributesProperty]: {} },
+            nodes: [person],
+            edges: [],
+          },
+        } as never,
+        protocol: {
+          id: 'protocol',
+          hash: 'hash',
+          schemaVersion: 8,
+          codebook: requiredNameCodebook,
+          stages: [
+            {
+              id: 'alter-form',
+              type: 'AlterForm',
+              label: 'Alter form',
+              subject: { entity: 'node', type: 'person' },
+              introductionPanel: { title: 'About this person', text: '' },
+              form,
+            },
+            {
+              id: 'next-screen',
+              type: 'Information',
+              label: 'Next screen',
+              title: 'Next screen',
+              items: [],
+            },
+          ],
+        } as never,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+    });
+    const onStepChange = vi.fn();
+    let goToStage: ((targetIndex: number) => Promise<void>) | undefined;
+
+    function JumpHarness() {
+      const navigation = useInterviewNavigation(0);
+      goToStage = navigation.goToStage;
+
+      return (
+        <StageMetadataProvider value={navigation.registerBeforeNext}>
+          <SlidesForm
+            form={form}
+            items={[person]}
+            subject={{ entity: 'node', type: 'person' }}
+            updateItem={vi.fn()}
+            moveForward={navigation.moveForward}
+            renderHeader={() => <span>Person header</span>}
+            form_kind="alter"
+          />
+        </StageMetadataProvider>
+      );
+    }
+
+    render(
+      <Provider store={store}>
+        <CurrentStepProvider currentStep={0} onStepChange={onStepChange}>
+          <DialogProvider>
+            <JumpHarness />
+          </DialogProvider>
+        </CurrentStepProvider>
+      </Provider>,
+    );
+
+    const field = await screen.findByRole('textbox', { name: 'Person name' });
+    fireEvent.change(field, { target: { value: '' } });
+    await screen.findByDisplayValue('');
+
+    let jump: Promise<void> | undefined;
+    await act(async () => {
+      jump = goToStage?.(1);
+      await Promise.resolve();
+    });
+
+    const discardChanges = await screen.findByRole('button', {
+      name: 'Discard changes',
+    });
+    await act(async () => {
+      fireEvent.click(discardChanges);
+      await jump;
+    });
+
+    expect(onStepChange).toHaveBeenCalledWith(1, expect.anything());
+  });
 });

--- a/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
@@ -70,6 +70,12 @@ const secondPerson: NcNode = {
   [entityAttributesProperty]: { name: 'Grace' },
 };
 
+const namelessPerson: NcNode = {
+  [entityPrimaryKeyProperty]: 'person-3',
+  type: 'person',
+  [entityAttributesProperty]: { name: '' },
+};
+
 const codebook = {
   node: {
     person: {
@@ -83,6 +89,23 @@ const codebook = {
   },
   edge: {},
   ego: { variables: {} },
+};
+
+const requiredNameCodebook = {
+  ...codebook,
+  node: {
+    person: {
+      ...codebook.node.person,
+      variables: {
+        name: {
+          name: 'Name',
+          type: 'text',
+          component: 'Text',
+          validation: { required: true },
+        },
+      },
+    },
+  },
 };
 
 describe('SlidesForm navigation ownership', () => {
@@ -272,5 +295,87 @@ describe('SlidesForm navigation ownership', () => {
     expect(screen.getByRole('textbox', { name: 'Person name' })).toHaveValue(
       'Ada',
     );
+  });
+
+  it('leaves the stage on a direct jump from an untouched invalid form', async () => {
+    const store = configureStore({
+      reducer: { session, protocol, ui },
+      preloadedState: {
+        session: {
+          id: 'session',
+          network: {
+            ego: { [entityAttributesProperty]: {} },
+            nodes: [namelessPerson],
+            edges: [],
+          },
+        } as never,
+        protocol: {
+          id: 'protocol',
+          hash: 'hash',
+          schemaVersion: 8,
+          codebook: requiredNameCodebook,
+          stages: [
+            {
+              id: 'alter-form',
+              type: 'AlterForm',
+              label: 'Alter form',
+              subject: { entity: 'node', type: 'person' },
+              introductionPanel: { title: 'About this person', text: '' },
+              form,
+            },
+            {
+              id: 'next-screen',
+              type: 'Information',
+              label: 'Next screen',
+              title: 'Next screen',
+              items: [],
+            },
+          ],
+        } as never,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+    });
+    const onStepChange = vi.fn();
+    let goToStage: ((targetIndex: number) => Promise<void>) | undefined;
+
+    function JumpHarness() {
+      const navigation = useInterviewNavigation(0);
+      goToStage = navigation.goToStage;
+
+      return (
+        <StageMetadataProvider value={navigation.registerBeforeNext}>
+          <SlidesForm
+            form={form}
+            items={[namelessPerson]}
+            subject={{ entity: 'node', type: 'person' }}
+            updateItem={vi.fn()}
+            moveForward={navigation.moveForward}
+            renderHeader={() => <span>Person header</span>}
+            form_kind="alter"
+          />
+        </StageMetadataProvider>
+      );
+    }
+
+    render(
+      <Provider store={store}>
+        <CurrentStepProvider currentStep={0} onStepChange={onStepChange}>
+          <DialogProvider>
+            <JumpHarness />
+          </DialogProvider>
+        </CurrentStepProvider>
+      </Provider>,
+    );
+
+    expect(
+      await screen.findByRole('textbox', { name: 'Person name' }),
+    ).toHaveValue('');
+
+    await act(async () => {
+      await goToStage?.(1);
+    });
+
+    expect(onStepChange).toHaveBeenCalledWith(1, expect.anything());
   });
 });

--- a/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
@@ -64,6 +64,27 @@ const person: NcNode = {
   [entityAttributesProperty]: { name: 'Ada' },
 };
 
+const secondPerson: NcNode = {
+  [entityPrimaryKeyProperty]: 'person-2',
+  type: 'person',
+  [entityAttributesProperty]: { name: 'Grace' },
+};
+
+const codebook = {
+  node: {
+    person: {
+      name: 'Person',
+      color: 'node-color-seq-1',
+      shape: { default: 'circle' },
+      variables: {
+        name: { name: 'Name', type: 'text', component: 'Text' },
+      },
+    },
+  },
+  edge: {},
+  ego: { variables: {} },
+};
+
 describe('SlidesForm navigation ownership', () => {
   it('keeps rendered form content on an unavailable stage with an initial override', async () => {
     const store = configureStore({
@@ -166,5 +187,90 @@ describe('SlidesForm navigation ownership', () => {
 
     await act(() => Promise.resolve());
     expect(onStepChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves the stage on a direct jump rather than advancing to the next item', async () => {
+    const store = configureStore({
+      reducer: { session, protocol, ui },
+      preloadedState: {
+        session: {
+          id: 'session',
+          network: {
+            ego: { [entityAttributesProperty]: {} },
+            nodes: [person, secondPerson],
+            edges: [],
+          },
+        } as never,
+        protocol: {
+          id: 'protocol',
+          hash: 'hash',
+          schemaVersion: 8,
+          codebook,
+          stages: [
+            {
+              id: 'alter-form',
+              type: 'AlterForm',
+              label: 'Alter form',
+              subject: { entity: 'node', type: 'person' },
+              introductionPanel: { title: 'About this person', text: '' },
+              form,
+            },
+            {
+              id: 'next-screen',
+              type: 'Information',
+              label: 'Next screen',
+              title: 'Next screen',
+              items: [],
+            },
+          ],
+        } as never,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+    });
+    const onStepChange = vi.fn();
+    let goToStage: ((targetIndex: number) => Promise<void>) | undefined;
+
+    function JumpHarness() {
+      const navigation = useInterviewNavigation(0);
+      goToStage = navigation.goToStage;
+
+      return (
+        <StageMetadataProvider value={navigation.registerBeforeNext}>
+          <SlidesForm
+            form={form}
+            items={[person, secondPerson]}
+            subject={{ entity: 'node', type: 'person' }}
+            updateItem={vi.fn()}
+            moveForward={navigation.moveForward}
+            renderHeader={() => <span>Person header</span>}
+            form_kind="alter"
+          />
+        </StageMetadataProvider>
+      );
+    }
+
+    render(
+      <Provider store={store}>
+        <CurrentStepProvider currentStep={0} onStepChange={onStepChange}>
+          <DialogProvider>
+            <JumpHarness />
+          </DialogProvider>
+        </CurrentStepProvider>
+      </Provider>,
+    );
+
+    expect(
+      await screen.findByRole('textbox', { name: 'Person name' }),
+    ).toHaveValue('Ada');
+
+    await act(async () => {
+      await goToStage?.(1);
+    });
+
+    expect(onStepChange).toHaveBeenCalledWith(1, expect.anything());
+    expect(screen.getByRole('textbox', { name: 'Person name' })).toHaveValue(
+      'Ada',
+    );
   });
 });

--- a/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
+++ b/packages/interview/src/interfaces/SlidesForm/__tests__/SlidesForm.navigation.test.tsx
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -377,5 +377,97 @@ describe('SlidesForm navigation ownership', () => {
     });
 
     expect(onStepChange).toHaveBeenCalledWith(1, expect.anything());
+  });
+
+  it('asks before discarding unsaved changes that cannot be saved on a jump', async () => {
+    const store = configureStore({
+      reducer: { session, protocol, ui },
+      preloadedState: {
+        session: {
+          id: 'session',
+          network: {
+            ego: { [entityAttributesProperty]: {} },
+            nodes: [person],
+            edges: [],
+          },
+        } as never,
+        protocol: {
+          id: 'protocol',
+          hash: 'hash',
+          schemaVersion: 8,
+          codebook: requiredNameCodebook,
+          stages: [
+            {
+              id: 'alter-form',
+              type: 'AlterForm',
+              label: 'Alter form',
+              subject: { entity: 'node', type: 'person' },
+              introductionPanel: { title: 'About this person', text: '' },
+              form,
+            },
+            {
+              id: 'next-screen',
+              type: 'Information',
+              label: 'Next screen',
+              title: 'Next screen',
+              items: [],
+            },
+          ],
+        } as never,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false }),
+    });
+    const onStepChange = vi.fn();
+    let goToStage: ((targetIndex: number) => Promise<void>) | undefined;
+
+    function JumpHarness() {
+      const navigation = useInterviewNavigation(0);
+      goToStage = navigation.goToStage;
+
+      return (
+        <StageMetadataProvider value={navigation.registerBeforeNext}>
+          <SlidesForm
+            form={form}
+            items={[person]}
+            subject={{ entity: 'node', type: 'person' }}
+            updateItem={vi.fn()}
+            moveForward={navigation.moveForward}
+            renderHeader={() => <span>Person header</span>}
+            form_kind="alter"
+          />
+        </StageMetadataProvider>
+      );
+    }
+
+    render(
+      <Provider store={store}>
+        <CurrentStepProvider currentStep={0} onStepChange={onStepChange}>
+          <DialogProvider>
+            <JumpHarness />
+          </DialogProvider>
+        </CurrentStepProvider>
+      </Provider>,
+    );
+
+    const field = await screen.findByRole('textbox', { name: 'Person name' });
+    fireEvent.change(field, { target: { value: '' } });
+    await screen.findByDisplayValue('');
+
+    let jump: Promise<void> | undefined;
+    await act(async () => {
+      jump = goToStage?.(1);
+      await Promise.resolve();
+    });
+
+    const keepChanges = await screen.findByRole('button', {
+      name: 'Keep changes',
+    });
+    await act(async () => {
+      fireEvent.click(keepChanges);
+      await jump;
+    });
+
+    expect(onStepChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/interview/src/interfaces/TieStrengthCensus/TieStrengthCensus.tsx
+++ b/packages/interview/src/interfaces/TieStrengthCensus/TieStrengthCensus.tsx
@@ -227,7 +227,12 @@ export default function TieStrengthCensus(props: TieStrengthCensusProps) {
   });
 
   // Navigation
-  useBeforeNext((direction) => {
+  useBeforeNext((direction, intent) => {
+    if (intent === 'jump') {
+      setPairIndex(0);
+      return true;
+    }
+
     if (direction === 'forwards') {
       setIsForwards(true);
 

--- a/packages/interview/src/interfaces/TieStrengthCensus/__tests__/TieStrengthCensus.test.tsx
+++ b/packages/interview/src/interfaces/TieStrengthCensus/__tests__/TieStrengthCensus.test.tsx
@@ -150,7 +150,7 @@ function renderInterface(
 
   const advancePastIntro = async () => {
     await act(async () => {
-      await beforeNext?.('forwards');
+      await beforeNext?.('forwards', 'step');
     });
     await waitFor(() =>
       expect(screen.getAllByRole('option').length).toBeGreaterThan(0),

--- a/packages/interview/src/types.ts
+++ b/packages/interview/src/types.ts
@@ -2,8 +2,11 @@ import type { Stage as TStage } from '@codaco/protocol-validation';
 
 export type Direction = 'forwards' | 'backwards';
 
+export type NavigationIntent = 'step' | 'jump';
+
 export type BeforeNextFunction = (
   direction: Direction,
+  intent: NavigationIntent,
 ) => Promise<boolean | 'FORCE'> | boolean | 'FORCE';
 
 export type RegisterBeforeNext = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct stage navigation from the navigation bar.
  - Current form changes are saved when possible before switching stages.
  - Users are prompted before discarding unsaveable changes.
  - Navigation now distinguishes between step-by-step movement and direct jumps, preserving form state and preventing unintended advancement.

- **Bug Fixes**
  - Prevented stage selection from incorrectly advancing to another person’s form or leaving the interview flow incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->