### PR TITLE
fix(interview): dyad-census capture race and NodeList reduced-motion exit

### DIFF
--- a/.changeset/interview-nodelist-reduced-motion-exit.md
+++ b/.changeset/interview-nodelist-reduced-motion-exit.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Node lists now respect reduced-motion preferences when moving between prompts. Previously the outgoing nodes always played a fade-out animation before the next prompt's nodes appeared, even when the participant's system requested reduced motion; the swap is now instant in that case.

--- a/packages/interview/e2e/fixtures/one-to-many-dyad-census-fixture.ts
+++ b/packages/interview/e2e/fixtures/one-to-many-dyad-census-fixture.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
  * Fixture for OneToManyDyadCensus stages.
@@ -55,8 +55,44 @@ export class OneToManyDyadCensusFixture {
     );
   }
 
+  /**
+   * Whether a target is fully opaque on screen. Crossing a prompt boundary
+   * changes the NodeList animationKey, which fades the old targets to inline
+   * opacity 0, swaps items, then re-runs the stagger entrance — and
+   * Playwright's visibility check ignores opacity, so mid-choreography
+   * targets count as "visible" while rendering as an empty panel. Checks
+   * every ancestor up to the list container because the animated opacity
+   * lives on wrapper elements, not the option itself.
+   */
+  async isTargetSettled(label: string): Promise<boolean> {
+    try {
+      return await this.getTargetNode(label).evaluate(
+        (el) => {
+          for (let node: Element | null = el; node; node = node.parentElement) {
+            if (Number(getComputedStyle(node).opacity) < 1) return false;
+            if (node.id === 'dyad-census-targets') break;
+          }
+          return true;
+        },
+        undefined,
+        { timeout: 1000 },
+      );
+    } catch {
+      // Not in the DOM yet (or detached mid-choreography) — not settled.
+      return false;
+    }
+  }
+
+  /** Wait until a target has fully entered the list. */
+  async waitForTargetSettled(label: string): Promise<void> {
+    await expect.poll(() => this.isTargetSettled(label)).toBe(true);
+  }
+
   /** Click a target node to toggle the edge to the current focal node. */
   async toggleTarget(label: string): Promise<void> {
+    // Clicking while the prompt-boundary choreography is re-creating the
+    // list detaches the element under the pointer (webkit flake).
+    await this.waitForTargetSettled(label);
     await this.getTargetNode(label).click();
   }
 

