### PR TITLE
Release Website

### DIFF
--- a/.changeset/paired-site-previews-website.md
+++ b/.changeset/paired-site-previews-website.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Make documentation links follow the active local or deploy-preview documentation site, automate paired local site development, repair outdated documentation and publication links, and derive Classic downloads from the latest GitHub releases.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,11 @@
 # networkcanvas.com
 
+## 0.2.2
+
+### Patch Changes
+
+- Make documentation links follow the active local or deploy-preview documentation site, automate paired local site development, repair outdated documentation and publication links, and derive Classic downloads from the latest GitHub releases.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.2.1 | 0.2.2 |

### networkcanvas.com@0.2.2

### Patch Changes

- Make documentation links follow the active local or deploy-preview documentation site, automate paired local site development, repair outdated documentation and publication links, and derive Classic downloads from the latest GitHub releases.
