### PR TITLE
Release Interviewer

### DIFF
--- a/.changeset/fiery-birds-give.md
+++ b/.changeset/fiery-birds-give.md
@@ -1,7 +1,0 @@
----
-"@codaco/interviewer": patch
----
-
-Bring the Import a protocol card to the front when a protocol file is dragged
-over Interviewer, and improve the card's text and icon scaling on smaller
-screens.

--- a/.changeset/interviewer-finished-interview-review.md
+++ b/.changeset/interviewer-finished-interview-review.md
@@ -1,6 +1,0 @@
----
-"@codaco/interviewer": minor
----
-
-Finished interviews can now be reviewed without saving changes, or marked
-unfinished when further editing is needed.

--- a/.changeset/interviewer-icon-optical-centre.md
+++ b/.changeset/interviewer-icon-optical-centre.md
@@ -1,7 +1,0 @@
----
-"@codaco/interviewer": patch
----
-
-The installed app's icon is now optically centred, correcting a slight rightward
-lean, and renders at a consistent size whether the app was installed from Safari
-or Chrome.

--- a/.changeset/interviewer-interview-typography.md
+++ b/.changeset/interviewer-interview-typography.md
@@ -1,6 +1,0 @@
----
-"@codaco/interviewer": patch
----
-
-Interview text now scales smoothly with your screen size — comfortably compact
-on smaller screens and larger on wide or high-resolution displays.

--- a/apps/interviewer/CHANGELOG.md
+++ b/apps/interviewer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @codaco/interviewer
 
+## 8.0.0-beta.10
+
+### Minor Changes
+
+- Finished interviews can now be reviewed without saving changes, or marked
+  unfinished when further editing is needed.
+
+### Patch Changes
+
+- Bring the Import a protocol card to the front when a protocol file is dragged
+  over Interviewer, and improve the card's text and icon scaling on smaller
+  screens.
+- The installed app's icon is now optically centred, correcting a slight rightward
+  lean, and renders at a consistent size whether the app was installed from Safari
+  or Chrome.
+- Interview text now scales smoothly with your screen size — comfortably compact
+  on smaller screens and larger on wide or high-resolution displays.
+
 ## 8.0.0-beta.9
 
 ### Minor Changes

--- a/apps/interviewer/package.json
+++ b/apps/interviewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer",
-  "version": "8.0.0-beta.9",
+  "version": "8.0.0-beta.10",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "author": "Complex Data Collective <hello@complexdatacollective.org>",


### PR DESCRIPTION
Merging this PR releases `@codaco/interviewer` to Netlify **production**.
It also creates a GitHub prerelease.

| Product | From | To |
| --- | --- | --- |
| `@codaco/interviewer` | 8.0.0-beta.9 | 8.0.0-beta.10 |

### @codaco/interviewer@8.0.0-beta.10

### Minor Changes

- Finished interviews can now be reviewed without saving changes, or marked
  unfinished when further editing is needed.

### Patch Changes

- Bring the Import a protocol card to the front when a protocol file is dragged
  over Interviewer, and improve the card's text and icon scaling on smaller
  screens.
- The installed app's icon is now optically centred, correcting a slight rightward
  lean, and renders at a consistent size whether the app was installed from Safari
  or Chrome.
- Interview text now scales smoothly with your screen size — comfortably compact
  on smaller screens and larger on wide or high-resolution displays.
