### PR TITLE
Add staggered software dropdown reveal

### DIFF
--- a/.changeset/soft-navigation-reveal.md
+++ b/.changeset/soft-navigation-reveal.md
@@ -1,0 +1,6 @@
+---
+'@codaco/fresco-ui': patch
+'@codaco/site-navigation-element': patch
+---
+
+Reveal the software destinations in the shared site navigation with a staggered animation, keep the dropdown stable while it closes, and respect reduced-motion preferences.

--- a/packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Monitor, Search } from 'lucide-react';
-import { expect, within } from 'storybook/test';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 
 import Button from '../Button';
 import SiteNavigation from './SiteNavigation';
@@ -12,6 +12,7 @@ type StoryArgs = {
     | 'community'
     | 'documentation'
     | 'resources'
+    | 'software'
     | 'getStarted';
   containerWidth: number;
   locale: SiteNavigationLocale;
@@ -81,6 +82,7 @@ const meta = {
         'community',
         'documentation',
         'resources',
+        'software',
         'getStarted',
       ],
     },
@@ -190,6 +192,27 @@ export const ResourcesExpanded: Story = {
     await expect(resourcesButton).not.toBeVisible();
     await expect(documentationLink).toBeVisible();
     await expect(documentationLink).toHaveAttribute('aria-current', 'page');
+  },
+};
+
+export const SoftwareExpanded: Story = {
+  args: {
+    activeItemId: 'software',
+    containerWidth: 1536,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Software' }));
+    await waitFor(() => {
+      const finalCard = screen
+        .getByRole('link', { name: 'Interviewer Classic' })
+        .closest('li');
+      if (!finalCard) throw new Error('Expected the final software card.');
+
+      expect(getComputedStyle(finalCard).opacity).toBe('1');
+      expect(getComputedStyle(finalCard).transform).toBe('none');
+    });
   },
 };
 

--- a/packages/fresco-ui/src/navigation/SiteNavigation.tsx
+++ b/packages/fresco-ui/src/navigation/SiteNavigation.tsx
@@ -139,6 +139,30 @@ const hoverAccentClasses: Record<SoftwareId, string> = {
   fresco: 'hover:bg-slate-blue/10 focus-visible:bg-slate-blue/10',
 };
 
+const softwareMenuVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: {
+      delayChildren: 0.05,
+      staggerChildren: 0.055,
+    },
+  },
+};
+
+const softwareCardVariants: Variants = {
+  hidden: { opacity: 0, y: 12, scale: 0.97 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: {
+      type: 'spring',
+      stiffness: 500,
+      damping: 30,
+    },
+  },
+};
+
 const softwareIcons: Record<SoftwareId, string> = {
   architect: new URL('./assets/architect.png', import.meta.url).href,
   architectClassic: new URL('./assets/architect-classic.png', import.meta.url)
@@ -287,8 +311,8 @@ function ResourcesMenu({
           collisionPadding={16}
           className="z-50 outline-none"
         >
-          <NavigationMenu.Popup className="bg-surface origin-top rounded-[1.75rem] p-3 shadow-2xl ring-1 ring-black/5 transition-[opacity,transform,scale] duration-200 ease-out data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
-            <NavigationMenu.Viewport />
+          <NavigationMenu.Popup className="bg-surface h-(--popup-height) w-(--popup-width) origin-top rounded-[1.75rem] p-3 shadow-2xl ring-1 ring-black/5 transition-[opacity,transform,scale] duration-200 ease-out data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+            <NavigationMenu.Viewport className="relative" />
           </NavigationMenu.Popup>
         </NavigationMenu.Positioner>
       </NavigationMenu.Portal>
@@ -381,6 +405,7 @@ function SoftwareMenu({
   renderLink: (props: SiteNavigationLinkRenderProps) => ReactElement;
 }) {
   const portalContainer = usePortalContainer();
+  const shouldReduceMotion = useReducedMotion();
 
   return (
     <NavigationMenu.Root
@@ -405,13 +430,22 @@ function SoftwareMenu({
             />
           </NavigationMenu.Trigger>
           <NavigationMenu.Content className="transition-opacity duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0">
-            <ul className="grid grid-cols-3 gap-1 p-1">
+            <motion.ul
+              initial={shouldReduceMotion ? false : 'hidden'}
+              animate="visible"
+              variants={softwareMenuVariants}
+              className="grid grid-cols-3 gap-1 p-1"
+            >
               {links.map((link) => (
-                <li key={link.id} className="flex">
+                <motion.li
+                  key={link.id}
+                  variants={softwareCardVariants}
+                  className="flex"
+                >
                   <SoftwareCard link={link} renderLink={renderLink} />
-                </li>
+                </motion.li>
               ))}
-            </ul>
+            </motion.ul>
           </NavigationMenu.Content>
         </NavigationMenu.Item>
       </NavigationMenu.List>
@@ -423,8 +457,8 @@ function SoftwareMenu({
           collisionPadding={16}
           className="z-50 outline-none"
         >
-          <NavigationMenu.Popup className="bg-surface max-h-[calc(100vh-7rem)] origin-top overflow-y-auto rounded p-5 shadow-2xl ring-1 ring-black/5 transition-[opacity,transform,scale] duration-200 ease-out data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
-            <NavigationMenu.Viewport />
+          <NavigationMenu.Popup className="bg-surface h-(--popup-height) max-h-[calc(100vh-7rem)] w-(--popup-width) origin-top overflow-y-auto rounded p-5 shadow-2xl ring-1 ring-black/5 transition-[opacity,transform,scale] duration-200 ease-out data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
+            <NavigationMenu.Viewport className="relative" />
           </NavigationMenu.Popup>
         </NavigationMenu.Positioner>
       </NavigationMenu.Portal>

--- a/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
+++ b/packages/fresco-ui/src/navigation/__tests__/SiteNavigation.test.tsx
@@ -149,9 +149,18 @@ describe('SiteNavigation', () => {
       name: 'Architect Classic',
     });
     const softwareGrid = architectClassicLink.closest('ul');
+    const softwarePopup = architectClassicLink.closest('nav');
     if (!softwareGrid) throw new Error('Expected the software grid.');
+    if (!softwarePopup) throw new Error('Expected the software popup.');
+    const softwareViewport = softwarePopup.querySelector(':scope > div');
+    if (!softwareViewport) throw new Error('Expected the software viewport.');
 
     expect(softwareGrid).toHaveClass('grid', 'grid-cols-3');
+    expect(softwarePopup).toHaveClass(
+      'h-(--popup-height)',
+      'w-(--popup-width)',
+    );
+    expect(softwareViewport).toHaveClass('relative');
     expect(within(softwareGrid).getAllByRole('listitem')).toHaveLength(5);
     expect(
       within(softwareGrid)


### PR DESCRIPTION
## Summary
- reveal software destinations with a staggered spring animation while respecting reduced-motion preferences
- preserve dropdown dimensions and padded positioning throughout the exit animation
- add an expanded Software Storybook story, navigation regression coverage, and paired package changesets

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/fresco-ui test:unit`
- [x] `pnpm --filter @codaco/fresco-ui test:storybook`
- [x] `pnpm --filter @codaco/site-navigation-element build`
- [x] `pnpm --filter @codaco/site-navigation-element exec vitest run`
- [x] manual review in the Website SiteNavigation Storybook story