### PR TITLE
test(website): give the jsdom suite headroom under CI load

### DIFF
--- a/apps/networkcanvas.com/vitest.config.ts
+++ b/apps/networkcanvas.com/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    // Parallelised with the rest of the workspace's tests in the CI quality
+    // job; a borderline jsdom test can be starved past the 5s default under
+    // peak runner load, so give generous headroom.
+    testTimeout: 20_000,
     setupFiles: ['./vitest.setup.ts'],
     server: {
       deps: {


### PR DESCRIPTION
## Summary

Every merge-queue failure in the last 40 runs — 10 of them — is the same test timing out:

```
FAIL components/summer-update/__tests__/SummerUpdatePage.test.tsx > SummerUpdatePage
     > links every Schema 8 explorer item to its relevant documentation
Error: Test timed out in 5000ms.
```

`apps/networkcanvas.com` was the only jsdom-heavy workspace with no `testTimeout`
override, so it ran on vitest's 5000 ms default. `architect`, `interviewer`,
`interview`, `fresco-ui` and `site-navigation-element` all set `20_000` for
exactly this reason — the website app was simply missed.

**Why it tips over:** the CI `test` job runs `turbo run test` at default
concurrency, starting 8+ vitest instances within three seconds of each other on a
single 4-vCPU runner, each with its own CPU-count worker pool. Under that
contention the suite's two heaviest tests — each rendering the whole
`SummerUpdatePage` and running ~30 accessible-name queries — stretch from ~1.1 s
to 5–7 s and cross the default budget. Observed: 6807 ms and 5421 ms.

Nothing is racy or async here; both tests are synchronous and CPU-bound. The
failure is purely wall-clock budget versus duration.

## Test plan

- [x] Reproduced the exact CI signature locally by scaling the budget instead of
      the load (`--testTimeout=800`): the same two tests fail first with the same
      `Test timed out in Nms` error, everything else passes.
- [x] Confirmed the config key is honoured (a temporary `testTimeout: 800` in the
      config produced `Test timed out in 800ms`, not the 5000 default).
- [x] `pnpm --filter networkcanvas.com test` — 29 files, 139 tests passing.
- [x] `pnpm --filter networkcanvas.com typecheck` clean; oxlint and oxfmt clean.
- [x] Audited every vitest workspace for the same gap. The next-slowest
      timeout-less workspace is `@codaco/art` at 207 ms worst case (~1.3 s
      projected under the measured CI factor) — comfortably clear, so no other
      config needs changing.

No changeset: test/CI-tooling-only, nothing consumer-visible ships.