### PR TITLE
fix(architect): preserve stage template defaults on node type selection

### DIFF
--- a/apps/architect/src/components/StageEditor/Interfaces.tsx
+++ b/apps/architect/src/components/StageEditor/Interfaces.tsx
@@ -52,6 +52,8 @@ import NodeConfiguration from '~/components/sections/NodeConfiguration/NodeConfi
 import { FilteredNodeType } from '~/components/sections/NodeType';
 import { interfaceDocumentationUrl } from '~/utils/documentationLinks';
 
+import { getInterfaceTemplate } from './interfaceTemplates';
+
 /**
  * Props that are passed to all stage editor section components.
  * These props are provided by the StageEditor component when rendering sections.
@@ -84,12 +86,6 @@ type InterfaceConfig = {
   readonly documentation: string;
   /** Optional display name override for the interface */
   readonly name?: string;
-  /**
-   * Optional template object containing default configuration values
-   * that will be merged into the initial stage values when creating
-   * a new stage of this type. Commonly used for setting default behaviors.
-   */
-  readonly template?: Record<string, unknown>;
 };
 
 /**
@@ -114,7 +110,6 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('per-alter-edge-form'),
-    template: {},
   },
   AlterForm: {
     sections: [
@@ -154,16 +149,10 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('one-to-many-dyad-census'),
-    template: {
-      behaviours: {
-        removeAfterConsideration: true,
-      },
-    },
   },
   EgoForm: {
     sections: [IntroductionPanel, Form, SkipLogic, InterviewScript],
     documentation: interfaceDocumentationUrl('ego-form'),
-    template: {},
   },
   Information: {
     sections: [Title, ContentGrid, SkipLogic, InterviewScript],
@@ -220,12 +209,6 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('narrative'),
-    template: {
-      behaviours: {
-        allowRepositioning: true,
-        automaticLayout: true,
-      },
-    },
   },
   OrdinalBin: {
     sections: [FilteredNodeType, OrdinalBinPrompts, SkipLogic, InterviewScript],
@@ -252,11 +235,6 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('network-composer'),
-    template: {
-      behaviours: {
-        automaticLayout: true,
-      },
-    },
   },
   TieStrengthCensus: {
     sections: [
@@ -300,23 +278,6 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('family-pedigree'),
-    template: {
-      framing: { mode: 'fixed', value: 'gamete' },
-      boundaries: {
-        requireGrandparents: 'off',
-        requireChildrenContributors: 'off',
-      },
-      introScreen: {
-        items: [
-          {
-            id: 'intro-text',
-            type: 'text',
-            content:
-              "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
-          },
-        ],
-      },
-    },
   },
   NarrativePedigree: {
     sections: [
@@ -327,11 +288,6 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
       InterviewScript,
     ],
     documentation: interfaceDocumentationUrl('narrative-pedigree'),
-    template: {
-      sourceStageId: '',
-      diseases: [],
-      showAtRiskStatuses: false,
-    },
   },
 };
 
@@ -348,9 +304,10 @@ const INTERFACE_CONFIGS: InterfaceRegistry = {
 			...,
 		], documentation: "...", name: "Name Generator (using forms)" }
  */
