### PR TITLE
feat(protocol-utilities): finite-domain constraint solving for synthetic data generation

### DIFF
--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-generation-spec.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-generation-spec.md
@@ -1,0 +1,194 @@
+# Finite-domain constraint solving for synthetic data generation
+
+Date: 2026-07-27
+Status: Specification, not yet implemented
+Branch: off `claude/synthetic-data-validation-2b18a2` (PR #1108), merged back into it
+
+## Why this exists
+
+PR #1108 made synthetic interview data satisfy the validation rules a researcher configures. It works for the overwhelming majority of protocols, and both bundled protocols pass. But fuzzing 4,000 random three-variable number shapes found that **18 of the 3,140 that pass the feasibility gate (0.6%) throw at draw time instead of generating**.
+
+That single number is two distinct defects.
+
+### Defect A — the generator cannot backtrack, so it fails on satisfiable protocols
+
+Generation walks variables in dependency order and draws each one greedily. It never reconsiders. A protocol with a perfectly good solution can therefore be painted into a corner:
+
+```
+A: number [3,4], differentFrom B
+B: number [3,4]
+D: number [2,4], lessThanOrEqualTo A, greaterThanOrEqualTo B
+```
+
+`B=3, A=4, D=3` satisfies every rule. Feasibility correctly accepts it. But `A` and `B` are drawn independently, and unless the draw happens to land `B=3, A=4`, there is no value left for `D`. Generation succeeds on roughly **2.5% of seeds** — a researcher running bulk generate gets almost nothing.
+
+This is the more serious half: the protocol is valid and the tool fails it.
+
+### Defect B — feasibility cannot prove some protocols unsatisfiable
+
+```
+a: number [3,4], differentFrom b
+b: number [4,5], lessThanOrEqualTo a
+```
+
+No assignment satisfies this. But the analysis reasons only about interval bounds, and has no way to represent "b's domain minus whatever value a took", so it accepts. The protocol then throws at draw time.
+
+The throw is correct — the protocol _is_ impossible — but it arrives at the wrong moment, in the wrong form, and **seed-dependently**, which is exactly the property the original design set out to eliminate: _a protocol must either always be refused or never be refused, independent of seed and of which session in a bulk run you are on._
+
+### The insight that unifies them
+
+**A complete search over finite domains solves both.** Exhausting the search space without finding an assignment _is_ a proof of unsatisfiability. Finding one and using it _is_ the backtracking Defect A needs.
+
+The obstacle is that domains are not always small — an unbounded `unique` number ranges over 100,000 values. So the work is not "implement a CSP solver" but "implement a complete solver, and decide rigorously when it is safe to use."
+
+## Scope
+
+**In scope.** Per-entity constraint solving for cross-variable rules — `sameAs`, `differentFrom`, and the four comparators — over variables whose domains are small enough to enumerate. Feasibility's verdict for those same variables. Preserving the existing behaviour everywhere else.
+
+**Out of scope.** `unique` remains a cross-_entity_ concern handled by the existing registry, not modelled as a global constraint (see "How `unique` participates"). Preventing contradictions at authoring time is a separate project. Nothing in `apps/`.
+
+## Design
+
+### Where it lives
+
+A new module under `packages/protocol-utilities/src/generateNetwork/constraints/`, consumed by both `feasibility.ts` and `generateEntityAttributes.ts` — the same shared-implementation discipline the existing `propagateComparatorBounds` follows, and for the same reason: the two must never disagree about what a constraint means.
+
+Do not fork the semantics. `COMPARATOR_DIRECTION` in `types.ts` is already the single source of truth for a comparator's direction and strictness; the solver reads it.
+
+### Domain construction
+
+Each variable's domain is the set of values the generator can actually produce for it — not the set the rules theoretically permit. This distinction has bitten this codebase twice already (see `valueSpaceSize`'s doc comment and `textDrawLength`). Reuse those, do not recompute.
+
+| Type                 | Domain                                                                                          |
+| -------------------- | ----------------------------------------------------------------------------------------------- |
+| `boolean`            | `{true, false}` — 2                                                                             |
+| `ordinal`            | the option values                                                                               |
+| `categorical`        | option subsets sized within `[minSelected, maxSelected]` — combinatorial, often above threshold |
+| `number`             | integers within the propagated bounds                                                           |
+| `scalar`             | the 2-decimal grid over `SCALAR_DOMAIN` — 101 values                                            |
+| `datetime`           | steps within the `dateWindow` at its resolution                                                 |
+| `text`               | effectively unbounded — always above threshold                                                  |
+| `layout`, `location` | no cross-variable rules are legal; excluded                                                     |
+
+Seed domains from the **propagated** bounds, not the declared ones. `propagateComparatorBounds` already narrows them correctly and cheaply; the solver starts from its output. This keeps the solver's work proportional to what propagation could not resolve.
+
+### Tractability threshold — the load-bearing decision
+
+Build the constraint graph over each entity type's variables and take its **connected components**. A component of one variable needs no solving. Solve a component completely when it is tractable; otherwise fall back to today's behaviour for that component alone.
+
+Tractability must be judged on the **product** of the component's domain sizes, not each domain individually — three variables of 500 values each is 125 million, not "small". Cap the product, and additionally cap the component's variable count.
+
+The spec deliberately does not fix the constants. Choose them from measurement (see completeness criterion C6) and document the reasoning where they are defined. State them in the implementation report.
+
+**A component above threshold must behave exactly as it does today** — same draw path, same output for a given seed. This is a hard requirement, not a nicety: it is what makes the change safe to ship. Criterion C5 tests it.
+
+### Search
+
+Standard backtracking with constraint propagation:
+
+1. **Propagate** — enforce arc consistency (AC-3 is sufficient) over the component's constraints, pruning domains. Comparators prune by bound; `differentFrom` prunes only when the opposing domain is a singleton.
+2. **Select the next variable** — minimum-remaining-values, breaking ties consistently so the search is deterministic.
+3. **Order values randomly, seeded.** This is essential and easy to get wrong: a solver that returns the lexicographically-first solution gives every entity in the network identical values, destroying the variation synthetic data exists to provide. Draw the value ordering from the run's seeded generator so output stays reproducible for a given seed while varying across entities and seeds.
+4. **Recurse**, undoing prunes on backtrack.
+5. **Bound the work** — cap nodes explored. Hitting the cap means "unknown", not "unsatisfiable", and must fall back rather than refuse. Criterion C4 covers this.
+
+Feasibility asks for existence: does _any_ solution exist. Generation asks for a witness: give me _a_ solution, varied across entities. The same search serves both — feasibility stops at the first solution and discards it.
+
+### How `unique` participates
+
+`unique` spans entities, so it is not a constraint inside the per-entity CSP. It enters as a **unary domain restriction**: when solving entity _n_, values already claimed in the registry for that variable are absent from its domain.
+
+Two consequences the implementation must handle:
+
+- A component containing a `unique` variable must be re-solved per entity, since its domain shrinks as the run proceeds. Do not cache a solution across entities.
+- If the restricted domain empties, that is registry exhaustion — the existing `SyntheticDataConstraintError` path, not a solver failure. Keep that distinction in the error.
+
+### Interaction with existing machinery
+
+- `propagateComparatorBounds` stays. It is cheap, it handles the common case, and it seeds the solver's domains.
+- The existing greedy draw path stays, for above-threshold components and for variables with no cross-variable rules — which is most variables in most protocols.
+- The `sameAs` / non-strict-cycle equality grouping in `dependencyOrder.ts` stays and runs first. The solver operates on groups, not raw variables.
+- `SCALAR_DOMAIN`, `textDrawLength`, `TEXT_ALPHABET_SIZE` and `valueSpaceSize` are existing sources of truth about what the generator can reach. Reuse them.
+
+## Completeness criteria
+
+These are acceptance gates. The work is not done until every one passes, with evidence in the implementation report. Where a criterion names a number, that number is a minimum.
+
+### C1 — Feasibility is sound and complete below threshold
+
+Over a corpus of **at least 20,000 randomly generated protocols** whose cross-variable components all fall below the tractability threshold, `analyseFeasibility`'s verdict must match brute-force ground truth **exactly**: zero false positives, zero false negatives.
+
+The corpus must include, in non-trivial proportion: `differentFrom` interacting with tight bounds; chains of 3-5 comparators; mixed strict and non-strict comparators; `sameAs` groups whose members carry different bounds; and all of `number`, `scalar`, `datetime`, `ordinal`, `boolean`.
+
+Ground truth is exhaustive enumeration over the component's domains, computed independently of the solver — a bug shared between the two would otherwise cancel out and pass.
+
+**Report the corpus size, the generator's shape distribution, and the mismatch count (which must be 0).**
+
+### C2 — Accepted protocols always generate
+
+For every protocol in the C1 corpus that feasibility accepts, `generateNetwork` must succeed on **500 consecutive seeds** with **zero draw-time throws**.
+
+The two named regressions must be explicitly among the cases and reach zero:
+
+- `A: number [3,4] differentFrom B`, `B: number [3,4]`, `D: number [2,4] lessThanOrEqualTo A greaterThanOrEqualTo B` — currently succeeds on ~2.5% of seeds, must reach 100%.
+- `a: number [3,4] differentFrom b`, `b: number [4,5] lessThanOrEqualTo a` — currently accepted then throws, must be **refused** by feasibility.
+
+**Report per-shape seed counts.**
+
+### C3 — Generated data stays varied
+
+A solver that returns the same solution every time satisfies C1 and C2 while making synthetic data useless. Guard it explicitly:
+
+For a component with a solution space of size _S_ ≥ 10, generating 200 entities must yield **at least `min(S, 20)` distinct assignments**, and no single assignment may account for more than **40%** of entities.
+
+**Report the distinct-assignment counts and the modal frequency for at least three component shapes.**
+
+### C4 — The node cap degrades safely
+
+When the search cap is hit, the result is "unknown". Feasibility must **not** refuse on unknown, and generation must fall back to the existing draw path. Construct a component that provably exceeds the cap and assert both. A protocol must never be refused because the solver ran out of budget.
+
+### C5 — Above-threshold behaviour is byte-identical
+
+For at least **10 protocols** whose components exceed the threshold, generated output must be **byte-identical** to the output of the commit this branch starts from, for at least 50 seeds each.
+
+This is the safety property that makes the change shippable. Diff the serialised networks; do not eyeball them.
+
+**Report the comparison method and the mismatch count (which must be 0).**
+
+### C6 — Performance is bounded and measured
+
+Report generation wall-clock for a realistic protocol (use the bundled development protocol) before and after, at 100 sessions. A regression beyond **20%** on that protocol requires either justification or a lower threshold.
+
+Separately, report the worst-case single-entity solve time observed across the C1 corpus. The threshold constants must be justified by these numbers, not chosen arbitrarily.
+
+### C7 — Nothing already working regresses
+
+- `pnpm typecheck`, `pnpm test`, `pnpm knip` all pass from the repo root.
+- The conformance seam test (`packages/interview/src/forms/__tests__/syntheticDataConformance.test.ts`) passes **unchanged** — if it needs modifying to accommodate the solver, that is a signal something is wrong; stop and explain.
+- The bundled development and sample protocols still pass the feasibility gate.
+- Every existing regression shape in `.superpowers/sdd/progress.md` stays at zero violations. The ledger lists them.
+
+### C8 — Guards are verified red by mutation
+
+For each of C1, C2, C3 and C5, disable the mechanism it protects, confirm the corresponding test fails, and restore it. **Report which test failed for each, with its message.** A guard that cannot fail proves nothing — this branch has already caught one mandated test that was a complete no-op.
+
+## Explicitly not required
+
+- Solving components above threshold. Falling back is correct.
+- Modelling `unique` as a global constraint.
+- Optimising the solution found. Any satisfying assignment is acceptable, subject to C3's variation requirement.
+- Closing the `categorical` subset explosion. Categorical components will usually exceed threshold; that is expected.
+
+## Branch and merge strategy
+
+Branch from the head of `claude/synthetic-data-validation-2b18a2` (PR #1108). Open a PR **targeting that branch**, not `main`, so it merges back into #1108 before #1108 merges.
+
+If #1108 has already merged to `main` by the time this is ready, rebase onto `main` and target `main` instead — the work is self-contained either way.
+
+No changeset is needed if this merges into #1108 before it ships, since #1108's changeset already describes the behaviour. If it lands separately after #1108, it needs its own **patch** changeset for `@codaco/protocol-utilities` on the library lane — invoke the `creating-a-changeset` skill.
+
+## Repo conventions
+
+Read `CLAUDE.md` at the repo root. The ones most likely to bite: no `any`, no `as` type assertions to silence type errors (`as const` is fine), no barrel files, only export what another module imports, comment only unusual or complex code, no `~/` path aliases inside package source. The husky pre-commit hook formats staged files — do not run the root `pnpm lint:fix`.
+
+Context worth reading first: `docs/superpowers/specs/2026-07-27-synthetic-data-validation-conformance-design.md` for the original design, and `.superpowers/sdd/progress.md` for the ledger of what was tried, what broke, and the regression shapes that must stay green. That ledger records four fix rounds on `generateEntityAttributes` alone, two of which introduced regressions while fixing others — the regression set exists because of them.

--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
@@ -262,6 +262,21 @@ superseded by these corpus-measured rates.
   subsequent draws, and domain sizes never show through as extra
   consumption. Guarded by "consumes exactly one seeded draw for a solved
   component" and the cap-file's exact-count assertion.
+- **P1 (second round), unique allocation capacity**: shuffling a `unique`
+  group's domain let one entity take an allocation that stranded the next —
+  `u` over `[0,1]`, `v` over `[1,2]`, `v > u` admits `(0,1)` then `(1,2)`,
+  but a shuffled `(0,2)` first left the second entity nothing, a
+  seed-dependent throw the old distinct-sequence ladder never produced.
+  Unique groups now keep their ascending enumeration order — the same
+  bottom-up consumption discipline as the sequence draw, and lexicographic
+  search still backtracks within the entity — while groups without a
+  registry slot keep the shuffle (their choices cost nothing across
+  entities, and unique values already vary across entities through the
+  ladder itself). This restores allocation parity with the pre-solver path;
+  a global cross-entity unique constraint stays out of scope per the spec.
+  Guarded by "allocates overlapping unique ranges so later entities keep a
+  value" (100 seeds × 2 entities), mutation-verified red by re-shuffling
+  unique domains.
 
 ### The number-domain decision
 

--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
@@ -159,3 +159,142 @@ remains a registry concern — inside a solve it is only a unary domain
 restriction, re-solved per entity, and registry exhaustion still surfaces
 through the existing `SyntheticDataConstraintError` draw path. Categorical
 subset explosions fall back as expected.
+
+## Addendum — reconciliation with the sixteen post-fork commits on #1108
+
+The parent branch gained sixteen commits (twelve review fixes) after this
+branch forked; `origin/claude/synthetic-data-validation-2b18a2` was merged
+back in and every claim below was re-verified at the merged head. Where the
+merge or the review changed a behaviour, the corpus evidence and benchmarks
+in this addendum supersede the sections above.
+
+### Consistency with the review fixes, item by item
+
+- **Finite counts for open-sided spaces** (`3d21a2738`, `00424bbe9`): the
+  solver does not consult `valueSpaceSize` for tractability; it enumerates
+  from propagated **declared** bounds and deliberately declines open-sided
+  numbers and half-open date windows, leaving their fallback windows to the
+  greedy draw. Where the solver does engage, its domain size now equals
+  `valueSpaceSize` exactly — asserted by a committed battery test across all
+  six solvable types ("agrees with valueSpaceSize about the size of every
+  enumerated domain").
+- **Categorical unranking + `selectionSizeRange`** (`3d21a2738`): the solver
+  now derives its subset sizes from `selectionSizeRange` — non-unique
+  defaults cap at two selections, `unique` reaches every size, and a
+  `minSelected` above the default cap becomes the single drawn size, exactly
+  the draw's own count clamp. This also resolved a Codex review finding
+  (P2): before, a `differentFrom` rule silently widened a variable's
+  selections beyond anything the plain draw produces.
+- **`numberDrawBounds`** (`3d21a2738`): not re-derived. The solver only
+  engages when both propagated bounds exist, where `numberDrawBounds`
+  returns the declared pair; open sides fall back to the greedy draw, which
+  owns the slide-down and unique-headroom behaviour.
+- **Date window shape changes** (`00424bbe9`): `resolveDateWindow` now fills
+  an absent `max`, so more datetime components arrive fully bounded and
+  solvable; a missing `min` still declines. `valueSpaceSize` purity is
+  untouched by the solver (no wall-clock reads anywhere in it).
+- **Bin-only variables** (`d40e479fe`): rules are stripped where the
+  descriptors are built, and both feasibility and generation build through
+  the same call, so a bin-only variable simply never forms a component.
+- **Fixed attributes as inputs** (`0e401ebea`): roster rows and prompt
+  `additionalAttributes` arrive as `existing` with `only` narrowing the
+  draw, which the solve classifies as **pins** — pre-assigned variables the
+  rest of the component is solved around. Covered end-to-end by a new
+  `generateNetwork`-level test fixing a boolean by `additionalAttributes`
+  inside a `differentFrom` pair ("solves the rest of a component around a
+  prompt-fixed attribute").
+- **Option-domain intersection for equality groups** (`d31b010bb`): the
+  solver enumerates from the intersected group entry, so a narrowed option
+  list narrows the domain automatically (pinned by "narrows a held-equal
+  group domain to the options every member offers"); an empty intersection
+  is refused by the group check before the solver ever runs.
+- **Resolution-mismatched date comparators** (`b9b43a917`): `comparatorSpan`
+  is undefined for them, so the component is declined and the greedy fold —
+  which now skips the edge — keeps its behaviour (pinned by "declines a
+  comparator between dates at different resolutions").
+- **Reserved roster values** (`c6bb79ac7`, `8d849c4c0`): the solve now
+  mirrors the draw's two-tier preference — a first pass excludes values the
+  registry reserved for undrawn roster rows, and only if no solution exists
+  without them does a second pass allow them (pinned by "prefers unreserved
+  values in a solved component, taking reserved ones only at need").
+
+### The count/reach relationship, per type
+
+Where the solver engages, reach equals count exactly: number = integers in
+the propagated declared bounds; scalar = the 0.01 grid between propagated
+bounds; datetime = window steps at the shared resolution; ordinal = the
+intersected option list; boolean = 2; categorical = all subsets of the
+`selectionSizeRange` sizes, which is what both `valueSpaceSize` and the
+unranked unique draw cover. The one deliberate divergence: a non-unique
+`minSelected` above the default cap, where `valueSpaceSize` sums an empty
+size range (0) while the draw and the solver emit size-`minSelected`
+selections — mirroring the count there would have refused satisfiable
+protocols, and the count is not consumed for non-unique variables. Where
+the solver declines (open-sided numbers and dates, text, oversized
+categoricals), the count may exceed what the solver would enumerate, and
+the greedy draw — whose reach the parent branch aligned the count to — is
+the path that runs.
+
+### The headline, re-measured at the merged head
+
+Measured with the corpus harness (4,000 shapes × 100 seeds) on the parent
+head **without** the solver: **62 of 2,728 accepted shapes (2.3%) are
+unsatisfiable yet accepted**, and **91 (3.3%) fail at draw time** — 8,558
+throwing runs out of 264,242 (3.2%), all throws, zero silent violations
+(the parent's fixes eliminated the silent-violation class; the
+seed-dependent throw class remains). With the solver, both counts are zero
+across the full 20,000-shape × 500-seed evidence run. The spec's original
+"0.6% of accepted" figure came from the earlier review fuzzer and is
+superseded by these corpus-measured rates.
+
+### Codex review findings (PR #1109)
+
+- **P1, categorical materialisation**: tractability is now judged by a
+  closed-form `domainSize` pass before anything is materialised; an
+  oversized component costs a binomial sum per entity instead of up to
+  200,000 discarded subset arrays. Guarded by "declines a categorical whose
+  combination space overflows the budget".
+- **P2, categorical default cap**: adopted via `selectionSizeRange`, above.
+- **P2, solver shuffling on the shared stream**: the solve now draws **one**
+  value from the run's stream to seed a local PRNG and shuffles with that,
+  so the stream advances by exactly one step per solved component whatever
+  the search outcome — a capped or unsatisfiable solve cannot shift
+  subsequent draws, and domain sizes never show through as extra
+  consumption. Guarded by "consumes exactly one seeded draw for a solved
+  component" and the cap-file's exact-count assertion.
+
+### The number-domain decision
+
+The solver's number domain is **integers**, deliberately: it matches the
+draw (which walks integers whenever the range holds one), keeps
+`comparatorGap`'s whole-unit semantics, and keeps synthetic ages whole. The
+consequence is accepted knowingly — `a < b < c` over `[0, 1]` stays
+refused, matching the review decision that declined that claim — and the
+propagated ranges that hold no integer (reachable only through
+scalar-to-number chains) stay on the greedy path, which draws the
+two-decimal fallback; that family is pinned by "generates a chain that
+forces a number into a fractional range".
+
+### Guards re-verified red at the merged head
+
+All six mechanism mutations were re-run after the merge and the review
+fixes:
+
+| Mechanism disabled                | Failing guard and message                                              |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| feasibility's solver-unsat report | corpus parity `feasible: true, satisfiable: false` (+3 targeted tests) |
+| generation's component solve      | corner shape: `Synthetic data cannot be generated…`                    |
+| seeded value ordering             | `expected 1 to be greater than or equal to 20`                         |
+| domain-size/product gate          | `expected { groups: [ 'b', 'a' ], … } to be undefined`                 |
+| `selectionSizeRange` mirroring    | `expected […] to have a length of 10 but got 15`                       |
+| reserved-value preference         | `expected +0 to be 2`                                                  |
+
+### Verification at the merged head
+
+protocol-utilities 419 tests, interview 1,228, interviewer `src/lib/synthetic`
+14 (the 200-row roster path), root `pnpm typecheck` 15/15 and `pnpm knip`
+clean; the full 20,000-shape × 500-seed corpus evidence re-run green after
+every change above (6,562,500 generation runs, zero mismatches, zero
+failures). Development-protocol wall-clock, re-measured contention-free at
+the merged head: parent without the solver **14.80 ms/session**, this branch
+**15.30 ms/session** (+3.4%; budget 20%).

--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
@@ -304,6 +304,21 @@ superseded by these corpus-measured rates.
   values only widen the second search, so a pass-1 unknown implies a pass-2
   unknown in every constructible case); the change aligns the code with the
   documented "unknown reads as oversized" contract.
+- **P2 (fourth round), below-cap categorical rebuild cost**: C(20,8) =
+  125,970 subsets sits under the product cap, yet holds ~1M elements —
+  rebuilt for every generated entity. Two fixes: the tractability gate now
+  also bounds **materialised elements** (`MAX_DOMAIN_ELEMENTS`, counted
+  closed-form in the same pass, so the named shape declines to the cheap
+  greedy path), and the component analysis is **memoised per entity-type
+  descriptor** (a `WeakMap` keyed by the `EntityConstraints` map, every
+  input to which is a pure function of it; domains are never mutated — each
+  solve copies what it filters or reorders). The cache alone cut the
+  enumeration-heavy 101×101 scalar-pair benchmark from 0.064 ms to
+  0.038 ms per entity. Guarded by "declines a categorical whose
+  materialised elements overflow the budget", mutation-verified red by
+  zeroing the element accumulation; the memoisation is behaviour-invisible
+  by construction and is covered by the full suite plus the determinism
+  tests.
 
 ### The number-domain decision
 

--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
@@ -277,6 +277,33 @@ superseded by these corpus-measured rates.
   Guarded by "allocates overlapping unique ranges so later entities keep a
   value" (100 seeds × 2 entities), mutation-verified red by re-shuffling
   unique domains.
+- **P1 (third round), interacting unique slots**: with **two** unique groups
+  in one component — `a` and `b` unique over `[0,2]`, `a differentFrom b`,
+  three entities — no per-entity ordering is capacity-safe: bottom-up
+  pairing allocates `(1,0)` then `(0,1)` and strands the third entity, while
+  the greedy draw's per-slot **monotonic** sequences stay offset and reach
+  `(1,0), (2,1), (0,2)`. Since cross-entity allocation is deliberately out
+  of scope, a component with more than one free unique slot now **declines**
+  and takes the greedy path untouched (zero stream footprint), preserving
+  the sequence draw's proven allocation exactly. Single-unique components
+  keep the bottom-up solve. Guarded by "leaves interacting unique groups to
+  the sequence ladder" (60 seeds × 3 entities), mutation-verified red by
+  re-allowing multi-unique solves.
+- **P2 (third round), duplicate option values**: an imported protocol may
+  list one categorical value under two labels; position-based enumeration
+  fabricated multiset selections (`['x','x']`) the deduplicating draw can
+  never produce. Domains now enumerate over distinct option values
+  (first occurrence kept), with `domainSize` counting the same set. Guarded
+  by "drops duplicate option values before enumerating selections",
+  mutation-verified red by restoring the raw list.
+- **P2 (third round), unknown must not unlock reserved values**: the second
+  reserved-allowing pass now runs only on a **proven** `unsat`, never on
+  `unknown` — an exhausted budget means unreserved assignments may remain
+  unexplored, and is handled like any other exhausted budget (fallback). The
+  distinction is not black-box observable at the real node budget (reserved
+  values only widen the second search, so a pass-1 unknown implies a pass-2
+  unknown in every constructible case); the change aligns the code with the
+  documented "unknown reads as oversized" contract.
 
 ### The number-domain decision
 

--- a/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
+++ b/docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md
@@ -1,0 +1,161 @@
+# Finite-domain constraint solving — implementation report
+
+Date: 2026-07-27
+Spec: `2026-07-27-finite-domain-csp-generation-spec.md`
+Base: `87c8de12c` (head of `claude/synthetic-data-validation-2b18a2`, PR #1108)
+
+This report records the evidence for the spec's eight completeness criteria.
+Every number below was produced by a run in this branch's history; the
+commands are reproducible from the committed corpus harness
+(`packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts`),
+which scales through `CORPUS_SHAPES` / `CORPUS_SEEDS` / `CORPUS_SHARD`
+environment variables.
+
+## What was built
+
+- `constraints/solver.ts` — domain enumeration over generator-reachable
+  values, constraint-graph connected components over groups, tractability
+  gating, and complete backtracking search (AC-3 preprocessing, MRV
+  selection, forward checking, seeded value ordering, node budget).
+- `constraints/solverLimits.ts` — the three tractability constants, with the
+  measurement-based reasoning in place.
+- `analyseFeasibility` runs the search on every tractable component no other
+  check has already refused; exhausting a component's space is reported as a
+  new conflict ("no combination of values these rules allow can satisfy all
+  of them at once").
+- `generateEntityAttributes` settles each tractable component per entity at
+  its first drawn group: unique-registry values are excluded from the free
+  groups' domains (own previous values released first), kept values enter as
+  pins, and domains are searched in a seeded shuffle. Anything short of a
+  solution — oversized, unknown, unsatisfiable — falls back to the untouched
+  greedy path.
+- A pre-existing soundness bug in `comparatorSpan` was fixed en route: a
+  strict comparison between a scalar and a number stepped bounds by the
+  _coarser_ end's unit, so `m[0,0] < s < n[1,1]` (satisfiable by
+  `s = 0.5`) was refused. The gap is now the finer granularity, with
+  per-end grid rounding; regression tests pin both directions.
+
+## C1 — Feasibility is sound and complete below threshold
+
+**20,000 randomly generated below-threshold protocols**, verdict compared
+against a test-local brute-force oracle (own PRNG, own date arithmetic, own
+domain construction, full-cartesian enumeration): **0 mismatches**.
+
+Corpus distribution (family: total / accepted):
+
+- chain (comparator chains of 3–5 edges, mixed strictness): 4,997 / 1,487
+- pinned (tight bounds + differentFrom + comparators): 3,957 / 1,951
+- sameAs (groups with differing member bounds, plus a rule): 3,047 / 2,290
+- scalarPair (scalar-vs-scalar comparators): 1,954 / 1,954
+- mixed (random soup over all five types): 6,045 / 5,443
+- variable types across all shapes: number 32,248, datetime 17,084,
+  scalar 6,443, boolean 5,278, ordinal 5,159
+- overall: 13,125 accepted (65.6%), 6,875 refused (34.4%)
+
+The first full-scale run caught one oracle blind spot rather than a solver
+defect: a number ordered against a scalar can be left a fractional propagated
+range (e.g. `[0.01, 0.99]`), where the generator's draw falls back to
+two-decimal floats an integer-domain oracle cannot model. The solver already
+declines those components (not crisply enumerable), so feasibility accepts
+and greedy generation succeeds — verified and pinned as a dedicated
+regression test over 500 seeds
+(`generateNetwork.constraints.test.ts`, "generates a chain that forces a
+number into a fractional range"). The corpus generator now keeps comparators
+within one type, where reachability is exact; this residual cross-type family
+is the documented boundary of the solver's claim.
+
+## C2 — Accepted protocols always generate
+
+Every accepted shape ran through `generateNetwork` (a two-node
+name-generator protocol) on **500 consecutive seeds**, and every generated
+node was checked against every rule of its shape: **6,562,500 runs
+(13,125 × 500), 0 throws, 0 rule violations**.
+
+The two named regressions:
+
+- `A[3,4] differentFrom B; B[3,4]; D[2,4] <=A >=B` — pinned per-entity over
+  500 seeds with full rule- and bound-checking: **500/500** (previously ~50%
+  per entity, compounding to ~2.5% per multi-entity network).
+- `a[3,4] differentFrom b; b[4,5] <= a` — now **refused** by
+  `analyseFeasibility` with rules `differentFrom, lessThanOrEqualToVariable,
+minValue, maxValue` (previously accepted, then threw seed-dependently).
+
+## C3 — Generated data stays varied
+
+200 entities per shape, one seeded run (gates: distinct ≥ min(S, 20), modal
+≤ 40%):
+
+| Shape                            | S   | Distinct | Modal |
+| -------------------------------- | --- | -------- | ----- |
+| `a < b` over `[0,9]`             | 45  | 41       | 11.0% |
+| date chain `w < x < y` in 5 days | 10  | 10       | 31.5% |
+| ring of 4 numbers over `[0,3]`   | 84  | 78       | 3.0%  |
+
+The committed guard ("varies the assignment a solved component takes across
+entities") enforces the S=45 case in CI.
+
+## C4 — The node cap degrades safely
+
+`solverCap.test.ts` mocks the limits module down to a 3-node budget — which
+any five-variable component provably exceeds — and drives the real public
+entry points: a five-boolean odd differentFrom ring (unsatisfiable, and
+refused under the full budget by the normal suite) is **not refused**, and a
+six-variable satisfiable ring **generates through the greedy path**. The
+solver-level "unknown" verdict is unit-tested separately.
+
+## C5 — Above-threshold behaviour is byte-identical
+
+12 protocols whose constrained components all exceed the limits (unbounded
+numbers, text, 12-option categorical, unbounded datetimes, thousand-wide
+ranges, a nine-variable ring past the variable cap, unique-text and
+unique-number interplay) × 50 seeds each, serialised in full (network,
+stage metadata, step state) with entity uuids normalised to encounter-order
+tokens (they are minted outside the seeded stream): **600 runs, byte-compared
+with `cmp` between base `87c8de12c` and this branch: 0 mismatches.** A
+same-commit double-run first established the capture itself is
+deterministic.
+
+## C6 — Performance is bounded and measured
+
+- Development protocol, 100 sessions, same machine, warmed: base
+  **9.48 ms/session**, branch **9.72 ms/session** (+2.5%; budget 20%).
+- Adversarial per-entity micro-benchmark (2,000 entities per shape): worst
+  shape mean **0.064 ms** (a 101×101-value scalar pair), worst single call
+  **0.5 ms**. Across the 6.56M-run corpus the slowest single
+  `generateNetwork` call was 92.8 ms (one outlier in an 820k-call process;
+  process-wide mean ≈0.27 ms per two-node network).
+- The limits (`MAX_COMPONENT_VARIABLES = 8`, `MAX_DOMAIN_PRODUCT = 200_000`,
+  `MAX_SEARCH_NODES = 50_000`) are justified against these numbers where
+  they are defined; the deepest search observed below the caps was a few
+  hundred nodes.
+
+## C7 — Nothing already working regresses
+
+- `pnpm typecheck` 15/15, `pnpm test` all workspaces, `pnpm knip` clean.
+- `packages/interview/src/forms/__tests__/syntheticDataConformance.test.ts`
+  passes **unchanged** (no edits to the file).
+- Both bundled protocols still pass the feasibility gate and generate.
+- Every pre-existing behavioural pin in the constraints suites — headroom
+  reservation, unique claim/release, pinned regeneration, distribution
+  assertions — passes without modification; the only test-file changes are
+  additions.
+
+## C8 — Guards verified red by mutation
+
+| Criterion | Mutation                                          | Failing guard and message                                                                                                                                                                                                    |
+| --------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1        | feasibility's solver-unsat report short-circuited | corpus parity: `expected [ { index: 24, … } ] to deeply equal []` (`feasible: true, satisfiable: false`); plus "reports a differentFrom its comparator pins…", "reports an odd ring…", "reports two single-option ordinals…" |
+| C2        | generation's component solve never consulted      | corner-shape 500-seed test and corpus generation: `threw: Synthetic data cannot be generated: this protocol declares validation rules that cannot all be satisfied together`                                                 |
+| C3        | seeded shuffle replaced with identity ordering    | variation guard: `expected 1 to be greater than or equal to 20`                                                                                                                                                              |
+| C5        | domain-product cap ignored                        | solver intractability guard: `expected { groups: [ 'b', 'a' ], … } to be undefined`; byteparity harness diverged from base                                                                                                   |
+
+All mutations were reverted; the full suite (330 tests in
+protocol-utilities) is green at the final commit.
+
+## Explicitly out of scope, confirmed unchanged
+
+Components above threshold fall back (C5 proves byte-identity). `unique`
+remains a registry concern — inside a solve it is only a unary domain
+restriction, re-solved per entity, and registry exhaustion still surfaces
+through the existing `SyntheticDataConstraintError` draw path. Categorical
+subset explosions fall back as expected.

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.constraints.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.constraints.test.ts
@@ -856,6 +856,49 @@ describe('cross-variable rules across a seed sweep', () => {
     expect(failures).toEqual([]);
   });
 
+  it('solves the rest of a component around a prompt-fixed attribute', () => {
+    // additionalAttributes fixes `flag` before anything is drawn, so the
+    // solve must treat it as assigned — `twin differentFrom flag` leaves
+    // exactly one boolean for every node.
+    const codebook = personCodebook({
+      flag: { name: 'Flag', type: 'boolean' },
+      twin: {
+        name: 'Twin',
+        type: 'boolean',
+        validation: { differentFrom: 'flag' },
+      },
+    });
+    const stage = {
+      id: 'stage-1',
+      type: 'NameGenerator',
+      label: 'Name generator',
+      subject: { entity: 'node', type: 'person' },
+      prompts: [
+        {
+          id: 'p1',
+          text: 'Name people',
+          additionalAttributes: [{ variable: 'flag', value: true }],
+        },
+      ],
+      behaviours: { minNodes: 4, maxNodes: 4 },
+    } as unknown as Stage;
+
+    const failures: string[] = [];
+    for (let seed = 1; seed <= 40; seed++) {
+      const { network } = generateNetwork({ seed, codebook, stages: [stage] });
+      for (const node of network.nodes) {
+        const attrs = node[entityAttributesProperty];
+        complain(
+          failures,
+          attrs.flag === true && attrs.twin === false,
+          () => `seed ${seed}: ${JSON.stringify(attrs)}`,
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
   it('generates a chain that forces a number into a fractional range', () => {
     // `v1 < v0` against a scalar leaves `v1` the propagated range
     // [0.01, 0.99], which holds no integer; the number draw falls back to

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.constraints.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.constraints.test.ts
@@ -654,4 +654,64 @@ describe('cross-variable rules across a seed sweep', () => {
 
     expect(failures).toEqual([]);
   });
+
+  it('generates a chain that forces a number into a fractional range', () => {
+    // `v1 < v0` against a scalar leaves `v1` the propagated range
+    // [0.01, 0.99], which holds no integer; the number draw falls back to
+    // two-decimal floats there. The complete solver deliberately declines
+    // such components — their reachable set is not crisply enumerable — so
+    // feasibility must keep accepting this and the greedy path must keep
+    // generating values that satisfy every comparison.
+    const codebook = personCodebook({
+      v0: { name: 'V0', type: 'scalar', component: 'VisualAnalogScale' },
+      v1: {
+        name: 'V1',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 3, lessThanVariable: 'v0' },
+      },
+      v2: {
+        name: 'V2',
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation: { lessThanVariable: 'v1' },
+      },
+      v3: {
+        name: 'V3',
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 3,
+          lessThanOrEqualToVariable: 'v2',
+        },
+      },
+    });
+
+    const failures: string[] = [];
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const { network } = generateNetwork({
+        seed,
+        codebook,
+        stages: [nameGeneratorStage],
+      });
+
+      for (const node of network.nodes) {
+        const attrs = node[entityAttributesProperty];
+        const [v0, v1, v2, v3] = ['v0', 'v1', 'v2', 'v3'].map((id) =>
+          Number(attrs[id]),
+        );
+        complain(
+          failures,
+          v1! < v0! &&
+            v2! < v1! &&
+            v3! <= v2! &&
+            v1! >= 0 &&
+            v1! <= 3 &&
+            v3! >= 0,
+          () => `seed ${seed}: ${JSON.stringify({ v0, v1, v2, v3 })}`,
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
 });

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
@@ -1,0 +1,655 @@
+import { env } from 'node:process';
+
+import { describe, expect, it } from 'vitest';
+
+import type { Stage } from '@codaco/protocol-validation';
+import {
+  entityAttributesProperty,
+  type VariableValue,
+} from '@codaco/shared-consts';
+
+import { generateNetwork } from '../generateNetwork';
+import { resolveGenerationConfig } from '../generateNetwork/config';
+import { analyseFeasibility } from '../generateNetwork/constraints/feasibility';
+
+/**
+ * Randomised acceptance corpus for the finite-domain solver.
+ *
+ * Every shape is built so its constraint components fall below the solver's
+ * tractability limits, which is the regime where two properties must hold
+ * exactly:
+ *
+ * 1. `analyseFeasibility`'s verdict equals brute-force satisfiability — the
+ *    oracle here enumerates the full cartesian space with its own local
+ *    domain construction and rule semantics, sharing no code with the solver.
+ * 2. Every accepted shape generates on every seed, with every emitted value
+ *    satisfying every rule.
+ *
+ * Scale is environment-driven so CI stays fast while the same file provides
+ * the full evidence run: CORPUS_SHAPES (total shapes), CORPUS_SEEDS (seeds
+ * per accepted shape), CORPUS_SHARD ("i/n" to split a large run across
+ * processes), CORPUS_REPORT=1 to print the distribution summary.
+ */
+const TODAY = '2026-07-27';
+const SHAPES = Number(env.CORPUS_SHAPES ?? 600);
+const SEEDS = Number(env.CORPUS_SEEDS ?? 8);
+const SHARD = env.CORPUS_SHARD ?? '0/1';
+const REPORT = env.CORPUS_REPORT === '1';
+
+const [shardIndex = 0, shardCount = 1] = SHARD.split('/').map(Number);
+
+const config = resolveGenerationConfig({ today: TODAY });
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type RuleKind =
+  | 'greaterThanVariable'
+  | 'lessThanVariable'
+  | 'greaterThanOrEqualToVariable'
+  | 'lessThanOrEqualToVariable'
+  | 'differentFrom'
+  | 'sameAs';
+
+type CorpusRule = { kind: RuleKind; target: string };
+
+type CorpusVariable = {
+  id: string;
+  type: 'number' | 'scalar' | 'datetime' | 'ordinal' | 'boolean';
+  minValue?: number;
+  maxValue?: number;
+  dateMin?: string;
+  dateMax?: string;
+  options?: number[];
+  rules: CorpusRule[];
+};
+
+type CorpusShape = {
+  index: number;
+  family: 'chain' | 'pinned' | 'sameAs' | 'scalarPair' | 'mixed';
+  variables: CorpusVariable[];
+};
+
+const COMPARATORS: RuleKind[] = [
+  'greaterThanVariable',
+  'lessThanVariable',
+  'greaterThanOrEqualToVariable',
+  'lessThanOrEqualToVariable',
+];
+
+// Test-local date arithmetic, deliberately not shared with dateWindow.ts.
+const MS_PER_DAY = 86_400_000;
+function dayNumber(ymd: string): number {
+  const [year = 0, month = 1, day = 1] = ymd.split('-').map(Number);
+  return Date.UTC(year, month - 1, day) / MS_PER_DAY;
+}
+function ymdOf(day: number): string {
+  const date = new Date(day * MS_PER_DAY);
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+
+type Rand = {
+  next: () => number;
+  int: (lo: number, hi: number) => number;
+  pick: <T>(items: readonly T[]) => T;
+};
+
+function randFor(seed: number): Rand {
+  const next = mulberry32(seed);
+  const int = (lo: number, hi: number): number =>
+    lo + Math.floor(next() * (hi - lo + 1));
+  const pick = <T>(items: readonly T[]): T =>
+    items[Math.floor(next() * items.length)]!;
+  return { next, int, pick };
+}
+
+function numberVariable(id: string, rand: Rand): CorpusVariable {
+  const minValue = rand.int(0, 5);
+  return {
+    id,
+    type: 'number',
+    minValue,
+    maxValue: minValue + rand.int(0, 5),
+    rules: [],
+  };
+}
+
+function datetimeVariable(id: string, rand: Rand): CorpusVariable {
+  const start = dayNumber('2024-03-01') + rand.int(0, 12);
+  return {
+    id,
+    type: 'datetime',
+    dateMin: ymdOf(start),
+    dateMax: ymdOf(start + rand.int(0, 6)),
+    rules: [],
+  };
+}
+
+function ordinalVariable(id: string, rand: Rand): CorpusVariable {
+  const count = rand.int(1, 5);
+  return {
+    id,
+    type: 'ordinal',
+    options: Array.from({ length: count }, (_value, at) => at + 1),
+    rules: [],
+  };
+}
+
+function variableOf(
+  id: string,
+  type: CorpusVariable['type'],
+  rand: Rand,
+): CorpusVariable {
+  if (type === 'number') return numberVariable(id, rand);
+  if (type === 'datetime') return datetimeVariable(id, rand);
+  if (type === 'ordinal') return ordinalVariable(id, rand);
+  return { id, type, rules: [] };
+}
+
+function chainShape(index: number, rand: Rand): CorpusShape {
+  const edgeCount = rand.int(3, 5);
+  const kind = rand.pick(['number', 'datetime'] as const);
+  const variables: CorpusVariable[] = [];
+
+  for (let i = 0; i <= edgeCount; i++) {
+    const id = `v${i}`;
+    if (kind === 'datetime') {
+      variables.push(datetimeVariable(id, rand));
+    } else {
+      variables.push(numberVariable(id, rand));
+    }
+  }
+
+  for (let i = 1; i <= edgeCount; i++) {
+    const strict = rand.next() < 0.5;
+    const declaresUpper = rand.next() < 0.5;
+    variables[i]!.rules.push({
+      kind: declaresUpper
+        ? strict
+          ? 'greaterThanVariable'
+          : 'greaterThanOrEqualToVariable'
+        : strict
+          ? 'lessThanVariable'
+          : 'lessThanOrEqualToVariable',
+      target: `v${i - 1}`,
+    });
+  }
+
+  return { index, family: 'chain', variables };
+}
+
+function pinnedShape(index: number, rand: Rand): CorpusShape {
+  const count = rand.int(2, 3);
+  const variables: CorpusVariable[] = [];
+  for (let i = 0; i < count; i++) {
+    const minValue = rand.int(2, 5);
+    variables.push({
+      id: `v${i}`,
+      type: 'number',
+      minValue,
+      maxValue: minValue + rand.int(0, 2),
+      rules: [],
+    });
+  }
+
+  variables[0]!.rules.push({ kind: 'differentFrom', target: 'v1' });
+  for (let i = 1; i < count; i++) {
+    variables[i]!.rules.push({
+      kind: rand.pick(COMPARATORS),
+      target: rand.pick(variables.filter((variable) => variable.id !== `v${i}`))
+        .id,
+    });
+  }
+
+  return { index, family: 'pinned', variables };
+}
+
+function sameAsShape(index: number, rand: Rand): CorpusShape {
+  const type = rand.pick(['number', 'ordinal', 'boolean', 'datetime'] as const);
+  const first = variableOf('v0', type, rand);
+  const second = variableOf('v1', type, rand);
+  if (type === 'ordinal') second.options = [...(first.options ?? [])];
+  second.rules.push({ kind: 'sameAs', target: 'v0' });
+
+  const variables = [first, second];
+  if (rand.next() < 0.7) {
+    const third = variableOf(
+      'v2',
+      type === 'boolean' || type === 'ordinal' ? type : 'number',
+      rand,
+    );
+    const comparable =
+      third.type === 'number' &&
+      (type === 'number' || type === 'datetime') &&
+      type === 'number';
+    third.rules.push(
+      comparable && rand.next() < 0.5
+        ? { kind: rand.pick(COMPARATORS), target: rand.pick(['v0', 'v1']) }
+        : { kind: 'differentFrom', target: rand.pick(['v0', 'v1']) },
+    );
+    variables.push(third);
+  }
+
+  return { index, family: 'sameAs', variables };
+}
+
+/**
+ * Two scalars ordered against each other, sometimes with a third variable
+ * excluded from one of them. Kept as its own small family because a scalar's
+ * 101-value grid multiplies fast: two grids and one more small variable is
+ * the widest shape that stays inside the tractability limits.
+ */
+function scalarPairShape(index: number, rand: Rand): CorpusShape {
+  const first: CorpusVariable = { id: 'v0', type: 'scalar', rules: [] };
+  const second: CorpusVariable = {
+    id: 'v1',
+    type: 'scalar',
+    rules: [{ kind: rand.pick(COMPARATORS), target: 'v0' }],
+  };
+
+  const variables = [first, second];
+  if (rand.next() < 0.5) {
+    const third = numberVariable('v2', rand);
+    third.rules.push({
+      kind: 'differentFrom',
+      target: rand.pick(['v0', 'v1']),
+    });
+    variables.push(third);
+  }
+
+  return { index, family: 'scalarPair', variables };
+}
+
+function mixedShape(index: number, rand: Rand): CorpusShape {
+  const count = rand.int(2, 4);
+  let scalarUsed = false;
+  const variables: CorpusVariable[] = [];
+  for (let i = 0; i < count; i++) {
+    const candidates: CorpusVariable['type'][] = [
+      'number',
+      'number',
+      'datetime',
+      'ordinal',
+      'boolean',
+      ...(scalarUsed ? [] : (['scalar'] as const)),
+    ];
+    const type = rand.pick(candidates);
+    if (type === 'scalar') scalarUsed = true;
+    variables.push(variableOf(`v${i}`, type, rand));
+  }
+
+  for (let i = 1; i < count; i++) {
+    const variable = variables[i]!;
+    const ruleCount = rand.next() < 0.85 ? rand.int(1, 2) : 0;
+    for (let r = 0; r < ruleCount; r++) {
+      const target = variables[rand.int(0, i - 1)]!;
+      // Comparators stay within one type. A number ordered against a scalar
+      // can leave the number a fractional range, where the generator falls
+      // back to two-decimal floats an integer-domain oracle cannot model;
+      // that residual family has its own pinned regression test instead.
+      const comparable =
+        variable.type === target.type &&
+        (variable.type === 'number' ||
+          variable.type === 'scalar' ||
+          variable.type === 'datetime');
+      const kinds: RuleKind[] = [];
+      if (comparable) kinds.push(...COMPARATORS);
+      if (variable.type !== 'scalar') kinds.push('differentFrom');
+      if (variable.type !== 'scalar' && variable.type === target.type) {
+        kinds.push('sameAs');
+      }
+      if (kinds.length === 0) continue;
+
+      const kind = rand.pick(kinds);
+      if (variable.rules.some((rule) => rule.kind === kind)) continue;
+      if (kind === 'sameAs' && variable.type === 'ordinal') {
+        variable.options = [...(target.options ?? [])];
+      }
+      variable.rules.push({ kind, target: target.id });
+    }
+  }
+
+  return { index, family: 'mixed', variables };
+}
+
+function generateShape(index: number): CorpusShape {
+  const rand = randFor((index + 1) * 0x9e3779b1);
+  const family = rand.next();
+  if (family < 0.25) return chainShape(index, rand);
+  if (family < 0.45) return pinnedShape(index, rand);
+  if (family < 0.6) return sameAsShape(index, rand);
+  if (family < 0.7) return scalarPairShape(index, rand);
+  return mixedShape(index, rand);
+}
+
+/** The generator-reachable values for one variable, oracle-side. */
+function oracleDomain(variable: CorpusVariable): VariableValue[] {
+  switch (variable.type) {
+    case 'number': {
+      const values: number[] = [];
+      for (let v = variable.minValue ?? 0; v <= (variable.maxValue ?? 0); v++) {
+        values.push(v);
+      }
+      return values;
+    }
+    case 'scalar':
+      return Array.from({ length: 101 }, (_value, at) =>
+        Number((at / 100).toFixed(2)),
+      );
+    case 'datetime': {
+      const from = dayNumber(variable.dateMin ?? TODAY);
+      const to = dayNumber(variable.dateMax ?? TODAY);
+      const values: string[] = [];
+      for (let day = from; day <= to; day++) values.push(ymdOf(day));
+      return values;
+    }
+    case 'ordinal':
+      return [...(variable.options ?? [])];
+    case 'boolean':
+      return [false, true];
+  }
+}
+
+function oracleKey(value: VariableValue): string {
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Whether one assignment satisfies every rule the shape declares. Shared by
+ * the oracle's enumeration and the check on generated output, because both
+ * need the same ground-truth rule semantics; the *search* is what stays
+ * independent of the solver.
+ */
+function satisfiesRules(
+  shape: CorpusShape,
+  valueOf: (id: string) => VariableValue,
+): boolean {
+  for (const variable of shape.variables) {
+    const own = valueOf(variable.id);
+    for (const rule of variable.rules) {
+      const other = valueOf(rule.target);
+      if (rule.kind === 'sameAs') {
+        if (oracleKey(own) !== oracleKey(other)) return false;
+        continue;
+      }
+      if (rule.kind === 'differentFrom') {
+        if (oracleKey(own) === oracleKey(other)) return false;
+        continue;
+      }
+      const ownComparable =
+        variable.type === 'datetime' ? String(own) : Number(own);
+      const otherComparable =
+        variable.type === 'datetime' ? String(other) : Number(other);
+      switch (rule.kind) {
+        case 'greaterThanVariable':
+          if (!(ownComparable > otherComparable)) return false;
+          break;
+        case 'lessThanVariable':
+          if (!(ownComparable < otherComparable)) return false;
+          break;
+        case 'greaterThanOrEqualToVariable':
+          if (!(ownComparable >= otherComparable)) return false;
+          break;
+        case 'lessThanOrEqualToVariable':
+          if (!(ownComparable <= otherComparable)) return false;
+          break;
+      }
+    }
+  }
+  return true;
+}
+
+/** Exhaustive cartesian search for any satisfying assignment. */
+function oracleSatisfiable(shape: CorpusShape): boolean {
+  const domains = shape.variables.map(oracleDomain);
+  if (domains.some((domain) => domain.length === 0)) return false;
+
+  const indices = domains.map(() => 0);
+  const assignment = new Map<string, VariableValue>();
+  const valueOf = (id: string): VariableValue => assignment.get(id) ?? null;
+
+  for (;;) {
+    shape.variables.forEach((variable, at) => {
+      assignment.set(variable.id, domains[at]![indices[at]!]!);
+    });
+    if (satisfiesRules(shape, valueOf)) return true;
+
+    let cursor = domains.length - 1;
+    while (cursor >= 0) {
+      indices[cursor]! += 1;
+      if (indices[cursor]! < domains[cursor]!.length) break;
+      indices[cursor] = 0;
+      cursor -= 1;
+    }
+    if (cursor < 0) return false;
+  }
+}
+
+type Codebook = Parameters<typeof generateNetwork>[0]['codebook'];
+
+function codebookFor(shape: CorpusShape): Codebook {
+  const variables: Record<string, unknown> = {};
+
+  for (const variable of shape.variables) {
+    const validation: Record<string, unknown> = {};
+    for (const rule of variable.rules) validation[rule.kind] = rule.target;
+
+    if (variable.type === 'number') {
+      validation.minValue = variable.minValue;
+      validation.maxValue = variable.maxValue;
+      variables[variable.id] = {
+        name: variable.id.toUpperCase(),
+        type: 'number',
+        validation,
+      };
+    } else if (variable.type === 'scalar') {
+      variables[variable.id] = {
+        name: variable.id.toUpperCase(),
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation,
+      };
+    } else if (variable.type === 'datetime') {
+      variables[variable.id] = {
+        name: variable.id.toUpperCase(),
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: {
+          type: 'full',
+          min: variable.dateMin,
+          max: variable.dateMax,
+        },
+        validation,
+      };
+    } else if (variable.type === 'ordinal') {
+      variables[variable.id] = {
+        name: variable.id.toUpperCase(),
+        type: 'ordinal',
+        options: (variable.options ?? []).map((option) => ({
+          label: `Option ${option}`,
+          value: option,
+        })),
+        validation,
+      };
+    } else {
+      variables[variable.id] = {
+        name: variable.id.toUpperCase(),
+        type: 'boolean',
+        validation,
+      };
+    }
+  }
+
+  return {
+    node: {
+      person: { color: 'node-color-seq-1', variables },
+    },
+  } as unknown as Codebook;
+}
+
+const nameGeneratorStage = {
+  id: 'stage-1',
+  type: 'NameGenerator',
+  label: 'Name generator',
+  subject: { entity: 'node', type: 'person' },
+  prompts: [{ id: 'p1', text: 'Name people' }],
+  behaviours: { minNodes: 2, maxNodes: 2 },
+} as unknown as Stage;
+
+type CorpusEntry = {
+  shape: CorpusShape;
+  feasible: boolean;
+  satisfiable: boolean;
+  conflictCount: number;
+};
+
+let cached: CorpusEntry[] | undefined;
+function corpus(): CorpusEntry[] {
+  if (cached) return cached;
+  const entries: CorpusEntry[] = [];
+  for (let index = 0; index < SHAPES; index++) {
+    if (index % shardCount !== shardIndex) continue;
+    const shape = generateShape(index);
+    const conflicts = analyseFeasibility(
+      codebookFor(shape),
+      [nameGeneratorStage],
+      config,
+    );
+    entries.push({
+      shape,
+      feasible: conflicts.length === 0,
+      satisfiable: oracleSatisfiable(shape),
+      conflictCount: conflicts.length,
+    });
+  }
+  cached = entries;
+
+  if (REPORT) {
+    const byFamily = new Map<string, { total: number; accepted: number }>();
+    for (const entry of entries) {
+      const bucket = byFamily.get(entry.shape.family) ?? {
+        total: 0,
+        accepted: 0,
+      };
+      bucket.total += 1;
+      if (entry.feasible) bucket.accepted += 1;
+      byFamily.set(entry.shape.family, bucket);
+    }
+    const typeCounts = new Map<string, number>();
+    for (const entry of entries) {
+      for (const variable of entry.shape.variables) {
+        typeCounts.set(variable.type, (typeCounts.get(variable.type) ?? 0) + 1);
+      }
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        shard: SHARD,
+        shapes: entries.length,
+        accepted: entries.filter((entry) => entry.feasible).length,
+        families: Object.fromEntries(byFamily),
+        variableTypes: Object.fromEntries(typeCounts),
+      }),
+    );
+  }
+
+  return entries;
+}
+
+describe(`solver acceptance corpus (${SHAPES} shapes, shard ${SHARD})`, () => {
+  it(
+    'gives a feasibility verdict matching brute-force satisfiability exactly',
+    { timeout: 1_800_000 },
+    () => {
+      const mismatches = corpus()
+        .filter((entry) => entry.feasible !== entry.satisfiable)
+        .map((entry) => ({
+          index: entry.shape.index,
+          family: entry.shape.family,
+          feasible: entry.feasible,
+          satisfiable: entry.satisfiable,
+          variables: entry.shape.variables,
+        }));
+
+      expect(mismatches).toEqual([]);
+    },
+  );
+
+  it(
+    `generates every accepted shape on ${SEEDS} consecutive seeds with valid values`,
+    { timeout: 3_600_000 },
+    () => {
+      const failures: {
+        index: number;
+        seed: number;
+        problem: string;
+      }[] = [];
+      let slowestMs = 0;
+      let slowestShape = -1;
+      let runs = 0;
+
+      for (const entry of corpus()) {
+        if (!entry.feasible) continue;
+        const codebook = codebookFor(entry.shape);
+
+        for (let seed = 0; seed < SEEDS; seed++) {
+          try {
+            const startedAt = performance.now();
+            const { network } = generateNetwork({
+              codebook,
+              stages: [nameGeneratorStage],
+              seed,
+              config: { today: TODAY },
+            });
+            const elapsed = performance.now() - startedAt;
+            runs += 1;
+            if (elapsed > slowestMs) {
+              slowestMs = elapsed;
+              slowestShape = entry.shape.index;
+            }
+            for (const node of network.nodes) {
+              const attributes = node[entityAttributesProperty];
+              const valueOf = (id: string): VariableValue => attributes[id]!;
+              if (!satisfiesRules(entry.shape, valueOf)) {
+                failures.push({
+                  index: entry.shape.index,
+                  seed,
+                  problem: `violates rules: ${JSON.stringify(attributes)} for ${JSON.stringify(entry.shape.variables)}`,
+                });
+              }
+            }
+          } catch (error) {
+            failures.push({
+              index: entry.shape.index,
+              seed,
+              problem: `threw: ${error instanceof Error ? error.message.slice(0, 200) : String(error)}`,
+            });
+          }
+        }
+      }
+
+      if (REPORT) {
+        // eslint-disable-next-line no-console
+        console.log(
+          JSON.stringify({
+            shard: SHARD,
+            generateRuns: runs,
+            slowestRunMs: Number(slowestMs.toFixed(2)),
+            slowestShape,
+          }),
+        );
+      }
+
+      expect(failures).toEqual([]);
+    },
+  );
+});

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
@@ -31,12 +31,35 @@ import { analyseFeasibility } from '../generateNetwork/constraints/feasibility';
  * processes), CORPUS_REPORT=1 to print the distribution summary.
  */
 const TODAY = '2026-07-27';
-const SHAPES = Number(env.CORPUS_SHAPES ?? 600);
-const SEEDS = Number(env.CORPUS_SEEDS ?? 8);
+
+/**
+ * A malformed scale variable must fail loudly: `Number('abc')` is NaN, and a
+ * NaN bound would run zero shapes and report the empty corpus as a pass.
+ */
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer, received "${raw}"`);
+  }
+  return parsed;
+}
+
+const SHAPES = positiveInt(env.CORPUS_SHAPES, 600);
+const SEEDS = positiveInt(env.CORPUS_SEEDS, 8);
 const SHARD = env.CORPUS_SHARD ?? '0/1';
 const REPORT = env.CORPUS_REPORT === '1';
 
 const [shardIndex = 0, shardCount = 1] = SHARD.split('/').map(Number);
+if (
+  !Number.isInteger(shardIndex) ||
+  !Number.isInteger(shardCount) ||
+  shardCount <= 0 ||
+  shardIndex < 0 ||
+  shardIndex >= shardCount
+) {
+  throw new Error(`Invalid CORPUS_SHARD "${SHARD}", expected "i/n"`);
+}
 
 const config = resolveGenerationConfig({ today: TODAY });
 
@@ -616,8 +639,26 @@ describe(`solver acceptance corpus (${SHAPES} shapes, shard ${SHARD})`, () => {
               slowestMs = elapsed;
               slowestShape = entry.shape.index;
             }
+            if (network.nodes.length === 0) {
+              failures.push({
+                index: entry.shape.index,
+                seed,
+                problem: 'generated no nodes',
+              });
+            }
             for (const node of network.nodes) {
               const attributes = node[entityAttributesProperty];
+              const missing = entry.shape.variables
+                .filter((variable) => attributes[variable.id] === undefined)
+                .map((variable) => variable.id);
+              if (missing.length > 0) {
+                failures.push({
+                  index: entry.shape.index,
+                  seed,
+                  problem: `missing attributes: ${missing.join(', ')}`,
+                });
+                continue;
+              }
               const valueOf = (id: string): VariableValue => attributes[id]!;
               if (!satisfiesRules(entry.shape, valueOf)) {
                 failures.push({

--- a/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
+++ b/packages/protocol-utilities/src/__tests__/generateNetwork.corpus.test.ts
@@ -250,10 +250,7 @@ function sameAsShape(index: number, rand: Rand): CorpusShape {
       type === 'boolean' || type === 'ordinal' ? type : 'number',
       rand,
     );
-    const comparable =
-      third.type === 'number' &&
-      (type === 'number' || type === 'datetime') &&
-      type === 'number';
+    const comparable = third.type === 'number' && type === 'number';
     third.rules.push(
       comparable && rand.next() < 0.5
         ? { kind: rand.pick(COMPARATORS), target: rand.pick(['v0', 'v1']) }
@@ -435,6 +432,17 @@ function satisfiesRules(
 function oracleSatisfiable(shape: CorpusShape): boolean {
   const domains = shape.variables.map(oracleDomain);
   if (domains.some((domain) => domain.length === 0)) return false;
+
+  // The shape families are written to keep this space small (the widest is
+  // two scalar grids beside one number, ~62k combinations). A future family
+  // that widens past this cap should fail loudly here, not stretch the run
+  // towards its timeout.
+  const product = domains.reduce((total, domain) => total * domain.length, 1);
+  if (product > 1_000_000) {
+    throw new Error(
+      `Shape ${shape.index} (${shape.family}) spans ${product} combinations; keep corpus families below the solver's tractability limits`,
+    );
+  }
 
   const indices = domains.map(() => 0);
   const assignment = new Map<string, VariableValue>();

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/feasibility.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/feasibility.test.ts
@@ -524,6 +524,157 @@ describe('analyseFeasibility', () => {
     expect(analyseFeasibility(codebook, [nameGenerator], config)).toEqual([]);
   });
 
+  it('reports a differentFrom its comparator pins to a single shared value', () => {
+    // Interval reasoning alone accepts this: every bound overlaps. But
+    // `b <= a` with these ranges forces both to 4, and 4 cannot differ from 4.
+    const codebook = codebookWith({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4, differentFrom: 'b' },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: {
+          minValue: 4,
+          maxValue: 5,
+          lessThanOrEqualToVariable: 'a',
+        },
+      },
+    });
+
+    const conflicts = analyseFeasibility(codebook, [nameGenerator], config);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.variableNames).toEqual(['A', 'B']);
+    expect(conflicts[0]?.rules).toContain('differentFrom');
+    expect(conflicts[0]?.rules).toContain('lessThanOrEqualToVariable');
+    expect(conflicts[0]?.reason).toContain('no combination of values');
+  });
+
+  it('accepts the pinned differentFrom shape once the bounds leave an escape', () => {
+    // Identical rules, but b's floor is 3: b = 3, a = 4 satisfies everything.
+    const codebook = codebookWith({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4, differentFrom: 'b' },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: {
+          minValue: 3,
+          maxValue: 4,
+          lessThanOrEqualToVariable: 'a',
+        },
+      },
+    });
+
+    expect(analyseFeasibility(codebook, [nameGenerator], config)).toEqual([]);
+  });
+
+  it('accepts the corner shape the greedy path cannot always draw', () => {
+    // B=3, A=4, D∈{3,4} satisfies every rule; refusing it would trade a
+    // draw-order defect for a soundness one.
+    const codebook = codebookWith({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4, differentFrom: 'b' },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4 },
+      },
+      d: {
+        name: 'D',
+        type: 'number',
+        validation: {
+          minValue: 2,
+          maxValue: 4,
+          lessThanOrEqualToVariable: 'a',
+          greaterThanOrEqualToVariable: 'b',
+        },
+      },
+    });
+
+    expect(analyseFeasibility(codebook, [nameGenerator], config)).toEqual([]);
+  });
+
+  it('accepts a strict chain from a number through a scalar to a pinned number', () => {
+    // m = 0, s = 0.5, n = 1: the scalar grid holds ninety-nine values strictly
+    // between the two integers.
+    const codebook = codebookWith({
+      m: {
+        name: 'M',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 0 },
+      },
+      s: {
+        name: 'S',
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation: { greaterThanVariable: 'm', lessThanVariable: 'n' },
+      },
+      n: {
+        name: 'N',
+        type: 'number',
+        validation: { minValue: 1, maxValue: 1 },
+      },
+    });
+
+    expect(analyseFeasibility(codebook, [nameGenerator], config)).toEqual([]);
+  });
+
+  it('reports an odd ring of mutually different booleans', () => {
+    // Five booleans in a differentFrom ring form an odd cycle over two
+    // values, which no assignment two-colours. Only a complete search can
+    // see this; every pair in isolation is satisfiable.
+    const variables: Record<string, unknown> = {};
+    for (let i = 0; i < 5; i++) {
+      variables[`v${i}`] = {
+        name: `V${i}`,
+        type: 'boolean',
+        validation: { differentFrom: i > 0 ? `v${i - 1}` : 'v4' },
+      };
+    }
+
+    const conflicts = analyseFeasibility(
+      codebookWith(variables),
+      [nameGenerator],
+      config,
+    );
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.rules).toEqual(['differentFrom']);
+    expect(conflicts[0]?.variableNames).toEqual(['V0', 'V1', 'V2', 'V3', 'V4']);
+  });
+
+  it('reports two single-option ordinals required to differ', () => {
+    const codebook = codebookWith({
+      x: {
+        name: 'X',
+        type: 'ordinal',
+        options: [{ label: 'Only', value: 1 }],
+      },
+      y: {
+        name: 'Y',
+        type: 'ordinal',
+        options: [{ label: 'Only', value: 1 }],
+        validation: { differentFrom: 'x' },
+      },
+    });
+
+    const conflicts = analyseFeasibility(codebook, [nameGenerator], config);
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.variableNames).toEqual(['X', 'Y']);
+    expect(conflicts[0]?.rules).toEqual(['differentFrom']);
+  });
+
   it('reports unique against a value space smaller than the worst-case count', () => {
     const codebook = codebookWith({
       band: {

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
@@ -1466,4 +1466,176 @@ describe('generateEntityAttributes', () => {
 
     expect(first).toEqual(second);
   });
+
+  it('satisfies the corner shape greedy drawing painted itself into, on every seed', () => {
+    // B drawn 4 leaves D and A nothing that satisfies every rule at once, so
+    // a draw that never reconsiders fails half its seeds. B=3, A=4, D∈{3,4}
+    // always exists; finding it is what the complete search is for.
+    const entity = buildEntityConstraints(
+      {
+        a: {
+          name: 'A',
+          type: 'number',
+          validation: {
+            minValue: 3,
+            maxValue: 4,
+            differentFrom: asEntityAttributeReference('b'),
+          },
+        },
+        b: {
+          name: 'B',
+          type: 'number',
+          validation: { minValue: 3, maxValue: 4 },
+        },
+        d: {
+          name: 'D',
+          type: 'number',
+          validation: {
+            minValue: 2,
+            maxValue: 4,
+            lessThanOrEqualToVariable: asEntityAttributeReference('a'),
+            greaterThanOrEqualToVariable: asEntityAttributeReference('b'),
+          },
+        },
+      },
+      TODAY,
+    );
+
+    expect(
+      breaches(
+        entity,
+        500,
+        (attrs) =>
+          Number(attrs.a) !== Number(attrs.b) &&
+          Number(attrs.d) <= Number(attrs.a) &&
+          Number(attrs.d) >= Number(attrs.b) &&
+          Number(attrs.a) >= 3 &&
+          Number(attrs.a) <= 4 &&
+          Number(attrs.b) >= 3 &&
+          Number(attrs.b) <= 4 &&
+          Number(attrs.d) >= 2 &&
+          Number(attrs.d) <= 4,
+      ),
+    ).toEqual([]);
+  });
+
+  it('varies the assignment a solved component takes across entities', () => {
+    // 45 assignments satisfy a < b over [0, 9]. A search that always returned
+    // the lexicographically-first one would hand every entity identical
+    // values, which is exactly what synthetic data must not do.
+    const entity = buildEntityConstraints(
+      {
+        a: {
+          name: 'A',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 9 },
+        },
+        b: {
+          name: 'B',
+          type: 'number',
+          validation: {
+            minValue: 0,
+            maxValue: 9,
+            greaterThanVariable: asEntityAttributeReference('a'),
+          },
+        },
+      },
+      TODAY,
+    );
+
+    const ctx = makeContext(11);
+    const seen = new Map<string, number>();
+    for (let index = 0; index < 200; index++) {
+      const attrs = generateEntityAttributes(
+        entity,
+        ctx,
+        { entity: 'node', type: 'person' },
+        index,
+      );
+      expect(Number(attrs.b)).toBeGreaterThan(Number(attrs.a));
+      const key = `${String(attrs.a)}|${String(attrs.b)}`;
+      seen.set(key, (seen.get(key) ?? 0) + 1);
+    }
+
+    expect(seen.size).toBeGreaterThanOrEqual(20);
+    expect(Math.max(...seen.values())).toBeLessThanOrEqual(80);
+  });
+
+  it('issues distinct unique values through a solved component', () => {
+    const entity = buildEntityConstraints(
+      {
+        u: {
+          name: 'U',
+          type: 'number',
+          validation: {
+            minValue: 0,
+            maxValue: 9,
+            unique: true,
+            differentFrom: asEntityAttributeReference('v'),
+          },
+        },
+        v: {
+          name: 'V',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 9 },
+        },
+      },
+      TODAY,
+    );
+
+    const ctx = makeContext(3);
+    const drawn = new Set<number>();
+    for (let index = 0; index < 8; index++) {
+      const attrs = generateEntityAttributes(
+        entity,
+        ctx,
+        { entity: 'node', type: 'person' },
+        index,
+      );
+      expect(attrs.u).not.toBe(attrs.v);
+      drawn.add(Number(attrs.u));
+    }
+
+    expect(drawn.size).toBe(8);
+  });
+
+  it('remains deterministic for a seed when a component is solved', () => {
+    const entity = buildEntityConstraints(
+      {
+        a: {
+          name: 'A',
+          type: 'number',
+          validation: {
+            minValue: 3,
+            maxValue: 4,
+            differentFrom: asEntityAttributeReference('b'),
+          },
+        },
+        b: {
+          name: 'B',
+          type: 'number',
+          validation: { minValue: 3, maxValue: 4 },
+        },
+      },
+      TODAY,
+    );
+
+    const run = (): Record<string, VariableValue>[] => {
+      const ctx = makeContext(5);
+      const results: Record<string, VariableValue>[] = [];
+      for (let index = 0; index < 5; index++) {
+        results.push(
+          generateEntityAttributes(
+            entity,
+            ctx,
+            { entity: 'node', type: 'person' },
+            index,
+          ),
+        );
+      }
+      return results;
+    };
+
+    expect(run()).toEqual(run());
+  });
 });

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
@@ -1762,6 +1762,54 @@ describe('generateEntityAttributes', () => {
     }
   });
 
+  it('leaves interacting unique groups to the sequence ladder', () => {
+    // Two unique slots inside one component cannot be allocated safely one
+    // entity at a time: a and b unique over [0,2] with a differentFrom b
+    // admit the complete allocation (1,0), (2,1), (0,2), but any per-entity
+    // ordering can pair the slots so the third entity is left (2,2). The
+    // greedy draw's per-slot monotonic sequences reach it, so such
+    // components must fall back rather than be solved.
+    const entity = buildEntityConstraints(
+      {
+        a: {
+          name: 'A',
+          type: 'number',
+          validation: {
+            minValue: 0,
+            maxValue: 2,
+            unique: true,
+            differentFrom: asEntityAttributeReference('b'),
+          },
+        },
+        b: {
+          name: 'B',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 2, unique: true },
+        },
+      },
+      TODAY,
+    );
+
+    for (let seed = 0; seed < 60; seed++) {
+      const ctx = makeContext(seed);
+      const seenA = new Set<number>();
+      const seenB = new Set<number>();
+      for (let index = 0; index < 3; index++) {
+        const attrs = generateEntityAttributes(
+          entity,
+          ctx,
+          { entity: 'node', type: 'person' },
+          index,
+        );
+        expect(attrs.a).not.toBe(attrs.b);
+        seenA.add(Number(attrs.a));
+        seenB.add(Number(attrs.b));
+      }
+      expect(seenA.size).toBe(3);
+      expect(seenB.size).toBe(3);
+    }
+  });
+
   it('consumes exactly one seeded draw for a solved component', () => {
     // The solve seeds a local shuffle from a single draw, so the shared
     // stream advances by the same amount whatever the search does — a capped

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
@@ -1722,6 +1722,46 @@ describe('generateEntityAttributes', () => {
     expect([0, 1, 2]).toContain(Number(forced.u));
   });
 
+  it('allocates overlapping unique ranges so later entities keep a value', () => {
+    // u over [0,1] and v over [1,2] with v > u leave exactly one allocation
+    // for two entities: (0,1) then (1,2). A shuffled first solve could take
+    // (0,2) and strand the second entity — unique groups must consume their
+    // values bottom-up, the way the distinct-sequence draw always did.
+    const entity = buildEntityConstraints(
+      {
+        u: {
+          name: 'U',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 1, unique: true },
+        },
+        v: {
+          name: 'V',
+          type: 'number',
+          validation: {
+            minValue: 1,
+            maxValue: 2,
+            unique: true,
+            greaterThanVariable: asEntityAttributeReference('u'),
+          },
+        },
+      },
+      TODAY,
+    );
+
+    for (let seed = 0; seed < 100; seed++) {
+      const ctx = makeContext(seed);
+      for (let index = 0; index < 2; index++) {
+        const attrs = generateEntityAttributes(
+          entity,
+          ctx,
+          { entity: 'node', type: 'person' },
+          index,
+        );
+        expect(Number(attrs.v)).toBeGreaterThan(Number(attrs.u));
+      }
+    }
+  });
+
   it('consumes exactly one seeded draw for a solved component', () => {
     // The solve seeds a local shuffle from a single draw, so the shared
     // stream advances by the same amount whatever the search does — a capped

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/generateEntityAttributes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { asEntityAttributeReference } from '@codaco/protocol-validation';
 import type { VariableValue } from '@codaco/shared-consts';
@@ -1668,6 +1668,95 @@ describe('generateEntityAttributes', () => {
     }
 
     expect(drawn.size).toBe(8);
+  });
+
+  it('prefers unreserved values in a solved component, taking reserved ones only at need', () => {
+    // Values a roster row reserved are held back the way the greedy draw
+    // holds them back: taken last, never refused outright.
+    const entity = buildEntityConstraints(
+      {
+        u: {
+          name: 'U',
+          type: 'number',
+          validation: {
+            minValue: 0,
+            maxValue: 2,
+            unique: true,
+            differentFrom: asEntityAttributeReference('v'),
+          },
+        },
+        v: {
+          name: 'V',
+          type: 'number',
+          validation: { minValue: 5, maxValue: 9 },
+        },
+      },
+      TODAY,
+    );
+
+    for (let seed = 0; seed < 10; seed++) {
+      const preferring = makeContext(seed);
+      preferring.uniqueRegistry.reserve('node:person', 'u', 0);
+      preferring.uniqueRegistry.reserve('node:person', 'u', 1);
+
+      const attrs = generateEntityAttributes(
+        entity,
+        preferring,
+        { entity: 'node', type: 'person' },
+        0,
+      );
+      expect(attrs.u).toBe(2);
+    }
+
+    const cornered = makeContext(7);
+    cornered.uniqueRegistry.reserve('node:person', 'u', 0);
+    cornered.uniqueRegistry.reserve('node:person', 'u', 1);
+    cornered.uniqueRegistry.reserve('node:person', 'u', 2);
+
+    const forced = generateEntityAttributes(
+      entity,
+      cornered,
+      { entity: 'node', type: 'person' },
+      0,
+    );
+    expect([0, 1, 2]).toContain(Number(forced.u));
+  });
+
+  it('consumes exactly one seeded draw for a solved component', () => {
+    // The solve seeds a local shuffle from a single draw, so the shared
+    // stream advances by the same amount whatever the search does — a capped
+    // or failed solve cannot shift every draw that follows it.
+    const entity = buildEntityConstraints(
+      {
+        a: {
+          name: 'A',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 9 },
+        },
+        b: {
+          name: 'B',
+          type: 'number',
+          validation: {
+            minValue: 0,
+            maxValue: 9,
+            greaterThanVariable: asEntityAttributeReference('a'),
+          },
+        },
+      },
+      TODAY,
+    );
+
+    const ctx = makeContext(5);
+    const spy = vi.spyOn(ctx.valueGen, 'randomInt');
+    generateEntityAttributes(
+      entity,
+      ctx,
+      { entity: 'node', type: 'person' },
+      0,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
   });
 
   it('remains deterministic for a seed when a component is solved', () => {

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/groupConstraints.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/groupConstraints.test.ts
@@ -122,4 +122,58 @@ describe('propagateComparatorBounds', () => {
 
     expect([...propagate(entity).inverted]).toEqual([]);
   });
+
+  it('steps a strict scalar-below-number comparison by the scalar grid', () => {
+    // `s < n` with `n` pinned to 1: the largest grid value below 1 is 0.99.
+    // Stepping by the number's whole-unit gap instead would empty the scalar's
+    // range and falsely refuse a protocol `s = 0.5, n = 1` satisfies.
+    const entity = buildEntityConstraints(
+      {
+        s: {
+          name: 'S',
+          type: 'scalar',
+          component: 'VisualAnalogScale',
+          validation: { lessThanVariable: asEntityAttributeReference('n') },
+        },
+        n: {
+          name: 'N',
+          type: 'number',
+          validation: { minValue: 1, maxValue: 1 },
+        },
+      },
+      TODAY,
+    );
+
+    const { groups, inverted } = propagate(entity);
+
+    expect(groups.get('s')?.constraints.maxValue).toBe(0.99);
+    expect([...inverted]).toEqual([]);
+  });
+
+  it('keeps a scalar ceiling stepped down from a number on the scalar grid', () => {
+    // 3 - 0.01 lands beside the grid in binary floating point; the stored
+    // bound must be the grid value itself or every draw would clamp oddly.
+    const entity = buildEntityConstraints(
+      {
+        s: {
+          name: 'S',
+          type: 'scalar',
+          component: 'VisualAnalogScale',
+          validation: { lessThanVariable: asEntityAttributeReference('n') },
+        },
+        n: {
+          name: 'N',
+          type: 'number',
+          validation: { minValue: 0, maxValue: 3 },
+        },
+      },
+      TODAY,
+    );
+
+    const { groups } = propagate(entity);
+
+    // The scalar's own domain caps it at 1 before the comparator's 2.99 could.
+    expect(groups.get('s')?.constraints.maxValue).toBe(1);
+    expect(groups.get('n')?.constraints.minValue).toBe(0.01);
+  });
 });

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
@@ -1,0 +1,585 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  asEntityAttributeReference,
+  type Variables,
+} from '@codaco/protocol-validation';
+import type { VariableValue } from '@codaco/shared-consts';
+
+import { buildEntityConstraints } from '../buildConstraints';
+import { resolveGenerationOrder } from '../dependencyOrder';
+import {
+  differentFromGroups,
+  groupComparatorEdges,
+  intersectGroupConstraints,
+  propagateComparatorBounds,
+} from '../groupConstraints';
+import { solvableComponents, solveComponent } from '../solver';
+import type { EntityConstraints } from '../types';
+import { valueKey } from '../uniqueRegistry';
+
+const TODAY = '2026-07-27';
+const ref = asEntityAttributeReference;
+
+/** The same pipeline feasibility and generation run before consulting the solver. */
+function componentsOf(entity: EntityConstraints) {
+  const { order, membersOf, groupOf } = resolveGenerationOrder(entity);
+  const { groups: propagated } = propagateComparatorBounds(
+    intersectGroupConstraints(entity, membersOf),
+    order,
+    groupComparatorEdges(entity, groupOf),
+  );
+  return solvableComponents(
+    propagated,
+    order,
+    groupComparatorEdges(entity, groupOf),
+    differentFromGroups(entity, groupOf),
+  );
+}
+
+function build(variables: Variables): EntityConstraints {
+  return buildEntityConstraints(variables, TODAY);
+}
+
+describe('solvableComponents', () => {
+  it('collects each connected set of constrained groups into one component', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 3 },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 3, greaterThanVariable: ref('a') },
+      },
+      c: { name: 'C', type: 'boolean' },
+      d: {
+        name: 'D',
+        type: 'boolean',
+        validation: { differentFrom: ref('c') },
+      },
+      lone: {
+        name: 'Lone',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 1 },
+      },
+    });
+
+    const components = componentsOf(entity);
+
+    expect(components).toHaveLength(2);
+    expect(components.map((component) => component.groups.toSorted())).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('enumerates integer, boolean, ordinal, scalar and datetime domains', () => {
+    const entity = build({
+      n: {
+        name: 'N',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 5, differentFrom: ref('m') },
+      },
+      m: {
+        name: 'M',
+        type: 'number',
+        validation: { minValue: 4, maxValue: 4 },
+      },
+      flag: {
+        name: 'Flag',
+        type: 'boolean',
+        validation: { differentFrom: ref('other') },
+      },
+      other: { name: 'Other', type: 'boolean' },
+      band: {
+        name: 'Band',
+        type: 'ordinal',
+        options: [
+          { label: 'Low', value: 1 },
+          { label: 'High', value: 2 },
+        ],
+        validation: { differentFrom: ref('twin') },
+      },
+      twin: {
+        name: 'Twin',
+        type: 'ordinal',
+        options: [
+          { label: 'Low', value: 1 },
+          { label: 'High', value: 2 },
+        ],
+      },
+      s: {
+        name: 'S',
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation: { lessThanVariable: ref('cap') },
+      },
+      cap: {
+        name: 'Cap',
+        type: 'number',
+        validation: { minValue: 1, maxValue: 1 },
+      },
+      when: {
+        name: 'When',
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: { type: 'full', min: '2020-01-01', max: '2020-01-03' },
+        validation: { differentFrom: ref('then') },
+      },
+      then: {
+        name: 'Then',
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: { type: 'full', min: '2020-01-01', max: '2020-01-03' },
+      },
+    });
+
+    const components = componentsOf(entity);
+    const domainOf = (group: string): VariableValue[] | undefined => {
+      const component = components.find((candidate) =>
+        candidate.groups.includes(group),
+      );
+      return component?.tractable?.domains.get(group);
+    };
+
+    expect(domainOf('n')).toEqual([3, 4, 5]);
+    expect(domainOf('m')).toEqual([4]);
+    expect(domainOf('flag')).toEqual([false, true]);
+    expect(domainOf('band')).toEqual([1, 2]);
+    // The scalar is capped below 1 by the comparator, so its propagated grid
+    // runs 0.00-0.99.
+    expect(domainOf('s')).toHaveLength(100);
+    expect(domainOf('s')?.[0]).toBe(0);
+    expect(domainOf('s')?.[99]).toBe(0.99);
+    expect(domainOf('when')).toEqual([
+      '2020-01-01',
+      '2020-01-02',
+      '2020-01-03',
+    ]);
+  });
+
+  it('enumerates categorical subsets within the selection bounds', () => {
+    const options = [
+      { label: 'X', value: 'x' },
+      { label: 'Y', value: 'y' },
+      { label: 'Z', value: 'z' },
+    ];
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: {
+          minSelected: 2,
+          maxSelected: 2,
+          differentFrom: ref('twin'),
+        },
+      },
+      twin: {
+        name: 'Twin',
+        type: 'categorical',
+        options,
+        validation: { minSelected: 2, maxSelected: 2 },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+    const domain = component?.tractable?.domains.get('tags');
+
+    expect(domain?.map((value) => valueKey(value)).toSorted()).toEqual([
+      valueKey(['x', 'y']),
+      valueKey(['x', 'z']),
+      valueKey(['y', 'z']),
+    ]);
+  });
+
+  it('leaves a component intractable when a domain cannot be enumerated', () => {
+    const unboundedNumber = build({
+      a: { name: 'A', type: 'number', validation: { differentFrom: ref('b') } },
+      b: { name: 'B', type: 'number' },
+    });
+    const text = build({
+      a: { name: 'A', type: 'text', validation: { differentFrom: ref('b') } },
+      b: { name: 'B', type: 'text' },
+    });
+
+    for (const entity of [unboundedNumber, text]) {
+      const [component] = componentsOf(entity);
+      expect(component?.groups.toSorted()).toEqual(['a', 'b']);
+      expect(component?.tractable).toBeUndefined();
+    }
+  });
+
+  it('leaves a component intractable when the domain product exceeds the cap', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 999, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 999 },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.groups.toSorted()).toEqual(['a', 'b']);
+    expect(component?.tractable).toBeUndefined();
+  });
+
+  it('leaves a component intractable beyond the variable-count cap', () => {
+    const variables: Variables = {};
+    for (let i = 0; i < 9; i++) {
+      variables[`v${i}`] = {
+        name: `V${i}`,
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 1,
+          ...(i > 0 ? { differentFrom: ref(`v${i - 1}`) } : {}),
+        },
+      };
+    }
+
+    const [component] = componentsOf(build(variables));
+
+    expect(component?.groups).toHaveLength(9);
+    expect(component?.tractable).toBeUndefined();
+  });
+
+  it('leaves a component intractable across an incomparable comparator', () => {
+    // A number ordered against a date cannot be stepped or compared; the
+    // greedy path ignores the rule, so the solver must not claim to decide it.
+    const entity = build({
+      n: {
+        name: 'N',
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 3,
+          greaterThanVariable: ref('when'),
+        },
+      },
+      when: {
+        name: 'When',
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: { type: 'full', min: '2020-01-01', max: '2020-01-03' },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.groups.toSorted()).toEqual(['n', 'when']);
+    expect(component?.tractable).toBeUndefined();
+  });
+});
+
+describe('solveComponent', () => {
+  it('finds a witness for the regression shape greedy drawing painted into a corner', () => {
+    // A: [3,4] differentFrom B; B: [3,4]; D: [2,4], D <= A, D >= B.
+    // B=3, A=4, D∈[3,4] satisfies everything.
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4 },
+      },
+      d: {
+        name: 'D',
+        type: 'number',
+        validation: {
+          minValue: 2,
+          maxValue: 4,
+          lessThanOrEqualToVariable: ref('a'),
+          greaterThanOrEqualToVariable: ref('b'),
+        },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+    expect(component?.tractable).toBeDefined();
+
+    const verdict = solveComponent(component!.tractable!, {});
+    expect(verdict.kind).toBe('sat');
+    if (verdict.kind !== 'sat') return;
+
+    const a = Number(verdict.assignment.get('a'));
+    const b = Number(verdict.assignment.get('b'));
+    const d = Number(verdict.assignment.get('d'));
+    expect(a).not.toBe(b);
+    expect(d).toBeLessThanOrEqual(a);
+    expect(d).toBeGreaterThanOrEqual(b);
+  });
+
+  it('proves the pinned differentFrom shape unsatisfiable', () => {
+    // a: [3,4] differentFrom b; b: [4,5] <= a. Propagation pins both to 4,
+    // and 4 cannot differ from 4.
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 3, maxValue: 4, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: {
+          minValue: 4,
+          maxValue: 5,
+          lessThanOrEqualToVariable: ref('a'),
+        },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.tractable).toBeDefined();
+    expect(solveComponent(component!.tractable!, {}).kind).toBe('unsat');
+  });
+
+  it('proves a pigeonhole of three mutually different values over two unsatisfiable', () => {
+    const bounds = { minValue: 0, maxValue: 1 };
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { ...bounds, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { ...bounds, differentFrom: ref('c') },
+      },
+      c: {
+        name: 'C',
+        type: 'number',
+        validation: { ...bounds, differentFrom: ref('a') },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(solveComponent(component!.tractable!, {}).kind).toBe('unsat');
+  });
+
+  it('honours pins, a domain restriction, and a value ordering', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 5, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 5 },
+      },
+    });
+    const [component] = componentsOf(entity);
+    const tractable = component!.tractable!;
+
+    const pinned = solveComponent(tractable, {
+      pins: new Map([['b', 3]]),
+      orderDomain: (_group, values) => [...values],
+    });
+    expect(pinned.kind).toBe('sat');
+    if (pinned.kind === 'sat') {
+      expect(pinned.assignment.get('b')).toBe(3);
+      expect(pinned.assignment.get('a')).not.toBe(3);
+    }
+
+    const restricted = solveComponent(tractable, {
+      pins: new Map([['b', 3]]),
+      restrict: (group, value) => group !== 'a' || value === 3 || value === 4,
+    });
+    expect(restricted.kind).toBe('sat');
+    if (restricted.kind === 'sat')
+      expect(restricted.assignment.get('a')).toBe(4);
+
+    const ordered = solveComponent(tractable, {
+      orderDomain: (_group, values) => [...values].toReversed(),
+    });
+    expect(ordered.kind).toBe('sat');
+    if (ordered.kind === 'sat') {
+      // `b` generates first; both domains run 5..0, so b takes 5 and the
+      // pruned `a` takes the next value down.
+      expect(ordered.assignment.get('b')).toBe(5);
+      expect(ordered.assignment.get('a')).toBe(4);
+    }
+  });
+
+  it('reports unsatisfiable when a pin conflicts with another pin', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 5, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 5 },
+      },
+    });
+    const [component] = componentsOf(entity);
+
+    const verdict = solveComponent(component!.tractable!, {
+      pins: new Map<string, VariableValue>([
+        ['a', 2],
+        ['b', 2],
+      ]),
+    });
+
+    expect(verdict.kind).toBe('unsat');
+  });
+
+  it('drops constraints to excluded groups rather than enforcing them', () => {
+    // Mirrors a partial regeneration where the counterpart holds no value:
+    // the greedy path has nothing to resolve the rule against and ignores it.
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 0, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 0 },
+      },
+    });
+    const [component] = componentsOf(entity);
+
+    const verdict = solveComponent(component!.tractable!, {
+      exclude: new Set(['b']),
+    });
+
+    expect(verdict.kind).toBe('sat');
+    if (verdict.kind === 'sat') {
+      expect(verdict.assignment.get('a')).toBe(0);
+      expect(verdict.assignment.has('b')).toBe(false);
+    }
+  });
+
+  it('returns unknown when the search cap is exhausted', () => {
+    // A ring of six mutually-different values needs at least six assignments,
+    // so a three-node budget runs out before any verdict is possible.
+    const variables: Variables = {};
+    for (let i = 0; i < 6; i++) {
+      variables[`v${i}`] = {
+        name: `V${i}`,
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 4,
+          differentFrom: ref(i > 0 ? `v${i - 1}` : 'v5'),
+        },
+      };
+    }
+
+    const [component] = componentsOf(build(variables));
+
+    expect(component?.tractable).toBeDefined();
+    expect(solveComponent(component!.tractable!, { maxNodes: 3 }).kind).toBe(
+      'unknown',
+    );
+  });
+
+  it('solves a mixed scalar and number chain on the scalar grid', () => {
+    // m [0,0] < s (scalar) < n [1,1]: the only integer endpoints pin m=0, n=1,
+    // and s must land strictly between on the 0.01 grid.
+    const entity = build({
+      m: {
+        name: 'M',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 0 },
+      },
+      s: {
+        name: 'S',
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation: {
+          greaterThanVariable: ref('m'),
+          lessThanVariable: ref('n'),
+        },
+      },
+      n: {
+        name: 'N',
+        type: 'number',
+        validation: { minValue: 1, maxValue: 1 },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+    const verdict = solveComponent(component!.tractable!, {});
+
+    expect(verdict.kind).toBe('sat');
+    if (verdict.kind !== 'sat') return;
+    const s = Number(verdict.assignment.get('s'));
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+  });
+
+  it('solves date chains by string comparison at the shared resolution', () => {
+    const window = {
+      type: 'datetime',
+      component: 'DatePicker',
+      parameters: { type: 'full', min: '2020-01-01', max: '2020-01-03' },
+    } as const;
+    const entity = build({
+      w: { name: 'W', ...window },
+      x: {
+        name: 'X',
+        ...window,
+        validation: { greaterThanVariable: ref('w') },
+      },
+      y: {
+        name: 'Y',
+        ...window,
+        validation: { greaterThanVariable: ref('x') },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+    const verdict = solveComponent(component!.tractable!, {});
+
+    expect(verdict.kind).toBe('sat');
+    if (verdict.kind !== 'sat') return;
+    expect(verdict.assignment.get('w')).toBe('2020-01-01');
+    expect(verdict.assignment.get('x')).toBe('2020-01-02');
+    expect(verdict.assignment.get('y')).toBe('2020-01-03');
+  });
+
+  it('is deterministic for a fixed value ordering', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 9, differentFrom: ref('b') },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: { minValue: 0, maxValue: 9 },
+      },
+    });
+    const [component] = componentsOf(entity);
+
+    const first = solveComponent(component!.tractable!, {});
+    const second = solveComponent(component!.tractable!, {});
+
+    expect(first).toEqual(second);
+  });
+});

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
@@ -335,6 +335,33 @@ describe('solvableComponents', () => {
     }
   });
 
