### PR TITLE
fix(ci): scope merge queue tests to affected tasks

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -448,15 +448,16 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      - name: Run tests (PRs run only tasks affected by the PR diff)
+      - name: Run tests (PRs and merge groups run only affected tasks)
+        env:
+          DIFF_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
-          # PR checkouts are a synthetic merge of the PR into its base, so
-          # HEAD^1 is the base tip and --affected scopes the run to tasks
-          # whose declared inputs the PR touches, plus their dependents
-          # (turbo.json enables futureFlags.affectedUsingTaskInputs so
+          # PR and merge-group checkouts are synthetic merges. Diff against
+          # the event's base SHA so merge groups that contain multiple PRs
+          # include the whole group's combined change. --affected scopes the
+          # run to tasks whose declared inputs the diff touches, plus their
+          # dependents (turbo.json enables affectedUsingTaskInputs so
           # selection matches what cache hashing considers an input).
-          # Anything skipped here is still covered by the full merge-queue
-          # run before it can land.
           #
           # Fail closed: a change outside the workspace package trees (this
           # workflow, composite actions, .nvmrc, pnpm-workspace.yaml, root
@@ -465,15 +466,23 @@ jobs:
           # lockfile stays on the affected path because turbo hashes it
           # granularly per package; docs, changesets, and markdown are inert
           # to tests.
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] \
-            && git diff --quiet HEAD^1 HEAD -- . \
-              ':(exclude)packages' ':(exclude)apps' ':(exclude)workers' \
-              ':(exclude)tooling' ':(exclude)docs' ':(exclude).changeset' \
-              ':(exclude)pnpm-lock.yaml' ':(exclude)*.md'; then
-            TURBO_SCM_BASE=$(git rev-parse HEAD^1) pnpm exec turbo run test --affected
-          else
-            pnpm exec turbo run test
-          fi
+          case "$GITHUB_EVENT_NAME" in
+            pull_request|merge_group)
+              if [[ -n "$DIFF_BASE_SHA" ]] \
+                && git cat-file -e "$DIFF_BASE_SHA^{commit}" \
+                && git diff --quiet "$DIFF_BASE_SHA" HEAD -- . \
+                  ':(exclude)packages' ':(exclude)apps' ':(exclude)workers' \
+                  ':(exclude)tooling' ':(exclude)docs' ':(exclude).changeset' \
+                  ':(exclude)pnpm-lock.yaml' ':(exclude)*.md'; then
+                echo "Running test tasks affected by $DIFF_BASE_SHA..HEAD"
+                TURBO_SCM_BASE="$DIFF_BASE_SHA" pnpm exec turbo run test --affected
+                exit 0
+              fi
+              ;;
+          esac
+
+          echo "Running the full test suite for $GITHUB_EVENT_NAME"
+          pnpm exec turbo run test
 
   quality:
     needs:

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -82,6 +82,30 @@ test('e2e-policy can query the Actions API for the merge-queue fast path', () =>
   assert.match(policyJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
 });
 
+test('unit tests use affected task selection for PRs and merge groups', () => {
+  const testJob = job('test');
+  assert.ok(testJob, 'test job exists');
+  assert.match(
+    testJob,
+    /DIFF_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
+    'test job diffs each event against its full base',
+  );
+  assert.match(
+    testJob,
+    /pull_request\|merge_group\)/,
+    'both PR and merge-group events enter the affected path',
+  );
+  assert.match(
+    testJob,
+    /TURBO_SCM_BASE="\$DIFF_BASE_SHA" pnpm exec turbo run test --affected/,
+  );
+  assert.match(
+    testJob,
+    /git cat-file -e "\$DIFF_BASE_SHA\^\{commit\}"/,
+    'a missing diff base fails closed to the full suite',
+  );
+});
+
 test('release job prunes ignored-lane changesets before changesets/action', () => {
   const releaseJob = job('release');
   assert.ok(releaseJob, 'release job exists');


### PR DESCRIPTION
## Summary

- run Turbo affected test selection for both pull requests and merge groups
- diff merge groups from `merge_group.base_sha` so batched groups include their full combined change
- retain the existing fail-closed full-suite path for CI, root config, or unavailable-base changes
- add a workflow contract test covering merge-group selection and base validation

## Evidence

The merge-group test job in run 30533358955 bypassed `--affected` because the workflow only admitted `pull_request` events, so 16 test tasks were selected and 5 executed after cache lookup. Replaying the updated selection against that exact merge-group range scopes Architect and Interviewer but executes zero unit-test tasks for the two PNG-only changes.

## Test plan

- [x] replay affected selection against merge-group SHA `442b28c9972a10fb75fa7b1811e19da037c2bfb1` and base `f379f091d8d33dba99e08d2398d378b2e87b0dcf`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm test:scripts`
- [x] workflow YAML parse and focused formatting checks

No changeset: CI and test infrastructure only.