### PR TITLE
fix(interview): keep Back inert at the interview start

### DIFF
--- a/.changeset/interview-first-stage-back.md
+++ b/.changeset/interview-first-stage-back.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interview': patch
+---
+
+Fix the Previous Step button at the start of an interview: it no longer lights up before there is anywhere to go back to, and pressing it when no earlier screen exists no longer silently breaks the current stage's own step-by-step navigation.

--- a/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
+++ b/packages/interview/src/hooks/__tests__/useInterviewNavigation.test.tsx
@@ -484,6 +484,68 @@ describe('useInterviewNavigation targeted skip routes', () => {
   });
 });
 
+describe('useInterviewNavigation Back at the interview start', () => {
+  it('keeps Back disabled on a fresh first stage even when a beforeNext handler registers', () => {
+    const { result } = renderStatefulNavigation(makeStages(2), 0);
+
+    act(() => {
+      result.current.registerBeforeNext(() => false);
+    });
+
+    expect(result.current.disableMoveBackward).toBe(true);
+  });
+
+  it('enables Back once the participant has attempted navigation on a handler stage', async () => {
+    const { result } = renderStatefulNavigation(makeStages(2), 0);
+
+    act(() => {
+      // Consumes the step internally, like a census moving intro -> first pair.
+      result.current.registerBeforeNext(() => false);
+    });
+
+    await act(async () => {
+      await result.current.moveForward();
+    });
+
+    expect(result.current.disableMoveBackward).toBe(false);
+  });
+
+  it('keeps Back disabled on a handler stage when every earlier screen is off the active route', () => {
+    const stages = makeStages(3);
+    stages[0]!.skipLogic = ALWAYS_SKIPPED;
+    const { result } = renderStatefulNavigation(stages, 1);
+
+    act(() => {
+      result.current.registerBeforeNext(() => false);
+    });
+
+    expect(result.current.disableMoveBackward).toBe(true);
+  });
+
+  it('leaves beforeNext handlers registered when Back has nowhere to go', async () => {
+    const { result, onStepChange } = renderStatefulNavigation(makeStages(2), 0);
+    const handler = vi.fn(() => true);
+
+    act(() => {
+      result.current.registerBeforeNext(handler);
+    });
+
+    await act(async () => {
+      await result.current.moveBackward();
+    });
+
+    // No previous stage: nothing to navigate to, and the stage's handler must
+    // survive so it still intercepts the next Forward.
+    expect(onStepChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.moveForward();
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('useInterviewNavigation goToStage (progress-bar jump)', () => {
   it('jumps directly to a non-skipped stage', async () => {
     const { result, onStepChange } = renderStatefulNavigation(makeStages(4), 0);

--- a/packages/interview/src/hooks/useInterviewNavigation.ts
+++ b/packages/interview/src/hooks/useInterviewNavigation.ts
@@ -62,6 +62,13 @@ export default function useInterviewNavigation(
   const [forceNavigationDisabled, setForceNavigationDisabled] = useState(false);
   const [beforeNextHandlerCount, setBeforeNextHandlerCount] = useState(0);
   const [reviewBoundaryReached, setReviewBoundaryReached] = useState(false);
+  // Whether any navigation has been attempted since the displayed stage
+  // mounted. A registered beforeNext handler only keeps Back enabled past the
+  // interview start once this is true: a freshly-mounted stage is at its
+  // internal starting position, so stage-internal Back has nothing to step
+  // back to yet.
+  const [hasAttemptedStageNavigation, setHasAttemptedStageNavigation] =
+    useState(false);
 
   // `showStage` toggles the rendered stage in/out of the JSX entirely so that
   // AnimatePresence sees "no child" during a transition (rather than a child
@@ -175,6 +182,7 @@ export default function useInterviewNavigation(
 
   const moveForward = useCallback(async () => {
     setForceNavigationDisabled(true);
+    setHasAttemptedStageNavigation(true);
 
     try {
       const stageAllowsNavigation = await canNavigate('forwards', 'step');
@@ -225,6 +233,7 @@ export default function useInterviewNavigation(
 
   const moveBackward = useCallback(async () => {
     setForceNavigationDisabled(true);
+    setHasAttemptedStageNavigation(true);
 
     try {
       const stageAllowsNavigation = await canNavigate('backwards', 'step');
@@ -245,6 +254,12 @@ export default function useInterviewNavigation(
         currentStepRef.current,
       );
       const previousStep = navigation.previousValidStageIndex;
+      // No earlier stage on the active route: there is nowhere to go, so bail
+      // out before clearing handlers — a same-step setStep never remounts the
+      // stage, and clearing would permanently detach its beforeNext handlers.
+      if (previousStep === currentStepRef.current) {
+        return;
+      }
       const meta = getInterviewProgress(protocolStages, previousStep);
       setProgress(meta.progress);
       registerBeforeNext(null);
@@ -273,6 +288,7 @@ export default function useInterviewNavigation(
       }
 
       setForceNavigationDisabled(true);
+      setHasAttemptedStageNavigation(true);
 
       try {
         const direction: Direction =
@@ -354,6 +370,7 @@ export default function useInterviewNavigation(
     beforeNextHandlers.current.clear();
     setBeforeNextHandlerCount(0);
     setReviewBoundaryReached(false);
+    setHasAttemptedStageNavigation(false);
     setShowStage(true);
   }, [commitDisplayedStep, dispatch]);
 
@@ -432,7 +449,7 @@ export default function useInterviewNavigation(
       forceNavigationDisabled ||
       isTransitioning ||
       ((!canMoveBackward || (isFirstPrompt && !hasPreviousAvailableStage)) &&
-        beforeNextHandlers.current.size === 0),
+        (beforeNextHandlerCount === 0 || !hasAttemptedStageNavigation)),
     pulseNext:
       (!isAtReviewEnd ||
         (beforeNextHandlerCount > 0 && !reviewBoundaryReached)) &&


### PR DESCRIPTION
## Summary

All three release-lane PRs (#1092, #1096, #1097) are currently blocked by 58 `interview-e2e` failures — every one the same one-line aria diff: the initial snapshot expects `button "Previous Step" [disabled]` on the first stage, but it now renders enabled.

**Root cause:** #1110 added `setBeforeNextHandlerCount(...)` inside `registerBeforeNext` (for review-mode forward gating). That state update re-renders the navigation hook the moment a stage registers its `beforeNext` handler on mount. `disableMoveBackward`'s escape clause read handler presence from a ref (`beforeNextHandlers.current.size === 0`), so pre-#1110 no re-render followed registration and the button stayed disabled at mount; post-#1110 it renders enabled from the first frame on every interface that registers a handler at mount (DyadCensus, TieStrengthCensus, OneToManyDyadCensus, FamilyPedigree, Geospatial, min-nodes name generators).

**The enabled button is not just cosmetic.** Pressing Back with no previous navigable stage runs `moveBackward`'s stage-level path: `previousValidStageIndex` clamps to the current step, so it cleared the stage's `beforeNext` handlers via `registerBeforeNext(null)` and then set the *same* step — no remount, so `useBeforeNext`'s effect never re-registers, and the next Forward click bypasses the stage's internal stepping (e.g. exits a census from its intro, skipping every pair). That path predates #1110 (it was already reachable once the button flipped enabled after any interaction, and via skip-logic hiding every earlier stage); #1110 just put it one click away from interview start.

## Fix

- `moveBackward` bails out before touching handlers when there is no earlier stage on the active route.
- The handler-presence escape in `disableMoveBackward` now only applies once navigation has been attempted on the current stage (tracked in state, reset on stage transition). A freshly-mounted stage is at its internal starting position, so stage-internal Back has nothing to step back to. This also replaces the render-timing-dependent ref read with deterministic state.

This reproduces exactly the rendered behaviour every committed aria baseline encodes (initial: disabled; after interaction on a handler stage: enabled), so **zero baseline changes** are needed.

Worth a follow-up discussion: the deeper design issue is that the interview level cannot know whether a stage can handle Back internally — a stage-reported capability would let the button reflect reality instead of a heuristic.

## Test plan

- [x] TDD: three new unit tests reproduce the regression and the handler-clearing bug on `main`, pass with the fix (34/34 in the file)
- [x] Full interview units project: 1222 passed
- [x] Full `chromium-matrix` e2e suite in the CI Docker image: **237 passed, zero snapshot changes**
- [x] `pnpm --filter @codaco/interview typecheck` passes
- [x] Changeset: `@codaco/interview` patch (library lane), `pnpm check:changesets` passes
