### PR TITLE
refactor(protocol-validation)!: domain-owned validation result, no zod internals

### DIFF
--- a/.changeset/architect-readable-validation-errors.md
+++ b/.changeset/architect-readable-validation-errors.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Protocol validation failures during import and stage preview now show a readable list of problems (one `path: message` line per issue) instead of raw JSON.

--- a/.changeset/protocol-validation-owned-validation-result.md
+++ b/.changeset/protocol-validation-owned-validation-result.md
@@ -1,0 +1,9 @@
+---
+'@codaco/protocol-validation': major
+---
+
+`validateProtocol` now returns a domain-owned `ProtocolValidationResult` instead of Zod's `SafeParseReturnType`. The result envelope is unchanged (`{ success: true, data }` / `{ success: false, error }`), but on failure `error` is now a `ProtocolValidationError` — an `Error` subclass carrying `issues: ProtocolValidationIssue[]` (`{ code, path, message }`) whose `message` renders the issues as a readable `path: message` list. `ProtocolValidationResult`, `ProtocolValidationIssue`, `ProtocolValidationError`, and `formatProtocolValidationIssues` are all exported.
+
+No changes are needed if you only read `result.success`, `result.data`, `result.error.message`, or the `code`/`path`/`message` fields of `result.error.issues`. Code relying on Zod specifics must migrate: `error instanceof z.ZodError` checks, `error.format()`/`error.flatten()`, per-code issue fields (`expected`, `received`, `minimum`, …), or narrowing against Zod's literal issue-code union. The CLI prints the formatted issue list on failure.
+
+Internally, entity-reference collection no longer touches Zod's private `zod/v4/core` internals; schema traversal now uses only Zod 4's public API.

--- a/apps/architect/src/ducks/modules/userActions/__tests__/userActions.test.ts
+++ b/apps/architect/src/ducks/modules/userActions/__tests__/userActions.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { z } from 'zod';
 
-import type { CurrentProtocol } from '@codaco/protocol-validation';
+import {
+  type CurrentProtocol,
+  ProtocolValidationError,
+} from '@codaco/protocol-validation';
 
 const capture = vi.fn();
 const setImportInProgress = vi.fn();