+  it('drops duplicate option values before enumerating selections', () => {
+    // An imported protocol may list one value under two labels; the draw
+    // deduplicates every selection, so the domain must never hold a multiset
+    // like ['x','x'] that no participant control can produce.
+    const options = [
+      { label: 'First X', value: 'x' },
+      { label: 'Second X', value: 'x' },
+      { label: 'Y', value: 'y' },
+    ];
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { differentFrom: ref('twin') },
+      },
+      twin: { name: 'Twin', type: 'categorical', options },
+    });
+
+    const [component] = componentsOf(entity);
+    const domain = component?.tractable?.domains.get('tags');
+
+    expect(domain?.map((value) => valueKey(value)).toSorted()).toEqual(
+      [valueKey(['x']), valueKey(['x', 'y']), valueKey(['y'])].toSorted(),
+    );
+  });
+
   it('declines a categorical whose combination space overflows the budget', () => {
     const options = Array.from({ length: 24 }, (_v, i) => ({
       label: `O${i}`,

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
@@ -17,24 +17,32 @@ import {
 import { solvableComponents, solveComponent } from '../solver';
 import type { EntityConstraints } from '../types';
 import { valueKey } from '../uniqueRegistry';
+import { valueSpaceSize } from '../valueSpace';
 
 const TODAY = '2026-07-27';
 const ref = asEntityAttributeReference;
 
 /** The same pipeline feasibility and generation run before consulting the solver. */
-function componentsOf(entity: EntityConstraints) {
+function analysed(entity: EntityConstraints) {
   const { order, membersOf, groupOf } = resolveGenerationOrder(entity);
   const { groups: propagated } = propagateComparatorBounds(
     intersectGroupConstraints(entity, membersOf),
     order,
     groupComparatorEdges(entity, groupOf),
   );
-  return solvableComponents(
+  return {
     propagated,
-    order,
-    groupComparatorEdges(entity, groupOf),
-    differentFromGroups(entity, groupOf),
-  );
+    components: solvableComponents(
+      propagated,
+      order,
+      groupComparatorEdges(entity, groupOf),
+      differentFromGroups(entity, groupOf),
+    ),
+  };
+}
+
+function componentsOf(entity: EntityConstraints) {
+  return analysed(entity).components;
 }
 
 function build(variables: Variables): EntityConstraints {
@@ -251,6 +259,257 @@ describe('solvableComponents', () => {
 
     expect(component?.groups).toHaveLength(9);
     expect(component?.tractable).toBeUndefined();
+  });
+
+  it('mirrors the draw default of at most two selections in a categorical domain', () => {
+    // A non-unique categorical without maxSelected draws one or two options;
+    // a solved value must come from the same sizes, or adding a rule would
+    // change what the data looks like.
+    const options = Array.from({ length: 4 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { differentFrom: ref('twin') },
+      },
+      twin: { name: 'Twin', type: 'categorical', options },
+    });
+
+    const [component] = componentsOf(entity);
+    const domain = component?.tractable?.domains.get('tags');
+
+    expect(domain).toHaveLength(10);
+    for (const value of domain ?? []) {
+      expect(Array.isArray(value) && value.length).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('widens a unique categorical domain to every selection size', () => {
+    const options = Array.from({ length: 4 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { unique: true, differentFrom: ref('twin') },
+      },
+      twin: { name: 'Twin', type: 'categorical', options },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.tractable?.domains.get('tags')).toHaveLength(15);
+  });
+
+  it('keeps a minSelected above the default cap as the one selection size', () => {
+    // The draw clamps its selection count up to minSelected even when that
+    // sits above the default ceiling of two, so the domain holds exactly the
+    // size-three subsets.
+    const options = Array.from({ length: 4 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { minSelected: 3, differentFrom: ref('twin') },
+      },
+      twin: { name: 'Twin', type: 'categorical', options },
+    });
+
+    const [component] = componentsOf(entity);
+    const domain = component?.tractable?.domains.get('tags');
+
+    expect(domain).toHaveLength(4);
+    for (const value of domain ?? []) {
+      expect(Array.isArray(value) && value.length).toBe(3);
+    }
+  });
+
+  it('declines a categorical whose combination space overflows the budget', () => {
+    const options = Array.from({ length: 24 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const entity = build({
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { maxSelected: 12, differentFrom: ref('twin') },
+      },
+      twin: {
+        name: 'Twin',
+        type: 'categorical',
+        options,
+        validation: { maxSelected: 2 },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.groups.toSorted()).toEqual(['tags', 'twin']);
+    expect(component?.tractable).toBeUndefined();
+  });
+
+  it('agrees with valueSpaceSize about the size of every enumerated domain', () => {
+    // The unique-feasibility check counts a variable's space with
+    // valueSpaceSize; the solver enumerates it. If the two drift apart, a
+    // unique variable could pass the count and then run out of solved values,
+    // or be refused values the solver could in fact reach.
+    const options = Array.from({ length: 4 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const window = {
+      type: 'datetime',
+      component: 'DatePicker',
+      parameters: { type: 'full', min: '2024-03-01', max: '2024-03-05' },
+    } as const;
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'number',
+        validation: { minValue: 2, maxValue: 9 },
+      },
+      b: {
+        name: 'B',
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 12,
+          greaterThanVariable: ref('a'),
+        },
+      },
+      s1: {
+        name: 'S1',
+        type: 'scalar',
+        component: 'VisualAnalogScale',
+        validation: { lessThanVariable: ref('s2') },
+      },
+      s2: { name: 'S2', type: 'scalar', component: 'VisualAnalogScale' },
+      w: { name: 'W', ...window },
+      x: {
+        name: 'X',
+        ...window,
+        validation: { greaterThanVariable: ref('w') },
+      },
+      band: {
+        name: 'Band',
+        type: 'ordinal',
+        options,
+        validation: { differentFrom: ref('flag') },
+      },
+      flag: { name: 'Flag', type: 'boolean' },
+      tags: {
+        name: 'Tags',
+        type: 'categorical',
+        options,
+        validation: { unique: true, differentFrom: ref('twin') },
+      },
+      twin: { name: 'Twin', type: 'categorical', options },
+    });
+
+    const { propagated, components } = analysed(entity);
+    const checked: string[] = [];
+    for (const component of components) {
+      const tractable = component.tractable;
+      expect(tractable).toBeDefined();
+      for (const group of component.groups) {
+        const variable = propagated.get(group);
+        expect(variable).toBeDefined();
+        if (variable === undefined) continue;
+        expect(tractable?.domains.get(group)?.length).toBe(
+          valueSpaceSize(variable, Number.MAX_SAFE_INTEGER),
+        );
+        checked.push(group);
+      }
+    }
+
+    expect(checked.toSorted()).toEqual([
+      'a',
+      'b',
+      'band',
+      'flag',
+      's1',
+      's2',
+      'tags',
+      'twin',
+      'w',
+      'x',
+    ]);
+  });
+
+  it('declines a comparator between dates at different resolutions', () => {
+    // The greedy fold skips such an edge; a complete search cannot claim to
+    // decide a rule the draw does not enforce.
+    const entity = build({
+      start: {
+        name: 'Start',
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: { type: 'full', min: '2026-01-01', max: '2026-01-20' },
+      },
+      end: {
+        name: 'End',
+        type: 'datetime',
+        component: 'DatePicker',
+        parameters: { type: 'month', min: '2026-01', max: '2026-06' },
+        validation: { greaterThanVariable: ref('start') },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.groups.toSorted()).toEqual(['end', 'start']);
+    expect(component?.tractable).toBeUndefined();
+  });
+
+  it('narrows a held-equal group domain to the options every member offers', () => {
+    const entity = build({
+      a: {
+        name: 'A',
+        type: 'ordinal',
+        options: [
+          { label: 'One', value: 1 },
+          { label: 'Two', value: 2 },
+          { label: 'Three', value: 3 },
+        ],
+      },
+      b: {
+        name: 'B',
+        type: 'ordinal',
+        options: [
+          { label: 'Two', value: 2 },
+          { label: 'Three', value: 3 },
+          { label: 'Four', value: 4 },
+        ],
+        validation: { sameAs: ref('a') },
+      },
+      c: {
+        name: 'C',
+        type: 'ordinal',
+        options: [
+          { label: 'Two', value: 2 },
+          { label: 'Three', value: 3 },
+        ],
+        validation: { differentFrom: ref('a') },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+    const groupId = component?.groups.find((group) => group !== 'c');
+
+    expect(component?.tractable?.domains.get(groupId ?? '')).toEqual([2, 3]);
   });
 
   it('leaves a component intractable across an incomparable comparator', () => {

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solver.test.ts
@@ -362,6 +362,43 @@ describe('solvableComponents', () => {
     );
   });
 
+  it('declines a categorical whose materialised elements overflow the budget', () => {
+    // C(20,8) = 125,970 subsets sits below the product cap, but each subset
+    // holds eight values — roughly a million elements built for every
+    // generated entity. Work is proportional to elements, not subsets, so
+    // the budget must count them.
+    const options = Array.from({ length: 20 }, (_v, i) => ({
+      label: `O${i}`,
+      value: i,
+    }));
+    const entity = build({
+      wide: {
+        name: 'Wide',
+        type: 'categorical',
+        options,
+        validation: {
+          minSelected: 8,
+          maxSelected: 8,
+          differentFrom: ref('narrow'),
+        },
+      },
+      narrow: {
+        name: 'Narrow',
+        type: 'categorical',
+        options: [
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ],
+        validation: { minSelected: 2, maxSelected: 2 },
+      },
+    });
+
+    const [component] = componentsOf(entity);
+
+    expect(component?.groups.toSorted()).toEqual(['narrow', 'wide']);
+    expect(component?.tractable).toBeUndefined();
+  });
+
   it('declines a categorical whose combination space overflows the budget', () => {
     const options = Array.from({ length: 24 }, (_v, i) => ({
       label: `O${i}`,

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  asEntityAttributeReference,
+  type Stage,
+  type StructuralCodebook,
+  type Variables,
+} from '@codaco/protocol-validation';
+
+import { ValueGenerator } from '../../../ValueGenerator';
+import { resolveGenerationConfig } from '../../config';
+import type { GenerationContext } from '../../context';
+import { buildEntityConstraints } from '../buildConstraints';
+import { analyseFeasibility } from '../feasibility';
+import { generateEntityAttributes } from '../generateEntityAttributes';
+import { UniqueRegistry } from '../uniqueRegistry';
+
+// A three-node search budget: any component of five or more variables
+// provably exceeds it, since a solution alone needs one node per variable.
+vi.mock('../solverLimits', () => ({
+  MAX_COMPONENT_VARIABLES: 8,
+  MAX_DOMAIN_PRODUCT: 200_000,
+  MAX_SEARCH_NODES: 3,
+}));
+
+const TODAY = '2026-07-27';
+const config = resolveGenerationConfig({ today: TODAY });
+
+const nameGenerator = {
+  id: 'stage-1',
+  type: 'NameGenerator',
+  label: 'Name generator',
+  subject: { entity: 'node', type: 'person' },
+  prompts: [{ id: 'p1', text: 'Name people' }],
+  behaviours: { maxNodes: 8 },
+} as unknown as Stage;
+
+/** Five booleans in a ring of differentFrom: an odd cycle, unsatisfiable. */
+function oddRingVariables(): Record<string, unknown> {
+  const variables: Record<string, unknown> = {};
+  for (let i = 0; i < 5; i++) {
+    variables[`v${i}`] = {
+      name: `V${i}`,
+      type: 'boolean',
+      validation: { differentFrom: i > 0 ? `v${i - 1}` : 'v4' },
+    };
+  }
+  return variables;
+}
+
+describe('solver search budget exhaustion', () => {
+  it('never refuses a protocol because the search ran out of budget', () => {
+    // With the full budget this odd ring is proven unsatisfiable and refused
+    // (see the feasibility suite). Under a three-node budget the search stops
+    // at "unknown" — and unknown must read as "cannot judge", not "refuse".
+    const codebook = {
+      node: {
+        person: { color: 'node-color-seq-1', variables: oddRingVariables() },
+      },
+    } as unknown as StructuralCodebook;
+
+    expect(analyseFeasibility(codebook, [nameGenerator], config)).toEqual([]);
+  });
+
+  it('generates through the greedy path when the search budget runs out', () => {
+    // Six values in a ring over [0, 4] is satisfiable but needs at least six
+    // nodes; under the tiny budget the solve reports unknown and the greedy
+    // path must still produce a complete entity.
+    const variables: Variables = {};
+    for (let i = 0; i < 6; i++) {
+      variables[`v${i}`] = {
+        name: `V${i}`,
+        type: 'number',
+        validation: {
+          minValue: 0,
+          maxValue: 4,
+          differentFrom: asEntityAttributeReference(i > 0 ? `v${i - 1}` : 'v5'),
+        },
+      };
+    }
+    const entity = buildEntityConstraints(variables, TODAY);
+
+    const ctx: GenerationContext = {
+      codebook: {},
+      valueGen: new ValueGenerator(1, TODAY),
+      config,
+      usedRosterUids: new Set(),
+      externalData: undefined,
+      respectSkipLogicAndFiltering: false,
+      uniqueRegistry: new UniqueRegistry(),
+      entityConstraints: { ego: new Map(), node: new Map(), edge: new Map() },
+    };
+
+    const attrs = generateEntityAttributes(
+      entity,
+      ctx,
+      { entity: 'node', type: 'person' },
+      0,
+    );
+
+    expect(Object.keys(attrs)).toHaveLength(6);
+    for (let i = 0; i < 6; i++) {
+      const value = Number(attrs[`v${i}`]);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(4);
+    }
+  });
+});

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
@@ -91,6 +91,7 @@ describe('solver search budget exhaustion', () => {
       entityConstraints: { ego: new Map(), node: new Map(), edge: new Map() },
     };
 
+    const spy = vi.spyOn(ctx.valueGen, 'randomInt');
     const attrs = generateEntityAttributes(
       entity,
       ctx,
@@ -104,5 +105,11 @@ describe('solver search budget exhaustion', () => {
       expect(value).toBeGreaterThanOrEqual(0);
       expect(value).toBeLessThanOrEqual(4);
     }
+
+    // One draw seeded the abandoned solve and one first-attempt draw fell to
+    // each of the six greedy values: the stream moves the same distance
+    // whether the search succeeded, failed, or ran out of budget.
+    expect(spy).toHaveBeenCalledTimes(7);
+    spy.mockRestore();
   });
 });

--- a/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/__tests__/solverCap.test.ts
@@ -17,9 +17,9 @@ import { UniqueRegistry } from '../uniqueRegistry';
 
 // A three-node search budget: any component of five or more variables
 // provably exceeds it, since a solution alone needs one node per variable.
-vi.mock('../solverLimits', () => ({
-  MAX_COMPONENT_VARIABLES: 8,
-  MAX_DOMAIN_PRODUCT: 200_000,
+// Only the search budget shrinks; every other limit keeps its real value.
+vi.mock(import('../solverLimits'), async (importOriginal) => ({
+  ...(await importOriginal()),
   MAX_SEARCH_NODES: 3,
 }));
 

--- a/packages/protocol-utilities/src/generateNetwork/constraints/feasibility.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/feasibility.ts
@@ -10,11 +10,13 @@ import { type ComparatorEdge, resolveGenerationOrder } from './dependencyOrder';
 import { worstCaseEntityCounts } from './entityCounts';
 import type { ConstraintConflict } from './error';
 import {
+  differentFromGroups,
   emptyGroupBounds,
   groupComparatorEdges,
   intersectGroupConstraints,
   propagateComparatorBounds,
 } from './groupConstraints';
+import { solvableComponents, solveComponent } from './solver';
 import {
   COMPARISON_RULES,
   type ConstrainedVariable,
@@ -97,12 +99,17 @@ function analyseEntity(
   const { order, membersOf, groupOf, cycles } = resolveGenerationOrder(entity);
   const groups = intersectGroupConstraints(entity, membersOf);
   const uniqueReported = new Set<string>();
+  // Groups an earlier check has already refused. The complete search below
+  // skips components touching them: re-proving a contradiction that already
+  // has a targeted message would only report it twice, less usefully.
+  const implicated = new Set<string>();
 
   const report = (
     variableIds: string[],
     rules: string[],
     reason: string,
   ): void => {
+    for (const id of variableIds) implicated.add(groupOf.get(id) ?? id);
     conflicts.push({
       entity: scope.entity,
       ...(scope.entityType !== undefined
@@ -260,7 +267,11 @@ function analyseEntity(
   // checks above, a single variable's bounds or a group's members' against each
   // other, and neither needs a comparator to be wrong.
   const edges = groupComparatorEdges(entity, groupOf);
-  const { inverted } = propagateComparatorBounds(groups, order, edges);
+  const { groups: propagated, inverted } = propagateComparatorBounds(
+    groups,
+    order,
+    edges,
+  );
   const cyclicGroups = new Set(
     cycles.flat().map((id) => groupOf.get(id) ?? id),
   );
@@ -309,7 +320,75 @@ function analyseEntity(
     );
   }
 
+  // Interval reasoning cannot represent "this range minus the value another
+  // variable took", so shapes like a differentFrom pinned to a single shared
+  // value slip through every check above and used to surface as seed-dependent
+  // draw failures. Where a component's domains are small enough to enumerate,
+  // a complete search settles it: exhausting the space without a solution is a
+  // proof of unsatisfiability, and anything short of that proof — including a
+  // search that ran out of budget — never refuses.
+  const components = solvableComponents(
+    propagated,
+    order,
+    edges,
+    differentFromGroups(entity, groupOf),
+  );
+  for (const component of components) {
+    if (component.tractable === undefined) continue;
+    if (component.groups.some((group) => implicated.has(group))) continue;
+    if (solveComponent(component.tractable).kind !== 'unsat') continue;
+
+    const members = new Set(component.groups);
+    const ids = [...entity.keys()].filter((id) =>
+      members.has(groupOf.get(id) ?? id),
+    );
+    report(
+      ids,
+      solvedComponentRules(entity, ids),
+      'no combination of values these rules allow can satisfy all of them at once',
+    );
+  }
+
   return conflicts;
+}
+
+/**
+ * The rules a solver refusal names: every reference rule the component's
+ * members declare, plus the declared bounds that box the search in. A scalar's
+ * implicit 0-1 scale is left out — naming a rule the protocol never wrote
+ * points its author at nothing.
+ */
+function solvedComponentRules(
+  entity: EntityConstraints,
+  ids: readonly string[],
+): string[] {
+  const rules = new Set<string>(
+    REFERENCE_RULES.filter((rule) =>
+      ids.some((id) => entity.get(id)?.constraints[rule] !== undefined),
+    ),
+  );
+
+  for (const id of ids) {
+    const variable = entity.get(id);
+    if (variable === undefined) continue;
+    const { entry, constraints } = variable;
+
+    if (entry.type !== 'scalar') {
+      if (constraints.minValue !== undefined) rules.add('minValue');
+      if (constraints.maxValue !== undefined) rules.add('maxValue');
+    }
+    if (constraints.minSelected !== undefined) rules.add('minSelected');
+    if (constraints.maxSelected !== undefined) rules.add('maxSelected');
+    const window = constraints.dateWindow;
+    if (
+      window !== undefined &&
+      (window.min !== undefined || window.max !== undefined)
+    ) {
+      rules.add('parameters');
+    }
+  }
+
+  return [...rules];
 }
 
 export function analyseFeasibility(

--- a/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
@@ -736,22 +736,45 @@ function solveTractableComponent(
     }
   }
 
-  const verdict = solveComponent(tractable, {
-    pins,
-    exclude,
-    ...(uniqueSlots.size > 0
-      ? {
-          restrict: (group: string, value: VariableValue): boolean => {
-            const slot = uniqueSlots.get(group);
-            return (
-              slot === undefined ||
-              !ctx.uniqueRegistry.isTaken(registry, slot, value)
-            );
-          },
-        }
-      : {}),
-    orderDomain: (_group, values) => seededShuffle(ctx, values),
-  });
+  // One draw from the run's stream seeds a local shuffle, so the stream
+  // advances by exactly one step per solve whatever the search does — a
+  // capped or unsatisfiable solve cannot shift the draws that follow it, and
+  // a domain's size never shows through as extra consumption.
+  const shuffleSeed = ctx.valueGen.randomInt(0, 2 ** 31 - 1);
+
+  const solveWith = (
+    allowReserved: boolean,
+  ): ReturnType<typeof solveComponent> => {
+    const rand = mulberry32(shuffleSeed);
+    return solveComponent(tractable, {
+      pins,
+      exclude,
+      ...(uniqueSlots.size > 0
+        ? {
+            restrict: (group: string, value: VariableValue): boolean => {
+              const slot = uniqueSlots.get(group);
+              if (slot === undefined) return true;
+              if (ctx.uniqueRegistry.isTaken(registry, slot, value)) {
+                return false;
+              }
+              return (
+                allowReserved ||
+                !ctx.uniqueRegistry.isReserved(registry, slot, value)
+              );
+            },
+          }
+        : {}),
+      orderDomain: (_group, values) => shuffledBy(rand, values),
+    });
+  };
+
+  // Values reserved for roster rows still to be drawn give way exactly as
+  // they do on the greedy path: preferred against while anything else
+  // satisfies the component, taken once nothing else does.
+  let verdict = solveWith(false);
+  if (verdict.kind !== 'sat' && uniqueSlots.size > 0) {
+    verdict = solveWith(true);
+  }
 
   if (verdict.kind !== 'sat') return undefined;
 
@@ -763,14 +786,27 @@ function solveTractableComponent(
   return assignment;
 }
 
-/** Fisher-Yates over the run's seeded generator, so output is reproducible. */
-function seededShuffle(
-  ctx: GenerationContext,
+// The same generator the corpus harness uses; any small seeded PRNG works, as
+// long as it is not the run's own faker stream.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Fisher-Yates over a local seeded stream, so output is reproducible. */
+function shuffledBy(
+  rand: () => number,
   values: readonly VariableValue[],
 ): VariableValue[] {
   const copy = [...values];
   for (let i = copy.length - 1; i > 0; i--) {
-    const j = ctx.valueGen.randomInt(0, i);
+    const j = Math.floor(rand() * (i + 1));
     const swap = copy[i]!;
     copy[i] = copy[j]!;
     copy[j] = swap;

--- a/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
@@ -722,9 +722,18 @@ function solveTractableComponent(
   const uniqueSlots = new Map<string, string>();
   for (const group of free) {
     if (plan.groups.get(group)?.constraints.unique !== true) continue;
-    const memberIds = plan.membersOf.get(group) ?? [group];
-    uniqueSlots.set(group, slotOf(memberIds));
+    uniqueSlots.set(group, slotOf(plan.membersOf.get(group) ?? [group]));
+  }
 
+  // Two unique slots inside one component cannot be allocated safely one
+  // entity at a time: whichever pairing this entity takes can strand a later
+  // one, and cross-entity allocation is deliberately not modelled here. The
+  // greedy draw's per-slot monotonic sequences allocate those families the
+  // way they always have, so the component is left to them untouched.
+  if (uniqueSlots.size > 1) return undefined;
+
+  for (const group of uniqueSlots.keys()) {
+    const memberIds = plan.membersOf.get(group) ?? [group];
     // Released before the domains are read, so a solution that lands back on
     // the entity's own value reclaims it rather than being refused it. The
     // greedy fallback re-releases on failure, which the registry tolerates.
@@ -777,9 +786,11 @@ function solveTractableComponent(
 
   // Values reserved for roster rows still to be drawn give way exactly as
   // they do on the greedy path: preferred against while anything else
-  // satisfies the component, taken once nothing else does.
+  // satisfies the component, taken once nothing else provably does. Only a
+  // proven unsat unlocks them — an unknown means unreserved assignments may
+  // remain unexplored, and is handled like any other exhausted budget.
   let verdict = solveWith(false);
-  if (verdict.kind !== 'sat' && uniqueSlots.size > 0) {
+  if (verdict.kind === 'unsat' && uniqueSlots.size > 0) {
     verdict = solveWith(true);
   }
 

--- a/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
@@ -764,7 +764,14 @@ function solveTractableComponent(
             },
           }
         : {}),
-      orderDomain: (_group, values) => shuffledBy(rand, values),
+      // A unique group's slot is shared with every entity still to come, so
+      // its values are consumed bottom-up the way the distinct-sequence draw
+      // always consumed them: u over [0,1] and v over [1,2] with v > u must
+      // allocate (0,1) before (1,2), where a shuffle could take (0,2) and
+      // strand the next entity. Groups without a slot cost nothing across
+      // entities and keep the shuffle that makes their data vary.
+      orderDomain: (group, values) =>
+        uniqueSlots.has(group) ? [...values] : shuffledBy(rand, values),
     });
   };
 

--- a/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
@@ -12,11 +12,18 @@ import {
 import { type ConstraintConflict, SyntheticDataConstraintError } from './error';
 import {
   comparatorGap,
+  differentFromGroups,
   groupComparatorEdges,
   intersectGroupConstraints,
   propagateComparatorBounds,
   tighten,
 } from './groupConstraints';
+import {
+  type SolvableComponent,
+  solvableComponents,
+  solveComponent,
+  type TractableComponent,
+} from './solver';
 import type {
   ConstrainedVariable,
   EntityConstraints,
@@ -40,43 +47,6 @@ export type EntityScopeRef =
 
 function scopeKey(scope: EntityScopeRef): string {
   return scope.entity === 'ego' ? 'ego' : `${scope.entity}:${scope.type}`;
-}
-
-/**
- * Which groups each group's value must differ from.
- *
- * `differentFrom` binds both of its ends, so the pair is recorded from both:
- * the ordering pass keeps one dependency edge per pair and drops it entirely
- * when it would close a cycle, which leaves the group that declared the rule as
- * likely to be drawn first as the group it names.
- */
-function differentFromGroups(
-  entity: EntityConstraints,
-  groupOf: Map<string, string>,
-): Map<string, Set<string>> {
-  const excluded = new Map<string, Set<string>>();
-
-  const link = (from: string, to: string): void => {
-    const targets = excluded.get(from) ?? new Set<string>();
-    targets.add(to);
-    excluded.set(from, targets);
-  };
-
-  for (const [id, variable] of entity) {
-    const targetId = variable.constraints.differentFrom;
-    if (targetId === undefined || !entity.has(targetId)) continue;
-
-    const group = groupOf.get(id) ?? id;
-    const target = groupOf.get(targetId) ?? targetId;
-    // One group holds a single value, which cannot differ from itself;
-    // `resolveGenerationOrder` reports that as a contradiction.
-    if (group === target) continue;
-
-    link(group, target);
-    link(target, group);
-  }
-
-  return excluded;
 }
 
 function isNumeric(variable: ConstrainedVariable): boolean {
@@ -604,6 +574,19 @@ export function generateEntityAttributes(
     excluded,
   };
 
+  const componentOf = new Map<string, SolvableComponent>();
+  for (const component of solvableComponents(
+    propagated,
+    order,
+    edges,
+    excluded,
+  )) {
+    for (const group of component.groups) componentOf.set(group, component);
+  }
+  const state: DrawState = { scope, index, resolved, only, existing };
+  const solved = new Map<string, VariableValue>();
+  const attempted = new Set<SolvableComponent>();
+
   for (const group of order) {
     const memberIds = membersOf.get(group) ?? [group];
     if (only && !memberIds.some((id) => only.has(id))) continue;
@@ -611,13 +594,35 @@ export function generateEntityAttributes(
     const variable = plan.groups.get(group);
     if (variable === undefined) continue;
 
-    const value = drawGroup(plan, group, variable, ctx, {
-      scope,
-      index,
-      resolved,
-      only,
-      existing,
-    });
+    // A whole component is settled at its first drawn group, so every value
+    // is chosen in sight of every rule. Anything short of a solution — an
+    // oversized component, an exhausted search, a genuinely unsatisfiable
+    // set — leaves `solved` empty and the greedy path below drawing exactly
+    // as it always has.
+    const component = componentOf.get(group);
+    if (component?.tractable !== undefined && !attempted.has(component)) {
+      attempted.add(component);
+      const assignment = solveTractableComponent(
+        component.tractable,
+        plan,
+        ctx,
+        state,
+      );
+      if (assignment !== undefined) {
+        for (const [solvedGroup, value] of assignment) {
+          solved.set(solvedGroup, value);
+        }
+      }
+    }
+
+    const value = drawGroup(
+      plan,
+      group,
+      variable,
+      ctx,
+      state,
+      solved.get(group),
+    );
 
     for (const id of memberIds) {
       resolved[id] = value;
@@ -626,6 +631,119 @@ export function generateEntityAttributes(
   }
 
   return produced;
+}
+
+/**
+ * One complete solve of a component for the entity being generated.
+ *
+ * Groups the entity keeps values for enter as pins; groups outside the run
+ * with nothing held are dropped along with their constraints, which is what
+ * the greedy path does with a rule whose counterpart never resolves. Free
+ * groups' domains lose whatever a unique registry has already issued — their
+ * own previous values are given back first, so a redraw may keep them — and
+ * are searched in a seeded shuffle: the run stays reproducible for a seed
+ * while entities land on different assignments.
+ *
+ * Returns the free groups' values, or undefined when the search found no
+ * solution or ran out of budget — never a refusal, always a fallback.
+ */
+function solveTractableComponent(
+  tractable: TractableComponent,
+  plan: Plan,
+  ctx: GenerationContext,
+  { scope, resolved, only, existing }: DrawState,
+): Map<string, VariableValue> | undefined {
+  const registry = scopeKey(scope);
+  const pins = new Map<string, VariableValue>();
+  const exclude = new Set<string>();
+  const free: string[] = [];
+
+  for (const group of tractable.groups) {
+    const memberIds = plan.membersOf.get(group) ?? [group];
+
+    if (only && !memberIds.some((id) => only.has(id))) {
+      const held = groupValue(memberIds, resolved);
+      // A null counterpart never binds a comparator, and no drawn value can
+      // collide with it, so dropping the group mirrors ignoring the rule.
+      if (held === undefined || held === null) exclude.add(group);
+      else pins.set(group, held);
+      continue;
+    }
+
+    if (only && existing) {
+      const keeper = memberIds.find(
+        (id) => !only.has(id) && existing[id] !== undefined,
+      );
+      if (keeper !== undefined) {
+        const held = existing[keeper];
+        if (held === undefined || held === null) exclude.add(group);
+        else pins.set(group, held);
+        continue;
+      }
+    }
+
+    free.push(group);
+  }
+
+  if (free.length === 0) return undefined;
+
+  const uniqueSlots = new Map<string, string>();
+  for (const group of free) {
+    if (plan.groups.get(group)?.constraints.unique !== true) continue;
+    const memberIds = plan.membersOf.get(group) ?? [group];
+    uniqueSlots.set(group, slotOf(memberIds));
+
+    // Released before the domains are read, so a solution that lands back on
+    // the entity's own value reclaims it rather than being refused it. The
+    // greedy fallback re-releases on failure, which the registry tolerates.
+    if (existing !== undefined) {
+      const previous = groupValue(memberIds, existing);
+      if (previous !== undefined) {
+        ctx.uniqueRegistry.release(registry, slotOf(memberIds), previous);
+      }
+    }
+  }
+
+  const verdict = solveComponent(tractable, {
+    pins,
+    exclude,
+    ...(uniqueSlots.size > 0
+      ? {
+          restrict: (group: string, value: VariableValue): boolean => {
+            const slot = uniqueSlots.get(group);
+            return (
+              slot === undefined ||
+              !ctx.uniqueRegistry.isTaken(registry, slot, value)
+            );
+          },
+        }
+      : {}),
+    orderDomain: (_group, values) => seededShuffle(ctx, values),
+  });
+
+  if (verdict.kind !== 'sat') return undefined;
+
+  const assignment = new Map<string, VariableValue>();
+  for (const group of free) {
+    const value = verdict.assignment.get(group);
+    if (value !== undefined) assignment.set(group, value);
+  }
+  return assignment;
+}
+
+/** Fisher-Yates over the run's seeded generator, so output is reproducible. */
+function seededShuffle(
+  ctx: GenerationContext,
+  values: readonly VariableValue[],
+): VariableValue[] {
+  const copy = [...values];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = ctx.valueGen.randomInt(0, i);
+    const swap = copy[i]!;
+    copy[i] = copy[j]!;
+    copy[j] = swap;
+  }
+  return copy;
 }
 
 /** The entity's groups and the rules between them, resolved once. */
@@ -718,6 +836,7 @@ function drawGroup(
   variable: ConstrainedVariable,
   ctx: GenerationContext,
   { scope, index, resolved, only, existing }: DrawState,
+  solved?: VariableValue,
 ): VariableValue {
   const { membersOf, edges } = plan;
   const memberIds = membersOf.get(group) ?? [group];
@@ -739,6 +858,10 @@ function drawGroup(
       if (!only.has(id) && held !== undefined) return claim(held);
     }
   }
+
+  // A value the component solve already chose. Its slot was released before
+  // the solve read the registry, so claiming is all that is left to do.
+  if (solved !== undefined) return claim(solved);
 
   // A group being redrawn over a value the entity already holds gives that
   // value's slot back first. Without it the entity would occupy two of the

--- a/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/generateEntityAttributes.ts
@@ -607,7 +607,8 @@ export function generateEntityAttributes(
   };
 
   const componentOf = new Map<string, SolvableComponent>();
-  for (const component of solvableComponents(
+  for (const component of componentsFor(
+    entity,
     propagated,
     order,
     edges,
@@ -663,6 +664,32 @@ export function generateEntityAttributes(
   }
 
   return produced;
+}
+
+/**
+ * Component analysis memoised by the entity-type descriptor it derives from.
+ *
+ * Every input to `solvableComponents` is a pure function of the descriptor,
+ * generation runs once per entity, and neither the components nor their
+ * domains are ever mutated (each solve copies what it filters or reorders) —
+ * so a type's domains are built once per run instead of once per node, which
+ * for a wide-but-tractable categorical is the difference between one and
+ * thousands of six-figure-element enumerations.
+ */
+const componentCache = new WeakMap<EntityConstraints, SolvableComponent[]>();
+
+function componentsFor(
+  entity: EntityConstraints,
+  propagated: Map<string, ConstrainedVariable>,
+  order: readonly string[],
+  edges: readonly ComparatorEdge[],
+  excluded: Map<string, Set<string>>,
+): SolvableComponent[] {
+  const cached = componentCache.get(entity);
+  if (cached !== undefined) return cached;
+  const components = solvableComponents(propagated, order, edges, excluded);
+  componentCache.set(entity, components);
+  return components;
 }
 
 /**

--- a/packages/protocol-utilities/src/generateNetwork/constraints/groupConstraints.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/groupConstraints.ts
@@ -210,6 +210,43 @@ export function comparatorGap(type: 'number' | 'scalar'): number {
 }
 
 /**
+ * Which groups each group's value must differ from.
+ *
+ * `differentFrom` binds both of its ends, so the pair is recorded from both:
+ * the ordering pass keeps one dependency edge per pair and drops it entirely
+ * when it would close a cycle, which leaves the group that declared the rule as
+ * likely to be drawn first as the group it names.
+ */
+export function differentFromGroups(
+  entity: EntityConstraints,
+  groupOf: Map<string, string>,
+): Map<string, Set<string>> {
+  const excluded = new Map<string, Set<string>>();
+
+  const link = (from: string, to: string): void => {
+    const targets = excluded.get(from) ?? new Set<string>();
+    targets.add(to);
+    excluded.set(from, targets);
+  };
+
+  for (const [id, variable] of entity) {
+    const targetId = variable.constraints.differentFrom;
+    if (targetId === undefined || !entity.has(targetId)) continue;
+
+    const group = groupOf.get(id) ?? id;
+    const target = groupOf.get(targetId) ?? targetId;
+    // One group holds a single value, which cannot differ from itself;
+    // `resolveGenerationOrder` reports that as a contradiction.
+    if (group === target) continue;
+
+    link(group, target);
+    link(target, group);
+  }
+
+  return excluded;
+}
+
+/**
  * Every comparator in the entity, rewritten as an ordering between the groups
  * that hold the two values. Both ends of an edge inside one group are the same
  * value, so nothing is left to order — a strict comparator of that shape is a
@@ -245,12 +282,13 @@ type Range = {
 };
 
 /**
- * How far apart a strict comparator holds its two ends, in the units the upper
- * end is drawn in: a whole number, one step of the scalar grid, or one unit at
- * the resolution both date windows share.
+ * How far apart a strict comparator provably holds its two ends: the finer of
+ * the two ends' granularities, or one unit at the resolution both date windows
+ * share. `gridUpper`/`gridLower` say which end sits on the scalar grid, so the
+ * bound stepped towards that end can be rounded back onto it.
  */
-type Span =
-  | { kind: 'numeric'; gap: number; grid: boolean }
+export type Span =
+  | { kind: 'numeric'; gap: number; gridUpper: boolean; gridLower: boolean }
   | { kind: 'date'; resolution: DateResolution };
 
 function isNumeric(variable: ConstrainedVariable): boolean {
@@ -261,17 +299,29 @@ function isNumeric(variable: ConstrainedVariable): boolean {
  * Comparisons the generator cannot step across — a number against a date, or
  * two dates written at different resolutions, whose bounds would not even
  * compare as strings — leave nothing to propagate.
+ *
+ * The numeric gap is the finer of the two ends' granularities, which is the
+ * largest step a strict comparison is guaranteed to leave: both ends are
+ * multiples of it, so any two distinct values differ by at least it. Stepping
+ * by the coarser end's unit instead over-tightens — a scalar strictly below a
+ * number pinned to 1 still reaches 0.99, not 0 — and an over-tight bound turns
+ * satisfiable protocols into refusals.
  */
-function comparatorSpan(
+export function comparatorSpan(
   lower: ConstrainedVariable,
   upper: ConstrainedVariable,
 ): Span | undefined {
   if (isNumeric(lower) && isNumeric(upper)) {
-    const grid = upper.entry.type === 'scalar';
+    const gridUpper = upper.entry.type === 'scalar';
+    const gridLower = lower.entry.type === 'scalar';
     return {
       kind: 'numeric',
-      gap: comparatorGap(grid ? 'scalar' : 'number'),
-      grid,
+      gap: Math.min(
+        comparatorGap(gridUpper ? 'scalar' : 'number'),
+        comparatorGap(gridLower ? 'scalar' : 'number'),
+      ),
+      gridUpper,
+      gridLower,
     };
   }
 
@@ -416,7 +466,7 @@ export function propagateComparatorBounds(
     if (span?.kind === 'numeric' && from.minValue !== undefined) {
       into.minValue = tighten(
         into.minValue,
-        onGrid(from.minValue + steps * span.gap, span.grid),
+        onGrid(from.minValue + steps * span.gap, span.gridUpper),
         true,
       );
     } else if (span?.kind === 'date' && from.windowMin !== undefined) {
@@ -441,7 +491,7 @@ export function propagateComparatorBounds(
     if (span?.kind === 'numeric' && from.maxValue !== undefined) {
       into.maxValue = tighten(
         into.maxValue,
-        onGrid(from.maxValue - steps * span.gap, span.grid),
+        onGrid(from.maxValue - steps * span.gap, span.gridLower),
         false,
       );
     } else if (span?.kind === 'date' && from.windowMax !== undefined) {

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
@@ -10,7 +10,11 @@ import {
 } from './solverLimits';
 import type { ConstrainedVariable } from './types';
 import { valueKey } from './uniqueRegistry';
-import { SCALAR_DECIMAL_PLACES, SCALAR_DOMAIN } from './valueSpace';
+import {
+  SCALAR_DECIMAL_PLACES,
+  SCALAR_DOMAIN,
+  selectionSizeRange,
+} from './valueSpace';
 
 /**
  * One connected web of cross-variable rules, ready for complete search: every
@@ -73,6 +77,31 @@ function integerRange(lo: number, hi: number): number[] {
   return values;
 }
 
+// Kept in sync with valueSpace's own binomial; both cap their sums long
+// before float imprecision could matter.
+function binomial(n: number, k: number): number {
+  if (k < 0 || k > n) return 0;
+  let result = 1;
+  for (let i = 0; i < k; i++) {
+    result = (result * (n - i)) / (i + 1);
+  }
+  return Math.round(result);
+}
+
+/**
+ * The selection sizes a solved categorical value may take: the draw's own
+ * size range, with the ceiling clamped up to the floor the way the draw
+ * clamps its count — a `minSelected` above the default cap of two still
+ * produces selections of exactly that size, never nothing.
+ */
+function subsetSizes(variable: ConstrainedVariable): {
+  min: number;
+  max: number;
+} {
+  const { min, max } = selectionSizeRange(variable);
+  return { min, max: Math.max(min, max) };
+}
+
 /**
  * Option subsets whose sizes fall inside the selection bounds, smallest sizes
  * first and lexicographic by option position within a size. Undefined once the
@@ -107,6 +136,85 @@ function enumerateSubsets(
     if (!walk(0, size)) return undefined;
   }
   return subsets;
+}
+
+/**
+ * How many values {@link enumerateDomain} would return, without building any
+ * of them. Kept branch-for-branch with the enumeration — the pair is guarded
+ * by a test asserting the sizes agree with `valueSpaceSize` — so tractability
+ * can be judged before a single value is materialised: a wide categorical
+ * used to allocate its whole subset budget per entity merely to learn the
+ * component was oversized.
+ */
+function domainSize(
+  variable: ConstrainedVariable,
+  cap: number,
+): number | undefined {
+  const { entry, constraints } = variable;
+
+  const within = (size: number): number | undefined =>
+    size > cap ? undefined : size;
+
+  switch (entry.type) {
+    case 'boolean':
+      return 2;
+
+    case 'ordinal': {
+      const count = entry.options?.length ?? 0;
+      return count === 0 ? undefined : within(count);
+    }
+
+    case 'number': {
+      const { minValue, maxValue } = constraints;
+      if (minValue === undefined || maxValue === undefined) return undefined;
+      if (maxValue < minValue) return 0;
+      const lo = Math.ceil(minValue);
+      const hi = Math.floor(maxValue);
+      if (hi < lo) return undefined;
+      return within(hi - lo + 1);
+    }
+
+    case 'scalar': {
+      const unit = 10 ** SCALAR_DECIMAL_PLACES;
+      const min = Math.max(
+        constraints.minValue ?? SCALAR_DOMAIN.minValue,
+        SCALAR_DOMAIN.minValue,
+      );
+      const max = Math.min(
+        constraints.maxValue ?? SCALAR_DOMAIN.maxValue,
+        SCALAR_DOMAIN.maxValue,
+      );
+      if (max <= min) return 1;
+      const lo = Math.ceil(min * unit - 1e-6);
+      const hi = Math.floor(max * unit + 1e-6);
+      return within(hi - lo + 1);
+    }
+
+    case 'datetime': {
+      const window = constraints.dateWindow;
+      if (window?.min === undefined || window.max === undefined) {
+        return undefined;
+      }
+      const steps = stepsBetween(window.min, window.max, window.resolution);
+      if (steps < 0) return 0;
+      return within(steps + 1);
+    }
+
+    case 'categorical': {
+      const count = entry.options?.length ?? 0;
+      if (count === 0) return undefined;
+      const { min, max } = subsetSizes(variable);
+      let total = 0;
+      for (let size = min; size <= max; size++) {
+        total += binomial(count, size);
+        if (total > cap) return undefined;
+      }
+      return total;
+    }
+
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -181,12 +289,7 @@ function enumerateDomain(
     case 'categorical': {
       const options = (entry.options ?? []).map((option) => option.value);
       if (options.length === 0) return undefined;
-      const min = Math.max(1, constraints.minSelected ?? 1);
-      const max = Math.min(
-        constraints.maxSelected ?? options.length,
-        options.length,
-      );
-      if (max < min) return [];
+      const { min, max } = subsetSizes(variable);
       return enumerateSubsets(options, min, max, cap);
     }
 
@@ -308,15 +411,25 @@ function tractableOf(
     comparators.push({ ...edge, span });
   }
 
-  const domains = new Map<string, VariableValue[]>();
+  // Sizes are judged before anything is materialised: an oversized component
+  // must cost a closed-form count per entity, not a mountain of discarded
+  // arrays.
   let product = 1;
+  for (const group of piece.groups) {
+    const variable = groups.get(group);
+    if (variable === undefined) return undefined;
+    const size = domainSize(variable, MAX_DOMAIN_PRODUCT);
+    if (size === undefined) return undefined;
+    product *= Math.max(1, size);
+    if (product > MAX_DOMAIN_PRODUCT) return undefined;
+  }
+
+  const domains = new Map<string, VariableValue[]>();
   for (const group of piece.groups) {
     const variable = groups.get(group);
     if (variable === undefined) return undefined;
     const domain = enumerateDomain(variable, MAX_DOMAIN_PRODUCT);
     if (domain === undefined) return undefined;
-    product *= Math.max(1, domain.length);
-    if (product > MAX_DOMAIN_PRODUCT) return undefined;
     domains.set(group, domain);
   }
 

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
@@ -5,6 +5,7 @@ import type { ComparatorEdge } from './dependencyOrder';
 import { comparatorSpan, type Span } from './groupConstraints';
 import {
   MAX_COMPONENT_VARIABLES,
+  MAX_DOMAIN_ELEMENTS,
   MAX_DOMAIN_PRODUCT,
   MAX_SEARCH_NODES,
 } from './solverLimits';
@@ -151,40 +152,44 @@ function enumerateSubsets(
   return subsets;
 }
 
+/** A domain's value count, and how many elements those values hold in total. */
+type DomainSize = { count: number; elements: number };
+
 /**
- * How many values {@link enumerateDomain} would return, without building any
- * of them. Kept branch-for-branch with the enumeration — the pair is guarded
- * by a test asserting the sizes agree with `valueSpaceSize` — so tractability
- * can be judged before a single value is materialised: a wide categorical
- * used to allocate its whole subset budget per entity merely to learn the
- * component was oversized.
+ * How many values {@link enumerateDomain} would return — and how many
+ * elements they carry once built, since a categorical selection of eight
+ * options costs eight — without building any of them. Kept branch-for-branch
+ * with the enumeration (the pair is guarded by a test asserting the counts
+ * agree with `valueSpaceSize`), so tractability can be judged before a single
+ * value is materialised: a wide categorical used to allocate its whole subset
+ * budget per entity merely to learn the component was oversized.
  */
 function domainSize(
   variable: ConstrainedVariable,
   cap: number,
-): number | undefined {
+): DomainSize | undefined {
   const { entry, constraints } = variable;
 
-  const within = (size: number): number | undefined =>
-    size > cap ? undefined : size;
+  const flat = (count: number): DomainSize | undefined =>
+    count > cap ? undefined : { count, elements: count };
 
   switch (entry.type) {
     case 'boolean':
-      return 2;
+      return flat(2);
 
     case 'ordinal': {
       const count = entry.options?.length ?? 0;
-      return count === 0 ? undefined : within(count);
+      return count === 0 ? undefined : flat(count);
     }
 
     case 'number': {
       const { minValue, maxValue } = constraints;
       if (minValue === undefined || maxValue === undefined) return undefined;
-      if (maxValue < minValue) return 0;
+      if (maxValue < minValue) return flat(0);
       const lo = Math.ceil(minValue);
       const hi = Math.floor(maxValue);
       if (hi < lo) return undefined;
-      return within(hi - lo + 1);
+      return flat(hi - lo + 1);
     }
 
     case 'scalar': {
@@ -197,10 +202,10 @@ function domainSize(
         constraints.maxValue ?? SCALAR_DOMAIN.maxValue,
         SCALAR_DOMAIN.maxValue,
       );
-      if (max <= min) return 1;
+      if (max <= min) return flat(1);
       const lo = Math.ceil(min * unit - 1e-6);
       const hi = Math.floor(max * unit + 1e-6);
-      return within(hi - lo + 1);
+      return flat(hi - lo + 1);
     }
 
     case 'datetime': {
@@ -209,20 +214,23 @@ function domainSize(
         return undefined;
       }
       const steps = stepsBetween(window.min, window.max, window.resolution);
-      if (steps < 0) return 0;
-      return within(steps + 1);
+      if (steps < 0) return flat(0);
+      return flat(steps + 1);
     }
 
     case 'categorical': {
-      const count = distinctOptionValues(entry.options ?? []).length;
-      if (count === 0) return undefined;
+      const optionCount = distinctOptionValues(entry.options ?? []).length;
+      if (optionCount === 0) return undefined;
       const { min, max } = subsetSizes(variable);
-      let total = 0;
+      let count = 0;
+      let elements = 0;
       for (let size = min; size <= max; size++) {
-        total += binomial(count, size);
-        if (total > cap) return undefined;
+        const subsets = binomial(optionCount, size);
+        count += subsets;
+        elements += subsets * size;
+        if (count > cap || elements > MAX_DOMAIN_ELEMENTS) return undefined;
       }
-      return total;
+      return { count, elements };
     }
 
     default:
@@ -426,15 +434,21 @@ function tractableOf(
 
   // Sizes are judged before anything is materialised: an oversized component
   // must cost a closed-form count per entity, not a mountain of discarded
-  // arrays.
+  // arrays. The element total is bounded alongside the product, because a
+  // combination-heavy categorical can hold a modest number of wide subsets
+  // whose materialisation and per-solve scans are what actually cost.
   let product = 1;
+  let elements = 0;
   for (const group of piece.groups) {
     const variable = groups.get(group);
     if (variable === undefined) return undefined;
     const size = domainSize(variable, MAX_DOMAIN_PRODUCT);
     if (size === undefined) return undefined;
-    product *= Math.max(1, size);
-    if (product > MAX_DOMAIN_PRODUCT) return undefined;
+    product *= Math.max(1, size.count);
+    elements += size.elements;
+    if (product > MAX_DOMAIN_PRODUCT || elements > MAX_DOMAIN_ELEMENTS) {
+      return undefined;
+    }
   }
 
   const domains = new Map<string, VariableValue[]>();

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
@@ -1,0 +1,650 @@
+import type { VariableValue } from '@codaco/shared-consts';
+
+import { addSteps, stepsBetween } from './dateWindow';
+import type { ComparatorEdge } from './dependencyOrder';
+import { comparatorSpan, type Span } from './groupConstraints';
+import {
+  MAX_COMPONENT_VARIABLES,
+  MAX_DOMAIN_PRODUCT,
+  MAX_SEARCH_NODES,
+} from './solverLimits';
+import type { ConstrainedVariable } from './types';
+import { valueKey } from './uniqueRegistry';
+import { SCALAR_DECIMAL_PLACES, SCALAR_DOMAIN } from './valueSpace';
+
+/**
+ * One connected web of cross-variable rules, ready for complete search: every
+ * group's finite domain, and the comparator and `differentFrom` constraints
+ * between them. Exhausting these domains without a solution is a proof that no
+ * assignment satisfies the component.
+ */
+export type TractableComponent = {
+  /** Group representative ids, in generation order. */
+  groups: string[];
+  /** Every value the generator can produce for each group, in a fixed order. */
+  domains: Map<string, VariableValue[]>;
+  comparators: {
+    lower: string;
+    upper: string;
+    strict: boolean;
+    span: Span;
+  }[];
+  different: [string, string][];
+};
+
+export type SolvableComponent = {
+  /** Group representative ids, in generation order. */
+  groups: string[];
+  /**
+   * Present only when every domain is enumerable within the solver limits.
+   * An absent value means the component must take the greedy draw path — it is
+   * never a verdict about satisfiability.
+   */
+  tractable?: TractableComponent;
+};
+
+export type SolveOptions = {
+  /** Values some groups already hold; solved values must fit around them. */
+  pins?: ReadonlyMap<string, VariableValue>;
+  /** Groups to leave out entirely, along with every constraint touching them. */
+  exclude?: ReadonlySet<string>;
+  /** Per-value filter, e.g. values a unique registry has already issued. */
+  restrict?: (group: string, value: VariableValue) => boolean;
+  /**
+   * Search order for each group's values. Generation passes a seeded shuffle
+   * so entities vary; feasibility leaves the enumeration order, which makes
+   * its verdict a pure function of the protocol.
+   */
+  orderDomain?: (
+    group: string,
+    values: readonly VariableValue[],
+  ) => VariableValue[];
+  maxNodes?: number;
+};
+
+export type SolveVerdict =
+  | { kind: 'sat'; assignment: Map<string, VariableValue> }
+  | { kind: 'unsat' }
+  | { kind: 'unknown' };
+
+function integerRange(lo: number, hi: number): number[] {
+  const values: number[] = [];
+  for (let value = lo; value <= hi; value++) values.push(value);
+  return values;
+}
+
+/**
+ * Option subsets whose sizes fall inside the selection bounds, smallest sizes
+ * first and lexicographic by option position within a size. Undefined once the
+ * count passes `cap` — combinatorial domains routinely explode, and an
+ * oversized domain is a fallback, not an error.
+ */
+function enumerateSubsets(
+  options: readonly (string | number | boolean)[],
+  minSelected: number,
+  maxSelected: number,
+  cap: number,
+): VariableValue[] | undefined {
+  const subsets: VariableValue[] = [];
+  const picked: (string | number | boolean)[] = [];
+
+  const walk = (start: number, remaining: number): boolean => {
+    if (remaining === 0) {
+      if (subsets.length >= cap) return false;
+      subsets.push([...picked]);
+      return true;
+    }
+    for (let i = start; i <= options.length - remaining; i++) {
+      picked.push(options[i]!);
+      const kept = walk(i + 1, remaining - 1);
+      picked.pop();
+      if (!kept) return false;
+    }
+    return true;
+  };
+
+  for (let size = minSelected; size <= maxSelected; size++) {
+    if (!walk(0, size)) return undefined;
+  }
+  return subsets;
+}
+
+/**
+ * Every value the generator can produce for this group, or undefined where the
+ * set is unbounded, larger than `cap`, or not faithfully enumerable — a number
+ * interval that contains no integer still admits fractional draws, so claiming
+ * its enumeration is empty would turn a satisfiable protocol into a refusal.
+ */
+function enumerateDomain(
+  variable: ConstrainedVariable,
+  cap: number,
+): VariableValue[] | undefined {
+  const { entry, constraints } = variable;
+
+  switch (entry.type) {
+    case 'boolean':
+      return [false, true];
+
+    case 'ordinal': {
+      const options = entry.options ?? [];
+      if (options.length === 0 || options.length > cap) return undefined;
+      return options.map((option) => option.value);
+    }
+
+    case 'number': {
+      const { minValue, maxValue } = constraints;
+      if (minValue === undefined || maxValue === undefined) return undefined;
+      if (maxValue < minValue) return [];
+      const lo = Math.ceil(minValue);
+      const hi = Math.floor(maxValue);
+      if (hi < lo) return undefined;
+      if (hi - lo + 1 > cap) return undefined;
+      return integerRange(lo, hi);
+    }
+
+    case 'scalar': {
+      const unit = 10 ** SCALAR_DECIMAL_PLACES;
+      const min = Math.max(
+        constraints.minValue ?? SCALAR_DOMAIN.minValue,
+        SCALAR_DOMAIN.minValue,
+      );
+      const max = Math.min(
+        constraints.maxValue ?? SCALAR_DOMAIN.maxValue,
+        SCALAR_DOMAIN.maxValue,
+      );
+      // Mirrors the draw's clamp: an inverted or single-point range collapses
+      // to its floor.
+      if (max <= min) return [min];
+      const lo = Math.ceil(min * unit - 1e-6);
+      const hi = Math.floor(max * unit + 1e-6);
+      if (hi - lo + 1 > cap) return undefined;
+      return integerRange(lo, hi).map((index) =>
+        Number((index / unit).toFixed(SCALAR_DECIMAL_PLACES)),
+      );
+    }
+
+    case 'datetime': {
+      const window = constraints.dateWindow;
+      if (window?.min === undefined || window.max === undefined) {
+        return undefined;
+      }
+      const steps = stepsBetween(window.min, window.max, window.resolution);
+      if (steps < 0) return [];
+      if (steps + 1 > cap) return undefined;
+      const values: VariableValue[] = [];
+      for (let step = 0; step <= steps; step++) {
+        values.push(addSteps(window.min, step, window.resolution));
+      }
+      return values;
+    }
+
+    case 'categorical': {
+      const options = (entry.options ?? []).map((option) => option.value);
+      if (options.length === 0) return undefined;
+      const min = Math.max(1, constraints.minSelected ?? 1);
+      const max = Math.min(
+        constraints.maxSelected ?? options.length,
+        options.length,
+      );
+      if (max < min) return [];
+      return enumerateSubsets(options, min, max, cap);
+    }
+
+    // text is effectively unbounded, and layout/location accept no
+    // cross-variable rules; none of them is ever solved.
+    case 'text':
+    case 'layout':
+    case 'location':
+      return undefined;
+
+    default:
+      return undefined;
+  }
+}
+
+type ComponentPieces = {
+  groups: string[];
+  edges: ComparatorEdge[];
+  different: [string, string][];
+};
+
+/**
+ * The webs of groups joined by comparator or `differentFrom` constraints, and
+ * for each the finite domains a complete search needs — where those exist
+ * within the solver limits.
+ *
+ * Domains are enumerated from the **propagated** bounds, so the search starts
+ * from everything interval propagation could already conclude. Groups with no
+ * cross-variable constraint belong to no component; they draw exactly as they
+ * always have.
+ */
+export function solvableComponents(
+  groups: Map<string, ConstrainedVariable>,
+  order: readonly string[],
+  edges: readonly ComparatorEdge[],
+  excluded: Map<string, Set<string>>,
+): SolvableComponent[] {
+  const adjacency = new Map<string, Set<string>>();
+  const link = (from: string, to: string): void => {
+    const neighbours = adjacency.get(from) ?? new Set<string>();
+    neighbours.add(to);
+    adjacency.set(from, neighbours);
+  };
+
+  for (const edge of edges) {
+    if (!groups.has(edge.lower) || !groups.has(edge.upper)) continue;
+    link(edge.lower, edge.upper);
+    link(edge.upper, edge.lower);
+  }
+  for (const [group, targets] of excluded) {
+    for (const target of targets) {
+      if (!groups.has(group) || !groups.has(target)) continue;
+      link(group, target);
+      link(target, group);
+    }
+  }
+
+  const position = new Map(order.map((group, index) => [group, index]));
+  const at = (group: string): number => position.get(group) ?? 0;
+
+  const seen = new Set<string>();
+  const pieces: ComponentPieces[] = [];
+
+  for (const start of order) {
+    if (!adjacency.has(start) || seen.has(start)) continue;
+    seen.add(start);
+
+    const members: string[] = [];
+    const pending = [start];
+    while (pending.length > 0) {
+      const group = pending.pop();
+      if (group === undefined) break;
+      members.push(group);
+      for (const next of adjacency.get(group) ?? []) {
+        if (seen.has(next)) continue;
+        seen.add(next);
+        pending.push(next);
+      }
+    }
+    members.sort((a, b) => at(a) - at(b));
+
+    const inComponent = new Set(members);
+    const componentEdges = edges.filter(
+      (edge) => inComponent.has(edge.lower) && inComponent.has(edge.upper),
+    );
+    const different: [string, string][] = [];
+    for (const group of members) {
+      for (const target of excluded.get(group) ?? []) {
+        if (!inComponent.has(target) || at(target) <= at(group)) continue;
+        different.push([group, target]);
+      }
+    }
+
+    pieces.push({ groups: members, edges: componentEdges, different });
+  }
+
+  return pieces.map((piece) => {
+    const tractable = tractableOf(piece, groups);
+    return { groups: piece.groups, ...(tractable ? { tractable } : {}) };
+  });
+}
+
+function tractableOf(
+  piece: ComponentPieces,
+  groups: Map<string, ConstrainedVariable>,
+): TractableComponent | undefined {
+  if (piece.groups.length > MAX_COMPONENT_VARIABLES) return undefined;
+
+  const comparators: TractableComponent['comparators'] = [];
+  for (const edge of piece.edges) {
+    const lower = groups.get(edge.lower);
+    const upper = groups.get(edge.upper);
+    if (lower === undefined || upper === undefined) return undefined;
+    const span = comparatorSpan(lower, upper);
+    // An incomparable pair — a number against a date, or two dates at
+    // different resolutions — is a rule the greedy path ignores; a complete
+    // search cannot claim to decide a component containing one.
+    if (span === undefined) return undefined;
+    comparators.push({ ...edge, span });
+  }
+
+  const domains = new Map<string, VariableValue[]>();
+  let product = 1;
+  for (const group of piece.groups) {
+    const variable = groups.get(group);
+    if (variable === undefined) return undefined;
+    const domain = enumerateDomain(variable, MAX_DOMAIN_PRODUCT);
+    if (domain === undefined) return undefined;
+    product *= Math.max(1, domain.length);
+    if (product > MAX_DOMAIN_PRODUCT) return undefined;
+    domains.set(group, domain);
+  }
+
+  return {
+    groups: piece.groups,
+    domains,
+    comparators,
+    different: piece.different,
+  };
+}
+
+/** Search state for one group: its remaining values and their compare keys. */
+type Cell = {
+  values: VariableValue[];
+  keys: string[];
+};
+
+function satisfiesComparator(
+  lowerValue: VariableValue,
+  upperValue: VariableValue,
+  strict: boolean,
+  span: Span,
+): boolean {
+  if (span.kind === 'date') {
+    // Date domains hold resolution strings; a pin of any other shape cannot
+    // satisfy the comparison, which sends the component to the greedy path.
+    if (typeof lowerValue !== 'string' || typeof upperValue !== 'string') {
+      return false;
+    }
+    return strict ? upperValue > lowerValue : upperValue >= lowerValue;
+  }
+  const lower = Number(lowerValue);
+  const upper = Number(upperValue);
+  if (Number.isNaN(lower) || Number.isNaN(upper)) return false;
+  return strict ? upper > lower : upper >= lower;
+}
+
+type InternalConstraint =
+  | {
+      kind: 'comparator';
+      lower: string;
+      upper: string;
+      strict: boolean;
+      span: Span;
+    }
+  | { kind: 'different'; a: string; b: string };
+
+function otherEnd(constraint: InternalConstraint, group: string): string {
+  if (constraint.kind === 'comparator') {
+    return constraint.lower === group ? constraint.upper : constraint.lower;
+  }
+  return constraint.a === group ? constraint.b : constraint.a;
+}
+
+type Removal = {
+  cell: Cell;
+  index: number;
+  value: VariableValue;
+  key: string;
+};
+
+function undoRemovals(removals: Removal[]): void {
+  // Reinserted in reverse so each recorded index is valid again.
+  for (let i = removals.length - 1; i >= 0; i--) {
+    const removal = removals[i]!;
+    removal.cell.values.splice(removal.index, 0, removal.value);
+    removal.cell.keys.splice(removal.index, 0, removal.key);
+  }
+}
+
+class SearchBudgetExhausted extends Error {}
+
+/**
+ * Complete backtracking search over one component: arc-consistency
+ * preprocessing, then minimum-remaining-values selection with forward
+ * checking. "unsat" is a proof — the whole space was covered; "unknown" means
+ * only that the node budget ran out first, and must be treated like an
+ * oversized component, never like a refusal.
+ */
+export function solveComponent(
+  component: TractableComponent,
+  options: SolveOptions = {},
+): SolveVerdict {
+  const active = component.groups.filter(
+    (group) => !options.exclude?.has(group),
+  );
+  if (active.length === 0) {
+    return { kind: 'sat', assignment: new Map() };
+  }
+  const activeSet = new Set(active);
+
+  const cells = new Map<string, Cell>();
+  for (const group of active) {
+    const pin = options.pins?.get(group);
+    let values: VariableValue[];
+    if (pin !== undefined) {
+      values = [pin];
+    } else {
+      values = component.domains.get(group) ?? [];
+      if (options.restrict) {
+        values = values.filter((value) => options.restrict!(group, value));
+      }
+      if (options.orderDomain) {
+        values = options.orderDomain(group, values);
+      } else {
+        values = [...values];
+      }
+    }
+    cells.set(group, { values, keys: values.map((value) => valueKey(value)) });
+  }
+
+  const constraints: InternalConstraint[] = [];
+  for (const comparator of component.comparators) {
+    if (!activeSet.has(comparator.lower) || !activeSet.has(comparator.upper)) {
+      continue;
+    }
+    constraints.push({ kind: 'comparator', ...comparator });
+  }
+  for (const [a, b] of component.different) {
+    if (!activeSet.has(a) || !activeSet.has(b)) continue;
+    constraints.push({ kind: 'different', a, b });
+  }
+
+  const touching = new Map<string, InternalConstraint[]>();
+  for (const group of active) touching.set(group, []);
+  for (const constraint of constraints) {
+    const [x, y] =
+      constraint.kind === 'comparator'
+        ? [constraint.lower, constraint.upper]
+        : [constraint.a, constraint.b];
+    touching.get(x)?.push(constraint);
+    touching.get(y)?.push(constraint);
+  }
+
+  /**
+   * Removes values of `group` with no support in the other end's remaining
+   * values. Comparator support only needs the counterpart's extreme value;
+   * `differentFrom` can only prune against a counterpart down to one value.
+   */
+  const revise = (group: string, constraint: InternalConstraint): boolean => {
+    const cell = cells.get(group);
+    const other = cells.get(otherEnd(constraint, group));
+    if (cell === undefined || other === undefined) return false;
+
+    let keep: (index: number) => boolean;
+    if (constraint.kind === 'different') {
+      if (other.values.length !== 1) return true;
+      const forbidden = other.keys[0];
+      keep = (index) => cell.keys[index] !== forbidden;
+    } else if (other.values.length === 0) {
+      keep = () => false;
+    } else {
+      const groupIsLower = constraint.lower === group;
+      keep = (index) =>
+        other.values.some((counterpart) =>
+          groupIsLower
+            ? satisfiesComparator(
+                cell.values[index]!,
+                counterpart,
+                constraint.strict,
+                constraint.span,
+              )
+            : satisfiesComparator(
+                counterpart,
+                cell.values[index]!,
+                constraint.strict,
+                constraint.span,
+              ),
+        );
+    }
+
+    let removed = false;
+    for (let index = cell.values.length - 1; index >= 0; index--) {
+      if (keep(index)) continue;
+      cell.values.splice(index, 1);
+      cell.keys.splice(index, 1);
+      removed = true;
+    }
+    return !removed || cell.values.length > 0;
+  };
+
+  // AC-3 to a fixpoint. `revise` returning false means a domain emptied.
+  const queue: [string, InternalConstraint][] = [];
+  for (const constraint of constraints) {
+    const [x, y] =
+      constraint.kind === 'comparator'
+        ? [constraint.lower, constraint.upper]
+        : [constraint.a, constraint.b];
+    queue.push([x, constraint], [y, constraint]);
+  }
+  while (queue.length > 0) {
+    const arc = queue.shift();
+    if (arc === undefined) break;
+    const [group, constraint] = arc;
+    const before = cells.get(group)?.values.length ?? 0;
+    if (!revise(group, constraint)) return { kind: 'unsat' };
+    const after = cells.get(group)?.values.length ?? 0;
+    if (after === before) continue;
+    for (const neighbourConstraint of touching.get(group) ?? []) {
+      const neighbour = otherEnd(neighbourConstraint, group);
+      queue.push([neighbour, neighbourConstraint]);
+    }
+  }
+  for (const cell of cells.values()) {
+    if (cell.values.length === 0) return { kind: 'unsat' };
+  }
+
+  const maxNodes = options.maxNodes ?? MAX_SEARCH_NODES;
+  let nodes = 0;
+  const assignment = new Map<string, VariableValue>();
+
+  const consistent = (
+    group: string,
+    value: VariableValue,
+    key: string,
+  ): boolean => {
+    for (const constraint of touching.get(group) ?? []) {
+      const counterpart = otherEnd(constraint, group);
+      const held = assignment.get(counterpart);
+      if (held === undefined) continue;
+      if (constraint.kind === 'different') {
+        if (valueKey(held) === key) return false;
+      } else if (constraint.lower === group) {
+        if (
+          !satisfiesComparator(value, held, constraint.strict, constraint.span)
+        ) {
+          return false;
+        }
+      } else if (
+        !satisfiesComparator(held, value, constraint.strict, constraint.span)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const forwardCheck = (
+    group: string,
+    value: VariableValue,
+    key: string,
+  ): { removals: Removal[]; emptied: boolean } => {
+    const removals: Removal[] = [];
+    let emptied = false;
+
+    for (const constraint of touching.get(group) ?? []) {
+      const counterpart = otherEnd(constraint, group);
+      if (assignment.has(counterpart)) continue;
+      const cell = cells.get(counterpart);
+      if (cell === undefined) continue;
+
+      for (let index = cell.values.length - 1; index >= 0; index--) {
+        const candidate = cell.values[index]!;
+        let ok: boolean;
+        if (constraint.kind === 'different') {
+          ok = cell.keys[index] !== key;
+        } else if (constraint.lower === counterpart) {
+          ok = satisfiesComparator(
+            candidate,
+            value,
+            constraint.strict,
+            constraint.span,
+          );
+        } else {
+          ok = satisfiesComparator(
+            value,
+            candidate,
+            constraint.strict,
+            constraint.span,
+          );
+        }
+        if (ok) continue;
+        removals.push({
+          cell,
+          index,
+          value: candidate,
+          key: cell.keys[index]!,
+        });
+        cell.values.splice(index, 1);
+        cell.keys.splice(index, 1);
+      }
+      if (cell.values.length === 0) emptied = true;
+    }
+
+    return { removals, emptied };
+  };
+
+  const search = (): boolean => {
+    let chosen: string | undefined;
+    let narrowest = Number.POSITIVE_INFINITY;
+    for (const group of active) {
+      if (assignment.has(group)) continue;
+      const size = cells.get(group)?.values.length ?? 0;
+      if (size < narrowest) {
+        narrowest = size;
+        chosen = group;
+      }
+    }
+    if (chosen === undefined) return true;
+
+    const cell = cells.get(chosen);
+    if (cell === undefined) return false;
+
+    // The cell's arrays are pruned by deeper forward checks, so iterate a
+    // snapshot of the values as they stand at this depth.
+    const values = [...cell.values];
+    const keys = [...cell.keys];
+    for (let index = 0; index < values.length; index++) {
+      const value = values[index]!;
+      const key = keys[index]!;
+      if (++nodes > maxNodes) throw new SearchBudgetExhausted();
+      if (!consistent(chosen, value, key)) continue;
+
+      assignment.set(chosen, value);
+      const { removals, emptied } = forwardCheck(chosen, value, key);
+      if (!emptied && search()) return true;
+      undoRemovals(removals);
+      assignment.delete(chosen);
+    }
+    return false;
+  };
+
+  try {
+    if (!search()) return { kind: 'unsat' };
+  } catch (error) {
+    if (error instanceof SearchBudgetExhausted) return { kind: 'unknown' };
+    throw error;
+  }
+
+  return { kind: 'sat', assignment };
+}

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solver.ts
@@ -103,6 +103,19 @@ function subsetSizes(variable: ConstrainedVariable): {
 }
 
 /**
+ * Option values with duplicates dropped, first occurrence kept. An imported
+ * protocol may list one value under two labels; the draw deduplicates every
+ * selection it emits, so a position-based enumeration over the raw list
+ * would fabricate multiset selections like `['x','x']` that no draw and no
+ * participant control can produce.
+ */
+function distinctOptionValues(
+  options: readonly { value: string | number | boolean }[],
+): (string | number | boolean)[] {
+  return [...new Set(options.map((option) => option.value))];
+}
+
+/**
  * Option subsets whose sizes fall inside the selection bounds, smallest sizes
  * first and lexicographic by option position within a size. Undefined once the
  * count passes `cap` — combinatorial domains routinely explode, and an
@@ -201,7 +214,7 @@ function domainSize(
     }
 
     case 'categorical': {
-      const count = entry.options?.length ?? 0;
+      const count = distinctOptionValues(entry.options ?? []).length;
       if (count === 0) return undefined;
       const { min, max } = subsetSizes(variable);
       let total = 0;
@@ -287,7 +300,7 @@ function enumerateDomain(
     }
 
     case 'categorical': {
-      const options = (entry.options ?? []).map((option) => option.value);
+      const options = distinctOptionValues(entry.options ?? []);
       if (options.length === 0) return undefined;
       const { min, max } = subsetSizes(variable);
       return enumerateSubsets(options, min, max, cap);

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solverLimits.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solverLimits.ts
@@ -1,0 +1,25 @@
+/**
+ * Bounds on the finite-domain solver's work, shared by feasibility analysis
+ * and generation so the two always agree about which components are solved.
+ *
+ * Exceeding any of them never refuses a protocol: an oversized component falls
+ * back to the greedy draw path, and a search that runs out of budget reports
+ * "unknown", which both consumers treat exactly like oversized.
+ *
+ * The values are set from measurement rather than taste (full numbers in the
+ * PR's implementation report). Components are re-solved once per generated
+ * entity, so the budget that matters is a single solve: at these limits the
+ * worst per-entity cost observed across the acceptance corpus and a battery
+ * of adversarial shapes — eight-variable rings, exact-fit chains, a
+ * 101x101-value scalar pair — was 0.06ms mean and 0.5ms worst, and the
+ * bundled development protocol generates 100 sessions within 2.5% of the
+ * pre-solver time. The variable cap is wider than any constraint web in the
+ * bundled protocols; the product cap keeps a component's full enumeration in
+ * the tens of microseconds; the node cap is two orders of magnitude above the
+ * deepest search those two caps admitted in measurement (a few hundred
+ * nodes), while still bounding a pathological instance to well under a
+ * second.
+ */
+export const MAX_COMPONENT_VARIABLES = 8;
+export const MAX_DOMAIN_PRODUCT = 200_000;
+export const MAX_SEARCH_NODES = 50_000;

--- a/packages/protocol-utilities/src/generateNetwork/constraints/solverLimits.ts
+++ b/packages/protocol-utilities/src/generateNetwork/constraints/solverLimits.ts
@@ -20,6 +20,16 @@
  * nodes), while still bounding a pathological instance to well under a
  * second.
  */
-export const MAX_COMPONENT_VARIABLES = 8;
-export const MAX_DOMAIN_PRODUCT = 200_000;
-export const MAX_SEARCH_NODES = 50_000;
+export const MAX_COMPONENT_VARIABLES: number = 8;
+export const MAX_DOMAIN_PRODUCT: number = 200_000;
+export const MAX_SEARCH_NODES: number = 50_000;
+
+/**
+ * Ceiling on the values a component's domains hold once materialised, where
+ * a categorical selection of eight options counts eight. The product cap
+ * bounds the search space; this bounds the memory and per-solve scan work,
+ * which a combination-heavy categorical can blow through while its subset
+ * count stays modest — C(20,8) is under the product cap yet nearly a
+ * million elements.
+ */
+export const MAX_DOMAIN_ELEMENTS: number = 200_000;


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-27-finite-domain-csp-generation-spec.md` (committed on this branch): a complete finite-domain search over each entity's tractable constraint components, shared by `analyseFeasibility` and `generateEntityAttributes`, fixing both defects the spec names with one mechanism — exhausting a small search space is a proof of unsatisfiability (defect B), and a found witness is the backtracking the greedy draw lacked (defect A).

Targets `claude/synthetic-data-validation-2b18a2` so it merges back into #1108 before #1108 ships; no changeset for that reason (per the spec's branch-and-merge section).

## What changed

- **`constraints/solver.ts` (new)** — domains enumerated from **propagated** bounds over exactly the values the generator can reach (integers, the scalar grid, date-window steps, option subsets); connected components over groups from comparator + `differentFrom` edges; complete backtracking search with AC-3 preprocessing, minimum-remaining-values selection, forward checking, injectable value ordering, and a node budget whose exhaustion is "unknown", never a verdict.
- **`constraints/solverLimits.ts` (new)** — `MAX_COMPONENT_VARIABLES = 8`, `MAX_DOMAIN_PRODUCT = 200_000`, `MAX_SEARCH_NODES = 50_000`, with measurement-based reasoning documented in place.
- **`analyseFeasibility`** — after every existing check, tractable components nothing else refused are searched; unsat components are reported as a new conflict. Components touching an already-reported group are skipped, so no contradiction is reported twice.
- **`generateEntityAttributes`** — each tractable component is settled once per entity at its first drawn group: kept values enter as pins, absent counterparts drop their constraints (mirroring the greedy path's ignore), unique free groups release their own previous value and exclude registry-issued values from their domains, and domains are searched in a seeded shuffle so entities vary while seeds reproduce. Anything short of a solution falls back to the untouched greedy path — including registry exhaustion, which still surfaces through the existing `SyntheticDataConstraintError` draw path.
- **`comparatorSpan` soundness fix (pre-existing bug)** — a strict scalar↔number comparison stepped bounds by the *coarser* end's unit, so `m[0,0] < s < n[1,1]` (satisfiable by `s = 0.5`) was falsely refused. The gap is now the finer of the two granularities (the largest step any strict pair provably leaves), with per-end grid rounding. Regression tests pin both directions at the propagation and feasibility levels.
- **`differentFromGroups`** moved to `groupConstraints.ts` alongside `groupComparatorEdges`, since feasibility, generation, and the solver all read it.

## Evidence (full numbers in `docs/superpowers/specs/2026-07-27-finite-domain-csp-implementation-report.md`)

| Criterion | Result |
| --- | --- |
| C1 sound + complete below threshold | 20,000-shape corpus vs an independent brute-force oracle: **0 mismatches** (13,125 accepted / 6,875 refused; five families; all five types) |
| C2 accepted always generates | **6,562,500** `generateNetwork` runs (every accepted shape × 500 seeds): **0 throws, 0 rule violations**. Named shape A→**500/500** per entity (was ~50%); named shape B→**refused** by feasibility |
| C3 variation | 41/45, 10/10, 78/84 distinct assignments over 200 entities; modal 11%/31.5%/3% (gate ≤40%); CI guard committed |
| C4 cap degrades safely | 3-node-budget mock: unsatisfiable odd ring **not refused**, satisfiable ring generates via greedy; solver-level "unknown" unit-tested |
| C5 above-threshold byte-identical | 12 protocols × 50 seeds serialised (uuid-normalised) and `cmp`'d against base `87c8de12c`: **0 mismatches** |
| C6 performance | Development protocol, 100 sessions: 9.48 → 9.72 ms/session (**+2.5%**, budget 20%); worst adversarial per-entity mean 0.064 ms |
| C7 no regressions | Root `typecheck` 15/15, `test` 16/16, `knip` clean; `syntheticDataConformance.test.ts` passes **unchanged**; bundled protocols pass; every pre-existing behavioural pin untouched |
| C8 guards red by mutation | All four mechanisms (C1 refusal, C2 solve, C3 shuffle, C5 product cap) disabled in turn; each named guard failed with the recorded message, then restored |

The first full-scale corpus run surfaced one *oracle* blind spot, not a solver defect: a number ordered against a scalar can be left a fractional propagated range where the generator falls back to two-decimal floats an integer-domain oracle can't model. The solver already declines those components; the family is pinned as a 500-seed regression test and documented in the report as the boundary of the solver's claim.

The corpus harness is committed (`generateNetwork.corpus.test.ts`) and runs at a small scale in CI (600 shapes × 8 seeds), scaling to the full evidence run via `CORPUS_SHAPES` / `CORPUS_SEEDS` / `CORPUS_SHARD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added finite-domain constraint solving for tractable synthetic data generation scenarios.
  * Improved feasibility analysis for complex comparisons, uniqueness, and “different from” constraints.
  * Added deterministic, seed-based backtracking to produce valid assignments while preserving variation.
  * Added safe fallback behavior when solver limits are exceeded.

* **Bug Fixes**
  * Corrected scalar and numeric boundary handling in strict comparisons.

* **Documentation**
  * Added implementation specifications and a completion report for the constraint-solving work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->