### PR TITLE
docs: document Architect template editor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ pnpm --filter "./packages/*" build
 pnpm --filter "./apps/*" dev
 ```
 
+### Architect Template Editor Mode
+
+Architect includes a development-only template editor mode for maintainers of
+the bundled research templates. Start it from the monorepo root:
+
+```bash
+pnpm --filter @codaco/architect dev:protocols
+```
+
+Open a protocol from Architect's **Templates** tab (or the Sample or
+Development protocol), then use **Save to source** in the editor toolbar. The
+mode validates the protocol and writes it back to its canonical entry in
+[`packages/protocols`](./packages/protocols), including the associated assets.
+It also removes asset files that the saved protocol no longer references, so
+review the resulting Git diff before committing. This workflow is unavailable
+in production builds and does not save ordinary protocols created or imported
+by a researcher.
+
 ### Working with Cloudflare Workers
 
 ```bash


### PR DESCRIPTION
## Summary
- Document the development-only Architect template editor workflow in the root README.
- Explain source saving, asset synchronization, and the production restriction.

## Test plan
- [x] `CI=true pnpm lint:fix`
- [x] `CI=true pnpm typecheck`
- [x] `CI=true pnpm knip`
- [x] `CI=true pnpm check:changesets`
- [x] `pnpm exec oxfmt --check README.md`
- [x] `git diff --check`