### PR TITLE
Fix Chromatic release diagnostics

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -339,7 +339,7 @@ jobs:
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_FRESCO_UI }}
         run: |
-          pnpm --filter @codaco/fresco-ui chromatic -- \
+          pnpm --filter @codaco/fresco-ui chromatic \
             --skip-update-check --no-interactive \
             --log-file="$RUNNER_TEMP/chromatic-fresco-ui.log"
       - name: Summarize Chromatic build
@@ -378,7 +378,7 @@ jobs:
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_INTERVIEW }}
         run: |
-          pnpm --filter @codaco/interview chromatic -- \
+          pnpm --filter @codaco/interview chromatic \
             --skip-update-check --no-interactive \
             --log-file="$RUNNER_TEMP/chromatic-interview.log"
       - name: Summarize Chromatic build
@@ -417,7 +417,7 @@ jobs:
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_INTERVIEWER }}
         run: |
-          pnpm --filter @codaco/interviewer chromatic -- \
+          pnpm --filter @codaco/interviewer chromatic \
             --skip-update-check --no-interactive \
             --log-file="$RUNNER_TEMP/chromatic-interviewer.log"
       - name: Summarize Chromatic build

--- a/scripts/chromatic-observability.mjs
+++ b/scripts/chromatic-observability.mjs
@@ -162,8 +162,25 @@ function main() {
     usageError('GITHUB_STEP_SUMMARY is not set');
   }
 
-  const log = readFileSync(logPath, 'utf8');
-  const result = parseChromaticLog(log, { mode });
+  let result;
+  try {
+    const log = readFileSync(logPath, 'utf8');
+    result = parseChromaticLog(log, { mode });
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+
+    result = {
+      state: 'diagnostics-unavailable',
+      snapshotsCaptured: null,
+      snapshotsInherited: null,
+      buildScope: 'unavailable',
+      bailoutReason: null,
+    };
+    process.stdout.write(
+      `::warning title=Chromatic diagnostics unavailable::${project} did not create its optional diagnostic log; the Chromatic step remains authoritative.\n`,
+    );
+  }
+
   appendFileSync(
     process.env.GITHUB_STEP_SUMMARY,
     formatChromaticSummary(project, mode, result),

--- a/scripts/chromatic-observability.test.mjs
+++ b/scripts/chromatic-observability.test.mjs
@@ -137,21 +137,42 @@ test('CLI appends a summary and succeeds when optional metrics are unavailable',
   }
 });
 
-test('CLI fails for invalid invocation and unreadable log files', () => {
+test('CLI fails for invalid invocation', () => {
   const invocation = spawnSync(process.execPath, [scriptPath], {
     encoding: 'utf8',
   });
   assert.notEqual(invocation.status, 0);
   assert.match(invocation.stderr, /Usage:/);
+});
 
-  const missingFile = spawnSync(
-    process.execPath,
-    [scriptPath, 'Interview', '/does/not/exist.log', 'affected'],
-    {
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_STEP_SUMMARY: '/tmp/summary.md' },
-    },
-  );
-  assert.notEqual(missingFile.status, 0);
-  assert.match(missingFile.stderr, /ENOENT/);
+test('CLI warns without failing when the optional log file is absent', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'chromatic-observability-'));
+  const summaryPath = join(directory, 'summary.md');
+  writeFileSync(summaryPath, '# Existing summary\n');
+
+  try {
+    const missingFile = spawnSync(
+      process.execPath,
+      [scriptPath, 'Interview', join(directory, 'missing.log'), 'affected'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, GITHUB_STEP_SUMMARY: summaryPath },
+      },
+    );
+    assert.equal(missingFile.status, 0);
+    assert.match(
+      missingFile.stdout,
+      /::warning title=Chromatic diagnostics unavailable::/,
+    );
+
+    const summary = readFileSync(summaryPath, 'utf8');
+    assert.match(summary, /^# Existing summary/m);
+    assert.match(
+      summary,
+      /\| Interview \| affected \| diagnostics-unavailable \|/,
+    );
+    assert.match(summary, /unavailable/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });

--- a/scripts/chromatic-workflow.test.mjs
+++ b/scripts/chromatic-workflow.test.mjs
@@ -134,6 +134,24 @@ test('unaffected release projects call Chromatic skip from one setup job', () =>
   }
 });
 
+test('affected release projects pass runtime options through pnpm', () => {
+  for (const [jobName, packageName] of [
+    ['fresco-ui', '@codaco/fresco-ui'],
+    ['interview', '@codaco/interview'],
+    ['interviewer', '@codaco/interviewer'],
+  ]) {
+    const body = job(jobName);
+    assert.ok(body, `${jobName} job exists`);
+    assert.match(
+      body,
+      new RegExp(
+        `pnpm --filter ${packageName.replace('/', '\\/')} chromatic \\\\\\n\\s+--skip-update-check --no-interactive \\\\\\n\\s+--log-file="\\$RUNNER_TEMP/chromatic-${jobName}\\.log"`,
+      ),
+    );
+    assert.doesNotMatch(body, /pnpm --filter [^\n]+ chromatic -- \\/);
+  }
+});
+
 test('Chromatic waits for rendering but leaves visual acceptance to UI Tests', () => {
   for (const [project, manifest] of Object.entries(packages)) {
     const script = manifest.scripts.chromatic;


### PR DESCRIPTION
## Summary

- pass Chromatic runtime options through pnpm in all three affected release jobs
- keep missing optional diagnostic logs from masking the authoritative Chromatic result
- add regression coverage for argument forwarding and the missing-log fallback

## Root cause

The affected jobs invoked the package script with a standalone `--`. pnpm forwarded that delimiter to Chromatic, so `--log-file` was treated as a positional argument. Chromatic completed successfully, but the always-running summary step then failed with `ENOENT` because the diagnostic file had never been created.

## Verification

- `pnpm lint:fix`
- `pnpm lint`
- `pnpm test:scripts` (144 tests)
- `pnpm typecheck`
- `pnpm knip`
- `pnpm check:changesets`
- `git diff --check`
- visual-baseline assessment: no rendered application path changed; no regeneration required

## Changeset

Not required: this is CI workflow and diagnostic tooling only.