### PR TITLE
fix(fresco-ui): restore label association on RelativeDatePicker

### DIFF
--- a/.changeset/relative-date-picker-label-association.md
+++ b/.changeset/relative-date-picker-label-association.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+RelativeDatePickerField now forwards the id supplied by Field to its native date input, restoring the label/input association so screen readers announce the field's label when the input receives focus.

--- a/packages/fresco-ui/src/form/fields/RelativeDatePicker.tsx
+++ b/packages/fresco-ui/src/form/fields/RelativeDatePicker.tsx
@@ -38,6 +38,7 @@ export default function RelativeDatePickerField(
     size = 'md',
     placeholder,
     className,
+    id,
     disabled,
     readOnly,
     ...rest
@@ -49,6 +50,7 @@ export default function RelativeDatePickerField(
 
   return (
     <InputField
+      id={id}
       type="date"
       size={size}
       min={minYmd}

--- a/packages/fresco-ui/src/form/fields/__tests__/RelativeDatePicker.test.tsx
+++ b/packages/fresco-ui/src/form/fields/__tests__/RelativeDatePicker.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import UnconnectedField from '../../Field/UnconnectedField';
+import RelativeDatePickerField from '../RelativeDatePicker';
+
+describe('RelativeDatePickerField accessibility', () => {
+  it('renders the native date input with the given id', () => {
+    const { container } = render(
+      <RelativeDatePickerField
+        name="date"
+        id="relative-date-id"
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+
+    const input = container.querySelector('input[type="date"]');
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('date input not rendered');
+    }
+    expect(input).toHaveAttribute('id', 'relative-date-id');
+  });
+
+  it('associates the visible label and error description', () => {
+    render(
+      <UnconnectedField
+        name="date"
+        label="Interview date"
+        hint="Choose carefully"
+        component={RelativeDatePickerField}
+        value=""
+        onChange={() => undefined}
+      />,
+    );
+
+    const control = screen.getByLabelText('Interview date');
+    expect(control).toHaveAccessibleDescription('Choose carefully');
+  });
+});


### PR DESCRIPTION
## Summary

- `RelativeDatePickerField` dropped the `id` that `Field` injects, so the `<label htmlFor={id}>` rendered by `BaseField` never matched any DOM id — the native date input rendered with no `id` at all, breaking the label/input association for assistive technology on every RelativeDatePicker field.
- Forward the injected `id` to the underlying `InputField`, matching how `DatePickerField` already handles it.
- Add `RelativeDatePicker.test.tsx` asserting the native input carries a directly-passed `id`, and that the visible label and hint resolve via `getByLabelText`/accessible description when rendered inside `UnconnectedField` (mirroring the existing `DatePicker.test.tsx` accessibility tests).
- Changeset: `@codaco/fresco-ui` patch.

Found incidentally while testing `useProtocolForm` date-window validation.

## Test plan

- [x] New tests fail without the fix, pass with it
- [x] `pnpm run test` in `packages/fresco-ui` (72 files, 924 tests pass)
- [x] `pnpm run typecheck` in `packages/fresco-ui`
- [x] `pnpm knip` and `pnpm check:changesets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)