### PR TITLE
fix(architect): reject options saved without a label or value

### DIFF
--- a/.changeset/architect-incomplete-option-save.md
+++ b/.changeset/architect-incomplete-option-save.md
@@ -1,0 +1,9 @@
+---
+'@codaco/architect': patch
+---
+
+Fix being able to save an option that has no label or no value. Confirming an
+option you had not filled in used to collapse it into the list with nothing to
+show it was incomplete, leaving a protocol that failed validation later. The
+option's editor now stays open and marks whichever field is still missing, and
+an options list containing an incomplete option says so.

--- a/apps/architect/src/components/Options/Option.tsx
+++ b/apps/architect/src/components/Options/Option.tsx
@@ -2,6 +2,7 @@ import { toNumber } from 'es-toolkit/compat';
 import { Check, Pencil, Trash2 } from 'lucide-react';
 import type { ComponentType } from 'react';
 import { useEffect, useRef } from 'react';
+import { touch } from 'redux-form';
 
 import { IconButton } from '@codaco/fresco-ui/Button';
 import useDialog from '@codaco/fresco-ui/dialogs/useDialog';
@@ -11,6 +12,7 @@ import RichTextEditorField from '@codaco/fresco-ui/form/fields/RichTextEditor';
 import type { FrescoReduxArrayFieldItemProps } from '~/components/Form/FrescoReduxArrayField';
 import FrescoReduxField from '~/components/Form/FrescoReduxField';
 import ValidatedField from '~/components/Form/ValidatedField';
