### PR TITLE
docs: describe Fresco as a mature platform

### DIFF
--- a/.changeset/fresco-mature-positioning.md
+++ b/.changeset/fresco-mature-positioning.md
@@ -1,0 +1,6 @@
+---
+"@codaco/documentation": patch
+---
+
+Describe Fresco consistently as a mature web platform, replacing outdated
+language that characterized the project or its shared platform as new.

--- a/apps/documentation/docs/collect-data/fresco/about.en.mdx
+++ b/apps/documentation/docs/collect-data/fresco/about.en.mdx
@@ -5,15 +5,15 @@ navOrder: 1
 ---
 
 <Paragraph variant="lead">
-  Fresco is an exciting new project that brings Network Canvas interviews to the
-  web browser.
+  Fresco is a mature web platform for conducting Network Canvas interviews in
+  the browser.
 </Paragraph>
 
 It allows you to take any existing Network Canvas protocol file, upload it to your own private instance of the app, and then share a URL with participants to allow them to complete the interview on their own device.
 
 The interview experience for participants is identical to that of the desktop applications, but you conduct all protocol, participant, and data management through a secure web-based dashboard.
 
-Although Fresco does not add new features to Network Canvas, it provides an entirely new way to conduct interviews using
+Although Fresco does not add new features to Network Canvas, it provides a flexible way to conduct interviews using
 your existing Network Canvas protocols.
 
 ![The Fresco dashboard.](/assets/img/fresco-images/features/dashboard.png)
@@ -84,7 +84,7 @@ Although there are no new features added to the interview experience, there are 
 
 You should be aware of several key differences between Fresco and the desktop applications:
 
-- Fresco is a web-based platform for administering Network Canvas interviews. It is not a replacement for the desktop applications, but rather a new way to conduct interviews. Fresco works with all existing Network Canvas protocols and does not add new features to Network Canvas.
+- Fresco is a web-based platform for administering Network Canvas interviews. It complements the desktop applications by supporting browser-based interviews. Fresco works with all existing Network Canvas protocols and does not add new features to Network Canvas.
 - In Fresco, **participants complete interviews in a browser** by visiting a URL. This means you can conduct interviews remotely, and participants can use their own devices to complete the interview. **Note that mobile phones are not supported!**
 - **You also conduct interview management in the browser** via a researcher-facing dashboard. You can manage protocols, participants, interviews, and settings configuration through the browser interface.
 - **Fresco stores all data in a database**. This means data is stored on a server on the internet, rather than on a local computer. This has implications for data security and privacy, so you will need to consider the legal and ethical implications of using Fresco.

--- a/apps/documentation/docs/collect-data/interviewer/using-interviewer.en.mdx
+++ b/apps/documentation/docs/collect-data/interviewer/using-interviewer.en.mdx
@@ -52,7 +52,7 @@ Interviewer comes in two supported versions. Choose the one you are using below 
 
 <AppOnly axis="interviewer" app="current">
 
-**Interviewer** runs in your web browser — with nothing to install — and can be installed to a device you control as a Progressive Web App. It is built on the same new platform as Fresco 4.0. It supports **schema 8** (so it can run protocols built in [Architect](/en/design-protocols/getting-started)) and is compatible with your existing protocols, while adding an improved interview experience, data export, and on-device security. Because some schema-8 interfaces (such as [Geospatial](/en/design-protocols/interface-documentation/geospatial)) need an internet connection, fully offline collection isn't always possible. It's **recommended for new studies**.
+**Interviewer** runs in your web browser — with nothing to install — and can be installed to a device you control as a Progressive Web App. It is built on the same web platform as Fresco 4.0. It supports **schema 8** (so it can run protocols built in [Architect](/en/design-protocols/getting-started)) and is compatible with your existing protocols, while adding an improved interview experience, data export, and on-device security. Because some schema-8 interfaces (such as [Geospatial](/en/design-protocols/interface-documentation/geospatial)) need an internet connection, fully offline collection isn't always possible. It's **recommended for new studies**.
 
 </AppOnly>
 

--- a/apps/documentation/docs/get-started/project-information/faq.en.md
+++ b/apps/documentation/docs/get-started/project-information/faq.en.md
@@ -9,7 +9,7 @@ navOrder: 5
 
 Network Canvas is a suite of three applications designed to assist researchers in the collection of social network data. These applications are: Architect for building interview protocols, Interviewer for use in the field to collect data, and [Fresco](/en/collect-data/fresco) for deploying protocols in the web browser.
 
-Interviewer comes in two supported versions: the established **Interviewer Classic**, and the normal app, which is built on the same new platform as Fresco, supports schema 8, and is recommended for new studies. See [Running Interviews](/en/collect-data) for a comparison of the interview apps. If you have used the Classic apps before and are considering the move, see [Migrating from the Classic Apps](/en/get-started/migrating-from-classic).
+Interviewer comes in two supported versions: the established **Interviewer Classic**, and the normal app, which is built on the same web platform as Fresco, supports schema 8, and is recommended for new studies. See [Running Interviews](/en/collect-data) for a comparison of the interview apps. If you have used the Classic apps before and are considering the move, see [Migrating from the Classic Apps](/en/get-started/migrating-from-classic).
 
 We have designed our software to overcome a few distinct barriers to social network data collection:
 


### PR DESCRIPTION
## Summary
- describe Fresco explicitly as a mature web platform
- replace stale “new way” and “new platform” wording across the documentation
- add a Documentation patch changeset

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/documentation test`
- [x] `pnpm --filter @codaco/documentation build`
- [x] `git diff --check`