### PR TITLE
Fix: toggle button label node stacking

### DIFF
--- a/.changeset/toggle-button-label-node-stacking.md
+++ b/.changeset/toggle-button-label-node-stacking.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Toggle button labels no longer paint over content stacked above them. Their text sat in the same stacking context as the surrounding page rather than being scoped to its own button, so a form's pinned header could be overlapped while scrolling.

--- a/packages/fresco-ui/src/form/fields/ToggleButtonGroup.tsx
+++ b/packages/fresco-ui/src/form/fields/ToggleButtonGroup.tsx
@@ -30,7 +30,7 @@ const toggleButtonGroupComposedVariants = compose(
 // Individual toggle button variants
 const toggleButtonVariants = cva({
   base: cx(
-    'relative inline-flex items-center justify-center',
+    'relative isolate inline-flex items-center justify-center',
     'shrink-0 cursor-pointer rounded-full',
     'overflow-hidden text-center font-medium',
     'border-4 bg-transparent',


### PR DESCRIPTION
fixes UI bug where toggle button label was rendered above Node label

<img width="890" height="488" alt="Screenshot 2026-07-21 at 12 31 03 PM" src="https://github.com/user-attachments/assets/8157a975-84cb-479c-921f-18742c4bc378" />
