### PR TITLE
Activate protocol import card on file drag

### DIFF
--- a/.changeset/fiery-birds-give.md
+++ b/.changeset/fiery-birds-give.md
@@ -1,0 +1,7 @@
+---
+"@codaco/interviewer": patch
+---
+
+Bring the Import a protocol card to the front when a protocol file is dragged
+over Interviewer, and improve the card's text and icon scaling on smaller
+screens.

--- a/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/DeckCard.tsx
@@ -25,7 +25,7 @@ import { cx } from '@codaco/fresco-ui/utils/cva';
 import { protocolDataViewPath } from '~/components/DataView/dataViewUrlState';
 import type { ProtocolWithCounts } from '~/lib/db/types';
 
-import { cardBase } from './cardStyles';
+import { cardBase, cardHeadingSizeClass } from './cardStyles';
 
 function Pill({
   children,
@@ -72,22 +72,6 @@ function withUnderscoreBreaks(name: string): ReactNode[] {
   return parts.flatMap((part, index) =>
     index < parts.length - 1 ? [`${part}_`, <wbr key={index} />] : [part],
   );
-}
-
-// Step the heading size down as names get longer so multi-line names stay
-// inside the heading's flex region instead of squeezing the description and
-// footer. Thresholds are pre-wrap character counts — crude, but stable: no
-// measurement loop, no reflow jitter, and the classes are static literals
-// so Tailwind's scanner emits them. Names are identifiers (machine-style
-// names often differ only at the END), so shrinking is preferred over
-// truncation; the fitted line clamp below is only a backstop for
-// pathological lengths. Each tier carries a pixel floor so the name stays
-// legible on the smallest cards — when text stops shrinking, the budget
-// hook trades description lines away instead.
-function headingSizeClass(name: string): string {
-  if (name.length <= 24) return 'text-[max(20px,8cqi)]';
-  if (name.length <= 48) return 'text-[max(18px,6.5cqi)]';
-  return 'text-[max(16px,5cqi)]';
 }
 
 // Ceiling on the description even when space allows — beyond this it trails
@@ -581,7 +565,7 @@ export function DeckCard(props: DeckCardProps) {
                   title={protocol.name}
                   className={cx(
                     'w-full text-left font-black wrap-break-word hyphens-auto',
-                    headingSizeClass(protocol.name),
+                    cardHeadingSizeClass(protocol.name),
                   )}
                   // line-height must be inline: leading-* utilities lose to
                   // the Heading component's own typography classes, so a

--- a/apps/interviewer/src/components/ProtocolCarousel/ImportTriggerCard.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ImportTriggerCard.tsx
@@ -5,7 +5,9 @@ import Heading from '@codaco/fresco-ui/typography/Heading';
 import { cx } from '@codaco/fresco-ui/utils/cva';
 
 import { ExternalLink } from '../ExternalLink';
-import { CARD_RADIUS_PX, cardBase } from './cardStyles';
+import { CARD_RADIUS_PX, cardBase, cardHeadingSizeClass } from './cardStyles';
+
+const IMPORT_HEADING = 'Import a protocol';
 
 type ImportTriggerCardProps = {
   // Carousel activation (click / Enter on the active card): opens the file
@@ -61,12 +63,23 @@ export function ImportTriggerCard({
       >
         <span
           aria-hidden
-          className="bg-surface text-sea-green inline-flex h-[84px] w-[84px] items-center justify-center rounded-full"
+          className="bg-surface text-sea-green inline-flex size-[clamp(52px,17.5cqi,84px)] items-center justify-center rounded-full"
         >
-          <Upload size={36} strokeWidth={2.5} aria-hidden />
+          <Upload
+            className="size-[clamp(24px,7.5cqi,36px)]"
+            strokeWidth={2.5}
+            aria-hidden
+          />
         </span>
-        <Heading level="h2" margin="none" className="text-text font-black">
-          Import a protocol
+        <Heading
+          level="h2"
+          margin="none"
+          className={cx(
+            'text-text font-black',
+            cardHeadingSizeClass(IMPORT_HEADING),
+          )}
+        >
+          {IMPORT_HEADING}
         </Heading>
         <span className="text-sm">
           Drop a <span className="font-monospace text-text">.netcanvas</span>{' '}

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.stories.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useCallback, useRef, useState } from 'react';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
 
 import type { CurrentProtocol } from '@codaco/protocol-validation';
 import type { ProtocolWithCounts } from '~/lib/db/types';
@@ -174,6 +174,42 @@ export const ChevronAndDotNavigation: Story = {
     await waitFor(() =>
       expect(dots[2]).toHaveAttribute('aria-current', 'true'),
     );
+  },
+};
+
+export const FileDragActivatesImportCard: Story = {
+  render: () => <DeckHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dots = await canvas.findAllByLabelText(/Go to card/);
+    const importDot = dots[dots.length - 1];
+    if (!importDot) throw new Error('Import card navigation dot not found');
+
+    await expect(dots[0]).toHaveAttribute('aria-current', 'true');
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(['netcanvas'], 'study.netcanvas', {
+        type: 'application/x-netcanvas',
+      }),
+    );
+    const dragEvent = (type: string) =>
+      new DragEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+
+    await fireEvent(document.body, dragEvent('dragenter'));
+
+    await waitFor(() =>
+      expect(importDot).toHaveAttribute('aria-current', 'true'),
+    );
+    await expect(canvas.getByRole('status')).toHaveTextContent(
+      'Import a protocol card selected',
+    );
+
+    await fireEvent(document.body, dragEvent('dragleave'));
   },
 };
 

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.stories.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.stories.tsx
@@ -49,7 +49,11 @@ async function uploadProtocolFile(canvas: ReturnType<typeof within>) {
 // to it, then the slot fills with the installed protocol), delete a
 // protocol (scale out, neighbours close the gap), and install the sample
 // (the slot's content swaps in place with simulated progress).
-function DeckHarness() {
+function DeckHarness({
+  newSessionProtocolHash,
+}: {
+  newSessionProtocolHash?: string;
+}) {
   const [protocols, setProtocols] = useState<ProtocolWithCounts[]>([
     makeProtocol('Friendship Ties', 'A quick two-prompt name generator.'),
     makeProtocol(
@@ -133,6 +137,8 @@ function DeckHarness() {
         }
         onInstallSample={installSample}
         onDismissSample={() => setShowSample(false)}
+        newSessionProtocolHash={newSessionProtocolHash}
+        onCancelNewSession={() => {}}
       />
     </div>
   );
@@ -210,6 +216,40 @@ export const FileDragActivatesImportCard: Story = {
     );
 
     await fireEvent(document.body, dragEvent('dragleave'));
+  },
+};
+
+export const FileDragDoesNotAnnounceSelectionDuringNewSession: Story = {
+  render: () => <DeckHarness newSessionProtocolHash="hash-Friendship Ties" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const status = canvas.getByRole('status');
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(
+      new File(['netcanvas'], 'study.netcanvas', {
+        type: 'application/x-netcanvas',
+      }),
+    );
+
+    await fireEvent(
+      document.body,
+      new DragEvent('dragenter', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
+
+    await expect(status).toBeEmptyDOMElement();
+
+    await fireEvent(
+      document.body,
+      new DragEvent('dragleave', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }),
+    );
   },
 };
 

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -408,7 +408,9 @@ export function ProtocolDeck({
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center">
       <output className="sr-only" aria-live="polite">
-        {isDragGlobal ? 'Import a protocol card selected' : ''}
+        {isDragGlobal && !newSessionActive
+          ? 'Import a protocol card selected'
+          : ''}
       </output>
       <AnimatePresence>
         {newSessionActive ? (

--- a/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
+++ b/apps/interviewer/src/components/ProtocolCarousel/ProtocolDeck.tsx
@@ -129,6 +129,7 @@ export function ProtocolDeck({
     getRootProps: getImportRootProps,
     getInputProps: getImportInputProps,
     isDragActive: isImportDragActive,
+    isDragGlobal,
     open: openImportDialog,
   } = useDropzone({
     onDrop: handleDrop,
@@ -250,6 +251,18 @@ export function ProtocolDeck({
     },
     [slides],
   );
+
+  useEffect(() => {
+    // File names are not reliably exposed until drop, so global drag state
+    // selects the target card while its dropzone remains the validation boundary.
+    if (!isDragGlobal || newSessionActive) return;
+    const importIndex = slides.findIndex(
+      (slide) => slide.entry.kind === 'import',
+    );
+    if (importIndex >= 0 && importIndex !== activeIndex) {
+      setActiveIndex(importIndex);
+    }
+  }, [activeIndex, isDragGlobal, newSessionActive, setActiveIndex, slides]);
 
   // Slot keys that were pending in the last committed deck, so a slot that
   // just TURNED pending (a user-started import) can be detected below.
@@ -394,6 +407,9 @@ export function ProtocolDeck({
 
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center">
+      <output className="sr-only" aria-live="polite">
+        {isDragGlobal ? 'Import a protocol card selected' : ''}
+      </output>
       <AnimatePresence>
         {newSessionActive ? (
           <motion.button

--- a/apps/interviewer/src/components/ProtocolCarousel/cardStyles.ts
+++ b/apps/interviewer/src/components/ProtocolCarousel/cardStyles.ts
@@ -7,3 +7,11 @@ export const cardBase = cva({
     'focus-visible:ring-sea-green focus-visible:ring-4 focus-visible:outline-none',
   ],
 });
+
+// Step headings down as labels get longer so they remain readable without
+// crowding lower-priority card content. Pixel floors keep small cards legible.
+export function cardHeadingSizeClass(label: string): string {
+  if (label.length <= 24) return 'text-[max(20px,8cqi)]';
+  if (label.length <= 48) return 'text-[max(18px,6.5cqi)]';
+  return 'text-[max(16px,5cqi)]';
+}


### PR DESCRIPTION
## Summary
- bring the Import a protocol card to the front when a file is dragged over Interviewer while keeping `.netcanvas` validation on the card dropzone
- reuse the protocol-card heading scale and make the upload badge and icon shrink with the card
- announce the automatic card selection and cover the document-level drag behavior in Storybook

## Test plan
- [x] `pnpm --filter @codaco/interviewer test` (444 tests)
- [x] `pnpm exec vitest run --project=storybook src/components/ProtocolCarousel/` (31 tests)
- [x] `pnpm exec vitest run --project=unit src/components/ProtocolCarousel/` (25 tests)
- [x] `pnpm --filter @codaco/interviewer typecheck`
- [x] `pnpm --filter @codaco/interviewer build`
- [x] `pnpm knip`
- [x] `pnpm lint`
- [x] `pnpm check:changesets`
- [x] verify responsive card sizing in the running app at medium and compact viewports