-export function getInterface(
-  interfaceType: StageType,
-): InterfaceConfig & { readonly name: string } {
+export function getInterface(interfaceType: StageType): InterfaceConfig & {
+  readonly name: string;
+  readonly template: Record<string, unknown>;
+} {
   const config = INTERFACE_CONFIGS[interfaceType];
 
   if (!config) {
@@ -362,5 +319,6 @@ export function getInterface(
   return {
     ...config,
     name: config.name ?? startCase(interfaceType),
+    template: getInterfaceTemplate(interfaceType),
   };
 }

--- a/apps/architect/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect/src/components/StageEditor/StageEditor.tsx
@@ -89,7 +89,7 @@ const StageEditor = (props: StageEditorProps) => {
 
   const stagePath = stageIndex !== -1 ? `stages[${stageIndex}]` : null;
   const interfaceType = (stage?.type || type || 'Information') as StageType;
-  const template = getInterface(interfaceType).template || {};
+  const template = getInterface(interfaceType).template;
   const initialValues = stage || { ...template, type: interfaceType };
 
   // Get form state

--- a/apps/architect/src/components/StageEditor/interfaceTemplates.ts
+++ b/apps/architect/src/components/StageEditor/interfaceTemplates.ts
@@ -1,0 +1,50 @@
+import type { StageType } from '@codaco/protocol-validation';
+
+const INTERFACE_TEMPLATES: Partial<Record<StageType, Record<string, unknown>>> =
+  {
+    AlterEdgeForm: {},
+    AlterForm: {},
+    EgoForm: {},
+    OneToManyDyadCensus: {
+      behaviours: {
+        removeAfterConsideration: true,
+      },
+    },
+    Narrative: {
+      behaviours: {
+        allowRepositioning: true,
+        automaticLayout: true,
+      },
+    },
+    NetworkComposer: {
+      behaviours: {
+        automaticLayout: true,
+      },
+    },
+    FamilyPedigree: {
+      framing: { mode: 'fixed', value: 'gamete' },
+      boundaries: {
+        requireGrandparents: 'off',
+        requireChildrenContributors: 'off',
+      },
+      introScreen: {
+        items: [
+          {
+            id: 'intro-text',
+            type: 'text',
+            content:
+              "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
+          },
+        ],
+      },
+    },
+    NarrativePedigree: {
+      sourceStageId: '',
+      diseases: [],
+      showAtRiskStatuses: false,
+    },
+  };
+
+export const getInterfaceTemplate = (
+  interfaceType: StageType,
+): Record<string, unknown> => INTERFACE_TEMPLATES[interfaceType] ?? {};

--- a/apps/architect/src/components/sections/FilteredEdgeType.tsx
+++ b/apps/architect/src/components/sections/FilteredEdgeType.tsx
@@ -1,40 +1,21 @@
-import type { UnknownAction } from '@reduxjs/toolkit';
-import { difference, get, keys } from 'es-toolkit/compat';
-import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
-import { change, getFormValues } from 'redux-form';
+import { get } from 'es-toolkit/compat';
 
 import { Row, Section } from '~/components/EditorLayout';
 // Screen message listeners removed as part of screen system refactor
 import ValidatedField from '~/components/Form/ValidatedField';
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
-import { useAppDispatch } from '~/ducks/hooks';
-import type { RootState } from '~/ducks/modules/root';
 
 import IssueAnchor from '../IssueAnchor';
 import EntitySelectField from './fields/EntitySelectField/EntitySelectField';
 import Filter from './Filter';
-import { SUBJECT_INDEPENDENT_FIELDS } from './NodeType';
+import useResetStageOnSubjectChange from './useResetStageOnSubjectChange';
 
 type FilteredEdgeTypeProps = StageEditorSectionProps;
 
 const FilteredEdgeType = (props: FilteredEdgeTypeProps) => {
-  const { form } = props;
+  const { form, interfaceType } = props;
 
-  const dispatch = useAppDispatch();
-  const formValues = useSelector((state: RootState) =>
-    getFormValues(form)(state),
-  );
-  const fields = keys(formValues);
-
-  const handleResetStage = useCallback(() => {
-    const fieldsToReset = difference(fields, SUBJECT_INDEPENDENT_FIELDS);
-    fieldsToReset.forEach((field) => {
-      dispatch(change(form, field, null) as UnknownAction);
-    });
-  }, [dispatch, fields, form]);
-
-  const _currentSubject = get(formValues, 'subject');
+  const handleResetStage = useResetStageOnSubjectChange(form, interfaceType);
 
   // TODO: Restore auto-selection of newly created types when type creation dialogs
   // are properly integrated with form state management

--- a/apps/architect/src/components/sections/NodeType.tsx
+++ b/apps/architect/src/components/sections/NodeType.tsx
@@ -1,16 +1,8 @@
-import type { UnknownAction } from '@reduxjs/toolkit';
-import { difference, get, keys } from 'es-toolkit/compat';
-import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
-import { change, getFormValues } from 'redux-form';
+import { get } from 'es-toolkit/compat';
 
 // Screen message listeners removed as part of screen system refactor
-// List of fields that are independent of the stage subject, and so do not need to be
-// reset when the subject changes.
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
-import { useAppDispatch } from '~/ducks/hooks';
-import type { RootState } from '~/ducks/modules/root';
 
 import Row from '../EditorLayout/Row';
 import Section from '../EditorLayout/Section';
@@ -18,33 +10,14 @@ import ValidatedField from '../Form/ValidatedField';
 import IssueAnchor from '../IssueAnchor';
 import EntitySelectField from './fields/EntitySelectField/EntitySelectField';
 import Filter from './Filter';
-export const SUBJECT_INDEPENDENT_FIELDS = [
-  'id',
-  'type',
-  'label',
-  'interviewScript',
-  'introductionPanel',
-  // The subject field itself never depends on its own value — omitting it
-  // here meant handleResetStage nulled the just-selected subject out from
-  // under the user on every change, including the very first selection.
-  'subject',
-];
+import useResetStageOnSubjectChange from './useResetStageOnSubjectChange';
+
 type NodeTypeProps = StageEditorSectionProps & {
   withFilter?: boolean;
 };
 const NodeType = (props: NodeTypeProps) => {
-  const { form, withFilter = false } = props;
-  const dispatch = useAppDispatch();
-  const formValues = useSelector((state: RootState) =>
-    getFormValues(form)(state),
-  );
-  const fields = keys(formValues);
-  const handleResetStage = useCallback(() => {
-    const fieldsToReset = difference(fields, SUBJECT_INDEPENDENT_FIELDS);
-    fieldsToReset.forEach((field) => {
-      dispatch(change(form, field, null) as UnknownAction);
-    });
-  }, [dispatch, fields, form]);
+  const { form, interfaceType, withFilter = false } = props;
+  const handleResetStage = useResetStageOnSubjectChange(form, interfaceType);
   // TODO: Restore auto-selection of newly created types when type creation dialogs
   // are properly integrated with form state management
   return (

--- a/apps/architect/src/components/sections/__tests__/NodeType.test.tsx
+++ b/apps/architect/src/components/sections/__tests__/NodeType.test.tsx
@@ -6,7 +6,16 @@ import {
   reduxForm,
   type InjectedFormProps,
 } from 'redux-form';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StageType } from '@codaco/protocol-validation';
+
+const confirm = vi.fn();
+const openDialog = vi.fn();
+
+vi.mock('@codaco/fresco-ui/dialogs/useDialog', () => ({
+  default: () => ({ confirm, openDialog }),
+}));
 
 import NodeType from '../NodeType';
 
@@ -14,20 +23,24 @@ type FormValues = {
   subject?: { entity: string; type: string | null };
   form?: unknown;
   prompts?: unknown;
+  behaviours?: unknown;
 };
 
-const Harness = (_props: InjectedFormProps<FormValues>) => (
-  <NodeType
-    form="edit-stage"
-    stagePath={null}
-    stagePosition={0}
-    interfaceType={'NameGeneratorForms' as never}
-  />
-);
+const setup = (
+  initialValues: FormValues = {},
+  interfaceType: StageType = 'NameGenerator',
+) => {
+  const Harness = (_props: InjectedFormProps<FormValues>) => (
+    <NodeType
+      form="edit-stage"
+      stagePath={null}
+      stagePosition={0}
+      interfaceType={interfaceType}
+    />
+  );
 
-const ReduxHarness = reduxForm<FormValues>({ form: 'edit-stage' })(Harness);
+  const ReduxHarness = reduxForm<FormValues>({ form: 'edit-stage' })(Harness);
 
-const setup = (initialValues: FormValues = {}) => {
   const store = configureStore({
     reducer: {
       form: formReducer,
@@ -39,6 +52,12 @@ const setup = (initialValues: FormValues = {}) => {
                 name: 'Person',
                 color: 'node-color-seq-1',
                 shape: { default: 'circle' },
+                variables: {},
+              },
+              place: {
+                name: 'Place',
+                color: 'node-color-seq-2',
+                shape: { default: 'square' },
                 variables: {},
               },
             },
@@ -66,6 +85,14 @@ const setup = (initialValues: FormValues = {}) => {
 };
 
 describe('NodeType', () => {
+  beforeEach(() => {
+    confirm.mockReset();
+    openDialog.mockReset();
+    confirm.mockImplementation(({ onConfirm }: { onConfirm?: () => void }) =>
+      onConfirm?.(),
+    );
+  });
+
   it('keeps the selected subject on a fresh stage instead of resetting it to null', () => {
     const { getValues } = setup();
 
@@ -74,17 +101,46 @@ describe('NodeType', () => {
     expect(getValues()?.subject).toEqual({ entity: 'node', type: 'person' });
   });
 
+  it('keeps the interface template defaults when the subject is first selected', () => {
+    const { getValues } = setup(
+      { behaviours: { removeAfterConsideration: true } },
+      'OneToManyDyadCensus',
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Person' }));
+
+    expect(getValues()?.behaviours).toEqual({ removeAfterConsideration: true });
+  });
+
   it('clears dependent fields, but not the subject itself, when the subject changes', () => {
     const { getValues } = setup({
+      subject: { entity: 'node', type: 'person' },
       form: { title: 'Add a person' },
       prompts: [{ id: 'prompt-1', text: 'Who do you turn to?' }],
     });
 
-    fireEvent.click(screen.getByRole('radio', { name: 'Select node Person' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Place' }));
 
     const values = getValues();
-    expect(values?.subject).toEqual({ entity: 'node', type: 'person' });
+    expect(values?.subject).toEqual({ entity: 'node', type: 'place' });
     expect(values?.form).toBeNull();
     expect(values?.prompts).toBeNull();
+  });
+
+  it('restores the interface template defaults when the subject changes', () => {
+    const { getValues } = setup(
+      {
+        subject: { entity: 'node', type: 'person' },
+        prompts: [{ id: 'prompt-1', text: 'Who do you turn to?' }],
+        behaviours: { removeAfterConsideration: false },
+      },
+      'OneToManyDyadCensus',
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Select node Place' }));
+
+    const values = getValues();
+    expect(values?.prompts).toBeNull();
+    expect(values?.behaviours).toEqual({ removeAfterConsideration: true });
   });
 });

--- a/apps/architect/src/components/sections/useResetStageOnSubjectChange.ts
+++ b/apps/architect/src/components/sections/useResetStageOnSubjectChange.ts
@@ -1,0 +1,51 @@
+import type { UnknownAction } from '@reduxjs/toolkit';
+import { difference, keys, union } from 'es-toolkit/compat';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { change, getFormValues } from 'redux-form';
+
+import type { StageType } from '@codaco/protocol-validation';
+import { getInterfaceTemplate } from '~/components/StageEditor/interfaceTemplates';
+import { useAppDispatch } from '~/ducks/hooks';
+import type { RootState } from '~/ducks/modules/root';
+
+const SUBJECT_INDEPENDENT_FIELDS = [
+  'id',
+  'type',
+  'label',
+  'interviewScript',
+  'introductionPanel',
+  'subject',
+];
+
+const useResetStageOnSubjectChange = (
+  form: string,
+  interfaceType: StageType,
+) => {
+  const dispatch = useAppDispatch();
+  const formValues = useSelector((state: RootState) =>
+    getFormValues(form)(state),
+  );
+  const fields = keys(formValues);
+
+  return useCallback(
+    (_event: unknown, _newValue?: unknown, previousValue?: unknown) => {
+      if (!previousValue) {
+        return;
+      }
+
+      const template = getInterfaceTemplate(interfaceType);
+      const fieldsToReset = difference(
+        union(fields, keys(template)),
+        SUBJECT_INDEPENDENT_FIELDS,
+      );
+
+      fieldsToReset.forEach((field) => {
+        dispatch(change(form, field, template[field] ?? null) as UnknownAction);
+      });
+    },
+    [dispatch, fields, form, interfaceType],
+  );
+};
+
+export default useResetStageOnSubjectChange;


### PR DESCRIPTION
Bug: Invalid protocol could be configured on the one-to-many dyad census due to selecting an initial subject or changing subject nulling stage defaults. 2 Fixes:
-  Don't reset on the first subject selection. Keeps stage defaults configured
-  On a real subject change, restore defaults instead of nulling