### PR TITLE
Explain Classic app downloads on summer update

### DIFF
--- a/.changeset/classic-app-definitions.md
+++ b/.changeset/classic-app-definitions.md
@@ -1,0 +1,5 @@
+---
+"networkcanvas.com": patch
+---
+
+Explain the original Classic apps and link to their downloads from the Summer 2026 update.

--- a/.changeset/interactive-definition-content.md
+++ b/.changeset/interactive-definition-content.md
@@ -1,0 +1,5 @@
+---
+"@codaco/fresco-ui": patch
+---
+
+Allow Definition popovers to contain keyboard-accessible links and controls.

--- a/apps/interviewer/src/components/SetupWizard/__tests__/Step3Configure.test.tsx
+++ b/apps/interviewer/src/components/SetupWizard/__tests__/Step3Configure.test.tsx
@@ -88,6 +88,9 @@ describe('Step3Configure — read-only summary reconciliation', () => {
     render(<Step3Configure allowChange={false} />);
 
     expect(await screen.findByText('PIN configured.')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(setNextEnabledMock).toHaveBeenLastCalledWith(true),
+    );
     expect(
       screen.queryByRole('button', { name: 'Change' }),
     ).not.toBeInTheDocument();

--- a/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
+++ b/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
@@ -15,11 +15,6 @@ import { Alert, AlertDescription, AlertTitle } from '@codaco/fresco-ui/Alert';
 import Definition from '@codaco/fresco-ui/Definition';
 import Surface from '@codaco/fresco-ui/layout/Surface';
 import { NativeLink } from '@codaco/fresco-ui/NativeLink';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@codaco/fresco-ui/Popover';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import InterfacePicture from '@codaco/interface-images/InterfacePicture';
@@ -66,71 +61,6 @@ function renderGetStartedLink(chunks: ReactNode) {
       {chunks}
     </Link>
   );
-}
-
-function ClassicAppDefinition({
-  app,
-  children,
-}: {
-  app: ClassicAppId;
-  children: ReactNode;
-}) {
-  const t = useTranslations('SummerUpdate');
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="text-link focusable inline-block cursor-help rounded-sm underline decoration-dashed decoration-2 underline-offset-3"
-        >
-          {children}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent className="w-max max-w-[min(var(--available-width),var(--container-sm))] text-pretty">
-        <Paragraph intent="smallText" margin="none">
-          {t(`definitions.${app}.description`)}
-        </Paragraph>
-        <Paragraph intent="smallText" margin="none" className="mt-3">
-          {t.rich(`definitions.${app}.download`, {
-            link: renderGetStartedLink,
-          })}
-        </Paragraph>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function renderArchitectClassic(chunks: ReactNode) {
-  return (
-    <ClassicAppDefinition app="architectClassic">{chunks}</ClassicAppDefinition>
-  );
-}
-
-function renderInterviewerClassic(chunks: ReactNode) {
-  return (
-    <ClassicAppDefinition app="interviewerClassic">
-      {chunks}
-    </ClassicAppDefinition>
-  );
-}
-
-function renderCompatibilityAppName(id: string, app: string) {
-  if (id === 'architectClassic') {
-    return (
-      <ClassicAppDefinition app="architectClassic">{app}</ClassicAppDefinition>
-    );
-  }
-
-  if (id === 'interviewerClassic') {
-    return (
-      <ClassicAppDefinition app="interviewerClassic">
-        {app}
-      </ClassicAppDefinition>
-    );
-  }
-
-  return app;
 }
 
 function ProgressiveWebAppTerm({
@@ -221,6 +151,27 @@ function renderCommunityLink(chunks: ReactNode) {
 
 export function SummerUpdatePage() {
   const t = useTranslations('SummerUpdate');
+  const renderClassicAppTerm = (app: ClassicAppId, chunks: ReactNode) => (
+    <Definition
+      interactive
+      definition={t.rich(`definitions.${app}`, {
+        link: renderGetStartedLink,
+      })}
+    >
+      {chunks}
+    </Definition>
+  );
+  const renderArchitectClassic = (chunks: ReactNode) =>
+    renderClassicAppTerm('architectClassic', chunks);
+  const renderInterviewerClassic = (chunks: ReactNode) =>
+    renderClassicAppTerm('interviewerClassic', chunks);
+  const renderCompatibilityAppName = (id: string, app: string) => {
+    if (id === 'architectClassic' || id === 'interviewerClassic') {
+      return renderClassicAppTerm(id, app);
+    }
+
+    return app;
+  };
   const { compatibilityRows, destinationLinks, interfaceFeatures } =
     useSummerUpdateContent();
   const featureGroupHeadings: Record<FeatureGroup, string> = {

--- a/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
+++ b/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
@@ -803,6 +803,9 @@ export function SummerUpdatePage() {
                     </div>
                     {compatibilityRows.map((row, index) => {
                       const previousGroup = compatibilityRows[index - 1]?.group;
+                      const hasClassicAppDefinition =
+                        row.id === 'architectClassic' ||
+                        row.id === 'interviewerClassic';
                       return (
                         <div key={`${row.app}-${row.version ?? 'current'}`}>
                           {row.group !== previousGroup ? (
@@ -822,14 +825,6 @@ export function SummerUpdatePage() {
                                 'bg-sea-serpent/10',
                             )}
                           >
-                            <span className="text-text font-bold">
-                              {renderCompatibilityAppName(row.id, row.app)}{' '}
-                              {row.version ? (
-                                <span className="font-monospace text-xs font-normal text-current/50">
-                                  {row.version}
-                                </span>
-                              ) : null}
-                            </span>
                             <button
                               type="button"
                               aria-label={t(
@@ -849,15 +844,38 @@ export function SummerUpdatePage() {
                                 },
                               )}
                               aria-pressed={selectedCompatibilityRow === index}
-                              className="focusable col-span-3 grid grid-cols-3 items-center gap-4 text-left"
+                              className="focusable col-span-4 grid grid-cols-4 items-center gap-4 text-left"
                               onClick={() => setSelectedCompatibilityRow(index)}
                             >
+                              <span
+                                className={cn(
+                                  'text-text font-bold',
+                                  hasClassicAppDefinition && 'invisible',
+                                )}
+                              >
+                                {row.app}{' '}
+                                {row.version ? (
+                                  <span className="font-monospace text-xs font-normal text-current/50">
+                                    {row.version}
+                                  </span>
+                                ) : null}
+                              </span>
                               <span className="text-sm text-current/65">
                                 {row.platform}
                               </span>
                               <StatusChip status={row.schema7} />
                               <StatusChip status={row.schema8} />
                             </button>
+                            {hasClassicAppDefinition ? (
+                              <span className="text-text z-10 col-start-1 row-start-1 font-bold">
+                                {renderCompatibilityAppName(row.id, row.app)}{' '}
+                                {row.version ? (
+                                  <span className="font-monospace text-xs font-normal text-current/50">
+                                    {row.version}
+                                  </span>
+                                ) : null}
+                              </span>
+                            ) : null}
                           </div>
                         </div>
                       );

--- a/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
+++ b/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
@@ -15,12 +15,18 @@ import { Alert, AlertDescription, AlertTitle } from '@codaco/fresco-ui/Alert';
 import Definition from '@codaco/fresco-ui/Definition';
 import Surface from '@codaco/fresco-ui/layout/Surface';
 import { NativeLink } from '@codaco/fresco-ui/NativeLink';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@codaco/fresco-ui/Popover';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import InterfacePicture from '@codaco/interface-images/InterfacePicture';
 import { Footer } from '~/components/layout/Footer';
 import { Reveal } from '~/components/ui/Reveal';
 import { cn } from '~/lib/cn';
+import { Link } from '~/lib/i18n/navigation';
 
 import { ActionButton } from './ActionButton';
 import { BenefitCard } from './BenefitCard';
@@ -47,6 +53,84 @@ function renderDefinitionName(chunks: ReactNode) {
 
 function renderStrong(chunks: ReactNode) {
   return <strong>{chunks}</strong>;
+}
+
+type ClassicAppId = 'architectClassic' | 'interviewerClassic';
+
+function renderGetStartedLink(chunks: ReactNode) {
+  return (
+    <Link
+      className="text-link focusable rounded-sm underline underline-offset-3"
+      href="/get-started"
+    >
+      {chunks}
+    </Link>
+  );
+}
+
+function ClassicAppDefinition({
+  app,
+  children,
+}: {
+  app: ClassicAppId;
+  children: ReactNode;
+}) {
+  const t = useTranslations('SummerUpdate');
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="text-link focusable inline-block cursor-help rounded-sm underline decoration-dashed decoration-2 underline-offset-3"
+        >
+          {children}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-max max-w-[min(var(--available-width),var(--container-sm))] text-pretty">
+        <Paragraph intent="smallText" margin="none">
+          {t(`definitions.${app}.description`)}
+        </Paragraph>
+        <Paragraph intent="smallText" margin="none" className="mt-3">
+          {t.rich(`definitions.${app}.download`, {
+            link: renderGetStartedLink,
+          })}
+        </Paragraph>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function renderArchitectClassic(chunks: ReactNode) {
+  return (
+    <ClassicAppDefinition app="architectClassic">{chunks}</ClassicAppDefinition>
+  );
+}
+
+function renderInterviewerClassic(chunks: ReactNode) {
+  return (
+    <ClassicAppDefinition app="interviewerClassic">
+      {chunks}
+    </ClassicAppDefinition>
+  );
+}
+
+function renderCompatibilityAppName(id: string, app: string) {
+  if (id === 'architectClassic') {
+    return (
+      <ClassicAppDefinition app="architectClassic">{app}</ClassicAppDefinition>
+    );
+  }
+
+  if (id === 'interviewerClassic') {
+    return (
+      <ClassicAppDefinition app="interviewerClassic">
+        {app}
+      </ClassicAppDefinition>
+    );
+  }
+
+  return app;
 }
 
 function ProgressiveWebAppTerm({
@@ -159,7 +243,12 @@ export function SummerUpdatePage() {
       ? undefined
       : compatibilityRows[selectedCompatibilityRow];
   const compatibilityNote =
-    selectedCompatibility?.note ?? t('compatibility.defaultNote');
+    selectedCompatibility === undefined
+      ? t('compatibility.defaultNote')
+      : t.rich(`compatibility.rows.${selectedCompatibility.id}.note`, {
+          architectClassic: renderArchitectClassic,
+          interviewerClassic: renderInterviewerClassic,
+        });
   if (!activeInterface) return null;
 
   return (
@@ -227,6 +316,8 @@ export function SummerUpdatePage() {
               <AlertTitle>{t('overview.classic.title')}</AlertTitle>
               <AlertDescription>
                 {t.rich('overview.classic.description', {
+                  architectClassic: renderArchitectClassic,
+                  interviewerClassic: renderInterviewerClassic,
                   strong: renderStrong,
                 })}
               </AlertDescription>
@@ -314,7 +405,9 @@ export function SummerUpdatePage() {
                   emphasis="muted"
                   className="mt-6 text-current/55"
                 >
-                  {t('apps.architect.classicNote')}
+                  {t.rich('apps.architect.classicNote', {
+                    architectClassic: renderArchitectClassic,
+                  })}
                 </Paragraph>
               </Reveal>
 
@@ -400,7 +493,10 @@ export function SummerUpdatePage() {
                   emphasis="muted"
                   className="mt-6 text-current/55"
                 >
-                  {t('apps.interviewer.classicNote')}
+                  {t.rich('apps.interviewer.classicNote', {
+                    architectClassic: renderArchitectClassic,
+                    interviewerClassic: renderInterviewerClassic,
+                  })}
                 </Paragraph>
               </Reveal>
 
@@ -768,42 +864,50 @@ export function SummerUpdatePage() {
                               {row.group}
                             </div>
                           ) : null}
-                          <button
-                            type="button"
-                            aria-label={t(
-                              row.version
-                                ? 'compatibility.rowAccessibleNameWithVersion'
-                                : 'compatibility.rowAccessibleName',
-                              {
-                                app: row.app,
-                                platform: row.platform,
-                                schema7: t(
-                                  `compatibility.statuses.${row.schema7}`,
-                                ),
-                                schema8: t(
-                                  `compatibility.statuses.${row.schema8}`,
-                                ),
-                                version: row.version ?? '',
-                              },
+                          <div
+                            className={cn(
+                              'border-text/10 has-[button:hover]:bg-text/5 grid grid-cols-4 items-center gap-4 border-t px-6 py-4 transition first:border-t-0',
+                              selectedCompatibilityRow === index &&
+                                'bg-sea-serpent/10',
                             )}
-                            aria-pressed={selectedCompatibilityRow === index}
-                            className="focusable border-text/10 hover:bg-text/5 aria-pressed:bg-sea-serpent/10 grid w-full grid-cols-4 items-center gap-4 border-t px-6 py-4 text-left transition first:border-t-0"
-                            onClick={() => setSelectedCompatibilityRow(index)}
                           >
                             <span className="text-text font-bold">
-                              {row.app}{' '}
+                              {renderCompatibilityAppName(row.id, row.app)}{' '}
                               {row.version ? (
                                 <span className="font-monospace text-xs font-normal text-current/50">
                                   {row.version}
                                 </span>
                               ) : null}
                             </span>
-                            <span className="text-sm text-current/65">
-                              {row.platform}
-                            </span>
-                            <StatusChip status={row.schema7} />
-                            <StatusChip status={row.schema8} />
-                          </button>
+                            <button
+                              type="button"
+                              aria-label={t(
+                                row.version
+                                  ? 'compatibility.rowAccessibleNameWithVersion'
+                                  : 'compatibility.rowAccessibleName',
+                                {
+                                  app: row.app,
+                                  platform: row.platform,
+                                  schema7: t(
+                                    `compatibility.statuses.${row.schema7}`,
+                                  ),
+                                  schema8: t(
+                                    `compatibility.statuses.${row.schema8}`,
+                                  ),
+                                  version: row.version ?? '',
+                                },
+                              )}
+                              aria-pressed={selectedCompatibilityRow === index}
+                              className="focusable col-span-3 grid grid-cols-3 items-center gap-4 text-left"
+                              onClick={() => setSelectedCompatibilityRow(index)}
+                            >
+                              <span className="text-sm text-current/65">
+                                {row.platform}
+                              </span>
+                              <StatusChip status={row.schema7} />
+                              <StatusChip status={row.schema8} />
+                            </button>
+                          </div>
                         </div>
                       );
                     })}
@@ -844,7 +948,9 @@ export function SummerUpdatePage() {
                   </Paragraph>
                   <Paragraph className="border-mustard/35 bg-mustard/10 rounded-sm border p-4">
                     {t.rich('compatibility.caution.fileNote', {
+                      architectClassic: renderArchitectClassic,
                       file: renderProtocolFile,
+                      interviewerClassic: renderInterviewerClassic,
                     })}
                   </Paragraph>
                 </div>
@@ -891,7 +997,10 @@ export function SummerUpdatePage() {
                     {t('compatibility.upgrade.ongoing.heading')}
                   </Heading>
                   <Paragraph className="">
-                    {t('compatibility.upgrade.ongoing.description')}
+                    {t.rich('compatibility.upgrade.ongoing.description', {
+                      architectClassic: renderArchitectClassic,
+                      interviewerClassic: renderInterviewerClassic,
+                    })}
                   </Paragraph>
                 </Surface>
               </Reveal>

--- a/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
+++ b/apps/networkcanvas.com/components/summer-update/SummerUpdatePage.tsx
@@ -52,15 +52,22 @@ function renderStrong(chunks: ReactNode) {
 
 type ClassicAppId = 'architectClassic' | 'interviewerClassic';
 
-function renderGetStartedLink(chunks: ReactNode) {
-  return (
-    <Link
-      className="text-link focusable rounded-sm underline underline-offset-3"
-      href="/get-started"
-    >
-      {chunks}
-    </Link>
-  );
+const classicAppDownloadHrefs = {
+  architectClassic: '/get-started/#design',
+  interviewerClassic: '/get-started/#collect',
+} satisfies Record<ClassicAppId, string>;
+
+function renderGetStartedLink(href: string) {
+  return function renderLink(chunks: ReactNode) {
+    return (
+      <Link
+        className="text-link focusable rounded-sm underline underline-offset-3"
+        href={href}
+      >
+        {chunks}
+      </Link>
+    );
+  };
 }
 
 function ProgressiveWebAppTerm({
@@ -155,7 +162,7 @@ export function SummerUpdatePage() {
     <Definition
       interactive
       definition={t.rich(`definitions.${app}`, {
-        link: renderGetStartedLink,
+        link: renderGetStartedLink(classicAppDownloadHrefs[app]),
       })}
     >
       {chunks}
@@ -820,7 +827,7 @@ export function SummerUpdatePage() {
                           ) : null}
                           <div
                             className={cn(
-                              'border-text/10 has-[button:hover]:bg-text/5 grid grid-cols-4 items-center gap-4 border-t px-6 py-4 transition first:border-t-0',
+                              'border-text/10 has-[button:hover]:bg-text/5 relative grid grid-cols-4 items-center gap-4 border-t px-6 py-4 transition first:border-t-0',
                               selectedCompatibilityRow === index &&
                                 'bg-sea-serpent/10',
                             )}
@@ -867,8 +874,9 @@ export function SummerUpdatePage() {
                               <StatusChip status={row.schema8} />
                             </button>
                             {hasClassicAppDefinition ? (
-                              <span className="text-text z-10 col-start-1 row-start-1 font-bold">
-                                {renderCompatibilityAppName(row.id, row.app)}{' '}
+                              <span className="text-text absolute inset-y-0 left-6 z-10 flex items-center font-bold">
+                                {renderCompatibilityAppName(row.id, row.app)}
+                                {' '}
                                 {row.version ? (
                                   <span className="font-monospace text-xs font-normal text-current/50">
                                     {row.version}

--- a/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
+++ b/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -451,15 +452,15 @@ describe('SummerUpdatePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('explains every Classic app term and provides an accessible download link', () => {
+  it('explains every Classic app term and provides an accessible download link', async () => {
     renderWithIntl(<SummerUpdatePage />);
 
-    const architectClassicTerms = screen.getAllByRole('button', {
-      name: 'Architect Classic',
-    });
-    const interviewerClassicTerms = screen.getAllByRole('button', {
-      name: 'Interviewer Classic',
-    });
+    const architectClassicTerms = screen
+      .getAllByText('Architect Classic')
+      .filter((term) => term.getAttribute('tabindex') === '0');
+    const interviewerClassicTerms = screen
+      .getAllByText('Interviewer Classic')
+      .filter((term) => term.getAttribute('tabindex') === '0');
 
     expect(architectClassicTerms).toHaveLength(6);
     expect(interviewerClassicTerms).toHaveLength(5);
@@ -469,15 +470,18 @@ describe('SummerUpdatePage', () => {
       throw new Error('Expected an Architect Classic definition trigger.');
     }
 
-    fireEvent.click(architectClassicTerm);
+    await act(async () => {
+      architectClassicTerm.focus();
+    });
 
-    expect(
-      screen.getByText(
-        'The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.',
-      ),
-    ).toBeInTheDocument();
+    const definitionPopover = screen.getByRole('dialog');
+    expect(definitionPopover).toHaveTextContent(
+      'The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features. Download it here.',
+    );
 
-    const downloadLink = screen.getByRole('link', { name: 'here' });
+    const downloadLink = within(definitionPopover).getByRole('link', {
+      name: 'here',
+    });
     expect(downloadLink).toHaveAttribute('href', '/get-started');
     expect(downloadLink).not.toHaveAttribute('tabindex', '-1');
   });
@@ -660,7 +664,7 @@ describe('SummerUpdatePage', () => {
     );
   });
 
-  it('localizes feature interactions, images, and compatibility statuses in Spanish', () => {
+  it('localizes feature interactions, images, and compatibility statuses in Spanish', async () => {
     renderWithIntl(<SummerUpdatePage />, 'es');
 
     expect(
@@ -684,21 +688,24 @@ describe('SummerUpdatePage', () => {
       }),
     ).toBeInTheDocument();
 
-    const [architectClassicTerm] = screen.getAllByRole('button', {
-      name: 'Architect Classic',
-    });
+    const [architectClassicTerm] = screen
+      .getAllByText('Architect Classic')
+      .filter((term) => term.getAttribute('tabindex') === '0');
     if (!architectClassicTerm) {
       throw new Error('Expected an Architect Classic definition trigger.');
     }
 
-    fireEvent.click(architectClassicTerm);
+    await act(async () => {
+      architectClassicTerm.focus();
+    });
 
+    const definitionPopover = screen.getByRole('dialog');
+    expect(definitionPopover).toHaveTextContent(
+      'La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas. Descárguela aquí.',
+    );
     expect(
-      screen.getByText(
-        'La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.',
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'aquí' })).toHaveAttribute(
+      within(definitionPopover).getByRole('link', { name: 'aquí' }),
+    ).toHaveAttribute(
       'href',
       '/get-started',
     );

--- a/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
+++ b/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
@@ -452,6 +452,22 @@ describe('SummerUpdatePage', () => {
     ).toBeInTheDocument();
   });
 
+  it('selects a compatibility row when its app cell is clicked', () => {
+    renderWithIntl(<SummerUpdatePage />);
+
+    const frescoCompatibilityRow = screen.getByRole('button', {
+      name: 'Fresco 3.1.2, Browser: Schema 7 Native; Schema 8 Not supported',
+    });
+
+    fireEvent.click(within(frescoCompatibilityRow).getByText('Fresco'));
+
+    expect(
+      screen.getByText(
+        /Fresco 3\.1\.2 supports Schema 7 protocols but does not support Schema 8 protocols/,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('explains every Classic app term and provides an accessible download link', async () => {
     renderWithIntl(<SummerUpdatePage />);
 
@@ -705,10 +721,7 @@ describe('SummerUpdatePage', () => {
     );
     expect(
       within(definitionPopover).getByRole('link', { name: 'aquí' }),
-    ).toHaveAttribute(
-      'href',
-      '/get-started',
-    );
+    ).toHaveAttribute('href', '/get-started');
 
     fireEvent.click(screen.getByRole('button', { name: 'Anonimización' }));
 

--- a/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
+++ b/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
@@ -451,6 +451,37 @@ describe('SummerUpdatePage', () => {
     ).toBeInTheDocument();
   });
 
+  it('explains every Classic app term and provides an accessible download link', () => {
+    renderWithIntl(<SummerUpdatePage />);
+
+    const architectClassicTerms = screen.getAllByRole('button', {
+      name: 'Architect Classic',
+    });
+    const interviewerClassicTerms = screen.getAllByRole('button', {
+      name: 'Interviewer Classic',
+    });
+
+    expect(architectClassicTerms).toHaveLength(6);
+    expect(interviewerClassicTerms).toHaveLength(5);
+
+    const [architectClassicTerm] = architectClassicTerms;
+    if (!architectClassicTerm) {
+      throw new Error('Expected an Architect Classic definition trigger.');
+    }
+
+    fireEvent.click(architectClassicTerm);
+
+    expect(
+      screen.getByText(
+        'The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.',
+      ),
+    ).toBeInTheDocument();
+
+    const downloadLink = screen.getByRole('link', { name: 'here' });
+    expect(downloadLink).toHaveAttribute('href', '/get-started');
+    expect(downloadLink).not.toHaveAttribute('tabindex', '-1');
+  });
+
   it('introduces the redesigned project website and documentation', () => {
     renderWithIntl(<SummerUpdatePage />);
 
@@ -652,6 +683,25 @@ describe('SummerUpdatePage', () => {
         name: 'Panel de Interviewer que muestra tarjetas de protocolos y una acción para reanudar una entrevista',
       }),
     ).toBeInTheDocument();
+
+    const [architectClassicTerm] = screen.getAllByRole('button', {
+      name: 'Architect Classic',
+    });
+    if (!architectClassicTerm) {
+      throw new Error('Expected an Architect Classic definition trigger.');
+    }
+
+    fireEvent.click(architectClassicTerm);
+
+    expect(
+      screen.getByText(
+        'La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'aquí' })).toHaveAttribute(
+      'href',
+      '/get-started',
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Anonimización' }));
 

--- a/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
+++ b/apps/networkcanvas.com/components/summer-update/__tests__/SummerUpdatePage.test.tsx
@@ -461,11 +461,7 @@ describe('SummerUpdatePage', () => {
 
     fireEvent.click(within(frescoCompatibilityRow).getByText('Fresco'));
 
-    expect(
-      screen.getByText(
-        /Fresco 3\.1\.2 supports Schema 7 protocols but does not support Schema 8 protocols/,
-      ),
-    ).toBeInTheDocument();
+    expect(frescoCompatibilityRow).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('explains every Classic app term and provides an accessible download link', async () => {
@@ -498,8 +494,32 @@ describe('SummerUpdatePage', () => {
     const downloadLink = within(definitionPopover).getByRole('link', {
       name: 'here',
     });
-    expect(downloadLink).toHaveAttribute('href', '/get-started');
+    expect(downloadLink).toHaveAttribute('href', '/get-started/#design');
     expect(downloadLink).not.toHaveAttribute('tabindex', '-1');
+    expect(
+      screen.getByText(
+        (_, element) => element?.textContent === 'Architect Classic\u00a06.6.0',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('links Interviewer Classic to the collect-data section', async () => {
+    renderWithIntl(<SummerUpdatePage />);
+
+    const [interviewerClassicTerm] = screen
+      .getAllByText('Interviewer Classic')
+      .filter((term) => term.getAttribute('tabindex') === '0');
+    if (!interviewerClassicTerm) {
+      throw new Error('Expected an Interviewer Classic definition trigger.');
+    }
+
+    await act(async () => {
+      interviewerClassicTerm.focus();
+    });
+
+    expect(
+      within(screen.getByRole('dialog')).getByRole('link', { name: 'here' }),
+    ).toHaveAttribute('href', '/get-started/#collect');
   });
 
   it('introduces the redesigned project website and documentation', () => {
@@ -721,7 +741,7 @@ describe('SummerUpdatePage', () => {
     );
     expect(
       within(definitionPopover).getByRole('link', { name: 'aquí' }),
-    ).toHaveAttribute('href', '/get-started');
+    ).toHaveAttribute('href', '/get-started/#design');
 
     fireEvent.click(screen.getByRole('button', { name: 'Anonimización' }));
 

--- a/apps/networkcanvas.com/components/summer-update/summerUpdateContent.ts
+++ b/apps/networkcanvas.com/components/summer-update/summerUpdateContent.ts
@@ -281,7 +281,6 @@ export function useSummerUpdateContent() {
         : 'compatibility.groups.new',
     ),
     platform: t(`compatibility.rows.${row.id}.platform`),
-    note: t(`compatibility.rows.${row.id}.note`),
   }));
 
   const destinationLinks: Destination[] = destinationDefinitions.map(

--- a/apps/networkcanvas.com/messages/en.json
+++ b/apps/networkcanvas.com/messages/en.json
@@ -272,7 +272,15 @@
     },
     "definitions": {
       "pwa": "<dfn>Progressive Web Apps</dfn> are specially crafted websites that can be installed on your device and provide a native app-like experience. This means they have an icon you can click to open them, they have their own storage, and they work offline.",
-      "protocolSchema": "Protocol Schemas are the technical specifications that define how protocol files are structured and interpreted by the apps. They ensure that protocols are compatible across different versions of the apps and provide a framework for implementing new features and interfaces."
+      "protocolSchema": "Protocol Schemas are the technical specifications that define how protocol files are structured and interpreted by the apps. They ensure that protocols are compatible across different versions of the apps and provide a framework for implementing new features and interfaces.",
+      "architectClassic": {
+        "description": "The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.",
+        "download": "Download it <link>here</link>."
+      },
+      "interviewerClassic": {
+        "description": "The original downloadable desktop and tablet app for collecting interview data. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.",
+        "download": "Download it <link>here</link>."
+      }
     },
     "common": {
       "documentation": "Documentation"
@@ -301,7 +309,7 @@
       },
       "classic": {
         "title": "What about the original desktop and tablet apps?",
-        "description": "The original desktop and tablet apps are now named <strong>Architect Classic</strong> and <strong>Interviewer Classic</strong>. They remain available for in-progress studies and are <strong>fully supported</strong>, but are in maintenance mode and will not receive new features."
+        "description": "The original desktop and tablet apps are now named <architectClassic>Architect Classic</architectClassic> and <interviewerClassic>Interviewer Classic</interviewerClassic>. They remain available for in-progress studies and are <strong>fully supported</strong>, but are in maintenance mode and will not receive new features."
       }
     },
     "apps": {
@@ -317,7 +325,7 @@
           "templates": "Includes <strong>protocol templates</strong>, designed to help you get started quickly and avoid common mistakes"
         },
         "open": "Open Architect",
-        "classicNote": "Architect Classic remains available for researchers who need to keep using older versions of Interviewer (e.g. 6.6.0). It is in maintenance mode — bug fixes only — and continues to produce Schema 7 protocols."
+        "classicNote": "<architectClassic>Architect Classic</architectClassic> remains available for researchers who need to keep using older versions of Interviewer (e.g. 6.6.0). It is in maintenance mode — bug fixes only — and continues to produce Schema 7 protocols."
       },
       "interviewer": {
         "label": "Face-to-face interviews",
@@ -331,7 +339,7 @@
           "compatibility": "Compatible with all desktop and tablet devices, including iPads and Android tablets"
         },
         "open": "Open Interviewer",
-        "classicNote": "Interviewer Classic remains available for in-progress studies. Like Architect Classic, it is in maintenance mode only, and does not benefit from new features."
+        "classicNote": "<interviewerClassic>Interviewer Classic</interviewerClassic> remains available for in-progress studies. Like <architectClassic>Architect Classic</architectClassic>, it is in maintenance mode only, and does not benefit from new features."
       },
       "fresco": {
         "label": "Remote self-administered interviews",
@@ -575,11 +583,11 @@
       "rows": {
         "interviewerClassic": {
           "platform": "Desktop & tablet",
-          "note": "Interviewer Classic runs Schema 7 natively, but cannot open Schema 8 protocols. Continue using it for in-progress Schema 7 studies — it remains supported with bug fixes."
+          "note": "<interviewerClassic>Interviewer Classic</interviewerClassic> runs Schema 7 natively, but cannot open Schema 8 protocols. Continue using it for in-progress Schema 7 studies — it remains supported with bug fixes."
         },
         "architectClassic": {
           "platform": "Desktop",
-          "note": "Architect Classic continues to produce Schema 7 protocols, in maintenance mode. Use it only if you need to keep running older versions of Interviewer (e.g. 6.6.0)."
+          "note": "<architectClassic>Architect Classic</architectClassic> continues to produce Schema 7 protocols, in maintenance mode. Use it only if you need to keep running older versions of Interviewer (e.g. 6.6.0)."
         },
         "frescoClassic": {
           "platform": "Browser",
@@ -591,7 +599,7 @@
         },
         "architect": {
           "platform": "Browser & PWA",
-          "note": "The new Architect builds Schema 8 protocols, and opens and automatically upgrades older Schema 7 protocols created in Architect Classic."
+          "note": "The new Architect builds Schema 8 protocols, and opens and automatically upgrades older Schema 7 protocols created in <architectClassic>Architect Classic</architectClassic>."
         },
         "fresco": {
           "platform": "Browser",
@@ -606,7 +614,7 @@
         "label": "Caution",
         "heading": "Protocol migration is one-way.",
         "description": "If you open a Schema 7 protocol in any new-generation app, it will be automatically upgraded to Schema 8. You will not be able to convert it back, or open it in the older apps afterward. This is especially important if you make changes to a protocol in Architect, as it will be upgraded to Schema 8 when you save it.",
-        "fileNote": "Keep a copy of your original <file>.netcanvas</file> file if you need to continue running it in Interviewer Classic, Architect Classic, or Fresco 3.x."
+        "fileNote": "Keep a copy of your original <file>.netcanvas</file> file if you need to continue running it in <interviewerClassic>Interviewer Classic</interviewerClassic>, <architectClassic>Architect Classic</architectClassic>, or Fresco 3.x."
       },
       "upgrade": {
         "label": "Should you upgrade?",
@@ -619,7 +627,7 @@
         "ongoing": {
           "label": "Running an ongoing study?",
           "heading": "There is no rush!",
-          "description": "Interviewer Classic and Architect Classic are still supported and will continue to receive bug fixes. Upgrade at a time that suits your project — just be mindful of the one-way migration when you do."
+          "description": "<interviewerClassic>Interviewer Classic</interviewerClassic> and <architectClassic>Architect Classic</architectClassic> are still supported and will continue to receive bug fixes. Upgrade at a time that suits your project — just be mindful of the one-way migration when you do."
         }
       }
     },

--- a/apps/networkcanvas.com/messages/en.json
+++ b/apps/networkcanvas.com/messages/en.json
@@ -273,14 +273,8 @@
     "definitions": {
       "pwa": "<dfn>Progressive Web Apps</dfn> are specially crafted websites that can be installed on your device and provide a native app-like experience. This means they have an icon you can click to open them, they have their own storage, and they work offline.",
       "protocolSchema": "Protocol Schemas are the technical specifications that define how protocol files are structured and interpreted by the apps. They ensure that protocols are compatible across different versions of the apps and provide a framework for implementing new features and interfaces.",
-      "architectClassic": {
-        "description": "The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.",
-        "download": "Download it <link>here</link>."
-      },
-      "interviewerClassic": {
-        "description": "The original downloadable desktop and tablet app for collecting interview data. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features.",
-        "download": "Download it <link>here</link>."
-      }
+      "architectClassic": "The original downloadable desktop app for designing Network Canvas protocols. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features. Download it <link>here</link>.",
+      "interviewerClassic": "The original downloadable desktop and tablet app for collecting interview data. It remains available for in-progress studies and is fully supported, but is in maintenance mode and will not receive new features. Download it <link>here</link>."
     },
     "common": {
       "documentation": "Documentation"

--- a/apps/networkcanvas.com/messages/es.json
+++ b/apps/networkcanvas.com/messages/es.json
@@ -272,7 +272,15 @@
     },
     "definitions": {
       "pwa": "<dfn>Las aplicaciones web progresivas</dfn> son sitios web diseñados para instalarse en un dispositivo y ofrecer una experiencia similar a la de una aplicación nativa. Puede abrirlas desde un icono propio, cuentan con su propio almacenamiento y funcionan sin conexión.",
-      "protocolSchema": "Los esquemas de protocolo son las especificaciones técnicas que definen cómo se estructuran los archivos de protocolo y cómo los interpretan las aplicaciones. Garantizan la compatibilidad de los protocolos entre distintas versiones de las aplicaciones y proporcionan un marco para implementar nuevas funciones e interfaces."
+      "protocolSchema": "Los esquemas de protocolo son las especificaciones técnicas que definen cómo se estructuran los archivos de protocolo y cómo los interpretan las aplicaciones. Garantizan la compatibilidad de los protocolos entre distintas versiones de las aplicaciones y proporcionan un marco para implementar nuevas funciones e interfaces.",
+      "architectClassic": {
+        "description": "La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.",
+        "download": "Descárguela <link>aquí</link>."
+      },
+      "interviewerClassic": {
+        "description": "La aplicación de escritorio y tableta descargable original para recopilar datos de entrevistas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.",
+        "download": "Descárguela <link>aquí</link>."
+      }
     },
     "common": {
       "documentation": "Documentación"
@@ -301,7 +309,7 @@
       },
       "classic": {
         "title": "¿Qué ocurre con las aplicaciones originales para computadoras y tabletas?",
-        "description": "Las aplicaciones originales para computadoras y tabletas ahora se llaman <strong>Architect Classic</strong> e <strong>Interviewer Classic</strong>. Siguen disponibles para los estudios en curso y cuentan con <strong>soporte completo</strong>, pero están en modo de mantenimiento y no recibirán funciones nuevas."
+        "description": "Las aplicaciones originales para computadoras y tabletas ahora se llaman <architectClassic>Architect Classic</architectClassic> e <interviewerClassic>Interviewer Classic</interviewerClassic>. Siguen disponibles para los estudios en curso y cuentan con <strong>soporte completo</strong>, pero están en modo de mantenimiento y no recibirán funciones nuevas."
       }
     },
     "apps": {
@@ -317,7 +325,7 @@
           "templates": "Incluye <strong>plantillas de protocolos</strong> diseñadas para ayudarle a comenzar rápidamente y evitar errores habituales"
         },
         "open": "Abrir Architect",
-        "classicNote": "Architect Classic sigue disponible para quienes necesiten continuar usando versiones anteriores de Interviewer (por ejemplo, la 6.6.0). Está en modo de mantenimiento —solo recibe correcciones de errores— y continúa generando protocolos del esquema 7."
+        "classicNote": "<architectClassic>Architect Classic</architectClassic> sigue disponible para quienes necesiten continuar usando versiones anteriores de Interviewer (por ejemplo, la 6.6.0). Está en modo de mantenimiento —solo recibe correcciones de errores— y continúa generando protocolos del esquema 7."
       },
       "interviewer": {
         "label": "Entrevistas presenciales",
@@ -331,7 +339,7 @@
           "compatibility": "Compatible con computadoras y tabletas, incluidos iPad y tabletas Android"
         },
         "open": "Abrir Interviewer",
-        "classicNote": "Interviewer Classic sigue disponible para los estudios en curso. Al igual que Architect Classic, está exclusivamente en modo de mantenimiento y no recibe las funciones nuevas."
+        "classicNote": "<interviewerClassic>Interviewer Classic</interviewerClassic> sigue disponible para los estudios en curso. Al igual que <architectClassic>Architect Classic</architectClassic>, está exclusivamente en modo de mantenimiento y no recibe las funciones nuevas."
       },
       "fresco": {
         "label": "Entrevistas autoadministradas a distancia",
@@ -575,11 +583,11 @@
       "rows": {
         "interviewerClassic": {
           "platform": "Computadora y tableta",
-          "note": "Interviewer Classic ejecuta el esquema 7 de forma nativa, pero no puede abrir protocolos del esquema 8. Continúe utilizándolo para los estudios en curso con el esquema 7; seguirá recibiendo correcciones de errores."
+          "note": "<interviewerClassic>Interviewer Classic</interviewerClassic> ejecuta el esquema 7 de forma nativa, pero no puede abrir protocolos del esquema 8. Continúe utilizándolo para los estudios en curso con el esquema 7; seguirá recibiendo correcciones de errores."
         },
         "architectClassic": {
           "platform": "Computadora",
-          "note": "Architect Classic sigue generando protocolos del esquema 7 y está en modo de mantenimiento. Utilícelo solo si necesita seguir ejecutando versiones anteriores de Interviewer (por ejemplo, la 6.6.0)."
+          "note": "<architectClassic>Architect Classic</architectClassic> sigue generando protocolos del esquema 7 y está en modo de mantenimiento. Utilícelo solo si necesita seguir ejecutando versiones anteriores de Interviewer (por ejemplo, la 6.6.0)."
         },
         "frescoClassic": {
           "platform": "Navegador",
@@ -591,7 +599,7 @@
         },
         "architect": {
           "platform": "Navegador y PWA",
-          "note": "El nuevo Architect crea protocolos del esquema 8, y abre y actualiza automáticamente los protocolos anteriores del esquema 7 creados en Architect Classic."
+          "note": "El nuevo Architect crea protocolos del esquema 8, y abre y actualiza automáticamente los protocolos anteriores del esquema 7 creados en <architectClassic>Architect Classic</architectClassic>."
         },
         "fresco": {
           "platform": "Navegador",
@@ -606,7 +614,7 @@
         "label": "Precaución",
         "heading": "La migración de protocolos es unidireccional.",
         "description": "Si abre un protocolo del esquema 7 en cualquier aplicación de nueva generación, se actualizará automáticamente al esquema 8. Después no podrá volver a convertirlo ni abrirlo en las aplicaciones anteriores. Esto es especialmente importante si modifica un protocolo en Architect, ya que se actualizará al esquema 8 cuando lo guarde.",
-        "fileNote": "Conserve una copia del archivo <file>.netcanvas</file> original si necesita seguir ejecutándolo en Interviewer Classic, Architect Classic o Fresco 3.x."
+        "fileNote": "Conserve una copia del archivo <file>.netcanvas</file> original si necesita seguir ejecutándolo en <interviewerClassic>Interviewer Classic</interviewerClassic>, <architectClassic>Architect Classic</architectClassic> o Fresco 3.x."
       },
       "upgrade": {
         "label": "¿Debe actualizar?",
@@ -619,7 +627,7 @@
         "ongoing": {
           "label": "¿Está realizando un estudio?",
           "heading": "¡No hay prisa!",
-          "description": "Interviewer Classic y Architect Classic siguen recibiendo soporte y correcciones de errores. Actualice cuando sea conveniente para su proyecto, teniendo presente que la migración es unidireccional."
+          "description": "<interviewerClassic>Interviewer Classic</interviewerClassic> y <architectClassic>Architect Classic</architectClassic> siguen recibiendo soporte y correcciones de errores. Actualice cuando sea conveniente para su proyecto, teniendo presente que la migración es unidireccional."
         }
       }
     },

--- a/apps/networkcanvas.com/messages/es.json
+++ b/apps/networkcanvas.com/messages/es.json
@@ -273,14 +273,8 @@
     "definitions": {
       "pwa": "<dfn>Las aplicaciones web progresivas</dfn> son sitios web diseñados para instalarse en un dispositivo y ofrecer una experiencia similar a la de una aplicación nativa. Puede abrirlas desde un icono propio, cuentan con su propio almacenamiento y funcionan sin conexión.",
       "protocolSchema": "Los esquemas de protocolo son las especificaciones técnicas que definen cómo se estructuran los archivos de protocolo y cómo los interpretan las aplicaciones. Garantizan la compatibilidad de los protocolos entre distintas versiones de las aplicaciones y proporcionan un marco para implementar nuevas funciones e interfaces.",
-      "architectClassic": {
-        "description": "La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.",
-        "download": "Descárguela <link>aquí</link>."
-      },
-      "interviewerClassic": {
-        "description": "La aplicación de escritorio y tableta descargable original para recopilar datos de entrevistas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas.",
-        "download": "Descárguela <link>aquí</link>."
-      }
+      "architectClassic": "La aplicación de escritorio descargable original para diseñar protocolos de Network Canvas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas. Descárguela <link>aquí</link>.",
+      "interviewerClassic": "La aplicación de escritorio y tableta descargable original para recopilar datos de entrevistas. Sigue disponible para estudios en curso y cuenta con soporte completo, pero está en modo de mantenimiento y no recibirá funciones nuevas. Descárguela <link>aquí</link>."
     },
     "common": {
       "documentation": "Documentación"

--- a/packages/fresco-ui/src/Definition.stories.tsx
+++ b/packages/fresco-ui/src/Definition.stories.tsx
@@ -11,9 +11,11 @@ const meta = {
     layout: 'centered',
     docs: {
       description: {
-        component: `An inline term that reveals an expanded definition on hover, keyboard focus, or press. It composes Fresco's Base UI Tooltip primitives and renders a keyboard-focusable \`span\` by default.
+        component: `An inline term that reveals an expanded definition on hover or keyboard focus. It composes Fresco's Base UI Tooltip primitives and renders a keyboard-focusable \`span\` by default.
 
-The definition is also connected to the term with \`aria-describedby\`, because Base UI tooltips are visual-only. Screen readers receive the definition without depending on the popup being visible.
+For non-interactive content, the definition is also connected to the term with \`aria-describedby\`, because Base UI tooltips are visual-only. Screen readers receive the definition without depending on the popup being visible.
+
+Pass \`interactive\` when the definition includes a link or another control. This switches to an accessible popover that opens on hover or keyboard focus, where controls can receive focus, instead of putting interactive content inside a tooltip.
 
 Use \`asAbbreviation\` only when the visible text is genuinely an abbreviation. This switches the term to an \`abbr\` element without adding a competing native \`title\` tooltip.
 
@@ -27,7 +29,8 @@ import Definition from '@codaco/fresco-ui/Definition';
 
 Props:
 - \`children\`: the visible term or phrase.
-- \`definition\`: non-interactive content shown in the tooltip.
+- \`definition\`: expanded content shown in the tooltip or interactive popover.
+- \`interactive\`: use a hover- and focus-triggered popover for definition content that includes links or controls.
 - \`asAbbreviation\`: renders the term as \`abbr\` instead of \`span\`.
 - \`side\`, \`align\`, and \`sideOffset\`: control tooltip placement.
 - \`showArrow\`: shows or hides the tooltip arrow.`,
@@ -47,6 +50,11 @@ Props:
     asAbbreviation: {
       control: 'boolean',
       description: 'Render the visible term as an abbr element.',
+    },
+    interactive: {
+      control: 'boolean',
+      description:
+        'Use a hover- and focus-triggered popover when the definition contains links or controls.',
     },
     side: {
       control: 'select',
@@ -68,6 +76,7 @@ Props:
     definition:
       'The people an individual knows and the relationships among them.',
     asAbbreviation: false,
+    interactive: false,
     side: 'top',
     align: 'center',
     sideOffset: 10,
@@ -116,6 +125,35 @@ export const LongDefinition: Story = {
   },
 };
 
+export const LinkedDefinition: Story = {
+  args: {
+    children: 'Architect Classic',
+    interactive: true,
+  },
+  render: (args) => (
+    <Definition
+      {...args}
+      definition={
+        <>
+          The original downloadable desktop app for designing Network Canvas
+          protocols. Download it <a href="/get-started">here</a>.
+        </>
+      }
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const term = canvas.getByText('Architect Classic');
+
+    await userEvent.hover(term);
+    await waitFor(() =>
+      expect(document.querySelector('[data-base-ui-portal]')).toHaveTextContent(
+        'Download it here.',
+      ),
+    );
+  },
+};
+
 export const KeyboardFocus: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -126,14 +164,5 @@ export const KeyboardFocus: Story = {
     await expect(term).toHaveAccessibleDescription(
       'The people an individual knows and the relationships among them.',
     );
-  },
-};
-
-export const TouchActivation: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const term = canvas.getByText('personal network');
-    await userEvent.click(term);
-    await waitFor(() => expect(term).toHaveAttribute('data-popup-open'));
   },
 };

--- a/packages/fresco-ui/src/Definition.test.tsx
+++ b/packages/fresco-ui/src/Definition.test.tsx
@@ -70,7 +70,7 @@ describe('Definition', () => {
     );
   });
 
-  it('opens when pressed without receiving focus', async () => {
+  it('does not open when pressed without receiving focus', async () => {
     render(
       <Definition definition="A collection of people and relationships.">
         network
@@ -82,6 +82,67 @@ describe('Definition', () => {
     fireEvent.click(term);
 
     expect(term).not.toHaveFocus();
-    await waitFor(() => expect(term).toHaveAttribute('data-popup-open'));
+    expect(term).not.toHaveAttribute('data-popup-open');
+  });
+
+  it('shows linked definitions on focus in an accessible popover', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Definition
+        interactive
+        definition={
+          <>
+            The original desktop app. Download it <a href="/get-started">here</a>.
+          </>
+        }
+      >
+        Architect Classic
+      </Definition>,
+    );
+
+    const term = screen.getByText('Architect Classic');
+
+    expect(term).not.toHaveAccessibleDescription();
+    expect(term).toHaveAttribute('tabindex', '0');
+
+    await user.tab();
+
+    expect(term).toHaveFocus();
+
+    const downloadLink = await screen.findByRole('link', { name: 'here' });
+    expect(downloadLink).toHaveAttribute('href', '/get-started');
+    expect(downloadLink).not.toHaveAttribute('tabindex', '-1');
+    expect(downloadLink.closest('[aria-hidden="true"]')).toBeNull();
+
+    await user.tab();
+
+    expect(downloadLink).toHaveFocus();
+  });
+
+  it('shows linked definitions on hover', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Definition
+        interactive
+        definition={
+          <>
+            The original desktop app. Download it <a href="/get-started">here</a>.
+          </>
+        }
+      >
+        Architect Classic
+      </Definition>,
+    );
+
+    const term = screen.getByText('Architect Classic');
+
+    await user.hover(term);
+
+    expect(await screen.findByRole('link', { name: 'here' })).toHaveAttribute(
+      'href',
+      '/get-started',
+    );
   });
 });

--- a/packages/fresco-ui/src/Definition.test.tsx
+++ b/packages/fresco-ui/src/Definition.test.tsx
@@ -93,7 +93,8 @@ describe('Definition', () => {
         interactive
         definition={
           <>
-            The original desktop app. Download it <a href="/get-started">here</a>.
+            The original desktop app. Download it{' '}
+            <a href="/get-started">here</a>.
           </>
         }
       >
@@ -128,7 +129,8 @@ describe('Definition', () => {
         interactive
         definition={
           <>
-            The original desktop app. Download it <a href="/get-started">here</a>.
+            The original desktop app. Download it{' '}
+            <a href="/get-started">here</a>.
           </>
         }
       >

--- a/packages/fresco-ui/src/Definition.test.tsx
+++ b/packages/fresco-ui/src/Definition.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import Definition from './Definition';
 
@@ -111,6 +111,11 @@ describe('Definition', () => {
 
     expect(term).toHaveFocus();
 
+    const definitionDialog = await screen.findByRole('dialog', {
+      name: 'Architect Classic',
+    });
+    expect(definitionDialog).toHaveAttribute('aria-labelledby', term.id);
+
     const downloadLink = await screen.findByRole('link', { name: 'here' });
     expect(downloadLink).toHaveAttribute('href', '/get-started');
     expect(downloadLink).not.toHaveAttribute('tabindex', '-1');
@@ -146,5 +151,48 @@ describe('Definition', () => {
       'href',
       '/get-started',
     );
+  });
+
+  it('composes consumer focus handlers for linked definitions', () => {
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
+
+    render(
+      <Definition
+        interactive
+        definition="The original desktop app."
+        onFocus={onFocus}
+        onBlur={onBlur}
+      >
+        Architect Classic
+      </Definition>,
+    );
+
+    const term = screen.getByText('Architect Classic');
+
+    fireEvent.focus(term);
+    fireEvent.blur(term, { relatedTarget: document.body });
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect(onBlur).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a focus-opened linked definition open after the pointer leaves', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Definition interactive definition="The original desktop app.">
+        Architect Classic
+      </Definition>,
+    );
+
+    const term = screen.getByText('Architect Classic');
+
+    await user.tab();
+    await user.hover(term);
+    await user.unhover(term);
+
+    expect(term).toHaveFocus();
+    await waitFor(() => expect(term).toHaveAttribute('aria-expanded', 'true'));
   });
 });

--- a/packages/fresco-ui/src/Definition.tsx
+++ b/packages/fresco-ui/src/Definition.tsx
@@ -3,6 +3,7 @@
 import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip';
 import * as React from 'react';
 
+import { Popover, PopoverContent, PopoverTrigger } from './Popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from './Tooltip';
 import { cx } from './utils/cva';
 
@@ -16,8 +17,10 @@ export type DefinitionProps = Omit<
 > & {
   /** The term or phrase that the definition describes. */
   children: React.ReactNode;
-  /** The expanded definition shown on hover, keyboard focus, or press. */
+  /** The expanded definition shown on hover or keyboard focus. */
   definition: React.ReactNode;
+  /** Use an accessible popover when the definition contains links or controls. */
+  interactive?: boolean;
   /** Render the term as an `abbr` element when it is an abbreviation. */
   asAbbreviation?: boolean;
   side?: TooltipContentProps['side'];
@@ -31,6 +34,7 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
     {
       children,
       definition,
+      interactive = false,
       asAbbreviation = false,
       side,
       align,
@@ -44,12 +48,102 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
     ref,
   ) => {
     const [tooltipHandle] = React.useState(() => BaseTooltip.createHandle());
+    const [interactiveOpen, setInteractiveOpen] = React.useState(false);
+    const interactiveTriggerRef = React.useRef<HTMLElement | null>(null);
+    const interactiveContentRef = React.useRef<HTMLDivElement | null>(null);
     const Element = asAbbreviation ? 'abbr' : 'span';
     const descriptionId = React.useId();
     const triggerId = React.useId();
+    const setInteractiveTriggerRef = React.useCallback(
+      (element: HTMLElement | null) => {
+        interactiveTriggerRef.current = element;
+
+        if (typeof ref === 'function') {
+          ref(element);
+        } else if (ref) {
+          ref.current = element;
+        }
+      },
+      [ref],
+    );
+    const keepInteractivePopoverOpen = React.useCallback(
+      (nextFocusedElement: EventTarget | null) => {
+        if (!(nextFocusedElement instanceof Node)) {
+          return false;
+        }
+
+        return Boolean(
+          interactiveTriggerRef.current?.contains(nextFocusedElement) ||
+            interactiveContentRef.current?.contains(nextFocusedElement),
+        );
+      },
+      [],
+    );
     const ariaDescribedBy = ariaDescribedByProp
       ? `${ariaDescribedByProp} ${descriptionId}`
       : descriptionId;
+
+    if (interactive) {
+      return (
+        <Popover
+          open={interactiveOpen}
+          triggerId={triggerId}
+          onOpenChange={setInteractiveOpen}
+        >
+          <PopoverTrigger
+            id={triggerId}
+            openOnHover
+            nativeButton={false}
+            render={
+              <Element
+                ref={setInteractiveTriggerRef}
+                className={cx(
+                  'text-link focusable inline-block cursor-help rounded-sm underline decoration-dashed decoration-2 underline-offset-3',
+                  className,
+                )}
+                {...props}
+                aria-describedby={ariaDescribedByProp}
+                onFocus={() => setInteractiveOpen(true)}
+                onBlur={(event) => {
+                  if (!keepInteractivePopoverOpen(event.relatedTarget)) {
+                    setInteractiveOpen(false);
+                  }
+                }}
+                onClick={(
+                  event: React.MouseEvent<HTMLElement> & {
+                    preventBaseUIHandler?: () => void;
+                  },
+                ) => {
+                  onClick?.(event);
+                  event.preventBaseUIHandler?.();
+                }}
+                role={undefined}
+                tabIndex={0}
+              >
+                {children}
+              </Element>
+            }
+          />
+          <PopoverContent
+            ref={interactiveContentRef}
+            className="w-max max-w-[min(var(--available-width),var(--container-sm))] text-pretty"
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+            showArrow={showArrow}
+            initialFocus={false}
+            onFocus={() => setInteractiveOpen(true)}
+            onBlur={(event) => {
+              if (!keepInteractivePopoverOpen(event.relatedTarget)) {
+                setInteractiveOpen(false);
+              }
+            }}
+          >
+            {definition}
+          </PopoverContent>
+        </Popover>
+      );
+    }
 
     return (
       <Tooltip handle={tooltipHandle}>
@@ -66,12 +160,7 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
               )}
               {...props}
               aria-describedby={ariaDescribedBy}
-              onClick={(event) => {
-                onClick?.(event);
-                if (!event.defaultPrevented) {
-                  tooltipHandle.open(triggerId);
-                }
-              }}
+              {...(onClick ? { onClick } : {})}
               tabIndex={0}
             />
           }

--- a/packages/fresco-ui/src/Definition.tsx
+++ b/packages/fresco-ui/src/Definition.tsx
@@ -74,7 +74,7 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
 
         return Boolean(
           interactiveTriggerRef.current?.contains(nextFocusedElement) ||
-            interactiveContentRef.current?.contains(nextFocusedElement),
+          interactiveContentRef.current?.contains(nextFocusedElement),
         );
       },
       [],
@@ -117,7 +117,6 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
                   onClick?.(event);
                   event.preventBaseUIHandler?.();
                 }}
-                role={undefined}
                 tabIndex={0}
               >
                 {children}

--- a/packages/fresco-ui/src/Definition.tsx
+++ b/packages/fresco-ui/src/Definition.tsx
@@ -41,7 +41,10 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
       sideOffset,
       showArrow,
       className,
+      id: idProp,
       'aria-describedby': ariaDescribedByProp,
+      onBlur,
+      onFocus,
       onClick,
       ...props
     },
@@ -53,7 +56,8 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
     const interactiveContentRef = React.useRef<HTMLDivElement | null>(null);
     const Element = asAbbreviation ? 'abbr' : 'span';
     const descriptionId = React.useId();
-    const triggerId = React.useId();
+    const generatedTriggerId = React.useId();
+    const triggerId = idProp ?? generatedTriggerId;
     const setInteractiveTriggerRef = React.useCallback(
       (element: HTMLElement | null) => {
         interactiveTriggerRef.current = element;
@@ -88,7 +92,17 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
         <Popover
           open={interactiveOpen}
           triggerId={triggerId}
-          onOpenChange={setInteractiveOpen}
+          onOpenChange={(nextOpen, eventDetails) => {
+            if (
+              !nextOpen &&
+              eventDetails.reason === 'trigger-hover' &&
+              keepInteractivePopoverOpen(document.activeElement)
+            ) {
+              return;
+            }
+
+            setInteractiveOpen(nextOpen);
+          }}
         >
           <PopoverTrigger
             id={triggerId}
@@ -102,9 +116,14 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
                   className,
                 )}
                 {...props}
+                id={triggerId}
                 aria-describedby={ariaDescribedByProp}
-                onFocus={() => setInteractiveOpen(true)}
+                onFocus={(event) => {
+                  onFocus?.(event);
+                  setInteractiveOpen(true);
+                }}
                 onBlur={(event) => {
+                  onBlur?.(event);
                   if (!keepInteractivePopoverOpen(event.relatedTarget)) {
                     setInteractiveOpen(false);
                   }
@@ -130,6 +149,7 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
             align={align}
             sideOffset={sideOffset}
             showArrow={showArrow}
+            aria-labelledby={triggerId}
             initialFocus={false}
             onFocus={() => setInteractiveOpen(true)}
             onBlur={(event) => {
@@ -158,7 +178,10 @@ const Definition = React.forwardRef<HTMLElement, DefinitionProps>(
                 className,
               )}
               {...props}
+              id={triggerId}
               aria-describedby={ariaDescribedBy}
+              {...(onFocus ? { onFocus } : {})}
+              {...(onBlur ? { onBlur } : {})}
               {...(onClick ? { onClick } : {})}
               tabIndex={0}
             />

--- a/packages/fresco-ui/src/Popover.tsx
+++ b/packages/fresco-ui/src/Popover.tsx
@@ -189,11 +189,11 @@ function PopoverContent({
     <BasePopover.Portal
       container={portalContainer ?? undefined}
       keepMounted={keepMounted}
-      {...(props as ComponentPropsWithoutRef<typeof BasePopover.Portal>)}
     >
       <AnimatePresence>
         {mounted && (
           <BasePopover.Positioner
+            className="z-3000"
             sideOffset={sideOffset}
             arrowPadding={POPOVER_ARROW_PADDING}
             align={align}


### PR DESCRIPTION
## Summary
- Add reusable, localized Classic-app definition popovers throughout the Summer 2026 announcement.
- Make the download link a keyboard-reachable, locale-aware `/get-started` link.
- Preserve accessible compatibility-row selection and add Website release notes.

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm --filter networkcanvas.com typecheck`
- [x] `pnpm --filter networkcanvas.com test -- components/summer-update/__tests__/SummerUpdatePage.test.tsx`
- [x] `pnpm --filter networkcanvas.com build`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`