### PR TITLE
test(interviewer): fix broken resume-notification e2e (Cancel selector)

### DIFF
--- a/apps/interviewer/e2e/specs/home-protocols.spec.ts
+++ b/apps/interviewer/e2e/specs/home-protocols.spec.ts
@@ -88,7 +88,10 @@ test.describe('protocol import & delete', () => {
     await expect(page.getByTestId('new-session-case-id')).toBeVisible();
     await expect(resumeNotification).not.toBeVisible();
 
-    await page.getByRole('button', { name: 'Cancel' }).click();
+    // exact: true — the new-session backdrop is itself a button labelled
+    // "Cancel starting interview" (ProtocolDeck.tsx), so a substring name match
+    // resolves to two elements. Target the form's own "Cancel" button.
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
     await expect(resumeNotification).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

The interviewer e2e suite had one deterministically-failing test:
`home-protocols.spec.ts` → "hides the resume notification while the case ID form is open".

Commit 3c8e89f71 ("fix(interviewer): stabilize tablet case ID entry") gave the
new-session backdrop button an accessible name — `aria-label="Cancel starting
interview"` (`ProtocolDeck.tsx`). Playwright's `getByRole` `name` option is a
**substring** match by default, so `{ name: 'Cancel' }` began matching *two*
elements — the backdrop and the form's own "Cancel" button — producing a
strict-mode violation:

```
strict mode violation: getByRole('button', { name: 'Cancel' }) resolved to 2 elements
  1) <button data-testid="new-session-backdrop" aria-label="Cancel starting interview">
  2) <button>Cancel</button>
```

The backdrop's accessible name is a genuine a11y improvement, so the fix is in
the test: target the form's Cancel button with `{ name: 'Cancel', exact: true }`.
Test-only change — no changeset (not consumer- or participant-visible).

## Test plan

- [x] Full Dockerized suite before the fix: 32 passed, **1 failed** (this test)
- [x] `apps/interviewer` e2e re-run of `home-protocols.spec.ts` after the fix:
      **6 passed** (includes the `@visual` delete-confirm baseline), via the
      font-stable Playwright Docker image