### PR TITLE
Feature: boolean toggle negative option styling

### DIFF
--- a/.changeset/architect-boolean-negative-help-text.md
+++ b/.changeset/architect-boolean-negative-help-text.md
@@ -1,0 +1,5 @@
+---
+'@codaco/architect': patch
+---
+
+Marking a boolean option as negative now takes effect during an interview — the option is shown in red once a participant selects it. The BooleanChoice help text has been corrected to describe what participants actually see.

--- a/.changeset/boolean-negative-option-styling.md
+++ b/.changeset/boolean-negative-option-styling.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+`BooleanField` now honours the `negative` flag on a boolean option. Selecting an option marked negative styles its border and indicator in the destructive colour instead of the primary one; unselected options are unchanged. Previously the flag was accepted by the protocol schema and written by Architect, but ignored at render time.

--- a/.changeset/boolean-negative-option-styling.md
+++ b/.changeset/boolean-negative-option-styling.md
@@ -1,5 +1,6 @@
 ---
 '@codaco/fresco-ui': patch
+'@codaco/interview': patch
 ---
 
 `BooleanField` now honours the `negative` flag on a boolean option. Selecting an option marked negative styles its border and indicator in the destructive colour instead of the primary one; unselected options are unchanged. Previously the flag was accepted by the protocol schema and written by Architect, but ignored at render time.

--- a/.changeset/interviewer-boolean-negative-option.md
+++ b/.changeset/interviewer-boolean-negative-option.md
@@ -1,0 +1,5 @@
+---
+'@codaco/interviewer': patch
+---
+
+Boolean questions now show an option in red once it is selected, where the protocol marks that option as a negative response.

--- a/apps/architect/src/components/BooleanChoice.tsx
+++ b/apps/architect/src/components/BooleanChoice.tsx
@@ -65,8 +65,7 @@ const Options = compose(connect(mapStateToProps, mapDispatchToProps))(({
       </Paragraph>
       <Paragraph>
         Each value can also be styled to indicate that it is negative. When
-        enabled, this will make the option red when selected, and use a cross
-        icon rather than a tick.
+        enabled, this will make the option red when selected.
       </Paragraph>
       <div className="grid grid-cols-1 gap-5">
         <div className="bg-surface-3 text-surface-3-contrast rounded p-7 [&_h3]:mt-0">

--- a/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<StoryArgs> = {
     docs: {
       description: {
         component:
-          'A radiogroup of option cards for a boolean value. Options sit side by side and wrap to a stack only when their container is too narrow for them — sizing is intrinsic, so the field also works inside fit-content parents. Use the container width control to watch the layout respond, and edit the options to see how label length affects when wrapping happens.',
+          'A radiogroup of option cards for a boolean value. Options sit side by side and wrap to a stack only when their container is too narrow for them — sizing is intrinsic, so the field also works inside fit-content parents. Use the container width control to watch the layout respond, and edit the options to see how label length affects when wrapping happens.\n\nAn option may be marked `negative` to style it as a negative response: once selected, its border and indicator take the destructive colour instead of the primary one. Unselected negative options look like any other option. The emphasis is presentational only — the option label carries the meaning, so nothing extra is announced to assistive technology.',
       },
     },
   },
@@ -31,9 +31,13 @@ const meta: Meta<StoryArgs> = {
     },
     'options': {
       control: 'object',
-      description: 'Label and value for each choice',
+      description:
+        'Label and value for each choice. Set `negative` to style a choice as a negative response when selected.',
       table: {
-        type: { summary: 'Array<{ label: string; value: boolean }>' },
+        type: {
+          summary:
+            'Array<{ label: string; value: boolean; negative?: boolean }>',
+        },
         defaultValue: {
           summary:
             '[{ label: "Yes", value: true }, { label: "No", value: false }]',
@@ -105,26 +109,71 @@ const meta: Meta<StoryArgs> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const renderField = (args: StoryArgs) => {
+  const { containerWidth, ...fieldArgs } = args;
+  const [value, setValue] = useState<boolean | undefined>(args.value);
+
+  useEffect(() => {
+    setValue(args.value);
+  }, [args.value]);
+
+  return (
+    <div style={{ width: containerWidth, maxWidth: '100%' }}>
+      <BooleanField
+        {...fieldArgs}
+        value={value}
+        onChange={(newValue) => {
+          setValue(newValue);
+          args.onChange?.(newValue);
+        }}
+      />
+    </div>
+  );
+};
+
 export const Default: Story = {
-  render: (args) => {
-    const { containerWidth, ...fieldArgs } = args;
-    const [value, setValue] = useState<boolean | undefined>(args.value);
+  render: renderField,
+};
 
-    useEffect(() => {
-      setValue(args.value);
-    }, [args.value]);
-
-    return (
-      <div style={{ width: containerWidth, maxWidth: '100%' }}>
-        <BooleanField
-          {...fieldArgs}
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-            args.onChange?.(newValue);
-          }}
-        />
-      </div>
-    );
+export const NegativeOption: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The "No" option is marked `negative`. Select it to see the destructive border and indicator; select "Yes" to confirm the negative option returns to the neutral unselected treatment.',
+      },
+    },
   },
+  args: {
+    value: false,
+    options: [
+      { label: 'Yes', value: true },
+      { label: 'No', value: false, negative: true },
+    ],
+  },
+  render: renderField,
+};
+
+export const NegativeOptionWithLongLabels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A negative option with a label long enough to wrap, in a narrow container — the indicator stays aligned to the first line and does not shrink.',
+      },
+    },
+  },
+  args: {
+    containerWidth: 260,
+    value: false,
+    options: [
+      { label: 'Yes, I am happy to take part in this study', value: true },
+      {
+        label: 'No, I would rather not take part in this study',
+        value: false,
+        negative: true,
+      },
+    ],
+  },
+  render: renderField,
 };