@@ -107,12 +109,11 @@ describe('userActions', () => {
       // A real codebook uniqueness failure embeds the raw variable record key
       // (a protocol-derived identifier) in its message.
       const secretVariableName = 'participant_hiv_status';
-      const error = new z.ZodError([
+      const error = new ProtocolValidationError([
         {
           code: 'custom',
           message: `Variable record key "${secretVariableName}" is reused across entity types`,
           path: ['codebook'],
-          input: undefined,
         },
       ]);
       validateProtocol.mockResolvedValue({ success: false, error });

--- a/apps/architect/src/ducks/modules/userActions/userActions.ts
+++ b/apps/architect/src/ducks/modules/userActions/userActions.ts
@@ -1,6 +1,5 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 import { navigate } from 'wouter/use-browser-location';
-import { type z } from 'zod';
 
 import {
   type CurrentProtocol,
@@ -10,6 +9,7 @@ import {
   type MigrationNote,
   migrateProtocol,
   NetcanvasInflationLimitError,
+  type ProtocolValidationError,
   validateProtocol,
 } from '@codaco/protocol-validation';
 import { posthog } from '~/analytics';
@@ -82,7 +82,7 @@ const openedResult: ProtocolOpenResult = { status: 'opened' };
 // report it as an exception.
 const trackImportValidationFailure = (
   source: ImportSource,
-  error: z.ZodError,
+  error: ProtocolValidationError,
 ) => {
   // Report only the structural shape of each failure — the issue code and its
   // schema path — never the prettified message or flattened error maps, which

--- a/packages/protocol-validation/scripts/cli.js
+++ b/packages/protocol-validation/scripts/cli.js
@@ -61,7 +61,7 @@ async function main() {
     } else {
       error('❌ Protocol validation failed:');
       // biome-ignore lint/suspicious/noConsole: CLI script intentionally uses console for error output
-      console.error(result.error);
+      console.error(result.error.message);
       process.exit(1);
     }
   } catch (_error) {

--- a/packages/protocol-validation/src/index.ts
+++ b/packages/protocol-validation/src/index.ts
@@ -19,7 +19,12 @@ import {
   type Network,
   validateNames,
 } from './utils/validateExternalData.ts';
-import validateProtocol from './validation/validate-protocol.ts';
+import validateProtocol, {
+  formatProtocolValidationIssues,
+  ProtocolValidationError,
+  type ProtocolValidationIssue,
+  type ProtocolValidationResult,
+} from './validation/validate-protocol.ts';
 
 export {
   MigrationChain,
@@ -48,12 +53,16 @@ export {
   type ExtractedAsset,
   extractProtocol,
   extractProtocolFromZip,
+  formatProtocolValidationIssues,
   getAssetMimeType,
   getVariableNamesFromNetwork,
   hashProtocol,
   MAX_INFLATED_BYTES,
   type Network,
   NetcanvasInflationLimitError,
+  ProtocolValidationError,
+  type ProtocolValidationIssue,
+  type ProtocolValidationResult,
   validateNames,
   validateProtocol,
 };

--- a/packages/protocol-validation/src/schemas/8/__tests__/entity-attribute-reference.test.ts
+++ b/packages/protocol-validation/src/schemas/8/__tests__/entity-attribute-reference.test.ts
@@ -22,7 +22,7 @@ describe('entityAttributeReference', () => {
 
   it('exposes the descriptor through an optional wrapper (meta on inner type)', () => {
     const schema = entityAttributeReference({ subject: 'ego' }).optional();
-    const inner = schema._zod.def.innerType as z.ZodType;
+    const inner = schema.unwrap();
     expect(getEntityAttributeReferenceDescriptor(inner)).toEqual({
       subject: 'ego',
     });

--- a/packages/protocol-validation/src/utils/__tests__/entity-attribute-reference-coverage.test.ts
+++ b/packages/protocol-validation/src/utils/__tests__/entity-attribute-reference-coverage.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type z } from 'zod';
-import type * as core from 'zod/v4/core';
+import { z } from 'zod';
 
 import { getEntityAttributeReferenceDescriptor } from '../../schemas/8/entity-attribute-reference.ts';
 import { CurrentProtocolSchema } from '../../schemas/index.ts';
@@ -12,37 +11,29 @@ const countTagged = (
 ): number => {
   if (seen.has(schema)) return 0;
   seen.add(schema);
-  const def = schema._zod.def;
   let count = getEntityAttributeReferenceDescriptor(schema) ? 1 : 0;
+  const countChild = (child: unknown): number =>
+    child instanceof z.ZodType ? countTagged(child, seen) : 0;
   if (
-    def.type === 'optional' ||
-    def.type === 'nullable' ||
-    def.type === 'default'
+    schema instanceof z.ZodOptional ||
+    schema instanceof z.ZodNullable ||
+    schema instanceof z.ZodDefault
   ) {
-    count += countTagged(
-      (def as core.$ZodOptionalDef).innerType as z.ZodType,
-      seen,
-    );
-  } else if (def.type === 'pipe') {
+    count += countChild(schema.unwrap());
+  } else if (schema instanceof z.ZodPipe) {
     // Mirror the extractor: a pipe is peeled to its input side, so tags in a
     // pipe's narrowing output union are intentionally not counted.
-    count += countTagged((def as core.$ZodPipeDef).in as z.ZodType, seen);
-  } else if (def.type === 'object') {
-    for (const child of Object.values(
-      (def as core.$ZodObjectDef).shape,
-    ) as z.ZodType[]) {
-      count += countTagged(child, seen);
+    count += countChild(schema.in);
+  } else if (schema instanceof z.ZodObject) {
+    for (const child of Object.values(schema.shape)) {
+      count += countChild(child);
     }
-  } else if (def.type === 'array') {
-    count += countTagged((def as core.$ZodArrayDef).element as z.ZodType, seen);
-  } else if (def.type === 'record') {
-    count += countTagged(
-      (def as core.$ZodRecordDef).valueType as z.ZodType,
-      seen,
-    );
-  } else if (def.type === 'union') {
-    for (const opt of (def as core.$ZodUnionDef).options as z.ZodType[])
-      count += countTagged(opt, seen);
+  } else if (schema instanceof z.ZodArray) {
+    count += countChild(schema.element);
+  } else if (schema instanceof z.ZodRecord) {
+    count += countChild(schema.valueType);
+  } else if (schema instanceof z.ZodUnion) {
+    for (const opt of schema.options) count += countChild(opt);
   }
   return count;
 };
@@ -57,7 +48,7 @@ const EXPECTED_TAGGED_FIELD_COUNT = 36;
 
 describe('entity-attribute reference coverage', () => {
   it('has tagged the expected number of reference fields', () => {
-    expect(countTagged(CurrentProtocolSchema as unknown as z.ZodType)).toBe(
+    expect(countTagged(CurrentProtocolSchema)).toBe(
       EXPECTED_TAGGED_FIELD_COUNT,
     );
   });

--- a/packages/protocol-validation/src/utils/__tests__/entity-type-reference-coverage.test.ts
+++ b/packages/protocol-validation/src/utils/__tests__/entity-type-reference-coverage.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type z } from 'zod';
-import type * as core from 'zod/v4/core';
+import { z } from 'zod';
 
 import { getEntityTypeReferenceDescriptor } from '../../schemas/8/entity-type-reference.ts';
 import { CurrentProtocolSchema } from '../../schemas/index.ts';
@@ -13,37 +12,29 @@ const countTagged = (
 ): number => {
   if (seen.has(schema)) return 0;
   seen.add(schema);
-  const def = schema._zod.def;
   let count = getEntityTypeReferenceDescriptor(schema) ? 1 : 0;
+  const countChild = (child: unknown): number =>
+    child instanceof z.ZodType ? countTagged(child, seen) : 0;
   if (
-    def.type === 'optional' ||
-    def.type === 'nullable' ||
-    def.type === 'default'
+    schema instanceof z.ZodOptional ||
+    schema instanceof z.ZodNullable ||
+    schema instanceof z.ZodDefault
   ) {
-    count += countTagged(
-      (def as core.$ZodOptionalDef).innerType as z.ZodType,
-      seen,
-    );
-  } else if (def.type === 'pipe') {
+    count += countChild(schema.unwrap());
+  } else if (schema instanceof z.ZodPipe) {
     // Mirror the extractor: a pipe is peeled to its input side, so tags in a
     // pipe's narrowing output union are intentionally not counted.
-    count += countTagged((def as core.$ZodPipeDef).in as z.ZodType, seen);
-  } else if (def.type === 'object') {
-    for (const child of Object.values(
-      (def as core.$ZodObjectDef).shape,
-    ) as z.ZodType[]) {
-      count += countTagged(child, seen);
+    count += countChild(schema.in);
+  } else if (schema instanceof z.ZodObject) {
+    for (const child of Object.values(schema.shape)) {
+      count += countChild(child);
     }
-  } else if (def.type === 'array') {
-    count += countTagged((def as core.$ZodArrayDef).element as z.ZodType, seen);
-  } else if (def.type === 'record') {
-    count += countTagged(
-      (def as core.$ZodRecordDef).valueType as z.ZodType,
-      seen,
-    );
-  } else if (def.type === 'union') {
-    for (const opt of (def as core.$ZodUnionDef).options as z.ZodType[])
-      count += countTagged(opt, seen);
+  } else if (schema instanceof z.ZodArray) {
+    count += countChild(schema.element);
+  } else if (schema instanceof z.ZodRecord) {
+    count += countChild(schema.valueType);
+  } else if (schema instanceof z.ZodUnion) {
+    for (const opt of schema.options) count += countChild(opt);
   }
   return count;
 };
@@ -58,7 +49,7 @@ const EXPECTED_TAGGED_FIELD_COUNT = 12;
 
 describe('entity-type reference coverage', () => {
   it('has tagged the expected number of reference fields', () => {
-    expect(countTagged(CurrentProtocolSchema as unknown as z.ZodType)).toBe(
+    expect(countTagged(CurrentProtocolSchema)).toBe(
       EXPECTED_TAGGED_FIELD_COUNT,
     );
   });

--- a/packages/protocol-validation/src/utils/collectEntityAttributeReferences.ts
+++ b/packages/protocol-validation/src/utils/collectEntityAttributeReferences.ts
@@ -1,5 +1,4 @@
-import { type z } from 'zod';
-import type * as core from 'zod/v4/core';
+import { z } from 'zod';
 
 import type { StageSubject } from '../schemas/8/common/index.ts';
 import {
@@ -39,6 +38,12 @@ type WalkContext = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+// Zod types its child accessors (`.unwrap()`, `.in`, `.element`, `.valueType`,
+// `.options`, `.shape`) against the structural schema type, which lacks the
+// `.meta()` / `.safeParse()` surface this walk uses; instanceof recovers it.
+const isZodType = (value: unknown): value is z.ZodType =>
+  value instanceof z.ZodType;
+
 // Peel optional / nullable / default wrappers to reach the meaningful node.
 // A pipe (loose-shape-with-refine piped into a narrowing union) is peeled to
 // its INPUT side: it carries the same reference tags at the same paths as the
@@ -47,17 +52,16 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const unwrap = (schema: z.ZodType): z.ZodType => {
   let current = schema;
   for (;;) {
-    const type = current._zod.def.type;
-    if (type === 'optional' || type === 'nullable' || type === 'default') {
-      current = (current._zod.def as core.$ZodOptionalDef)
-        .innerType as z.ZodType;
-      continue;
-    }
-    if (type === 'pipe') {
-      current = (current._zod.def as core.$ZodPipeDef).in as z.ZodType;
-      continue;
-    }
-    return current;
+    const inner =
+      current instanceof z.ZodOptional ||
+      current instanceof z.ZodNullable ||
+      current instanceof z.ZodDefault
+        ? current.unwrap()
+        : current instanceof z.ZodPipe
+          ? current.in
+          : undefined;
+    if (!isZodType(inner)) return current;
+    current = inner;
   }
 };
 
@@ -73,32 +77,24 @@ const hasReference = (schema: z.ZodType): boolean => {
   if (cached !== undefined) return cached;
   // Provisional false guards against schema cycles while computing.
   subtreeHasReference.set(node, false);
-  const def = node._zod.def;
   let result =
     getEntityAttributeReferenceDescriptor(node) !== undefined ||
     getEntityTypeReferenceDescriptor(node) !== undefined;
   if (!result) {
-    switch (def.type) {
-      case 'object':
-        result = Object.values((def as core.$ZodObjectDef).shape).some(
-          (child) => hasReference(child as z.ZodType),
-        );
-        break;
-      case 'array':
-        result = hasReference((def as core.$ZodArrayDef).element as z.ZodType);
-        break;
-      case 'record':
-        result = hasReference(
-          (def as core.$ZodRecordDef).valueType as z.ZodType,
-        );
-        break;
-      case 'union':
-        result = ((def as core.$ZodUnionDef).options as z.ZodType[]).some(
-          (option) => hasReference(option),
-        );
-        break;
-      default:
-        result = false;
+    if (node instanceof z.ZodObject) {
+      result = Object.values(node.shape).some(
+        (child: unknown) => isZodType(child) && hasReference(child),
+      );
+    } else if (node instanceof z.ZodArray) {
+      const element = node.element;
+      result = isZodType(element) && hasReference(element);
+    } else if (node instanceof z.ZodRecord) {
+      const valueType = node.valueType;
+      result = isZodType(valueType) && hasReference(valueType);
+    } else if (node instanceof z.ZodUnion) {
+      result = node.options.some(
+        (option) => isZodType(option) && hasReference(option),
+      );
     }
   }
   subtreeHasReference.set(node, result);
@@ -107,13 +103,9 @@ const hasReference = (schema: z.ZodType): boolean => {
 
 // Literal/enum values a schema node accepts, for virtual-discriminator detection.
 const literalValuesOf = (schema: z.ZodType): unknown[] | undefined => {
-  const def = unwrap(schema)._zod.def;
-  if (def.type === 'literal') {
-    return (def as core.$ZodLiteralDef<core.util.Literal>).values as unknown[];
-  }
-  if (def.type === 'enum') {
-    return Object.values((def as core.$ZodEnumDef).entries);
-  }
+  const node = unwrap(schema);
+  if (node instanceof z.ZodLiteral) return [...node.values];
+  if (node instanceof z.ZodEnum) return node.options;
   return undefined;
 };
 
@@ -135,22 +127,22 @@ const getVirtualDiscriminator = (
   const cached = virtualDiscriminatorCache.get(union);
   if (cached !== undefined) return cached;
   const shapes = options.map((option) => {
-    const def = unwrap(option)._zod.def;
-    return def.type === 'object'
-      ? ((def as core.$ZodObjectDef).shape as Record<string, z.ZodType>)
-      : undefined;
+    const node = unwrap(option);
+    return node instanceof z.ZodObject ? node.shape : undefined;
   });
   let result: VirtualDiscriminator | null = null;
   if (shapes.every((shape) => shape !== undefined)) {
     for (const field of Object.keys(shapes[0] ?? {})) {
       const map = new Map<unknown, z.ZodType[]>();
-      const usable = shapes.every((shape, index) => {
-        const fieldSchema = shape?.[field];
-        const values = fieldSchema ? literalValuesOf(fieldSchema) : undefined;
+      const usable = options.every((option, index) => {
+        const fieldSchema: unknown = shapes[index]?.[field];
+        const values = isZodType(fieldSchema)
+          ? literalValuesOf(fieldSchema)
+          : undefined;
         if (!values?.length) return false;
         for (const value of values) {
           const branches = map.get(value) ?? [];
-          branches.push(options[index] as z.ZodType);
+          branches.push(option);
           map.set(value, branches);
         }
         return true;
@@ -222,129 +214,123 @@ const walk = (
   const node = unwrap(schema);
   // Prune reference-free subtrees: nothing below can produce a hit.
   if (!hasReference(node)) return [];
-  const def = node._zod.def;
 
-  switch (def.type) {
-    case 'string': {
-      if (typeof value !== 'string') return [];
-      const attributeDescriptor = getEntityAttributeReferenceDescriptor(node);
-      if (attributeDescriptor) {
-        return [
-          {
-            kind: 'attribute',
-            path,
-            variableId: value,
-            subject: resolveSubject(attributeDescriptor.subject, path, ctx),
-            requireType: attributeDescriptor.requireType,
-          },
-        ];
-      }
-      const typeDescriptor = getEntityTypeReferenceDescriptor(node);
-      if (typeDescriptor) {
-        const entity =
-          typeDescriptor.entity === 'filterRule'
-            ? ctx.filterRuleEntity
-            : typeDescriptor.entity;
-        // Unresolvable (e.g. an ego filter rule) references no codebook type.
-        if (entity === undefined) return [];
-        return [{ kind: 'type', path, typeId: value, entity }];
-      }
-      return [];
+  if (node instanceof z.ZodString) {
+    if (typeof value !== 'string') return [];
+    const attributeDescriptor = getEntityAttributeReferenceDescriptor(node);
+    if (attributeDescriptor) {
+      return [
+        {
+          kind: 'attribute',
+          path,
+          variableId: value,
+          subject: resolveSubject(attributeDescriptor.subject, path, ctx),
+          requireType: attributeDescriptor.requireType,
+        },
+      ];
     }
-    case 'object': {
-      if (!isRecord(value)) return [];
-      const shape = (def as core.$ZodObjectDef).shape;
-      const childCtx: WalkContext = {
-        stageSubject: stageSubjectOf(value) ?? ctx.stageSubject,
-        parent: value,
-        filterRuleEntity: filterRuleEntityOf(value) ?? ctx.filterRuleEntity,
-      };
-      return Object.keys(shape).flatMap((key) => {
-        const child = shape[key] as z.ZodType;
-        if (!hasReference(child)) return [];
-        return walk(child, value[key], [...path, key], childCtx);
-      });
+    const typeDescriptor = getEntityTypeReferenceDescriptor(node);
+    if (typeDescriptor) {
+      const entity =
+        typeDescriptor.entity === 'filterRule'
+          ? ctx.filterRuleEntity
+          : typeDescriptor.entity;
+      // Unresolvable (e.g. an ego filter rule) references no codebook type.
+      if (entity === undefined) return [];
+      return [{ kind: 'type', path, typeId: value, entity }];
     }
-    case 'array': {
-      if (!Array.isArray(value)) return [];
-      const element = (def as core.$ZodArrayDef).element as z.ZodType;
-      return value.flatMap((item, index) =>
-        walk(element, item, [...path, index], ctx),
-      );
-    }
-    case 'record': {
-      if (!isRecord(value)) return [];
-      const valueType = (def as core.$ZodRecordDef).valueType as z.ZodType;
-      return Object.keys(value).flatMap((key) =>
-        walk(valueType, value[key], [...path, key], ctx),
-      );
-    }
-    case 'union': {
-      const unionDef = def as
-        | core.$ZodDiscriminatedUnionDef
-        | core.$ZodUnionDef;
-      const options = unionDef.options as z.ZodType[];
-      const discriminator =
-        'discriminator' in unionDef ? unionDef.discriminator : undefined;
-      if (discriminator !== undefined && isRecord(value)) {
-        const discValue = value[discriminator];
-        const match = options.find((option) => {
-          const shape = (option._zod.def as core.$ZodObjectDef).shape;
-          const discField = shape[discriminator] as z.ZodType | undefined;
-          if (!discField) return false;
-          const literalValues = (
-            discField._zod.def as core.$ZodLiteralDef<core.util.Literal>
-          ).values;
-          return (
-            Array.isArray(literalValues) &&
-            literalValues.includes(discValue as core.util.Literal)
-          );
-        });
-        return match ? walk(match, value, path, ctx) : [];
-      }
-      // plain union: only reference-bearing branches can yield hits, so restrict
-      // both the branch search and safeParse cost to them (the top-level guard
-      // guarantees at least one such branch exists). Prefer the branch that
-      // fully parses — unchanged behaviour for valid data.
-      const refOptions = options.filter((option) => hasReference(option));
-      // Narrow the branch search with a virtual discriminator — a literal/enum
-      // field every option shares (e.g. a variable's `type`). This restricts the
-      // safeParse probes to the branches whose discriminator matches the value
-      // (usually one) instead of every reference-bearing branch.
-      const virtualDiscriminator = getVirtualDiscriminator(node, options);
-      const discriminated =
-        virtualDiscriminator && isRecord(value)
-          ? virtualDiscriminator.map.get(value[virtualDiscriminator.field])
-          : undefined;
-      const searchOptions = discriminated
-        ? discriminated.filter((option) => hasReference(option))
-        : refOptions;
-      const match = searchOptions.find(
-        (option) => option.safeParse(value).success,
-      );
-      if (match) return walk(match, value, path, ctx);
-      // No reference-bearing branch matched. If the value validly belongs to a
-      // reference-free branch there is nothing to collect; only when it matches
-      // no branch at all (structurally-invalid, in-progress edit) do we merge
-      // references across the reference-bearing branches so they still surface.
-      const matchesRefFreeBranch = options.some(
-        (option) => !hasReference(option) && option.safeParse(value).success,
-      );
-      if (matchesRefFreeBranch) return [];
-      // De-dupe on the full hit (path AND resolved subject/requireType): two
-      // branches can expose the same path with different validation metadata,
-      // and those are distinct references that must both survive.
-      const merged = new Map<string, ReferenceHit>();
-      for (const option of refOptions) {
-        for (const hit of walk(option, value, path, ctx)) {
-          merged.set(JSON.stringify(hit), hit);
-        }
-      }
-      return [...merged.values()];
-    }
-    default:
-      return [];
+    return [];
   }
+
+  if (node instanceof z.ZodObject) {
+    if (!isRecord(value)) return [];
+    const shape = node.shape;
+    const childCtx: WalkContext = {
+      stageSubject: stageSubjectOf(value) ?? ctx.stageSubject,
+      parent: value,
+      filterRuleEntity: filterRuleEntityOf(value) ?? ctx.filterRuleEntity,
+    };
+    return Object.keys(shape).flatMap((key) => {
+      const child: unknown = shape[key];
+      if (!isZodType(child) || !hasReference(child)) return [];
+      return walk(child, value[key], [...path, key], childCtx);
+    });
+  }
+
+  if (node instanceof z.ZodArray) {
+    if (!Array.isArray(value)) return [];
+    const element = node.element;
+    if (!isZodType(element)) return [];
+    return value.flatMap((item, index) =>
+      walk(element, item, [...path, index], ctx),
+    );
+  }
+
+  if (node instanceof z.ZodRecord) {
+    if (!isRecord(value)) return [];
+    const valueType = node.valueType;
+    if (!isZodType(valueType)) return [];
+    return Object.keys(value).flatMap((key) =>
+      walk(valueType, value[key], [...path, key], ctx),
+    );
+  }
+
+  if (node instanceof z.ZodUnion) {
+    const options = node.options.filter(isZodType);
+    if (node instanceof z.ZodDiscriminatedUnion && isRecord(value)) {
+      const discriminator = node.def.discriminator;
+      const discValue = value[discriminator];
+      const match = options.find((option) => {
+        if (!(option instanceof z.ZodObject)) return false;
+        const discField: unknown = option.shape[discriminator];
+        if (!(discField instanceof z.ZodLiteral)) return false;
+        const accepted: ReadonlySet<unknown> = discField.values;
+        return accepted.has(discValue);
+      });
+      return match ? walk(match, value, path, ctx) : [];
+    }
+    // plain union: only reference-bearing branches can yield hits, so restrict
+    // both the branch search and safeParse cost to them (the top-level guard
+    // guarantees at least one such branch exists). Prefer the branch that
+    // fully parses — unchanged behaviour for valid data.
+    const refOptions = options.filter((option) => hasReference(option));
+    // Narrow the branch search with a virtual discriminator — a literal/enum
+    // field every option shares (e.g. a variable's `type`). This restricts the
+    // safeParse probes to the branches whose discriminator matches the value
+    // (usually one) instead of every reference-bearing branch.
+    const virtualDiscriminator = getVirtualDiscriminator(node, options);
+    const discriminated =
+      virtualDiscriminator && isRecord(value)
+        ? virtualDiscriminator.map.get(value[virtualDiscriminator.field])
+        : undefined;
+    const searchOptions = discriminated
+      ? discriminated.filter((option) => hasReference(option))
+      : refOptions;
+    const match = searchOptions.find(
+      (option) => option.safeParse(value).success,
+    );
+    if (match) return walk(match, value, path, ctx);
+    // No reference-bearing branch matched. If the value validly belongs to a
+    // reference-free branch there is nothing to collect; only when it matches
+    // no branch at all (structurally-invalid, in-progress edit) do we merge
+    // references across the reference-bearing branches so they still surface.
+    const matchesRefFreeBranch = options.some(
+      (option) => !hasReference(option) && option.safeParse(value).success,
+    );
+    if (matchesRefFreeBranch) return [];
+    // De-dupe on the full hit (path AND resolved subject/requireType): two
+    // branches can expose the same path with different validation metadata,
+    // and those are distinct references that must both survive.
+    const merged = new Map<string, ReferenceHit>();
+    for (const option of refOptions) {
+      for (const hit of walk(option, value, path, ctx)) {
+        merged.set(JSON.stringify(hit), hit);
+      }
+    }
+    return [...merged.values()];
+  }
+
+  return [];
 };
 
 const isAttributeHit = (
@@ -367,10 +353,7 @@ export const collectEntityAttributeReferencesFromSchema = (
 export const collectEntityAttributeReferences = (
   protocol: unknown,
 ): EntityAttributeReferenceHit[] =>
-  collectEntityAttributeReferencesFromSchema(
-    CurrentProtocolSchema as unknown as z.ZodType,
-    protocol,
-  );
+  collectEntityAttributeReferencesFromSchema(CurrentProtocolSchema, protocol);
 
 /**
  * Every codebook node/edge TYPE referenced by a protocol, discovered from the
@@ -382,6 +365,6 @@ export const collectEntityAttributeReferences = (
 export const collectEntityTypeReferences = (
   protocol: unknown,
 ): EntityTypeReferenceHit[] =>
-  walk(CurrentProtocolSchema as unknown as z.ZodType, protocol, [], {})
+  walk(CurrentProtocolSchema, protocol, [], {})
     .filter(isTypeHit)
     .map(({ kind: _kind, ...hit }) => hit);

--- a/packages/protocol-validation/src/validation/validate-protocol.ts
+++ b/packages/protocol-validation/src/validation/validate-protocol.ts
@@ -4,18 +4,73 @@ import {
 } from '../schemas/index.ts';
 import { ensureError } from '../utils/ensureError.ts';
 
+export type ProtocolValidationIssue = {
+  /** Machine-readable issue code (currently Zod's issue codes, e.g. 'invalid_type', 'custom'). */
+  code: string;
+  /** Segments from the protocol root to the failing value. */
+  path: (string | number)[];
+  /** Human-readable description of the failure. */
+  message: string;
+};
+
+/** Single-string rendering of validation issues for dialogs, CLI output, and logs. */
+export const formatProtocolValidationIssues = (
+  issues: readonly ProtocolValidationIssue[],
+): string =>
+  issues
+    .map((issue) => {
+      const path = issue.path.join('.');
+      return path === '' ? issue.message : `${path}: ${issue.message}`;
+    })
+    .join('\n');
+
+export class ProtocolValidationError extends Error {
+  readonly issues: ProtocolValidationIssue[];
+
+  constructor(issues: ProtocolValidationIssue[]) {
+    super(formatProtocolValidationIssues(issues));
+    this.name = 'ProtocolValidationError';
+    this.issues = issues;
+  }
+}
+
+// The `never` members mirror Zod's safe-parse envelope so a caller can read
+// `result.error?.issues` without first narrowing on `success`.
+export type ProtocolValidationResult =
+  | { success: true; data: VersionedProtocol; error?: never }
+  | { success: false; data?: never; error: ProtocolValidationError };
+
 /**
  * Enhanced validateProtocol that uses Zod 4 with integrated cross-reference validation.
  * All validation logic (schema + cross-references) is now handled natively by Zod.
- * Returns Zod's SafeParseReturnType directly.
+ * Returns a domain-owned result: the parsed protocol on success, or a
+ * ProtocolValidationError carrying the validation issues on failure.
  */
-const validateProtocol = async (protocol: VersionedProtocol) => {
+const validateProtocol = async (
+  protocol: VersionedProtocol,
+): Promise<ProtocolValidationResult> => {
   if (protocol === undefined) {
     throw new Error('Protocol is undefined');
   }
 
   try {
-    return await VersionedProtocolSchema.safeParseAsync(protocol);
+    const result = await VersionedProtocolSchema.safeParseAsync(protocol);
+
+    if (result.success) {
+      return { success: true, data: result.data };
+    }
+
+    const issues = result.error.issues.map((issue) => ({
+      code: issue.code,
+      // Zod paths are PropertyKey[]; symbols cannot appear in protocol JSON but
+      // are stringified so the domain path stays (string | number)[].
+      path: issue.path.map((segment) =>
+        typeof segment === 'symbol' ? String(segment) : segment,
+      ),
+      message: issue.message,
+    }));
+
+    return { success: false, error: new ProtocolValidationError(issues) };
   } catch (e) {
     const error = ensureError(e);
 


### PR DESCRIPTION
## Summary

Two decoupling moves in `@codaco/protocol-validation`, replacing a planned Effect Schema conversion after evaluating it:

- **Own the `validateProtocol` error boundary.** The result is now a domain-owned `ProtocolValidationResult`: `{ success: true, data }` or `{ success: false, error: ProtocolValidationError }`, where `ProtocolValidationError extends Error` carries `issues: { code, path, message }[]` and its `message` renders the issues as a readable `path: message` list. The envelope deliberately mirrors Zod's safe-parse shape (including `error?: never` / `data?: never` members), so consumers reading the contracted surface — `success`, `data`, `error.message`, `error.issues[].code/path/message` — need **no code changes**. In this repo the only consumer edits were one type annotation in Architect (`z.ZodError` → `ProtocolValidationError`) and the CLI printing `error.message`. Architect's import/preview dialogs now show formatted issue lists instead of Zod's raw JSON dump, for free, via the `ensureError(...).message` path.
- **Migrate entity-reference traversal off `zod/v4/core` internals.** `collectEntityAttributeReferences` (and the internals-touching tests) now use only Zod 4's public API: `instanceof` narrowing plus `unwrap()/in/shape/element/valueType/options/values` and `def.discriminator`. `grep -rn "_zod\|zod/v4/core" packages/protocol-validation/src` returns nothing. Net −35 lines and fewer type assertions than the internals version.

Breaking (major) for external npm consumers only if they relied on Zod specifics: `instanceof z.ZodError`, `.format()`/`.flatten()`, per-code issue fields (`expected`, `received`, …), or Zod's literal issue-code union. Changesets: major for the library (interview picks up its peer-range major mechanically), patch for Architect (readable validation dialogs).

## Test plan

- [x] `pnpm --filter @codaco/protocol-validation test` — 741 passed (corpus-download spec self-skips locally without `GITHUB_TOKEN`; runs in CI)
- [x] Architect suite — 971 passed, incl. the #766 privacy-redaction test now constructing a real `ProtocolValidationError`
- [x] Interviewer suite — 444 passed (zero source changes needed there)
- [x] `pnpm typecheck` across protocol-validation, architect, interviewer, interview, network-exporters, network-query, protocol-utilities
- [x] `pnpm knip` and `pnpm check:changesets` clean
- [x] Runtime-verified under Node's type-stripping loader (architect's `vite.config.ts` chain): `error instanceof Error`, unnarrowed `result.error?.issues`, formatted `message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)