### PR TITLE
Use medium Architect list action buttons

### DIFF
--- a/.changeset/architect-medium-list-actions.md
+++ b/.changeset/architect-medium-list-actions.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Use medium-sized edit and delete buttons throughout editable lists.

--- a/apps/architect/src/components/AssignAttributes/Attribute.tsx
+++ b/apps/architect/src/components/AssignAttributes/Attribute.tsx
@@ -108,7 +108,6 @@ const Attribute = ({
       <IconButton
         icon={<Trash2 />}
         aria-label="Delete attribute"
-        size="lg"
         color="destructive"
         disabled={disabled || readOnly}
         className="ml-5 self-center"

--- a/apps/architect/src/components/Form/DialogArrayField.tsx
+++ b/apps/architect/src/components/Form/DialogArrayField.tsx
@@ -110,7 +110,6 @@ const DialogItem = ({
       <IconButton
         icon={<Pencil />}
         aria-label={`Edit ${itemLabel}`}
-        size="lg"
         color="dynamic"
         disabled={interactionDisabled}
         onClick={onEdit}
@@ -118,7 +117,6 @@ const DialogItem = ({
       <IconButton
         icon={<Trash2 />}
         aria-label={`Remove ${itemLabel}`}
-        size="lg"
         color="destructive"
         disabled={interactionDisabled}
         onClick={handleDelete}

--- a/apps/architect/src/components/Form/MultiSelect.tsx
+++ b/apps/architect/src/components/Form/MultiSelect.tsx
@@ -170,7 +170,6 @@ const ItemComponent: React.FC<ItemComponentProps> = ({
         <IconButton
           icon={<Trash2 />}
           aria-label="Remove item"
-          size="lg"
           color="destructive"
           disabled={interactionDisabled}
           className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"

--- a/apps/architect/src/components/Options/Option.tsx
+++ b/apps/architect/src/components/Options/Option.tsx
@@ -128,7 +128,6 @@ const Option = ({
           <IconButton
             icon={<Pencil />}
             aria-label={`Edit option ${index + 1}`}
-            size="lg"
             color="dynamic"
             disabled={interactionDisabled}
             onClick={onEdit}
@@ -136,7 +135,6 @@ const Option = ({
           <IconButton
             icon={<Trash2 />}
             aria-label={`Remove option ${index + 1}`}
-            size="lg"
             color="destructive"
             disabled={interactionDisabled}
             onClick={handleDelete}
@@ -171,7 +169,6 @@ const Option = ({
         <IconButton
           icon={<Trash2 />}
           aria-label={`Remove option ${index + 1}`}
-          size="lg"
           color="destructive"
           disabled={interactionDisabled}
           onClick={handleDelete}

--- a/apps/architect/src/components/Query/Rules/PreviewRule.tsx
+++ b/apps/architect/src/components/Query/Rules/PreviewRule.tsx
@@ -41,7 +41,6 @@ export const PreviewRule = ({
           type="button"
           icon={<Trash2 />}
           aria-label="Delete rule"
-          size="lg"
           color="destructive"
           className="shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
           onClick={onDelete}

--- a/apps/architect/src/components/Validations/Validation.tsx
+++ b/apps/architect/src/components/Validations/Validation.tsx
@@ -194,14 +194,12 @@ const Validation = ({
           <IconButton
             icon={<Pencil />}
             aria-label={`Edit ${label} validation rule`}
-            size="lg"
             color="dynamic"
             onClick={onEdit}
           />
           <IconButton
             icon={<Trash2 />}
             aria-label={`Delete ${label} validation rule`}
-            size="lg"
             color="destructive"
             onClick={() => onDelete(itemKey)}
           />

--- a/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
+++ b/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
@@ -183,7 +183,6 @@ const NodePanel = ({
       <IconButton
         icon={<Trash2 />}
         aria-label="Remove side panel"
-        size="lg"
         color="destructive"
         disabled={interactionDisabled}
         onClick={handleDelete}


### PR DESCRIPTION
## Summary
- let Architect editable-list edit and delete `IconButton`s inherit the medium default size
- keep large reorder, save, and cancel controls unchanged
- add an Architect patch changeset

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/architect test`
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts`
