### PR TITLE
fix(tsconfig): enable strict in the shared base config

### DIFF
--- a/tooling/typescript/base.json
+++ b/tooling/typescript/base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ES2024",
     "lib": ["ES2024"],
+    "strict": true,
     "allowJs": true,
     "checkJs": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

`tooling/typescript/base.json` (and `web.json`/`dev.json` extending it) never set `"strict": true` — strict was only enabled per-app in `apps/*/tsconfig.app.json`. Every `packages/*` typecheck program, the apps' `tsconfig.node.json` programs, the two Next.js sites' configs, and the workers' configs ran **without strict**, contradicting the repo CLAUDE.md's "Strict type checking enabled across all packages". (Verified with `tsc --showConfig`; surfaced while fixing the e2e tsconfigs in #1112.)

The gap was masked by the source-first architecture: apps compile package source inside their own strict `tsconfig.app.json` programs, so package source stayed strict-clean even though the packages' own gates never enforced it.

**Audit before changing anything:** all 20 programs that extend the shared base were measured with `--strict` — every one is already clean (0 errors). The only failures seen were 3 pre-existing stale-`.next` artifact errors per Next.js site in the local checkout, present with and without strict. So this is pure enforcement: one line, no code changes.

## Test plan

- [x] Per-program audit: 14 package/tooling programs + 2 app node configs + 2 sites + 2 workers, all 0 errors under `--strict`
- [x] `pnpm typecheck` — 15/15 tasks pass, fully uncached (the base change invalidates every typecheck hash, confirming Turbo picks it up)

Merge-order note: independent of #1112 and #1113; the `strict: true` in #1112's e2e tsconfigs becomes redundant-but-harmless once this lands.