### PR TITLE
Fix Chromatic target snapshots on main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -361,9 +361,14 @@ jobs:
       - name: Run Chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_FRESCO_UI }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          chromatic_args=(--skip-update-check --no-interactive)
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            chromatic_args+=(--force-rebuild)
+          fi
           pnpm --filter @codaco/fresco-ui chromatic \
-            --skip-update-check --no-interactive \
+            "${chromatic_args[@]}" \
             --log-file="$RUNNER_TEMP/chromatic-fresco-ui.log"
       - name: Summarize Chromatic build
         if: always()
@@ -403,9 +408,14 @@ jobs:
       - name: Run Chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_INTERVIEW }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          chromatic_args=(--skip-update-check --no-interactive)
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            chromatic_args+=(--force-rebuild)
+          fi
           pnpm --filter @codaco/interview chromatic \
-            --skip-update-check --no-interactive \
+            "${chromatic_args[@]}" \
             --log-file="$RUNNER_TEMP/chromatic-interview.log"
       - name: Summarize Chromatic build
         if: always()
@@ -445,9 +455,14 @@ jobs:
       - name: Run Chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_INTERVIEWER }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          chromatic_args=(--skip-update-check --no-interactive)
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            chromatic_args+=(--force-rebuild)
+          fi
           pnpm --filter @codaco/interviewer chromatic \
-            --skip-update-check --no-interactive \
+            "${chromatic_args[@]}" \
             --log-file="$RUNNER_TEMP/chromatic-interviewer.log"
       - name: Summarize Chromatic build
         if: always()

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,7 +3,11 @@ name: Chromatic
 on:
   push:
     branches:
+      - main
       - 'changeset-release/**'
+  # Merge groups publish zero-snapshot statuses at the commit that later lands
+  # on main. The subsequent main push must replace that skipped target with a
+  # real build for every project so future PR changesets have snapshots to use.
   # Once the three `UI Tests: ...` contexts are required on main, every PR and
   # merge-group SHA must receive them. Normal trusted PRs and merge groups use
   # Chromatic's zero-snapshot `--skip` path below; release PRs receive the same
