### PR TITLE
fix(fresco-ui): keep field query container off sibling-dependent spacing

### DIFF
--- a/.changeset/architect-input-control-disappears.md
+++ b/.changeset/architect-input-control-disappears.md
@@ -1,0 +1,6 @@
+---
+'@codaco/architect': patch
+---
+
+Fix the Input Control picker vanishing after you choose an input control for a
+newly created variable, which left the field impossible to complete.

--- a/.changeset/fresco-ui-field-container-layout.md
+++ b/.changeset/fresco-ui-field-container-layout.md
@@ -1,0 +1,8 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+Fix form controls disappearing when content is added below them. A field's query
+container and its sibling-dependent spacing shared one element, so inserting a
+sibling after a field could leave its control with no layout box at all —
+present but invisible and unusable.

--- a/packages/fresco-ui/src/form/Field/BaseField.tsx
+++ b/packages/fresco-ui/src/form/Field/BaseField.tsx
@@ -69,51 +69,50 @@ export function BaseField({
   return (
     <div
       {...containerProps}
-      className={cx(
-        'group @container w-full grow not-last:mb-8',
-        'flex flex-col',
-      )}
+      className={cx('group w-full grow not-last:mb-8', 'flex flex-col')}
     >
-      <div
-        className={cx(
-          // `inline` fields lay out as two columns (label | control) once the
-          // field's own CONTAINER is wide enough, and stack when it's narrow —
-          // a container query, not a viewport breakpoint, so a field adapts to
-          // where it's placed (e.g. a narrow sidebar) rather than the screen.
-          inline &&
-            '@min-[28rem]:flex-row @min-[28rem]:items-center @min-[28rem]:justify-between @min-[28rem]:gap-4',
-          'flex flex-col',
-        )}
-      >
+      <div className="@container flex flex-col">
         <div
           className={cx(
-            inline && 'min-w-0',
-            // Keep the gap below the label block only when something visible
-            // remains there — the label itself, or a hint under a hidden label.
-            !inline && (!labelHidden || hasVisibleHint) && 'mb-2',
+            // `inline` fields lay out as two columns (label | control) once the
+            // field's own CONTAINER is wide enough, and stack when it's narrow —
+            // a container query, not a viewport breakpoint, so a field adapts to
+            // where it's placed (e.g. a narrow sidebar) rather than the screen.
+            inline &&
+              '@min-[28rem]:flex-row @min-[28rem]:items-center @min-[28rem]:justify-between @min-[28rem]:gap-4',
+            'flex flex-col',
           )}
         >
-          <FieldLabel
-            id={`${id}-label`}
-            htmlFor={id}
-            required={required}
-            className={labelHidden ? 'sr-only' : undefined}
+          <div
+            className={cx(
+              inline && 'min-w-0',
+              // Keep the gap below the label block only when something visible
+              // remains there — the label itself, or a hint under a hidden label.
+              !inline && (!labelHidden || hasVisibleHint) && 'mb-2',
+            )}
           >
-            {label}
-          </FieldLabel>
-          {required && (
-            <span id={`${id}-required`} className="sr-only">
-              Required
-            </span>
-          )}
-          {(hint ?? validationSummary) && (
-            <Hint id={`${id}-hint`}>
-              {hint}
-              {validationSummary}
-            </Hint>
-          )}
+            <FieldLabel
+              id={`${id}-label`}
+              htmlFor={id}
+              required={required}
+              className={labelHidden ? 'sr-only' : undefined}
+            >
+              {label}
+            </FieldLabel>
+            {required && (
+              <span id={`${id}-required`} className="sr-only">
+                Required
+              </span>
+            )}
+            {(hint ?? validationSummary) && (
+              <Hint id={`${id}-hint`}>
+                {hint}
+                {validationSummary}
+              </Hint>
+            )}
+          </div>
+          <div className={cx(inline && 'shrink-0')}>{children}</div>
         </div>
-        <div className={cx(inline && 'shrink-0')}>{children}</div>
       </div>
       <FieldErrors
         id={`${id}-error`}

--- a/packages/fresco-ui/src/form/Field/__tests__/BaseField.test.tsx
+++ b/packages/fresco-ui/src/form/Field/__tests__/BaseField.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BaseField } from '../BaseField';
+
+describe('BaseField', () => {
+  it('keeps the query container off the element with sibling-dependent spacing', () => {
+    const { container } = render(
+      <BaseField id="field" name="component" label="Input control">
+        <select name="component" aria-labelledby="field-label" />
+      </BaseField>,
+    );
+
+    const spacingElement = container.querySelector('.not-last\\:mb-8');
+    expect(spacingElement).not.toBeNull();
+    expect(spacingElement?.classList.contains('@container')).toBe(false);
+
+    const queryContainer = container.querySelector('.\\@container');
+    expect(queryContainer).not.toBeNull();
+    expect(queryContainer?.contains(container.querySelector('select'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Fixes issue where input control picker disappears  

<img width="841" height="188" alt="Screenshot 2026-07-29 at 11 24 17 AM" src="https://github.com/user-attachments/assets/fbd75f6a-63ee-4b52-b42d-fae2cf3e8a90" />