+import { useAppDispatch } from '~/ducks/hooks';
 import { cx } from '~/utils/cva';
 import {
   markdownToRichTextContent,
@@ -18,7 +20,9 @@ import {
   type RichTextContent,
 } from '~/utils/markdownAdapter';
 
+import { isOptionComplete, isOptionValueEmpty } from './optionCompleteness';
 import type { OptionValue } from './Options';
+
 const isNumberLike = (value: string) =>
   Number.parseInt(value, 10).toString() === value; // eslint-disable-line
 
@@ -34,9 +38,6 @@ const optionLabelFromRedux = (value: unknown) =>
 const optionLabelToRedux = (value: unknown) =>
   richTextContentToMarkdown(value as RichTextContent | undefined, true);
 
-const isValueEmpty = (value: unknown) =>
-  value === undefined || value === null || value === '';
-
 // Background and rounding live on the ArrayField item Surface (see Options.tsx
 // itemClasses); this inner wrapper only owns layout + the error-state border.
 const ROW_CLASSES =
@@ -47,6 +48,7 @@ type OptionProps = FrescoReduxArrayFieldItemProps<OptionValue>;
 const Option = ({
   item,
   fieldName,
+  form,
   index,
   itemCount,
   isSortable,
@@ -61,6 +63,7 @@ const Option = ({
   showErrors,
 }: OptionProps) => {
   const { confirm } = useDialog();
+  const dispatch = useAppDispatch();
   const interactionDisabled = disabled || readOnly;
 
   // immediateAdd (see Options.tsx) commits a new option straight into the
@@ -71,10 +74,19 @@ const Option = ({
   const hasAutoOpenedRef = useRef(false);
   useEffect(() => {
     if (hasAutoOpenedRef.current || isBeingEdited) return;
-    if (item.label || !isValueEmpty(item.value)) return;
+    if (item.label || !isOptionValueEmpty(item.value)) return;
     hasAutoOpenedRef.current = true;
     onEdit();
   }, [isBeingEdited, item.label, item.value, onEdit]);
+
+  const handleFinishEditing = () => {
+    if (!isOptionComplete(item)) {
+      dispatch(touch(form, `${fieldName}.label`, `${fieldName}.value`));
+      return;
+    }
+
+    onCancel();
+  };
 
   const handleDelete = () => {
     void confirm({
@@ -89,7 +101,7 @@ const Option = ({
 
   if (!isBeingEdited) {
     const hasLabel = typeof item.label === 'string' && item.label.length > 0;
-    const hasValue = !isValueEmpty(item.value);
+    const hasValue = !isOptionValueEmpty(item.value);
 
     return (
       <div
@@ -154,7 +166,7 @@ const Option = ({
       onKeyDown={(event) => {
         if (event.key !== 'Escape') return;
         event.stopPropagation();
-        onCancel();
+        handleFinishEditing();
       }}
     >
       <div className="flex items-center justify-end gap-2">
@@ -164,7 +176,7 @@ const Option = ({
           size="lg"
           color="primary"
           disabled={interactionDisabled}
-          onClick={onCancel}
+          onClick={handleFinishEditing}
         />
         <IconButton
           icon={<Trash2 />}

--- a/apps/architect/src/components/Options/Option.tsx
+++ b/apps/architect/src/components/Options/Option.tsx
@@ -20,7 +20,11 @@ import {
   type RichTextContent,
 } from '~/utils/markdownAdapter';
 
-import { isOptionComplete, isOptionValueEmpty } from './optionCompleteness';
+import {
+  isOptionComplete,
+  isOptionLabelEmpty,
+  isOptionValueEmpty,
+} from './optionCompleteness';
 import type { OptionValue } from './Options';
 
 const isNumberLike = (value: string) =>
@@ -100,7 +104,7 @@ const Option = ({
   };
 
   if (!isBeingEdited) {
-    const hasLabel = typeof item.label === 'string' && item.label.length > 0;
+    const hasLabel = !isOptionLabelEmpty(item.label);
     const hasValue = !isOptionValueEmpty(item.value);
 
     return (

--- a/apps/architect/src/components/Options/Options.tsx
+++ b/apps/architect/src/components/Options/Options.tsx
@@ -4,12 +4,18 @@ import type { VariableOptions } from '@codaco/protocol-validation';
 import FrescoReduxArrayField from '~/components/Form/FrescoReduxArrayField';
 
 import Option from './Option';
+import { isOptionComplete } from './optionCompleteness';
 
 export type OptionValue = VariableOptions[number];
 
 export const minTwoOptions = (value: unknown) =>
   !value || (Array.isArray(value) && value.length < 2)
     ? 'Requires a minimum of two options. If you need fewer options, consider using a boolean variable.'
+    : undefined;
+
+export const completeOptions = (value: unknown) =>
+  Array.isArray(value) && !value.every(isOptionComplete)
+    ? 'Every option needs both a label and a value.'
     : undefined;
 
 type OptionsProps = {
@@ -30,7 +36,7 @@ const Options = ({ name, label = '' }: OptionsProps) => (
     immediateAdd
     sortable
     confirmDelete={false}
-    validate={minTwoOptions}
+    validate={[minTwoOptions, completeOptions]}
     rerenderOnEveryChange
   />
 );

--- a/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
+++ b/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
@@ -86,6 +86,16 @@ describe('Option', () => {
     expect(isFormValid()).toBe(true);
   });
 
+  it('shows a whitespace-only label as untitled, matching the validator', () => {
+    const { isFormValid } = setup([
+      ...TWO_VALID_OPTIONS,
+      { label: '   ', value: 3 },
+    ]);
+
+    expect(screen.getByText('Untitled option')).toBeInTheDocument();
+    expect(isFormValid()).toBe(false);
+  });
+
   it('reports an incomplete option that was collapsed by adding another', async () => {
     const { isFormValid, getOptions } = setup();
 

--- a/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
+++ b/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
@@ -47,10 +47,7 @@ const setup = (options: OptionValue[] = TWO_VALID_OPTIONS) => {
 
   return {
     isFormValid: () => isValid(FORM)(store.getState()),
-    getOptions: () =>
-      (store.getState() as { form: Record<string, { values?: unknown }> }).form[
-        FORM
-      ]?.values,
+    getOptions: () => store.getState().form[FORM]?.values,
   };
 };
 

--- a/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
+++ b/apps/architect/src/components/Options/__tests__/Option.behaviour.test.tsx
@@ -1,0 +1,106 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import {
+  isValid,
+  reducer as formReducer,
+  reduxForm,
+  type InjectedFormProps,
+} from 'redux-form';
+import { describe, expect, it } from 'vitest';
+
+import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
+
+import type { OptionValue } from '../Options';
+import Options from '../Options';
+
+const FORM = 'optionsBehaviour';
+
+const Harness = (_props: InjectedFormProps) => (
+  <Options name="options" label="Options" />
+);
+
+const OptionsForm = reduxForm({ form: FORM })(Harness);
+
+const TWO_VALID_OPTIONS: OptionValue[] = [
+  { label: 'One', value: 1 },
+  { label: 'Two', value: 2 },
+];
+
+const setup = (options: OptionValue[] = TWO_VALID_OPTIONS) => {
+  const store = configureStore({
+    reducer: { form: formReducer },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  });
+
+  render(
+    <Provider store={store}>
+      <DialogProvider>
+        <OptionsForm initialValues={{ options }} />
+      </DialogProvider>
+    </Provider>,
+  );
+
+  return {
+    isFormValid: () => isValid(FORM)(store.getState()),
+    getOptions: () =>
+      (store.getState() as { form: Record<string, { values?: unknown }> }).form[
+        FORM
+      ]?.values,
+  };
+};
+
+const addNewOption = async () => {
+  fireEvent.click(screen.getByRole('button', { name: /add new/i }));
+  return screen.findByRole('button', { name: /finish editing option/i });
+};
+
+describe('Option', () => {
+  it('keeps the editor open when finishing an option with no label or value', async () => {
+    const { isFormValid } = setup();
+
+    fireEvent.click(await addNewOption());
+
+    expect(
+      screen.getByRole('button', { name: /finish editing option/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Required').length).toBeGreaterThan(0);
+    expect(isFormValid()).toBe(false);
+  });
+
+  it('collapses an option that has both a label and a value', async () => {
+    const { isFormValid } = setup([
+      ...TWO_VALID_OPTIONS,
+      { label: 'Three', value: 3 },
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit option 3/i }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: /finish editing option/i }),
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /finish editing option/i }),
+    ).not.toBeInTheDocument();
+    expect(isFormValid()).toBe(true);
+  });
+
+  it('reports an incomplete option that was collapsed by adding another', async () => {
+    const { isFormValid, getOptions } = setup();
+
+    await addNewOption();
+    await addNewOption();
+
+    expect(
+      screen.getByText('Every option needs both a label and a value.'),
+    ).toBeInTheDocument();
+    expect(isFormValid()).toBe(false);
+    expect(getOptions()).toEqual({
+      options: [...TWO_VALID_OPTIONS, {}, {}],
+    });
+  });
+});

--- a/apps/architect/src/components/Options/__tests__/Options.test.ts
+++ b/apps/architect/src/components/Options/__tests__/Options.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { getValidations } from '~/utils/validations';
 
 import { parseOptionValue } from '../Option';
-import { minTwoOptions } from '../Options';
+import { completeOptions, minTwoOptions } from '../Options';
 
 describe('Options', () => {
   it('requires at least two options', () => {
@@ -18,6 +18,27 @@ describe('Options', () => {
         { label: 'Two', value: 2 },
       ]),
     ).toBeUndefined();
+  });
+
+  it('requires every option to have a label and a value', () => {
+    expect(
+      completeOptions([
+        { label: 'One', value: 1 },
+        { label: 'Two', value: 2 },
+      ]),
+    ).toBeUndefined();
+    expect(completeOptions([{ label: 'Zero', value: 0 }])).toBeUndefined();
+    expect(completeOptions(undefined)).toBeUndefined();
+
+    expect(completeOptions([{}])).toMatch(/label and a value/i);
+    expect(completeOptions([{ label: 'One' }])).toMatch(/label and a value/i);
+    expect(completeOptions([{ value: 1 }])).toMatch(/label and a value/i);
+    expect(completeOptions([{ label: '  ', value: 1 }])).toMatch(
+      /label and a value/i,
+    );
+    expect(completeOptions([{ label: 'One', value: '' }])).toMatch(
+      /label and a value/i,
+    );
   });
 
   it('normalizes integer-like input without collapsing other strings', () => {

--- a/apps/architect/src/components/Options/optionCompleteness.ts
+++ b/apps/architect/src/components/Options/optionCompleteness.ts
@@ -4,7 +4,8 @@ export const isOptionValueEmpty = (value: unknown) =>
 export const isOptionComplete = (option: unknown) => {
   if (!option || typeof option !== 'object') return false;
 
-  const { label, value } = option as { label?: unknown; value?: unknown };
+  const label = 'label' in option ? option.label : undefined;
+  const value = 'value' in option ? option.value : undefined;
 
   return (
     typeof label === 'string' &&

--- a/apps/architect/src/components/Options/optionCompleteness.ts
+++ b/apps/architect/src/components/Options/optionCompleteness.ts
@@ -1,0 +1,14 @@
+export const isOptionValueEmpty = (value: unknown) =>
+  value === undefined || value === null || value === '';
+
+export const isOptionComplete = (option: unknown) => {
+  if (!option || typeof option !== 'object') return false;
+
+  const { label, value } = option as { label?: unknown; value?: unknown };
+
+  return (
+    typeof label === 'string' &&
+    label.trim() !== '' &&
+    !isOptionValueEmpty(value)
+  );
+};

--- a/apps/architect/src/components/Options/optionCompleteness.ts
+++ b/apps/architect/src/components/Options/optionCompleteness.ts
@@ -1,3 +1,6 @@
+export const isOptionLabelEmpty = (label: unknown) =>
+  typeof label !== 'string' || label.trim() === '';
+
 export const isOptionValueEmpty = (value: unknown) =>
   value === undefined || value === null || value === '';
 
@@ -7,9 +10,5 @@ export const isOptionComplete = (option: unknown) => {
   const label = 'label' in option ? option.label : undefined;
   const value = 'value' in option ? option.value : undefined;
 
-  return (
-    typeof label === 'string' &&
-    label.trim() !== '' &&
-    !isOptionValueEmpty(value)
-  );
+  return !isOptionLabelEmpty(label) && !isOptionValueEmpty(value);
 };


### PR DESCRIPTION
## Fixes bug where options could be saved without a label or value, resulting in an invalid protocol.

### Bug:
An option's label and value fields are only mounted while its row is expanded, so redux-form unregistered their required validators when the row collapsed. Clicking the check button on a blank option therefore left in the options array with nothing left to report it, and the form reported itself valid, which saved an invalid protocol.

**Fix:**
Add a  validator on the options FieldArray, which outlives the per-row fields, and hold the editor open on an incomplete option instead of collapsing it, touching both fields so their errors show

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete options from being saved.
  * Option editors now remain open when a label or value is missing, with required fields highlighted.
  * Added validation to ensure every option includes both a label and a value.
  * Improved handling of numeric option values.

* **Tests**
  * Added coverage for incomplete-option validation, editing behavior, and form validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->