### PR TITLE
fix(e2e): resolve shared tsconfigs with Playwright 1.62

### DIFF
--- a/apps/architect/e2e/tsconfig.json
+++ b/apps/architect/e2e/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@codaco/tsconfig/dev.json",
+  "extends": "../../../tooling/typescript/dev.json",
   "compilerOptions": {
     "strict": true,
     "noEmit": true

--- a/apps/interviewer/e2e/tsconfig.json
+++ b/apps/interviewer/e2e/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@codaco/tsconfig/dev.json",
+  "extends": "../../../tooling/typescript/dev.json",
   "compilerOptions": {
     "strict": true,
     "noEmit": true

--- a/packages/interview/e2e/tsconfig.json
+++ b/packages/interview/e2e/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@codaco/tsconfig/web.json",
+  "extends": "../../../tooling/typescript/web.json",
   "compilerOptions": {
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

- resolve Architect and Interviewer E2E TypeScript configs through checked-in relative paths so Playwright 1.62 can load them
- apply the same fix to the Interview runtime E2E config required by both app release lanes
- preserve the existing strict shared TypeScript configuration without aliases or ignored validation

## Test plan

- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/architect test:e2e` (39 passed)
- [x] `pnpm --filter @codaco/interviewer test:e2e` (34 passed)
- [x] Playwright test discovery for `@codaco/interview` (444 tests)
