### PR TITLE
fix(architect): keep variable pill rename controls in view

### DIFF
--- a/.changeset/architect-variable-pill-rename-overflow.md
+++ b/.changeset/architect-variable-pill-rename-overflow.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Keep the confirm and cancel buttons reachable when renaming a variable with a long name.

--- a/apps/architect/src/components/VariablePill.tsx
+++ b/apps/architect/src/components/VariablePill.tsx
@@ -72,7 +72,7 @@ const BaseVariablePill = React.forwardRef<
         <div className="flex shrink-0 basis-12 items-center justify-center border-r border-white/25 bg-(--variable-pill-accent) [&_.icon]:w-5">
           <img className="icon opacity-80" src={icon} alt={type} />
         </div>
-        <div className="flex w-[calc(100%-3rem)] flex-1 items-center justify-between">
+        <div className="flex w-[calc(100%-3rem)] min-w-0 flex-1 items-center justify-between">
           {children}
         </div>
       </div>
@@ -195,7 +195,7 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
         {editing ? (
           <motion.div
             key="edit"
-            className="flex-1"
+            className="min-w-0 flex-1"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -203,7 +203,7 @@ const EditableVariablePill = ({ uuid, width }: EditableVariablePillProps) => {
             <Tooltip open={!!validation}>
               <TooltipTrigger
                 render={
-                  <div className="w-full flex-auto">
+                  <div className="w-full min-w-0 flex-auto">
                     <InputField
                       autoFocus
                       placeholder="Enter a new variable name..."


### PR DESCRIPTION
For variables with long names, confirm and cancel controls were being pushed past the variable pill's clipped right edge and could become unclickable:

<img width="537" height="205" alt="Screenshot 2026-07-29 at 10 05 03 AM" src="https://github.com/user-attachments/assets/ec4aaf41-c6cd-4c9f-a731-20946654272d" />

Fix makes input shrink to the available space while leaving the confirm/cancel buttons in place
<img width="571" height="206" alt="Screenshot 2026-07-29 at 10 22 22 AM" src="https://github.com/user-attachments/assets/b23d8d26-0b52-417a-86ee-d54c7da9b097" />

 

