### PR TITLE
Reduce Architect editable list item spacing

### DIFF
--- a/.changeset/architect-editable-list-spacing.md
+++ b/.changeset/architect-editable-list-spacing.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Reduce spacing around editable list item previews.

--- a/apps/architect/src/components/sections/FamilyPedigree/NodeFormFieldPreview.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/NodeFormFieldPreview.tsx
@@ -33,7 +33,7 @@ const NodeFormFieldPreview = ({
   };
 
   return (
-    <div className="m-5 flex flex-col gap-2.5">
+    <div className="flex flex-col gap-2.5">
       <Markdown label={prompt} className="[&>p]:m-0" />
       <div>
         <Badge color={getColorForType(codebookVariable.type)}>

--- a/apps/architect/src/components/sections/FamilyPedigree/NominationPromptPreview.tsx
+++ b/apps/architect/src/components/sections/FamilyPedigree/NominationPromptPreview.tsx
@@ -33,7 +33,7 @@ const NominationPromptPreview = ({
   };
 
   return (
-    <div className="m-5 flex flex-col gap-2.5">
+    <div className="flex flex-col gap-2.5">
       <Markdown label={text} className="[&>p]:m-0" />
       <div>
         <Badge color={getColorForType(codebookVariable.type)}>

--- a/apps/architect/src/components/sections/Form/ComposerFieldPreview.tsx
+++ b/apps/architect/src/components/sections/Form/ComposerFieldPreview.tsx
@@ -34,7 +34,7 @@ const ComposerFieldPreview = ({
   };
 
   return (
-    <div className="m-5 flex flex-col gap-2.5">
+    <div className="flex flex-col gap-2.5">
       {/* Mirror the drawer's caption: the field label, else the variable name. */}
       <strong>{label ?? codebookVariable.name ?? variable}</strong>
       <div>

--- a/apps/architect/src/components/sections/Form/FieldPreview.tsx
+++ b/apps/architect/src/components/sections/Form/FieldPreview.tsx
@@ -33,7 +33,7 @@ const FieldPreview = ({
   };
 
   return (
-    <div className="m-5 flex flex-col gap-2.5">
+    <div className="flex flex-col gap-2.5">
       <Markdown label={prompt} className="[&>p]:m-0" />
       <div>
         <Badge color={getColorForType(codebookVariable.type)}>


### PR DESCRIPTION
## Summary
- remove excess outer margins from Architect editable-list item previews
- update all four preview components that supplied `m-5` containers
- add an Architect patch changeset

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/architect test`
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts`