--- a/packages/fresco-ui/src/form/fields/Boolean.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.tsx
@@ -123,7 +123,7 @@ function BooleanIndicator({
         fill="currentColor"
         className={cx(
           'size-full overflow-hidden rounded-full p-[0.1em]',
-          negative ? 'text-destructive' : 'text-primary',
+          negative && isSelected ? 'text-destructive' : 'text-primary',
         )}
       >
         <motion.circle

--- a/packages/fresco-ui/src/form/fields/Boolean.tsx
+++ b/packages/fresco-ui/src/form/fields/Boolean.tsx
@@ -21,6 +21,7 @@ import { getInputState } from '../utils/getInputState';
 type BooleanOption = {
   label: string;
   value: boolean;
+  negative?: boolean;
 };
 
 const optionCardVariants = compose(
@@ -45,8 +46,17 @@ const optionCardVariants = compose(
         readOnly: 'pointer-events-none cursor-default',
         invalid: 'border-destructive',
       },
+      negative: {
+        true: '',
+        false: '',
+      },
     },
     compoundVariants: [
+      {
+        selected: true,
+        negative: true,
+        className: 'border-destructive',
+      },
       {
         selected: true,
         state: 'invalid',
@@ -61,6 +71,7 @@ const optionCardVariants = compose(
     defaultVariants: {
       selected: false,
       state: 'normal',
+      negative: false,
     },
   }),
 );
@@ -98,9 +109,11 @@ type BooleanFieldProps = CreateFormFieldProps<
 function BooleanIndicator({
   isSelected,
   state,
+  negative,
 }: {
   isSelected: boolean;
   state?: 'normal' | 'disabled' | 'readOnly' | 'invalid';
+  negative?: boolean;
 }) {
   return (
     <span aria-hidden className={booleanIndicatorVariants({ state })}>
@@ -108,7 +121,10 @@ function BooleanIndicator({
         aria-hidden="true"
         viewBox="0 0 24 24"
         fill="currentColor"
-        className="text-primary size-full overflow-hidden rounded-full p-[0.1em]"
+        className={cx(
+          'size-full overflow-hidden rounded-full p-[0.1em]',
+          negative ? 'text-destructive' : 'text-primary',
+        )}
       >
         <motion.circle
           cx="12"
@@ -228,12 +244,14 @@ export default function BooleanField(props: BooleanFieldProps) {
               role="radio"
               aria-checked={isSelected}
               data-value={String(option.value)}
+              data-negative={option.negative ? 'true' : undefined}
               tabIndex={
                 isSelected || (value === undefined && index === 0) ? 0 : -1
               }
               className={optionCardVariants({
                 selected: isSelected,
                 state: optionState,
+                negative: option.negative ?? false,
                 size: 'md',
               })}
               onClick={() => {
@@ -246,7 +264,11 @@ export default function BooleanField(props: BooleanFieldProps) {
               whileTap={disabled || readOnly ? undefined : { scale: 0.98 }}
               transition={selectionSpring}
             >
-              <BooleanIndicator isSelected={isSelected} state={optionState} />
+              <BooleanIndicator
+                isSelected={isSelected}
+                state={optionState}
+                negative={option.negative}
+              />
               <span
                 className={headingVariants({ level: 'label', margin: 'none' })}
               >

--- a/packages/fresco-ui/src/form/fields/__tests__/Boolean.test.tsx
+++ b/packages/fresco-ui/src/form/fields/__tests__/Boolean.test.tsx
@@ -40,7 +40,10 @@ describe('BooleanField negative options', () => {
     );
 
     const negativeOption = screen.getByRole('radio', { name: 'No' });
+    const negativeIndicator = negativeOption.querySelector('svg');
     expect(negativeOption.className).not.toContain('border-destructive');
+    expect(negativeIndicator).toHaveClass('text-primary');
+    expect(negativeIndicator).not.toHaveClass('text-destructive');
 
     rerender(
       <BooleanField
@@ -54,12 +57,15 @@ describe('BooleanField negative options', () => {
     expect(screen.getByRole('radio', { name: 'No' }).className).toContain(
       'border-destructive',
     );
+    expect(negativeIndicator).toHaveClass('text-destructive');
+    expect(negativeIndicator).not.toHaveClass('text-primary');
     expect(screen.getByRole('radio', { name: 'Yes' }).className).not.toContain(
       'border-destructive',
     );
   });
 
   it('reports the option value unchanged when a negative option is chosen', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     render(
       <BooleanField
@@ -70,7 +76,7 @@ describe('BooleanField negative options', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('radio', { name: 'No' }));
+    await user.click(screen.getByRole('radio', { name: 'No' }));
 
     expect(onChange).toHaveBeenCalledWith(false);
   });

--- a/packages/fresco-ui/src/form/fields/__tests__/Boolean.test.tsx
+++ b/packages/fresco-ui/src/form/fields/__tests__/Boolean.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import BooleanField from '../Boolean';
+
+const consentOptions = [
+  { label: 'Yes', value: true },
+  { label: 'No', value: false, negative: true },
+];
+
+describe('BooleanField negative options', () => {
+  it('marks only the negative option', () => {
+    render(
+      <BooleanField
+        name="consent"
+        options={consentOptions}
+        value={undefined}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: 'No' })).toHaveAttribute(
+      'data-negative',
+      'true',
+    );
+    expect(screen.getByRole('radio', { name: 'Yes' })).not.toHaveAttribute(
+      'data-negative',
+    );
+  });
+
+  it('applies the destructive treatment only while the negative option is selected', () => {
+    const { rerender } = render(
+      <BooleanField
+        name="consent"
+        options={consentOptions}
+        value={true}
+        onChange={() => undefined}
+      />,
+    );
+
+    const negativeOption = screen.getByRole('radio', { name: 'No' });
+    expect(negativeOption.className).not.toContain('border-destructive');
+
+    rerender(
+      <BooleanField
+        name="consent"
+        options={consentOptions}
+        value={false}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: 'No' }).className).toContain(
+      'border-destructive',
+    );
+    expect(screen.getByRole('radio', { name: 'Yes' }).className).not.toContain(
+      'border-destructive',
+    );
+  });
+
+  it('reports the option value unchanged when a negative option is chosen', async () => {
+    const onChange = vi.fn();
+    render(
+      <BooleanField
+        name="consent"
+        options={consentOptions}
+        value={undefined}
+        onChange={onChange}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('radio', { name: 'No' }));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/interview/e2e/matrix/ego-form.scenarios.ts
+++ b/packages/interview/e2e/matrix/ego-form.scenarios.ts
@@ -470,10 +470,6 @@ export const egoFormScenarios: InterfaceScenarios = {
           prompt: 'How many siblings do you have?',
         });
 
-        // Boolean with custom labels. `negative` is accepted by the schema
-        // (booleanOptionsSchema) but never read by Boolean.tsx (BooleanOption
-        // is `{ label, value }`), so it renders identically — documented, not
-        // separately asserted.
         const booleanVar = synth.addEgoVariable({
           type: 'boolean',
           component: 'Boolean',
@@ -512,6 +508,8 @@ export const egoFormScenarios: InterfaceScenarios = {
         const nope = page.getByRole('radio', { name: 'Nope' });
         await expect(sure).toHaveAttribute('data-value', 'true');
         await expect(nope).toHaveAttribute('data-value', 'false');
+        await expect(nope).toHaveAttribute('data-negative', 'true');
+        await expect(sure).not.toHaveAttribute('data-negative', 'true');
         await nope.click();
 
         await interview.next();

--- a/packages/interview/e2e/matrix/ego-form.scenarios.ts
+++ b/packages/interview/e2e/matrix/ego-form.scenarios.ts
@@ -509,7 +509,7 @@ export const egoFormScenarios: InterfaceScenarios = {
         await expect(sure).toHaveAttribute('data-value', 'true');
         await expect(nope).toHaveAttribute('data-value', 'false');
         await expect(nope).toHaveAttribute('data-negative', 'true');
-        await expect(sure).not.toHaveAttribute('data-negative', 'true');
+        await expect(sure).not.toHaveAttribute('data-negative');
         await nope.click();
 
         await interview.next();

--- a/packages/interview/e2e/matrix/option-inventory.ts
+++ b/packages/interview/e2e/matrix/option-inventory.ts
@@ -192,7 +192,7 @@ export const OPTION_INVENTORY: Record<string, readonly string[]> = {
     'egoVariable.name-fallback-label', // dead: prompt is required, fallback unreachable
     'RadioGroup-auto-columns->6-options',
     'Boolean-custom-options',
-    'Boolean-options[].negative', // dead: Boolean.tsx never reads it
+    'Boolean-options[].negative',
     'validation.required',
     'validation.requiredAcceptsNull', // dead: declared, consumed nowhere
     'validation.minLength/maxLength',


### PR DESCRIPTION
"Style option as negative" in Architect did nothing because the BooleanField was ignoring the `negative` flag. This implements styling the boolean field as negative when that option is configured in Architect.

<img width="788" height="159" alt="Screenshot 2026-07-31 at 11 13 17 AM" src="https://github.com/user-attachments/assets/f1c82ecd-668f-4237-84fa-8dd93990085e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Negative Boolean options now display destructive styling when selected.
  * Corrected help text for negative Boolean choices.
  * Positive and unselected options retain their standard appearance.

* **Documentation**
  * Updated Boolean option guidance and examples, including support for negative options and long labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->