### PR TITLE
fix(interviewer-classic): remove non-functional Merge Sessions export toggle

### DIFF
--- a/apps/interviewer-classic/CHANGELOG.md
+++ b/apps/interviewer-classic/CHANGELOG.md
@@ -10,6 +10,11 @@
 - **Improved security.** We've adopted current security best practices for building and
   distributing the app — including properly signed and notarized macOS builds — so you can be
   confident the software you download is genuine and safe to run.
+- **Removed the "Merge Sessions" export option.** The updated export pipeline always exports
+  each interview session as separate files. If you need a combined dataset, you can merge the
+  per-session CSV files during analysis instead — see the
+  [Data Export documentation](https://documentation.networkcanvas.com/en/analyze-data/data-export#merge-sessions-by-protocol)
+  for guidance.
 
 ## 6.5.10
 

--- a/apps/interviewer-classic/src/components/SettingsMenu/Sections/ExportOptions.jsx
+++ b/apps/interviewer-classic/src/components/SettingsMenu/Sections/ExportOptions.jsx
@@ -12,7 +12,6 @@ const ExportOptions = (props) => {
   const {
     exportGraphML,
     exportCSV,
-    unifyNetworks,
     useScreenLayoutCoordinates,
     screenLayoutHeight,
     screenLayoutWidth,
@@ -69,27 +68,6 @@ const ExportOptions = (props) => {
             <strong>attribute list file</strong> for each node type, an
             <strong>edge list file</strong> for each edge type, and an
             <strong>ego attribute file</strong> that also contains session data.
-          </p>
-        </div>
-      </motion.article>
-      <motion.article className="settings-element">
-        <Toggle
-          input={{
-            value: unifyNetworks,
-            onChange: () => toggleSetting('unifyNetworks'),
-          }}
-        />
-        <div>
-          <h2>Merge Sessions</h2>
-          <p>
-            If you enable this option, exporting multiple sessions at the same
-            time will cause them to be merged into a single file, on a
-            per-protocol basis. In the case of CSV export, you will receive one
-            of each type of file for each protocol. In the case of GraphML you
-            will receive a single GraphML file with multiple{' '}
-            <code>&lt;graph&gt;</code> elements. Please note that with the
-            exception of Network Canvas Server, most software does not yet
-            support multiple graphs in a single GraphML file.
           </p>
         </div>
       </motion.article>
@@ -170,7 +148,6 @@ const mapDispatchToProps = {
 const mapStateToProps = (state) => ({
   exportGraphML: state.deviceSettings.exportGraphML,
   exportCSV: state.deviceSettings.exportCSV,
-  unifyNetworks: state.deviceSettings.unifyNetworks,
   useScreenLayoutCoordinates: state.deviceSettings.useScreenLayoutCoordinates,
   screenLayoutWidth: state.deviceSettings.screenLayoutWidth,
   screenLayoutHeight: state.deviceSettings.screenLayoutHeight,
@@ -179,7 +156,6 @@ const mapStateToProps = (state) => ({
 ExportOptions.propTypes = {
   exportGraphML: PropTypes.bool.isRequired,
   exportCSV: PropTypes.bool.isRequired,
-  unifyNetworks: PropTypes.bool.isRequired,
   useScreenLayoutCoordinates: PropTypes.bool.isRequired,
   screenLayoutWidth: PropTypes.number.isRequired,
   screenLayoutHeight: PropTypes.number.isRequired,

--- a/apps/interviewer-classic/src/ducks/modules/__tests__/deviceSettings.test.js
+++ b/apps/interviewer-classic/src/ducks/modules/__tests__/deviceSettings.test.js
@@ -24,7 +24,6 @@ const initialState = {
   showGettingStarted: true,
   showWhatsNew: false,
   startFullScreen: false,
-  unifyNetworks: false,
   useDynamicScaling: undefined,
   useFullScreenForms: false,
   useScreenLayoutCoordinates: false,

--- a/apps/interviewer-classic/src/ducks/modules/deviceSettings.js
+++ b/apps/interviewer-classic/src/ducks/modules/deviceSettings.js
@@ -27,7 +27,6 @@ const initialState = {
   // Export Options
   exportGraphML: true,
   exportCSV: true,
-  unifyNetworks: false,
   useScreenLayoutCoordinates: false,
   screenLayoutHeight: window.screen.height,
   screenLayoutWidth: window.screen.width,

--- a/apps/interviewer-classic/src/utils/exportProcess.jsx
+++ b/apps/interviewer-classic/src/utils/exportProcess.jsx
@@ -76,10 +76,8 @@ const mapEventToProgress = (event) => {
 
 /**
  * Build an ExportOptions object from device settings.
- * Note: the maintained @codaco/network-exporters pipeline no longer accepts
- * `exportFilename`/`unifyNetworks`; those legacy options are intentionally
- * dropped. The output filename is derived by the pipeline and surfaced via the
- * sink (see runExport).
+ * The output filename is derived by the pipeline and surfaced via the sink
+ * (see runExport).
  */
 const buildExportOptions = (deviceSettings) => ({
   exportGraphML: deviceSettings.exportGraphML,


### PR DESCRIPTION
## Summary

Since the export migration to the maintained `@codaco/network-exporters` pipeline (3b4ab9e4f), Interviewer Classic's "Merge Sessions" settings toggle has been rendered but ignored — the pipeline has no per-protocol merge option, and `buildExportOptions` intentionally drops the legacy `unifyNetworks` setting. This removes the dead toggle rather than shipping it in 6.6.0:

- Removed the "Merge Sessions" article and its `unifyNetworks` wiring from the export settings section
- Removed the `unifyNetworks` default from `deviceSettings` and its expected-state entry in the reducer test
- Simplified the now-stale legacy-options comment in `exportProcess.jsx`
- Added a user-facing bullet to the 6.6.0 section of the CHANGELOG (the source `scripts/release-notes.mjs` extracts into the GitHub release body); the existing v6.6.0 draft release bodies on the external mirrors are being updated to match

Docs are updated separately in #1081, which scopes the option to Interviewer Classic ≤6.5.

No changeset: classic apps have no changeset lane.

## Test plan

- [x] `pnpm --filter @codaco/interviewer-classic test` — 443 passed, 6 todo
- [x] `oxlint` / `oxfmt --check` clean on touched files
- [x] `grep unifyNetworks|Merge Sessions` returns nothing under `apps/*-classic/src`