### PR TITLE
Fix Interviewer case ID entry on short iPad viewports

### DIFF
--- a/.changeset/calm-ipads-focus.md
+++ b/.changeset/calm-ipads-focus.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Keep the case ID form stable when starting an interview on short tablet viewports, with compact responsive spacing and a focused backdrop that preserves the surrounding protocol deck.

--- a/apps/interviewer/e2e/specs/visual-viewport.spec.ts
+++ b/apps/interviewer/e2e/specs/visual-viewport.spec.ts
@@ -112,24 +112,67 @@ async function expectInsideVisualViewport(
     .toBe(true);
 }
 
+test('keeps the selected protocol card stable above the backdrop when the software keyboard makes the viewport compact', async ({
+  protocol,
+  page,
+}) => {
+  await installVisualViewportStub(page, LAYOUT_VISUAL_VIEWPORT);
+  await protocol.import(LEAN_E2E_PROTOCOL_PATH, LEAN_E2E_PROTOCOL_NAME);
+  await page.getByRole('button', { name: 'Start new interview' }).click();
+  const card = page.getByLabel(`${LEAN_E2E_PROTOCOL_NAME} (active)`);
+  const caseIdInput = card.getByTestId('new-session-case-id');
+  await expect(page.getByTestId('new-session-backdrop')).toBeVisible();
+  await expect(caseIdInput).toBeVisible();
+  await expect(page.getByText('Import a protocol')).toBeVisible();
+  await expect(
+    page.getByTestId('protocol-deck-inactive-backdrop').first(),
+  ).toBeVisible();
+  await expect(
+    page.locator('button[aria-label="Previous protocol"]'),
+  ).toBeVisible();
+  const restingCardBox = await getBox(card);
+
+  await setVisualViewport(page, KEYBOARD_VIEWPORT);
+  await expect
+    .poll(async () =>
+      page
+        .locator('#root')
+        .evaluate((root) => root.getBoundingClientRect().height),
+    )
+    .toBe(526);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  const keyboardCardBox = await getBox(card);
+
+  expect(keyboardCardBox.width).toBeCloseTo(restingCardBox.width, 1);
+  expect(keyboardCardBox.height).toBeCloseTo(restingCardBox.height, 1);
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(caseIdInput).toBeFocused();
+  await expect(page.getByTestId('new-session-case-id')).toHaveCount(1);
+
+  await setVisualViewport(page, LAYOUT_VISUAL_VIEWPORT);
+  await expect(caseIdInput).toBeVisible();
+});
+
 test('keeps the Name Generator prompt, quick add, and new node inside the iOS visual viewport', async ({
   protocol,
   interviewNav,
   page,
 }) => {
-  // Keep setup at the full layout size so the deck carousel cannot overlap
-  // the new-session dialog at this deliberately large test resolution. The
-  // regression begins once the interview is running and Safari chrome reduces
-  // and offsets the visible viewport.
+  // Keep setup at the full layout size. The regression begins once the
+  // interview is running and Safari chrome reduces and offsets the visible
+  // viewport.
   await installVisualViewportStub(page, LAYOUT_VISUAL_VIEWPORT);
   await protocol.import(LEAN_E2E_PROTOCOL_PATH, LEAN_E2E_PROTOCOL_NAME);
   await page.getByRole('button', { name: 'Start new interview' }).click();
   const caseId = page.getByTestId('new-session-case-id');
   await caseId.fill('IOS-VIEWPORT');
-  // At this iPad-sized resolution, a fanned protocol card's 2D hit box
-  // overlaps the submit button even though the card is visually behind the
-  // dialog. Submitting the real form with Enter avoids that unrelated deck
-  // actionability quirk.
+  // Submitting the card-hosted form with Enter avoids neighboring fanned-card
+  // hit boxes at this deliberately large test resolution.
   await caseId.press('Enter');
   await expect(page).toHaveURL(/\/interview\//, { timeout: 15_000 });
   await interviewNav.waitForStage();

--- a/apps/interviewer/src/components/BrandHeader.stories.tsx
+++ b/apps/interviewer/src/components/BrandHeader.stories.tsx
@@ -5,12 +5,31 @@ import { BrandHeader } from './BrandHeader';
 // The app logo + "Interviewer" wordmark shown at the top of Home. Pure
 // presentation — no props, no context reads — so it's storied directly.
 
-const meta: Meta = {
+const meta: Meta<typeof BrandHeader> = {
   title: 'Components/BrandHeader',
+  component: BrandHeader,
+  tags: ['autodocs'],
   render: () => <BrandHeader />,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The Home header brand scales down in tablet landscape to preserve vertical space, then returns to its larger presentation at laptop widths.',
+      },
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj;
 
 export const Default: Story = {};
+
+export const TabletLandscape: Story = {
+  globals: {
+    viewport: {
+      value: 'tablet',
+      isRotated: true,
+    },
+  },
+};

--- a/apps/interviewer/src/components/BrandHeader.tsx
+++ b/apps/interviewer/src/components/BrandHeader.tsx
@@ -11,18 +11,21 @@ const variants = {
 
 export function BrandHeader() {
   return (
-    <motion.div variants={variants} className="flex items-center gap-4">
+    <motion.div
+      variants={variants}
+      className="tablet-landscape:gap-3 laptop:gap-4 flex items-center gap-4"
+    >
       <span className="inline-flex shrink-0">
         <img
           src={ncMarkUrl}
           alt=""
-          className="tablet-landscape:h-20 h-16 w-auto"
+          className="tablet-landscape:h-14 laptop:h-20 h-16 w-auto"
         />
       </span>
       <Heading
         level="h1"
         margin="none"
-        className="tablet-landscape:not-sr-only sr-only font-black tracking-tight"
+        className="tablet-landscape:not-sr-only tablet-landscape:text-2xl laptop:text-3xl sr-only font-black tracking-tight"
       >
         Interviewer
       </Heading>

--- a/apps/interviewer/src/components/DataView/DataView.tsx
+++ b/apps/interviewer/src/components/DataView/DataView.tsx
@@ -176,7 +176,7 @@ export function DataView({ protocols, onReload, refreshKey }: DataViewProps) {
       initial="hidden"
       animate="visible"
       exit="exit"
-      className="tablet-landscape:px-11 flex min-h-0 w-full flex-1 flex-col gap-6 px-6 pt-8 pb-8"
+      className="laptop:px-11 flex min-h-0 w-full flex-1 flex-col gap-6 px-6 pt-8 pb-8"
     >
       <DataViewToolbar
         table={table}

--- a/apps/interviewer/src/components/NewSessionForm.tsx
+++ b/apps/interviewer/src/components/NewSessionForm.tsx
@@ -5,7 +5,6 @@ import InputField from '@codaco/fresco-ui/form/fields/InputField';
 import Form from '@codaco/fresco-ui/form/Form';
 import type { FormSubmissionResult } from '@codaco/fresco-ui/form/store/types';
 import SubmitButton from '@codaco/fresco-ui/form/SubmitButton';
-import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { createInitialNetwork } from '@codaco/interview';
 import { useStepUpAuth } from '~/lib/auth/StepUpAuthProvider';
 import { createSession, getSettings } from '~/lib/db/api';
@@ -19,17 +18,19 @@ type NewSessionFormProps = {
   onCancel: () => void;
 };
 
+type NewSessionFormViewProps = {
+  requiresInternet: boolean;
+  online: boolean;
+  onSubmit: (caseId: string) => Promise<FormSubmissionResult>;
+  onCancel: () => void;
+};
+
 export function NewSessionFormView({
   requiresInternet,
   online,
   onSubmit,
   onCancel,
-}: {
-  requiresInternet: boolean;
-  online: boolean;
-  onSubmit: (caseId: string) => Promise<FormSubmissionResult>;
-  onCancel: () => void;
-}) {
+}: NewSessionFormViewProps) {
   const { openDialog } = useDialog();
 
   return (
@@ -63,15 +64,10 @@ export function NewSessionFormView({
         return onSubmit(caseId);
       }}
     >
-      <Paragraph>
-        Before the interview begins, enter a case ID. This will be shown on the
-        resume interview screen to help you quickly identify this session.
-      </Paragraph>
-
       <Field
         name="caseId"
         label="Case ID"
-        hint="A label used to identify this interview in exports."
+        hint="This will be shown on the resume interview screen to help you quickly identify this session."
         component={InputField}
         required="Case ID is required"
         minLength={1}

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.stories.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.stories.tsx
@@ -352,19 +352,16 @@ export const RequiresInternetPill: Story = {
 };
 
 // Stand-in for NewSessionForm (which needs app providers the story can't
-// host), sized like the real thing: intro paragraph, label + hint, input,
-// and the Cancel/submit row.
+// host), sized like the real thing: label + hint, input, and the Cancel/submit
+// row.
 function CaseIdFormStandIn() {
   return (
     <div className="flex flex-col gap-4 text-base">
-      <span>
-        Before the interview begins, enter a case ID. This will be shown on the
-        resume interview screen to help you quickly identify this session.
-      </span>
       <div>
         <div className="font-bold">Case ID</div>
         <div className="text-current/80">
-          A label used to identify this interview in exports.
+          This will be shown on the resume interview screen to help you quickly
+          identify this session.
         </div>
       </div>
       <div className="border-navy-taupe/40 rounded-full border px-4 py-3">

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCarousel.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCarousel.tsx
@@ -20,6 +20,7 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from 'react';
 
+import { CARD_RADIUS_PX } from './cardStyles';
 import {
   DECK_PERSPECTIVE_PX,
   SLOT_TO_CARD_RATIO,
@@ -86,6 +87,7 @@ type DeckCarouselProps = {
   activeIndex: number;
   onActiveIndexChange: (index: number) => void;
   disabled: boolean;
+  isolateActiveSlide?: boolean;
   cardWidth: number;
   cardHeight: number;
   ref?: Ref<DeckCarouselHandle>;
@@ -107,6 +109,7 @@ export function DeckCarousel({
   activeIndex,
   onActiveIndexChange,
   disabled,
+  isolateActiveSlide = false,
   cardWidth,
   cardHeight,
   ref,
@@ -239,6 +242,7 @@ export function DeckCarousel({
             cardWidth={cardWidth}
             cardHeight={cardHeight}
             disabled={disabled}
+            isolateActiveSlide={isolateActiveSlide}
             onSelect={onActiveIndexChange}
           />
         ))}
@@ -255,6 +259,7 @@ type DeckSlideProps = {
   cardWidth: number;
   cardHeight: number;
   disabled: boolean;
+  isolateActiveSlide: boolean;
   onSelect: (index: number) => void;
 };
 
@@ -266,6 +271,7 @@ function DeckSlide({
   cardWidth,
   cardHeight,
   disabled,
+  isolateActiveSlide,
   onSelect,
 }: DeckSlideProps) {
   const isPresent = useIsPresent();
@@ -298,10 +304,11 @@ function DeckSlide({
   );
 
   const isActive = index === activeIndex;
+  const isolated = isolateActiveSlide && !isActive;
   // Matches the pose's opacity-0 plateau: fully invisible slides must not
   // be reachable by assistive tech or the tab order. Exiting slides
   // likewise.
-  const hidden = Math.abs(index - activeIndex) >= 4 || !isPresent;
+  const hidden = isolated || Math.abs(index - activeIndex) >= 4 || !isPresent;
 
   const activate = () => {
     if (disabled || !isPresent) return;
@@ -349,16 +356,25 @@ function DeckSlide({
       inert={hidden}
       className={`absolute inset-0 m-auto origin-[center_bottom] will-change-transform ${
         slide.backdropBlur ? 'backdrop-blur-md' : ''
-      }`}
+      } ${isolateActiveSlide && isActive ? 'pointer-events-auto' : ''}`}
     >
       <motion.div
         initial={SLIDE_ENTER}
         animate={SLIDE_REST}
         exit={SLIDE_EXIT}
         transition={SLIDE_ENTER_SPRING}
-        className={`h-full w-full ${isPresent ? '' : 'pointer-events-none'}`}
+        className={`relative h-full w-full ${isPresent ? '' : 'pointer-events-none'}`}
       >
         {slide.render(isActive, activate)}
+        <motion.div
+          aria-hidden
+          data-testid={isolated ? 'protocol-deck-inactive-backdrop' : undefined}
+          className="bg-overlay publish-colors pointer-events-none absolute inset-0 z-50 backdrop-blur-xs"
+          style={{ borderRadius: CARD_RADIUS_PX }}
+          initial={false}
+          animate={{ opacity: isolated ? 1 : 0 }}
+          transition={{ duration: 0.25 }}
+        />
       </motion.div>
     </motion.div>
   );

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { motion } from 'motion/react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 
@@ -21,7 +21,8 @@ import { DeckSlotCard } from './DeckSlotCard';
 import { ImportTriggerCard } from './ImportTriggerCard';
 import { useDeckKeyboard } from './useDeckKeyboard';
 
-// Cards are square; height is measured from the section, width follows.
+// Cards are square; height is measured from the section while the deck is
+// idle, and width follows.
 const CARD_ASPECT = 1 / 1;
 // Readability floor: below this the card's container-query type becomes too
 // small to read, so the deck stops shrinking and lets the section clip
@@ -60,9 +61,8 @@ type ProtocolDeckProps = {
   onInstallSample?: () => void;
   onDismissSample?: () => void;
   onInstallDevelopment?: () => void;
-  // When set, the matching card is rendered in its "new session" state: the
-  // case-ID form replaces the description, metadata, and Start button in the
-  // card footer, and swipe/keyboard navigation is locked.
+  // When set, swipe/keyboard navigation is locked and the matching protocol
+  // card is isolated above a modal backdrop with the case-ID form.
   newSessionProtocolHash?: string | null;
   onCancelNewSession?: () => void;
   onSessionCreated?: (session: StoredSession) => void;
@@ -84,15 +84,9 @@ const sectionVariants = {
   },
 } as const;
 
-// Chevron row needs both a view-transition cascade (hidden/visible/exit)
-// and a "fade out while the new-session form is open" toggle. We model
-// the toggle as a `muted` variant and drive `animate` explicitly when it
-// applies — outside of `muted`, `animate="visible"` lines up with the
-// state that the parent cascade is propagating anyway.
 const chevronRowVariants = {
   hidden: { opacity: 0, y: '10%' },
   visible: { opacity: 1, y: 0 },
-  muted: { opacity: 0, y: 0 },
   exit: {
     opacity: 0,
     y: '10%',
@@ -334,13 +328,16 @@ export function ProtocolDeck({
   }, [slides, initialProtocolHash]);
 
   // Observe the section (not the outer container) so cardHeight tracks the
-  // space actually available to the carousel. The outer container also
-  // holds the chevron+dots row. Read borderBoxSize; contentRect excludes
-  // our own padding and would feed back into the calculation.
+  // space actually available to the carousel. Freeze the last resting size
+  // while the case-ID form is active: the software keyboard can shrink the
+  // app's visual-viewport frame, but must not reflow the card around its
+  // focused input. Read borderBoxSize; contentRect excludes our own padding
+  // and would feed back into the calculation.
   useEffect(() => {
     const el = sectionRef.current;
-    if (!el) return;
+    if (!el) return undefined;
     const ro = new ResizeObserver((entries) => {
+      if (newSessionActive) return;
       const entry = entries[0];
       if (!entry) return;
       const box = entry.borderBoxSize?.[0];
@@ -349,7 +346,7 @@ export function ProtocolDeck({
     });
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [newSessionActive]);
 
   const { cardWidth, cardHeight } = useMemo(() => {
     const padding = computeSectionPadding(sectionHeight);
@@ -377,10 +374,11 @@ export function ProtocolDeck({
     }, [slides, activeIndex]),
   });
 
-  // Esc cancels the new-session form. Listen at the window so it works
-  // regardless of which form control currently has focus.
+  // The manually orchestrated backdrop does not own keyboard dismissal like
+  // Base UI's full Modal component would, so keep Escape available from any
+  // focused form control.
   useEffect(() => {
-    if (!newSessionActive) return;
+    if (!newSessionActive) return undefined;
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
@@ -396,11 +394,28 @@ export function ProtocolDeck({
 
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center">
+      <AnimatePresence>
+        {newSessionActive ? (
+          <motion.button
+            key="new-session-backdrop"
+            type="button"
+            tabIndex={-1}
+            aria-label="Cancel starting interview"
+            data-testid="new-session-backdrop"
+            className="bg-overlay publish-colors fixed inset-0 z-40 cursor-default border-0 p-0 backdrop-blur-xs"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1, transition: { duration: 0.25 } }}
+            exit={{ opacity: 0 }}
+            onClick={onCancelNewSession}
+          />
+        ) : null}
+      </AnimatePresence>
+
       <motion.section
         ref={sectionRef}
         variants={sectionVariants}
         aria-label="Protocol deck"
-        className="flex max-h-[45rem] min-h-0 w-full flex-1 items-center justify-center"
+        className={`flex max-h-[45rem] min-h-0 w-full flex-1 items-center justify-center ${newSessionActive ? 'pointer-events-none relative z-50' : ''}`}
       >
         {cardHeight > 0 ? (
           <DeckCarousel
@@ -409,6 +424,7 @@ export function ProtocolDeck({
             activeIndex={activeIndex}
             onActiveIndexChange={setActiveIndex}
             disabled={newSessionActive}
+            isolateActiveSlide={newSessionActive}
             cardWidth={cardWidth}
             cardHeight={cardHeight}
           />
@@ -419,7 +435,7 @@ export function ProtocolDeck({
         <motion.div
           variants={chevronRowVariants}
           initial="hidden"
-          animate={newSessionActive ? 'muted' : 'visible'}
+          animate="visible"
           exit="exit"
           // Hide the row from assistive tech and pointer/keyboard events
           // while the form is open so it can't be tabbed into behind the

--- a/apps/interviewer/src/components/StatusRow.tsx
+++ b/apps/interviewer/src/components/StatusRow.tsx
@@ -76,7 +76,7 @@ export function StatusRowView({
   return (
     <motion.div
       variants={variants}
-      className="font-monospace text-text/60 tablet-landscape:px-11 tablet-landscape:justify-between flex items-center justify-end px-6 pb-4 text-xs"
+      className="font-monospace text-text/60 tablet-landscape:justify-between laptop:px-11 flex items-center justify-end px-6 pb-4 text-xs"
     >
       <Link
         href="/data"

--- a/apps/interviewer/src/components/__tests__/BrandHeader.test.tsx
+++ b/apps/interviewer/src/components/__tests__/BrandHeader.test.tsx
@@ -10,6 +10,8 @@ describe('BrandHeader', () => {
     expect(screen.getByRole('heading', { name: 'Interviewer' })).toHaveClass(
       'sr-only',
       'tablet-landscape:not-sr-only',
+      'tablet-landscape:text-2xl',
+      'laptop:text-3xl',
     );
   });
 
@@ -17,7 +19,12 @@ describe('BrandHeader', () => {
     const { container } = render(<BrandHeader />);
     const mark = container.querySelector('img');
 
-    expect(mark).toHaveClass('h-16', 'tablet-landscape:h-20', 'w-auto');
+    expect(mark).toHaveClass(
+      'h-16',
+      'tablet-landscape:h-14',
+      'laptop:h-20',
+      'w-auto',
+    );
     expect(mark).not.toHaveClass('size-20');
   });
 });

--- a/apps/interviewer/src/routes/Home.tsx
+++ b/apps/interviewer/src/routes/Home.tsx
@@ -175,7 +175,7 @@ export function HomeRoute() {
           controls out of the tab order while the new-session form is up. */}
       <InstallBanner />
       <header
-        className="tablet-landscape:px-11 tablet-landscape:pt-9 relative flex items-center justify-between px-6 pt-6"
+        className="laptop:px-11 laptop:pt-9 relative flex items-center justify-between px-6 pt-4"
         inert={newSessionActive}
       >
         <BrandHeader />
@@ -197,7 +197,7 @@ export function HomeRoute() {
             actual ORIENTATION, not a min-width breakpoint: the 13" iPad's
             portrait width (~1024px) would otherwise trip a min-width
             breakpoint and pull the pill up into the header. */}
-        <div className="tablet-landscape:px-11 tablet-landscape:pt-9 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-6 landscape:translate-y-0">
+        <div className="laptop:px-11 laptop:pt-9 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-4 landscape:translate-y-0">
           <AnimatePresence>
             {showResumePill ? (
               <ResumePill key="resume-pill" sessions={sessions} />

--- a/apps/interviewer/src/routes/__tests__/Home.test.tsx
+++ b/apps/interviewer/src/routes/__tests__/Home.test.tsx
@@ -142,6 +142,19 @@ describe('HomeRoute resume notification', () => {
     });
   });
 
+  it('uses compact page insets by default and increases them at laptop width', () => {
+    const { container } = render(<HomeRoute />);
+    const header = container.querySelector('header');
+
+    expect(header).toHaveClass('px-6', 'pt-4', 'laptop:px-11', 'laptop:pt-9');
+    expect(header).not.toHaveClass(
+      'pt-6',
+      'tablet-landscape:px-11',
+      'tablet-landscape:pt-4',
+      'tablet-landscape:pt-9',
+    );
+  });
+
   it('hides while the case ID form is active and returns when it closes', async () => {
     render(<HomeRoute />);
 


### PR DESCRIPTION
## Summary
- keep the protocol card size stable when the iPad software keyboard reduces the visual viewport
- show the case ID form on the selected carousel card above a manually animated backdrop, while preserving the surrounding deck behind it
- reduce Interviewer header branding and page insets on compact tablet layouts
- simplify the case ID guidance and add responsive/WebKit regression coverage

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] full workspace tests, serially with the CI-secret-bound encrypted protocol corpus skipped
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/interviewer build`
- [x] focused WebKit visual-viewport regression test