### PR TITLE
Fix homepage weave scroll stutter

### DIFF
--- a/.changeset/smooth-homepage-weave.md
+++ b/.changeset/smooth-homepage-weave.md
@@ -1,0 +1,5 @@
+---
+'networkcanvas.com': patch
+---
+
+Smooth the homepage background weave as visitors scroll beyond the hero.

--- a/apps/networkcanvas.com/components/ui/HomepagePageBackground.tsx
+++ b/apps/networkcanvas.com/components/ui/HomepagePageBackground.tsx
@@ -199,7 +199,7 @@ export function HomepagePageBackground({
       flare={background.flare}
       speedFactor={SPEED_FACTOR}
       layerRef={layerRef}
-      motionMode="target"
+      motionMode="direct"
       resolved={background.resolved && reveal}
     />
   );

--- a/apps/networkcanvas.com/components/ui/__tests__/HomepagePageBackground.test.tsx
+++ b/apps/networkcanvas.com/components/ui/__tests__/HomepagePageBackground.test.tsx
@@ -9,6 +9,7 @@ type MockPageBackgroundProps = {
   flare: number;
   intensity: number;
   layerRef: RefObject<HTMLDivElement | null>;
+  motionMode: string;
   resolved: boolean;
 };
 
@@ -122,6 +123,7 @@ describe('HomepagePageBackground', () => {
       x: 0.5,
       y: 0.3,
     });
+    expect(getLatestBackgroundProps().motionMode).toBe('direct');
 
     act(() => {
       window.scrollY = 400;

--- a/packages/art/src/PageBackground/PageBackground.tsx
+++ b/packages/art/src/PageBackground/PageBackground.tsx
@@ -41,6 +41,7 @@ const SCROLL_OPACITY_RANGE = [1, 0];
 const SCROLL_SCALE_RANGE = [1, 1.8];
 
 type ScrollFlareRange = readonly [number, number];
+type PageBackgroundMotionMode = 'direct' | 'scroll' | 'target';
 
 // The weave is hidden behind an inverse-radial mask until the convergence target
 // (the hero video) resolves, then the masked disc shrinks to nothing at the
@@ -189,7 +190,7 @@ export function PageBackgroundProvider({
   colors?: readonly string[];
   fallbackConvergence?: NetworkWeaveConvergence;
   intensity?: number;
-  motionMode?: 'scroll' | 'target';
+  motionMode?: PageBackgroundMotionMode;
   scrollFlareRange?: ScrollFlareRange;
   waitForTarget?: boolean;
 }) {
@@ -429,7 +430,7 @@ export function PageBackground({
   intensity?: number;
   flare?: number;
   speedFactor?: number;
-  motionMode?: 'scroll' | 'target';
+  motionMode?: PageBackgroundMotionMode;
   resolved?: boolean;
   scrollFadeEnd?: number;
   scrollFlareRange?: ScrollFlareRange;
@@ -589,15 +590,15 @@ export function PageBackground({
     reduceMotion,
   );
   const renderedSettings =
-    motionMode === 'scroll'
-      ? {
+    motionMode === 'target'
+      ? weaveSettings
+      : {
           convergence,
           complexity,
           intensity,
           flare,
           speedFactor,
-        }
-      : weaveSettings;
+        };
   const renderedFlare =
     scrollFlareRange && reduceMotion === false
       ? scrollFlare

--- a/packages/art/src/__tests__/PageBackground.component.test.tsx
+++ b/packages/art/src/__tests__/PageBackground.component.test.tsx
@@ -446,6 +446,49 @@ describe('PageBackground', () => {
     );
   });
 
+  it('renders directly controlled parameters without target animation', () => {
+    const { rerender } = render(
+      <PageBackground
+        convergence={{ x: 0.2, y: 0.4 }}
+        complexity={40}
+        intensity={0.62}
+        flare={1.45}
+        speedFactor={0.28}
+        motionMode="direct"
+        resolved
+      />,
+    );
+
+    animateMock.mockClear();
+    networkWeaveProps.mockClear();
+    rerender(
+      <PageBackground
+        convergence={{ x: 0.1, y: 0.2 }}
+        complexity={24}
+        intensity={0.2}
+        flare={1.85}
+        speedFactor={0.39}
+        motionMode="direct"
+        resolved
+      />,
+    );
+
+    expect(animateMock).not.toHaveBeenCalled();
+    expect(networkWeaveProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        convergence: { x: 0.1, y: 0.2 },
+        complexity: 24,
+        intensity: 0.2,
+        flare: 1.85,
+        speedFactor: 0.39,
+      }),
+    );
+    expect(motionDivProps.mock.lastCall?.[0].style).not.toHaveProperty(
+      'opacity',
+    );
+    expect(motionDivProps.mock.lastCall?.[0].style).not.toHaveProperty('scale');
+  });
+
   it('updates the current target position immediately during scroll', () => {
     const { rerender } = render(
       <PageBackground


### PR DESCRIPTION
## Summary
- add a direct render mode for continuously controlled page-background parameters
- use direct mode for the homepage weave to remove target-state synchronization during hero scrolling
- cover the new mode and homepage integration with regression tests

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/art test`
- [x] `pnpm --filter networkcanvas.com test`
- [x] `pnpm --filter networkcanvas.com build`
- [x] verify the homepage scroll transition in the local browser with no console warnings