### PR TITLE
test(architect): fix drifted e2e stage snapshots

### DIFF
--- a/apps/architect/e2e/visual-snapshots/chromium/narrative-stage.json
+++ b/apps/architect/e2e/visual-snapshots/chromium/narrative-stage.json
@@ -1,5 +1,10 @@
 {
   "label": "Explore Your Network",
+  "behaviours": {
+    "allowRepositioning": true,
+    "automaticLayout": true,
+    "freeDraw": false
+  },
   "type": "Narrative",
   "background": {
     "image": "narrative_background"

--- a/apps/architect/e2e/visual-snapshots/chromium/network-composer-stage.json
+++ b/apps/architect/e2e/visual-snapshots/chromium/network-composer-stage.json
@@ -5,6 +5,7 @@
   },
   "type": "NetworkComposer",
   "background": {
+    "skewedTowardCenter": false,
     "concentricCircles": 4
   },
   "subject": {

--- a/apps/architect/e2e/visual-snapshots/chromium/one-to-many-dyad-census-stage.json
+++ b/apps/architect/e2e/visual-snapshots/chromium/one-to-many-dyad-census-stage.json
@@ -1,5 +1,8 @@
 {
   "label": "Who Knows This Person?",
+  "behaviours": {
+    "removeAfterConsideration": true
+  },
   "type": "OneToManyDyadCensus",
   "subject": {
     "type": "id-1",

--- a/apps/architect/e2e/visual-snapshots/chromium/sociogram-stage.json
+++ b/apps/architect/e2e/visual-snapshots/chromium/sociogram-stage.json
@@ -2,6 +2,7 @@
   "label": "Draw Your Network",
   "type": "Sociogram",
   "background": {
+    "skewedTowardCenter": false,
     "concentricCircles": 4
   },
   "subject": {


### PR DESCRIPTION
## What

Refreshes four Architect e2e create-from-scratch stage snapshots that had drifted from the app:

- `narrative-stage.json` — adds `behaviours: { allowRepositioning, automaticLayout, freeDraw }`
- `one-to-many-dyad-census-stage.json` — adds `behaviours: { removeAfterConsideration }`
- `sociogram-stage.json` — adds `background.skewedTowardCenter: false`
- `network-composer-stage.json` — adds `background.skewedTowardCenter: false`

## Why

The suite was red on these four interface specs. The drift is the **intended** consequence of a previously-merged bug fix — `fix(architect): preserve stage template defaults on node type selection` (commit `4de2f81`). That fix keeps interface template defaults and Background toggle defaults through node-type selection, so the editor now persists these values in the saved stage where it previously wiped them.

The Architect e2e suite is release-gated (skipped on ordinary PRs), so the snapshot drift went uncaught when that fix merged.

## Verification

- Every added field is a schema-valid explicit default (e.g. `skewedTowardCenter` is `z.boolean().optional()` in the concentric-circles background variant); no fields were removed and no assertions weakened.
- Only the stale JSON snapshots were regenerated — no app source changed.
- Full Architect e2e suite run locally against the production build: **39 passed**.

No changeset: this touches only e2e test fixtures, with no product or library release impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xcfWGFwQH6wqFnSkPMG5e

---
_Generated by [Claude Code](https://claude.ai/code/session_014xcfWGFwQH6wqFnSkPMG5e)_