### PR TITLE
Fix Fresco Storybook interaction races

### DIFF
--- a/packages/fresco-ui/src/Definition.stories.tsx
+++ b/packages/fresco-ui/src/Definition.stories.tsx
@@ -93,7 +93,8 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const term = canvas.getByText('personal network');
-    await userEvent.hover(term);
+    term.focus();
+    await expect(term).toHaveFocus();
     await waitFor(() => expect(term).toHaveAttribute('data-popup-open'));
     await expect(term).toHaveAccessibleDescription(
       'The people an individual knows and the relationships among them.',

--- a/packages/fresco-ui/src/collection/stories/Collection.stories.tsx
+++ b/packages/fresco-ui/src/collection/stories/Collection.stories.tsx
@@ -1090,11 +1090,9 @@ export const KeyboardNavigation = meta.story({
     const canvas = within(canvasElement);
 
     // Click first item to establish focus
-    await userEvent.click(canvas.getByTestId('item-1'));
-    await expect(canvas.getByTestId('item-1')).toHaveAttribute(
-      'data-focused',
-      'true',
-    );
+    const firstItem = await canvas.findByTestId('item-1');
+    await userEvent.click(firstItem);
+    await expect(firstItem).toHaveAttribute('data-focused', 'true');
 
     // ArrowDown moves focus to next item
     await userEvent.keyboard('{ArrowDown}');
@@ -1143,11 +1141,9 @@ export const SingleSelection = meta.story({
     const canvas = within(canvasElement);
 
     // Click item-1 to select it
-    await userEvent.click(canvas.getByTestId('item-1'));
-    await expect(canvas.getByTestId('item-1')).toHaveAttribute(
-      'data-selected',
-      'true',
-    );
+    const firstItem = await canvas.findByTestId('item-1');
+    await userEvent.click(firstItem);
+    await expect(firstItem).toHaveAttribute('data-selected', 'true');
 
     // Click item-3 replaces selection (single mode)
     await userEvent.click(canvas.getByTestId('item-3'));
@@ -1191,11 +1187,9 @@ export const MultipleSelection = meta.story({
     const canvas = within(canvasElement);
 
     // Click item-1 to select
-    await userEvent.click(canvas.getByTestId('item-1'));
-    await expect(canvas.getByTestId('item-1')).toHaveAttribute(
-      'data-selected',
-      'true',
-    );
+    const firstItem = await canvas.findByTestId('item-1');
+    await userEvent.click(firstItem);
+    await expect(firstItem).toHaveAttribute('data-selected', 'true');
 
     // Click item-3 adds to selection (toggle behavior)
     await userEvent.click(canvas.getByTestId('item-3'));
@@ -1244,11 +1238,9 @@ export const TypeAheadSearch = meta.story({
     const canvas = within(canvasElement);
 
     // Click first item to establish focus
-    await userEvent.click(canvas.getByTestId('item-1'));
-    await expect(canvas.getByTestId('item-1')).toHaveAttribute(
-      'data-focused',
-      'true',
-    );
+    const firstItem = await canvas.findByTestId('item-1');
+    await userEvent.click(firstItem);
+    await expect(firstItem).toHaveAttribute('data-focused', 'true');
 
     // Type 'b' to jump to Bob Baker
     await userEvent.keyboard('b');
@@ -1288,10 +1280,8 @@ export const DisabledItems = meta.story({
     const canvas = within(canvasElement);
 
     // Verify disabled items have the disabled attribute
-    await expect(canvas.getByTestId('item-2')).toHaveAttribute(
-      'data-disabled',
-      'true',
-    );
+    const firstDisabledItem = await canvas.findByTestId('item-2');
+    await expect(firstDisabledItem).toHaveAttribute('data-disabled', 'true');
     await expect(canvas.getByTestId('item-4')).toHaveAttribute(
       'data-disabled',
       'true',


### PR DESCRIPTION
## Summary
- wait for Collection items to render before running Storybook interactions
- use Definition's deterministic keyboard-focus path in automation while preserving the open-tooltip snapshot
- fix the six Fresco UI component errors exposed by the production Chromatic build

## Test plan
- [x] `pnpm --filter @codaco/fresco-ui exec vitest run --project=storybook src/collection/stories/Collection.stories.tsx src/Definition.stories.tsx --reporter=verbose`
- [x] `pnpm --filter @codaco/fresco-ui test:storybook`
- [x] `pnpm --filter @codaco/fresco-ui test:unit`
- [x] `pnpm --filter @codaco/fresco-ui typecheck`
- [x] `pnpm --filter @codaco/fresco-ui build-storybook`
- [x] verify all six formerly failing production stories locally with `chromatic=true`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] focused Oxlint and formatting checks

No changeset is needed because this changes only Storybook interaction tests. E2E visual baselines are unaffected because no application rendering or captured state changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved interaction test reliability for definition popups by verifying focus before opening.
  * Updated collection tests to wait for items to load before testing keyboard navigation, selection, type-ahead search, and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->