@@ -35,10 +39,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Keep release uploads separate from status-only PR runs so the PR event
-  # caused by a generated-branch push cannot cancel its real capture. Within an
-  # event class, only the newest run for a ref can publish statuses.
-  group: chromatic-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.event.workflow_run.pull_requests[0].number || github.ref_name || github.run_id }}
+  # Main needs one completed target build for every merge commit, so give each
+  # push its own group. Other event classes keep only the newest run for a ref;
+  # release uploads remain isolated from status-only PR runs.
+  group: chromatic-${{ github.event_name }}-${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && github.sha) || github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.event.workflow_run.pull_requests[0].number || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -156,7 +160,8 @@ jobs:
   detect:
     if: >-
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && github.actor != 'dependabot[bot]'
+      && (github.ref_name == github.event.repository.default_branch
+      || github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     outputs:
       fresco_ui: ${{ steps.affected.outputs.fresco_ui }}
@@ -212,11 +217,24 @@ jobs:
           fi
 
           head_sha=$(git rev-parse HEAD)
-          selection=$(node scripts/chromatic-affected.mjs \
-            --base "$BEFORE_SHA" \
-            --head "$head_sha" \
-            --main "origin/$DEFAULT_BRANCH" \
-            --release-ref "$GITHUB_REF_NAME")
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            selection=$(jq -cn '{
+              fresco_ui: true,
+              interview: true,
+              interviewer: true,
+              reasons: {
+                fresco_ui: ["default branch needs a complete target build"],
+                interview: ["default branch needs a complete target build"],
+                interviewer: ["default branch needs a complete target build"]
+              }
+            }')
+          else
+            selection=$(node scripts/chromatic-affected.mjs \
+              --base "$BEFORE_SHA" \
+              --head "$head_sha" \
+              --main "origin/$DEFAULT_BRANCH" \
+              --release-ref "$GITHUB_REF_NAME")
+          fi
 
           fresco_ui=$(jq -r '.fresco_ui' <<< "$selection")
           interview=$(jq -r '.interview' <<< "$selection")
@@ -247,6 +265,8 @@ jobs:
     needs: detect
     if: >-
       needs.detect.result == 'success'
+      && !(github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch)
       && (needs.detect.outputs.fresco_ui != 'true'
       || needs.detect.outputs.interview != 'true'
       || needs.detect.outputs.interviewer != 'true')
@@ -322,7 +342,10 @@ jobs:
   fresco-ui:
     name: Fresco UI
     needs: detect
-    if: needs.detect.outputs.fresco_ui == 'true'
+    if: >-
+      (github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch)
+      || needs.detect.outputs.fresco_ui == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -361,7 +384,10 @@ jobs:
   interview:
     name: Interview
     needs: detect
-    if: needs.detect.outputs.interview == 'true'
+    if: >-
+      (github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch)
+      || needs.detect.outputs.interview == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -400,7 +426,10 @@ jobs:
   interviewer:
     name: Interviewer
     needs: detect
-    if: needs.detect.outputs.interviewer == 'true'
+    if: >-
+      (github.event_name == 'push'
+      && github.ref_name == github.event.repository.default_branch)
+      || needs.detect.outputs.interviewer == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     chromatic:
-      specifier: ^17.3.0
-      version: 17.3.0
+      specifier: ^18.1.0
+      version: 18.1.0
     csvtojson:
       specifier: ^2.0.14
       version: 2.0.14
@@ -1018,7 +1018,7 @@ importers:
         version: 4.1.10(playwright@1.62.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       chromatic:
         specifier: 'catalog:'
-        version: 17.3.0
+        version: 18.1.0
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
@@ -1657,7 +1657,7 @@ importers:
         version: 4.1.10(playwright@1.62.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       chromatic:
         specifier: 'catalog:'
-        version: 17.3.0
+        version: 18.1.0
       jsdom:
         specifier: 'catalog:'
         version: 30.0.0(@noble/hashes@2.2.0)
@@ -1890,7 +1890,7 @@ importers:
         version: 5.6.2
       chromatic:
         specifier: 'catalog:'
-        version: 17.3.0
+        version: 18.1.0
       jsdom:
         specifier: 'catalog:'
         version: 30.0.0(@noble/hashes@2.2.0)
@@ -8176,8 +8176,8 @@ packages:
       '@chromatic-com/vitest':
         optional: true
 
-  chromatic@17.3.0:
-    resolution: {integrity: sha512-x6fjCx72uvc37RyqHxa8I8LqaYhiwzvGg0KyOR1Pwgx+KQ9w1SA7e1rg4oBhGW14gcpcyptLVnVaGxX8wSkaxA==}
+  chromatic@18.1.0:
+    resolution: {integrity: sha512-I9av8lUc5CQRlYzwKpmOG9cwYvZ4AFmTvtHeNrzOMC1353F9xYw45CHpSNIsNKuOiqqmzci9esXQd5akl0fi6w==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -20445,7 +20445,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  chromatic@17.3.0:
+  chromatic@18.1.0:
     dependencies:
       semver: 7.8.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ catalog:
   '@vitest/browser': ^4.1.10
   '@vitest/browser-playwright': ^4.1.10
   '@vitest/coverage-v8': ^4.1.10
-  chromatic: ^17.3.0
+  chromatic: ^18.1.0
   class-variance-authority: 0.7.1
   csvtojson: ^2.0.14
   dotenv: ^17.4.2

--- a/scripts/chromatic-observability.mjs
+++ b/scripts/chromatic-observability.mjs
@@ -5,7 +5,9 @@ const ANSI_ESCAPE_PATTERN =
   // oxlint-disable-next-line no-control-regex -- Chromatic logs contain ANSI styling.
   /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[\dA-PR-TZcf-nq-uy=><~]|(?:[\dA-PR-TZcf-nq-uy=><~](?:;[-a-zA-Z\d/#&.:=?%@~_]+)*))\u0007)|(?:(?:\d{1,4}(?:[;:]\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
 const SNAPSHOT_COUNTS_PATTERN =
-  /\b(?:Captured|Capturing)\s+([\d,]+)\s+snapshots?\s+and\s+(?:skipped|skipping)\s+([\d,]+)\s+snapshots?\.?/i;
+  /\b(?:Captured|Capturing)\s+([\d,]+)\s+snapshots?(?:\s+and\s+(?:skipped|skipping)\s+([\d,]+)\s+snapshots?|,\s+(?:copied|copying)\s+([\d,]+)\s+TurboSnaps?)\.?/i;
+const BYPASSED_SNAPSHOTS_PATTERN =
+  /\bBypassed\s+([\d,]+)\s+snapshots?\s+because no frontend files were changed\.?/i;
 const TURBOSNAP_DISABLED_PATTERN =
   /\bTurboSnap disabled(?: due to ([^\r\n]+))?/i;
 const FULL_BUILD_REASON_PATTERN =
@@ -24,6 +26,19 @@ function cleanLog(log) {
 function parseCount(value) {
   const count = Number(value.replaceAll(',', ''));
   return Number.isSafeInteger(count) ? count : null;
+}
+
+function findSnapshotCounts(log) {
+  const counts = log.match(SNAPSHOT_COUNTS_PATTERN);
+  if (counts) {
+    return {
+      captured: parseCount(counts[1]),
+      inherited: parseCount(counts[2] ?? counts[3]),
+    };
+  }
+
+  const bypassed = log.match(BYPASSED_SNAPSHOTS_PATTERN);
+  return bypassed ? { captured: 0, inherited: parseCount(bypassed[1]) } : null;
 }
 
 function findBailout(lines) {
@@ -87,14 +102,14 @@ export function parseChromaticLog(log, { mode = 'affected' } = {}) {
 
   const lines = cleanLog(log);
   const clean = lines.join('\n');
-  const counts = clean.match(SNAPSHOT_COUNTS_PATTERN);
+  const counts = findSnapshotCounts(clean);
   const bailoutReason = findBailout(lines);
   const turboSnapEnabled = /\bTurboSnap enabled\b/i.test(clean);
 
   return {
     state: findState(clean, mode),
-    snapshotsCaptured: counts ? parseCount(counts[1]) : null,
-    snapshotsInherited: counts ? parseCount(counts[2]) : null,
+    snapshotsCaptured: counts?.captured ?? null,
+    snapshotsInherited: counts?.inherited ?? null,
     buildScope:
       mode === 'skipped'
         ? 'skipped'

--- a/scripts/chromatic-observability.mjs
+++ b/scripts/chromatic-observability.mjs
@@ -24,6 +24,7 @@ function cleanLog(log) {
 }
 
 function parseCount(value) {
+  if (typeof value !== 'string') return null;
   const count = Number(value.replaceAll(',', ''));
   return Number.isSafeInteger(count) ? count : null;
 }

--- a/scripts/chromatic-observability.test.mjs
+++ b/scripts/chromatic-observability.test.mjs
@@ -63,6 +63,17 @@ test('parses Chromatic 18 TurboSnap bypass counts', () => {
   assert.equal(result.buildScope, 'partial');
 });
 
+test('ignores incomplete snapshot count lines without throwing', () => {
+  const result = parseChromaticLog(`
+    ✔ TurboSnap enabled
+    Captured 12 snapshots.
+  `);
+
+  assert.equal(result.snapshotsCaptured, null);
+  assert.equal(result.snapshotsInherited, null);
+  assert.equal(result.buildScope, 'partial');
+});
+
 test('reports a full-build file-change reason and quota state from audited output', () => {
   const result = parseChromaticLog(`
     2026-07-30T16:39:12.3340238Z ⚠ TurboSnap disabled due to file change

--- a/scripts/chromatic-observability.test.mjs
+++ b/scripts/chromatic-observability.test.mjs
@@ -15,10 +15,10 @@ const scriptPath = fileURLToPath(
   new URL('./chromatic-observability.mjs', import.meta.url),
 );
 
-test('parses the Chromatic 17 TurboSnap count wording', () => {
+test('parses the Chromatic 18 TurboSnap count wording', () => {
   const result = parseChromaticLog(`
     ✔ TurboSnap enabled
-    Capturing 12 snapshots and skipping 517 snapshots.
+    Capturing 12 snapshots, copying 517 TurboSnaps.
   `);
 
   assert.deepEqual(result, {
@@ -30,14 +30,36 @@ test('parses the Chromatic 17 TurboSnap count wording', () => {
   });
 });
 
-test('parses completed interactive and singular snapshot count wording', () => {
+test('parses completed Chromatic 18 singular snapshot count wording', () => {
   const result = parseChromaticLog(`
     ✔ TurboSnap enabled
-    Captured 1 snapshot and skipped 1 snapshot.
+    Captured 1 snapshot, copied 1 TurboSnap.
   `);
 
   assert.equal(result.snapshotsCaptured, 1);
   assert.equal(result.snapshotsInherited, 1);
+  assert.equal(result.buildScope, 'partial');
+});
+
+test('retains compatibility with Chromatic 17 snapshot count wording', () => {
+  const result = parseChromaticLog(`
+    ✔ TurboSnap enabled
+    Captured 12 snapshots and skipped 517 snapshots.
+  `);
+
+  assert.equal(result.snapshotsCaptured, 12);
+  assert.equal(result.snapshotsInherited, 517);
+  assert.equal(result.buildScope, 'partial');
+});
+
+test('parses Chromatic 18 TurboSnap bypass counts', () => {
+  const result = parseChromaticLog(`
+    ✔ TurboSnap enabled
+    Bypassed 529 snapshots because no frontend files were changed.
+  `);
+
+  assert.equal(result.snapshotsCaptured, 0);
+  assert.equal(result.snapshotsInherited, 529);
   assert.equal(result.buildScope, 'partial');
 });
 

--- a/scripts/chromatic-workflow.test.mjs
+++ b/scripts/chromatic-workflow.test.mjs
@@ -47,7 +47,10 @@ test('all required UI Test contexts are emitted for PR and merge queue SHAs', ()
   assert.match(workflow, /^  workflow_run:$/m);
   assert.doesNotMatch(workflow, /pull_request_target/);
   assert.match(workflow, /- CI and Release/);
-  assert.match(workflow, /branches:\n\s+- 'changeset-release\/\*\*'/);
+  assert.match(
+    workflow,
+    /branches:\n\s+- main\n\s+- 'changeset-release\/\*\*'/,
+  );
 
   const statuses = job('required-statuses');
   assert.ok(statuses, 'required-statuses job exists');
@@ -78,13 +81,17 @@ test('all required UI Test contexts are emitted for PR and merge queue SHAs', ()
   assert.match(statuses, /--skip --skip-update-check --no-interactive/);
 });
 
-test('release runs serialize by ref and cancel superseded work', () => {
+test('release runs serialize by ref while main builds are commit-scoped', () => {
   const concurrency = workflow.match(
     /^concurrency:\n(?<body>[\s\S]*?)\n\njobs:/m,
   )?.groups?.body;
   assert.ok(concurrency, 'top-level concurrency exists');
   assert.match(concurrency, /github\.event_name/);
   assert.match(concurrency, /github\.ref_name/);
+  assert.match(
+    concurrency,
+    /github\.ref_name == github\.event\.repository\.default_branch && github\.sha/,
+  );
   assert.match(concurrency, /cancel-in-progress: true/);
 });
 
@@ -106,6 +113,38 @@ test('release selection uses the fail-closed lockfile-aware detector', () => {
   assert.match(detect, /--main "origin\/\$DEFAULT_BRANCH"/);
   assert.doesNotMatch(detect, /git merge-base/);
   assert.match(detect, /GITHUB_STEP_SUMMARY/);
+});
+
+test('default-branch pushes replace merge-queue skip builds with real builds', () => {
+  const detect = job('detect');
+  assert.ok(detect, 'detect job exists');
+  assert.match(
+    detect,
+    /github\.ref_name == github\.event\.repository\.default_branch\n\s+\|\| github\.actor != 'dependabot\[bot\]'/,
+  );
+  assert.match(
+    detect,
+    /"\$GITHUB_EVENT_NAME" == "push" && "\$GITHUB_REF_NAME" == "\$DEFAULT_BRANCH"/,
+  );
+  assert.match(detect, /default branch needs a complete target build/);
+
+  const skipped = job('skip-unaffected');
+  assert.ok(skipped, 'skip-unaffected job exists');
+  assert.match(
+    skipped,
+    /!\(github\.event_name == 'push'\n\s+&& github\.ref_name == github\.event\.repository\.default_branch\)/,
+  );
+
+  for (const jobName of ['fresco-ui', 'interview', 'interviewer']) {
+    const body = job(jobName);
+    assert.ok(body, `${jobName} job exists`);
+    assert.match(
+      body,
+      /\(github\.event_name == 'push'\n\s+&& github\.ref_name == github\.event\.repository\.default_branch\)/,
+    );
+    assert.match(body, /Build Storybook/);
+    assert.doesNotMatch(body, /--skip /);
+  }
 });
 
 test('unaffected release projects call Chromatic skip from one setup job', () => {

--- a/scripts/chromatic-workflow.test.mjs
+++ b/scripts/chromatic-workflow.test.mjs
@@ -143,6 +143,14 @@ test('default-branch pushes replace merge-queue skip builds with real builds', (
       /\(github\.event_name == 'push'\n\s+&& github\.ref_name == github\.event\.repository\.default_branch\)/,
     );
     assert.match(body, /Build Storybook/);
+    assert.match(
+      body,
+      /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/,
+    );
+    assert.match(
+      body,
+      /if \[\[ "\$GITHUB_EVENT_NAME" == "push" && "\$GITHUB_REF_NAME" == "\$DEFAULT_BRANCH" \]\]; then\n\s+chromatic_args\+=\(--force-rebuild\)/,
+    );
     assert.doesNotMatch(body, /--skip /);
   }
 });
@@ -184,7 +192,7 @@ test('affected release projects pass runtime options through pnpm', () => {
     assert.match(
       body,
       new RegExp(
-        `pnpm --filter ${packageName.replace('/', '\\/')} chromatic \\\\\\n\\s+--skip-update-check --no-interactive \\\\\\n\\s+--log-file="\\$RUNNER_TEMP/chromatic-${jobName}\\.log"`,
+        `pnpm --filter ${packageName.replace('/', '\\/')} chromatic \\\\\\n\\s+"\\$\\{chromatic_args\\[@\\]\\}" \\\\\\n\\s+--log-file="\\$RUNNER_TEMP/chromatic-${jobName}\\.log"`,
       ),
     );
     assert.doesNotMatch(body, /pnpm --filter [^\n]+ chromatic -- \\/);


### PR DESCRIPTION
## Summary
- publish real Chromatic builds for Fresco UI, Interview, and Interviewer after every push that lands on `main`
- force same-SHA default-branch rebuilds so merge-queue `--skip` statuses are replaced by snapshot-bearing builds
- keep main builds commit-scoped so rapid merge-queue completions cannot cancel a required target build
- update the workspace-catalog Chromatic CLI from 17.3.0 to 18.1.0; `@chromatic-com/storybook` is already current at 5.2.1
- support Chromatic 18 TurboSnap diagnostic wording while retaining Chromatic 17 log compatibility
- preserve affected-project selection for release branches and manual single-project dispatches

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint:fix`
- [x] `pnpm test:scripts` (149 tests)
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] build all three Storybooks and verify `preview-stats.json`
- [x] verify Chromatic CLI 18.1.0 retains required workflow flags
- [x] visual-impact review: dependency and parser changes affect upload diagnostics only; no rendered-pixel baseline changes

No changeset: this is CI/tooling-only.