--- a/packages/interview/e2e/fixtures/one-to-many-dyad-census-fixture.ts
+++ b/packages/interview/e2e/fixtures/one-to-many-dyad-census-fixture.ts
@@ -56,25 +56,42 @@ export class OneToManyDyadCensusFixture {
   }
 
   /**
-   * Whether a target is fully opaque on screen. Crossing a prompt boundary
-   * changes the NodeList animationKey, which fades the old targets to inline
-   * opacity 0, swaps items, then re-runs the stagger entrance — and
-   * Playwright's visibility check ignores opacity, so mid-choreography
-   * targets count as "visible" while rendering as an empty panel. Checks
-   * every ancestor up to the list container because the animated opacity
-   * lives on wrapper elements, not the option itself.
+   * Whether a target is fully opaque on screen AND belongs to the active
+   * prompt's list. Crossing a prompt boundary changes the NodeList
+   * animationKey, which fades the old targets to inline opacity 0, swaps
+   * items, then re-runs the stagger entrance — and Playwright's visibility
+   * check ignores opacity, so mid-choreography targets count as "visible"
+   * while rendering as an empty panel. Checks every ancestor up to the list
+   * container because the animated opacity lives on wrapper elements, not
+   * the option itself.
+   *
+   * Opacity alone can't guard the pre-exit window: a label present in both
+   * the outgoing and incoming lists (NodeList buffers the old items until
+   * the exit completes) matches the still-opaque OLD node. The stagger
+   * wrapper's data-stagger-key carries the buffered displayAnimationKey,
+   * which only advances to the active prompt index after the swap — so on
+   * multi-prompt stages (pips rendered) also require it to match.
    */
   async isTargetSettled(label: string): Promise<boolean> {
+    const activePromptIndex = await this.getActivePipIndex();
     try {
       return await this.getTargetNode(label).evaluate(
-        (el) => {
+        (el, expectedStaggerKey) => {
+          if (expectedStaggerKey !== null) {
+            const wrapper = el.closest('[data-stagger-item]');
+            if (
+              wrapper?.getAttribute('data-stagger-key') !== expectedStaggerKey
+            ) {
+              return false;
+            }
+          }
           for (let node: Element | null = el; node; node = node.parentElement) {
             if (Number(getComputedStyle(node).opacity) < 1) return false;
             if (node.id === 'dyad-census-targets') break;
           }
           return true;
         },
-        undefined,
+        activePromptIndex === -1 ? null : String(activePromptIndex),
         { timeout: 1000 },
       );
     } catch {

--- a/packages/interview/e2e/matrix/one-to-many-dyad-census.scenarios.ts
+++ b/packages/interview/e2e/matrix/one-to-many-dyad-census.scenarios.ts
@@ -273,6 +273,13 @@ export const oneToManyDyadCensusScenarios: InterfaceScenarios = {
         await expect(stage.getPrompt('Prompt one: friendship')).toBeVisible();
         await expect.poll(() => census.getActivePipIndex()).toBe(0);
         await expect.poll(() => census.getSourceLabel()).toBe('Bob');
+        // The boundary crossing re-runs the target list's exit + entrance
+        // choreography, and the source label settles before the targets do.
+        // Wait for both targets so the visual capture (and baseline
+        // regeneration) can't record the transient empty panel — the bad
+        // chromium baseline committed in #1057.
+        await census.waitForTargetSettled('Carol');
+        await census.waitForTargetSettled('Alice');
       },
     },
 

--- a/packages/interview/src/components/NodeList.tsx
+++ b/packages/interview/src/components/NodeList.tsx
@@ -1,4 +1,4 @@
-import { motion, animate as motionAnimate } from 'motion/react';
+import { motion } from 'motion/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -10,6 +10,7 @@ import type {
   ItemProps,
 } from '@codaco/fresco-ui/collection/types';
 import type { DragMetadata, DropCallback } from '@codaco/fresco-ui/dnd/types';
+import { useSafeAnimate } from '@codaco/fresco-ui/hooks/useSafeAnimate';
 import { cx } from '@codaco/fresco-ui/utils/cva';
 import {
   entityAttributesProperty,
@@ -70,7 +71,10 @@ const NodeList = memo(
     ...collectionProps
   }: NodeListProps) => {
     const layout = useMemo(() => new InlineGridLayout<NcNode>({ gap: 4 }), []);
-    const containerRef = useRef<HTMLDivElement>(null);
+    // Safe animate so the exit fade skips (instant swap) under reduced
+    // motion / MotionConfig skipAnimations; the scope doubles as the
+    // container ref for querying stagger items.
+    const [containerRef, safeAnimate] = useSafeAnimate();
 
     // --- Item buffering for prompt transitions ---
     const [displayItems, setDisplayItems] = useState(items);
@@ -131,7 +135,7 @@ const NodeList = memo(
 
       const nextKey = animationKey;
 
-      void motionAnimate(
+      void safeAnimate(
         staggerItems,
         { opacity: 0, scale: 0.6 },
         { duration: EXIT_DURATION },
@@ -140,7 +144,7 @@ const NodeList = memo(
         setDisplayAnimationKey(nextKey);
         isTransitioningRef.current = false;
       });
-    }, [animationKey]);
+    }, [animationKey, containerRef, safeAnimate]);
 
     // Build drag and drop hooks if accepts or onDrop is provided
     const { dragAndDropHooks } = useDragAndDrop<NcNode>({


### PR DESCRIPTION
## Summary

Fixes the race behind the bad chromium visual baseline committed in #1057 (the failure blocking the `changeset-release/main` E2E gate), on both sides of the seam: the e2e scenario/fixture that allowed a transient state to be captured, and the NodeList behaviour that created the transient state under reduced motion.

Crossing a prompt boundary changes the target `NodeList`'s `animationKey`, which fades the old targets to inline `opacity: 0`, swaps items, then re-runs the stagger entrance. The scenario's final wait only covered the focal label, and neither Playwright's visibility check nor the capture fixture's entrance-settle wait can see this window (visibility ignores opacity; individual nodes sit below the settle wait's `MIN_PENDING_AREA`). The regeneration workflow captured that empty-panel frame and it was adopted as the baseline.

### Test hardening

- `OneToManyDyadCensusFixture` gains `isTargetSettled` / `waitForTargetSettled`: effective-opacity check up the stagger-wrapper chain, plus a `data-stagger-key` match against the active pip index so a label present in both the outgoing and incoming lists can't satisfy the check against pre-transition DOM (review finding).
- The back-nav scenario waits for both targets to settle before returning, so `captureFinal` and `--update-snapshots` regeneration can no longer record the transient empty panel.
- `toggleTarget` settles before clicking — the same race detached the element mid-click in the webkit regeneration run.

### App fix

- `NodeList`'s prompt-transition exit ran through motion's raw `animate()`, which ignores `reducedMotion`/`skipAnimations` — participants requesting reduced motion still got the fade. It now routes through `useSafeAnimate` (as the entrance already does), making the swap instant under reduced motion. Patch changeset for `@codaco/interview` included.

The wrong committed baseline PNG itself is being restored separately; ordinary PRs skip E2E, so this PR does not depend on it.

## Test plan

- [x] `tsc` (src + e2e), `oxlint`, `oxfmt`, `pnpm knip` clean; interview unit suite (1198 tests) passes
- [x] Full interview E2E suite in the pinned Playwright Docker image: green except this scenario's chromium-visual comparison against the known-bad committed baseline — now deterministic instead of racily passing
- [x] The hardened capture's actual PNG is pixel-identical (0/921600 differing) to the correct pre-#1057 chromium baseline
- [x] Post-NodeList-change re-run of the affected visual tests: all pass; residual first-attempt flakes are the pre-existing family (also seen in yesterday's CI regen job) in stages that don't render NodeList

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved node-list transitions for participants using reduced-motion settings. Moving between prompts now swaps content immediately without the outgoing nodes’ fade-out animation.
  - Improved transition handling when navigating between prompts, helping ensure prompt content and navigation indicators appear consistently after moving forward or backward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->