### PR TITLE
Fix Classic app download links

### DIFF
--- a/.changeset/quick-cats-download.md
+++ b/.changeset/quick-cats-download.md
@@ -1,0 +1,5 @@
+---
+'networkcanvas.com': patch
+---
+
+Keep Architect Classic and Interviewer Classic installer links working when GitHub release assets change.

--- a/apps/networkcanvas.com/app/__tests__/classicDownloadRouting.test.ts
+++ b/apps/networkcanvas.com/app/__tests__/classicDownloadRouting.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import classicDownload, {
+  config,
+  getClassicDownloadDestination,
+} from '~/netlify/edge-functions/classic-download';
+
+const architectAsset = {
+  name: 'Network.Canvas.Architect-6.6.0-mac-arm64.dmg',
+  browser_download_url:
+    'https://github.com/complexdatacollective/Architect/releases/download/v6.6.0/Network.Canvas.Architect-6.6.0-mac-arm64.dmg',
+};
+
+describe('Classic download routing', () => {
+  it('runs the resolver for every Classic download route', () => {
+    expect(config.path).toBe('/downloads/classic/*');
+  });
+
+  it('resolves the current release asset when a download is requested', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(Response.json({ assets: [architectAsset] }));
+    const request = new Request(
+      'https://networkcanvas.com/downloads/classic/architect/6.6.0/apple-silicon',
+    );
+
+    await expect(getClassicDownloadDestination(request, fetcher)).resolves.toBe(
+      architectAsset.browser_download_url,
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://api.github.com/repos/complexdatacollective/Architect/releases/tags/v6.6.0',
+      {
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+  });
+
+  it('falls back to the release page when GitHub cannot resolve an asset', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 429 }));
+
+    await expect(
+      getClassicDownloadDestination(
+        new Request(
+          'https://networkcanvas.com/downloads/classic/interviewer/6.6.0/windows',
+        ),
+        fetcher,
+      ),
+    ).resolves.toBe(
+      'https://github.com/complexdatacollective/Interviewer/releases/tag/v6.6.0',
+    );
+  });
+
+  it('rejects unknown download routes without querying GitHub', async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    const request = new Request(
+      'https://networkcanvas.com/downloads/classic/architect/6.6.0/android',
+    );
+
+    await expect(
+      getClassicDownloadDestination(request, fetcher),
+    ).resolves.toBeUndefined();
+    const response = await classicDownload(request);
+
+    expect(response.status).toBe(404);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/apps/networkcanvas.com/app/__tests__/classicDownloadRouting.test.ts
+++ b/apps/networkcanvas.com/app/__tests__/classicDownloadRouting.test.ts
@@ -34,6 +34,7 @@ describe('Classic download routing', () => {
           'Accept': 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: expect.any(AbortSignal),
       },
     );
   });
@@ -55,6 +56,23 @@ describe('Classic download routing', () => {
     );
   });
 
+  it('falls back to the release page when the GitHub request times out', async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new DOMException('Timed out', 'TimeoutError'));
+
+    await expect(
+      getClassicDownloadDestination(
+        new Request(
+          'https://networkcanvas.com/downloads/classic/architect/6.6.0/windows',
+        ),
+        fetcher,
+      ),
+    ).resolves.toBe(
+      'https://github.com/complexdatacollective/Architect/releases/tag/v6.6.0',
+    );
+  });
+
   it('rejects unknown download routes without querying GitHub', async () => {
     const fetcher = vi.fn<typeof fetch>();
     const request = new Request(
@@ -64,9 +82,10 @@ describe('Classic download routing', () => {
     await expect(
       getClassicDownloadDestination(request, fetcher),
     ).resolves.toBeUndefined();
+    expect(fetcher).not.toHaveBeenCalled();
+
     const response = await classicDownload(request);
 
     expect(response.status).toBe(404);
-    expect(fetcher).not.toHaveBeenCalled();
   });
 });

--- a/apps/networkcanvas.com/app/__tests__/localeRouting.test.ts
+++ b/apps/networkcanvas.com/app/__tests__/localeRouting.test.ts
@@ -181,5 +181,12 @@ describe('locale routing', () => {
     expect(
       getLocaleRedirect(new Request('http://localhost/images/logo.svg')),
     ).toBeUndefined();
+    expect(
+      getLocaleRedirect(
+        new Request(
+          'http://localhost/downloads/classic/architect/6.6.0/apple-silicon',
+        ),
+      ),
+    ).toBeUndefined();
   });
 });

--- a/apps/networkcanvas.com/lib/__tests__/classicReleases.test.ts
+++ b/apps/networkcanvas.com/lib/__tests__/classicReleases.test.ts
@@ -74,15 +74,15 @@ describe('latest Classic releases', () => {
     );
     expect(apps.map(({ version }) => version)).toEqual(['7.0.0', '8.0.0']);
     expect(apps[0]?.platforms.map(({ href }) => href)).toEqual([
-      'https://example.com/architect-arm.dmg',
-      'https://example.com/architect-intel.dmg',
-      'https://example.com/architect.exe',
+      '/downloads/classic/architect/7.0.0/apple-silicon',
+      '/downloads/classic/architect/7.0.0/apple-intel',
+      '/downloads/classic/architect/7.0.0/windows',
       'https://github.com/complexdatacollective/Architect/releases/latest',
     ]);
     expect(apps[1]?.platforms.map(({ href }) => href)).toEqual([
-      'https://example.com/interviewer-arm.dmg',
-      'https://example.com/interviewer-intel.dmg',
-      'https://example.com/interviewer.exe',
+      '/downloads/classic/interviewer/8.0.0/apple-silicon',
+      '/downloads/classic/interviewer/8.0.0/apple-intel',
+      '/downloads/classic/interviewer/8.0.0/windows',
       'https://github.com/complexdatacollective/Interviewer/releases/latest',
       'https://play.google.com/store/apps/details?id=org.codaco.NetworkCanvasInterviewer6',
     ]);

--- a/apps/networkcanvas.com/lib/__tests__/getStarted.test.ts
+++ b/apps/networkcanvas.com/lib/__tests__/getStarted.test.ts
@@ -25,15 +25,15 @@ describe('get started content', () => {
     expect(classicApps.every(({ version }) => version === '6.6.0')).toBe(true);
 
     expect(classicApps[0]?.platforms.map(({ href }) => href)).toEqual([
-      expect.stringContaining('Network.Canvas.Architect-6.6.0-mac-arm64.dmg'),
-      expect.stringContaining('Network.Canvas.Architect-6.6.0-mac-x64.dmg'),
-      expect.stringContaining('Network.Canvas.Architect-6.6.0-win-x64.exe'),
+      '/downloads/classic/architect/6.6.0/apple-silicon',
+      '/downloads/classic/architect/6.6.0/apple-intel',
+      '/downloads/classic/architect/6.6.0/windows',
       'https://github.com/complexdatacollective/Architect/releases/latest',
     ]);
     expect(classicApps[1]?.platforms.map(({ href }) => href)).toEqual([
-      expect.stringContaining('Network.Canvas.Interviewer-6.6.0-arm64.dmg'),
-      expect.stringContaining('Network.Canvas.Interviewer-6.6.0.dmg'),
-      expect.stringContaining('Network.Canvas.Interviewer.Setup.6.6.0.exe'),
+      '/downloads/classic/interviewer/6.6.0/apple-silicon',
+      '/downloads/classic/interviewer/6.6.0/apple-intel',
+      '/downloads/classic/interviewer/6.6.0/windows',
       'https://github.com/complexdatacollective/Interviewer/releases/latest',
       'https://play.google.com/store/apps/details?id=org.codaco.NetworkCanvasInterviewer6',
     ]);

--- a/apps/networkcanvas.com/lib/classicDownloads.ts
+++ b/apps/networkcanvas.com/lib/classicDownloads.ts
@@ -1,0 +1,101 @@
+export type ClassicDownloadApp = 'architect' | 'interviewer';
+export type ClassicDownloadPlatform =
+  | 'apple-silicon'
+  | 'apple-intel'
+  | 'windows';
+
+export type ClassicDownloadAsset = {
+  name: string;
+  browserDownloadUrl: string;
+};
+
+export type ClassicDownloadDefinition = {
+  app: ClassicDownloadApp;
+  platform: ClassicDownloadPlatform;
+  repository: 'Architect' | 'Interviewer';
+  description: string;
+  matches: (name: string) => boolean;
+};
+
+export const CLASSIC_DOWNLOAD_PATH_PREFIX = '/downloads/classic';
+
+const classicDownloadDefinitions = [
+  {
+    app: 'architect',
+    platform: 'apple-silicon',
+    repository: 'Architect',
+    description: 'Architect Apple Silicon DMG',
+    matches: (name) => name.endsWith('-mac-arm64.dmg'),
+  },
+  {
+    app: 'architect',
+    platform: 'apple-intel',
+    repository: 'Architect',
+    description: 'Architect Apple Intel DMG',
+    matches: (name) => name.endsWith('-mac-x64.dmg'),
+  },
+  {
+    app: 'architect',
+    platform: 'windows',
+    repository: 'Architect',
+    description: 'Architect Windows installer',
+    matches: (name) => name.endsWith('-win-x64.exe'),
+  },
+  {
+    app: 'interviewer',
+    platform: 'apple-silicon',
+    repository: 'Interviewer',
+    description: 'Interviewer Apple Silicon DMG',
+    matches: (name) => name.endsWith('-arm64.dmg'),
+  },
+  {
+    app: 'interviewer',
+    platform: 'apple-intel',
+    repository: 'Interviewer',
+    description: 'Interviewer Apple Intel DMG',
+    matches: (name) => name.endsWith('.dmg') && !name.endsWith('-arm64.dmg'),
+  },
+  {
+    app: 'interviewer',
+    platform: 'windows',
+    repository: 'Interviewer',
+    description: 'Interviewer Windows installer',
+    matches: (name) => name.endsWith('.exe'),
+  },
+] satisfies readonly ClassicDownloadDefinition[];
+
+export function getClassicDownloadDefinition(app: string, platform: string) {
+  return classicDownloadDefinitions.find(
+    (definition) => definition.app === app && definition.platform === platform,
+  );
+}
+
+export function getClassicDownloadPath(
+  app: ClassicDownloadApp,
+  platform: ClassicDownloadPlatform,
+  version: string,
+) {
+  return `${CLASSIC_DOWNLOAD_PATH_PREFIX}/${app}/${version}/${platform}`;
+}
+
+export function getClassicReleaseTagUrl(
+  repository: ClassicDownloadDefinition['repository'],
+  version: string,
+) {
+  return `https://github.com/complexdatacollective/${repository}/releases/tag/v${version}`;
+}
+
+export function getClassicDownloadAssetUrl(
+  definition: ClassicDownloadDefinition,
+  assets: readonly ClassicDownloadAsset[],
+) {
+  const matchingAssets = assets.filter(({ name }) => definition.matches(name));
+
+  if (matchingAssets.length !== 1) {
+    throw new Error(
+      `Expected one ${definition.description}; found ${matchingAssets.length}.`,
+    );
+  }
+
+  return matchingAssets[0]!.browserDownloadUrl;
+}

--- a/apps/networkcanvas.com/lib/classicDownloads.ts
+++ b/apps/networkcanvas.com/lib/classicDownloads.ts
@@ -93,7 +93,7 @@ export function getClassicDownloadAssetUrl(
 
   if (matchingAssets.length !== 1) {
     throw new Error(
-      `Expected one ${definition.description}; found ${matchingAssets.length}.`,
+      `Expected one ${definition.description} asset for Classic ${definition.app} (${definition.platform}); found ${matchingAssets.length}.`,
     );
   }
 

--- a/apps/networkcanvas.com/lib/getStarted.ts
+++ b/apps/networkcanvas.com/lib/getStarted.ts
@@ -100,7 +100,11 @@ function getReleaseAssetPath(
     );
   }
 
-  void getClassicDownloadAssetUrl(definition, release.assets);
+  try {
+    void getClassicDownloadAssetUrl(definition, release.assets);
+  } catch {
+    // Ignore: the /downloads/classic edge resolver will fall back to the release page.
+  }
 
   return getClassicDownloadPath(app, platform, release.version);
 }

--- a/apps/networkcanvas.com/lib/getStarted.ts
+++ b/apps/networkcanvas.com/lib/getStarted.ts
@@ -100,7 +100,7 @@ function getReleaseAssetPath(
     );
   }
 
-  getClassicDownloadAssetUrl(definition, release.assets);
+  void getClassicDownloadAssetUrl(definition, release.assets);
 
   return getClassicDownloadPath(app, platform, release.version);
 }

--- a/apps/networkcanvas.com/lib/getStarted.ts
+++ b/apps/networkcanvas.com/lib/getStarted.ts
@@ -1,3 +1,10 @@
+import {
+  getClassicDownloadAssetUrl,
+  getClassicDownloadDefinition,
+  getClassicDownloadPath,
+  type ClassicDownloadApp,
+  type ClassicDownloadPlatform,
+} from '~/lib/classicDownloads';
 import { documentationUrl } from '~/lib/siteUrls';
 
 export type Workflow = 'design' | 'collect';
@@ -81,20 +88,19 @@ export type ClassicRelease = {
   }[];
 };
 
-function getReleaseAssetUrl(
+function getReleaseAssetPath(
   release: ClassicRelease,
-  description: string,
-  matches: (name: string) => boolean,
+  app: ClassicDownloadApp,
+  platform: ClassicDownloadPlatform,
 ) {
-  const matchingAssets = release.assets.filter(({ name }) => matches(name));
-
-  if (matchingAssets.length !== 1) {
-    throw new Error(
-      `Expected one ${description} asset for Classic ${release.version}; found ${matchingAssets.length}.`,
-    );
+  const definition = getClassicDownloadDefinition(app, platform);
+  if (!definition) {
+    throw new Error(`Missing Classic download definition for ${app}.`);
   }
 
-  return matchingAssets[0]!.browserDownloadUrl;
+  getClassicDownloadAssetUrl(definition, release.assets);
+
+  return getClassicDownloadPath(app, platform, release.version);
 }
 
 export const GET_STARTED_PATH = '/get-started';
@@ -199,29 +205,17 @@ export function createClassicApps({
         {
           id: 'apple-silicon',
           labelKey: 'platforms.appleSilicon',
-          href: getReleaseAssetUrl(
-            architect,
-            'Architect Apple Silicon DMG',
-            (name) => name.endsWith('-mac-arm64.dmg'),
-          ),
+          href: getReleaseAssetPath(architect, 'architect', 'apple-silicon'),
         },
         {
           id: 'apple-intel',
           labelKey: 'platforms.appleIntel',
-          href: getReleaseAssetUrl(
-            architect,
-            'Architect Apple Intel DMG',
-            (name) => name.endsWith('-mac-x64.dmg'),
-          ),
+          href: getReleaseAssetPath(architect, 'architect', 'apple-intel'),
         },
         {
           id: 'windows',
           labelKey: 'platforms.windows',
-          href: getReleaseAssetUrl(
-            architect,
-            'Architect Windows installer',
-            (name) => name.endsWith('-win-x64.exe'),
-          ),
+          href: getReleaseAssetPath(architect, 'architect', 'windows'),
         },
         {
           id: 'linux',
@@ -246,29 +240,21 @@ export function createClassicApps({
         {
           id: 'apple-silicon',
           labelKey: 'platforms.appleSilicon',
-          href: getReleaseAssetUrl(
+          href: getReleaseAssetPath(
             interviewer,
-            'Interviewer Apple Silicon DMG',
-            (name) => name.endsWith('-arm64.dmg'),
+            'interviewer',
+            'apple-silicon',
           ),
         },
         {
           id: 'apple-intel',
           labelKey: 'platforms.appleIntel',
-          href: getReleaseAssetUrl(
-            interviewer,
-            'Interviewer Apple Intel DMG',
-            (name) => name.endsWith('.dmg') && !name.endsWith('-arm64.dmg'),
-          ),
+          href: getReleaseAssetPath(interviewer, 'interviewer', 'apple-intel'),
         },
         {
           id: 'windows',
           labelKey: 'platforms.windows',
-          href: getReleaseAssetUrl(
-            interviewer,
-            'Interviewer Windows installer',
-            (name) => name.endsWith('.exe'),
-          ),
+          href: getReleaseAssetPath(interviewer, 'interviewer', 'windows'),
         },
         {
           id: 'linux',

--- a/apps/networkcanvas.com/lib/getStarted.ts
+++ b/apps/networkcanvas.com/lib/getStarted.ts
@@ -95,7 +95,9 @@ function getReleaseAssetPath(
 ) {
   const definition = getClassicDownloadDefinition(app, platform);
   if (!definition) {
-    throw new Error(`Missing Classic download definition for ${app}.`);
+    throw new Error(
+      `Missing Classic download definition for ${app} (${platform}).`,
+    );
   }
 
   getClassicDownloadAssetUrl(definition, release.assets);

--- a/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
+++ b/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
@@ -119,5 +119,5 @@ export default async function classicDownload(request: Request) {
 }
 
 export const config: Config = {
-  path: '/downloads/classic/*',
+  path: `${CLASSIC_DOWNLOAD_PATH_PREFIX}/*`,
 };

--- a/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
+++ b/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
@@ -1,0 +1,123 @@
+import type { Config } from '@netlify/edge-functions';
+
+import {
+  CLASSIC_DOWNLOAD_PATH_PREFIX,
+  getClassicDownloadAssetUrl,
+  getClassicDownloadDefinition,
+  getClassicReleaseTagUrl,
+  type ClassicDownloadAsset,
+  type ClassicDownloadDefinition,
+} from '../../lib/classicDownloads.ts';
+
+function parseAssets(value: unknown): readonly ClassicDownloadAsset[] {
+  if (typeof value !== 'object' || value === null || !('assets' in value)) {
+    throw new Error('GitHub release response has no assets.');
+  }
+
+  const { assets } = value;
+  if (!Array.isArray(assets)) {
+    throw new Error('GitHub release assets are not an array.');
+  }
+
+  return assets.map((asset) => {
+    if (
+      typeof asset !== 'object' ||
+      asset === null ||
+      !('name' in asset) ||
+      typeof asset.name !== 'string' ||
+      !('browser_download_url' in asset) ||
+      typeof asset.browser_download_url !== 'string'
+    ) {
+      throw new Error('GitHub returned an invalid release asset.');
+    }
+
+    return {
+      name: asset.name,
+      browserDownloadUrl: asset.browser_download_url,
+    };
+  });
+}
+
+function isTrustedAssetUrl(
+  value: string,
+  definition: ClassicDownloadDefinition,
+) {
+  const url = new URL(value);
+  const expectedPathPrefix =
+    `/complexdatacollective/${definition.repository}/releases/download/`.toLowerCase();
+
+  return (
+    url.origin === 'https://github.com' &&
+    url.pathname.toLowerCase().startsWith(expectedPathPrefix)
+  );
+}
+
+function getDownloadDefinition(request: Request) {
+  const path = new URL(request.url).pathname
+    .slice(CLASSIC_DOWNLOAD_PATH_PREFIX.length)
+    .replace(/^\/+|\/+$/g, '');
+  const [app, version, platform, ...extraSegments] = path.split('/');
+  if (
+    !app ||
+    !version ||
+    !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version) ||
+    !platform ||
+    extraSegments.length > 0
+  ) {
+    return undefined;
+  }
+
+  const definition = getClassicDownloadDefinition(app, platform);
+  if (!definition) return undefined;
+
+  return { definition, version };
+}
+
+export async function getClassicDownloadDestination(
+  request: Request,
+  fetcher: typeof fetch = fetch,
+) {
+  const download = getDownloadDefinition(request);
+  if (!download) return undefined;
+
+  const { definition, version } = download;
+  const releaseUrl = getClassicReleaseTagUrl(definition.repository, version);
+
+  try {
+    const response = await fetcher(
+      `https://api.github.com/repos/complexdatacollective/${definition.repository}/releases/tags/v${version}`,
+      {
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!response.ok) return releaseUrl;
+
+    const assets = parseAssets(await response.json());
+    const assetUrl = getClassicDownloadAssetUrl(definition, assets);
+
+    return isTrustedAssetUrl(assetUrl, definition) ? assetUrl : releaseUrl;
+  } catch {
+    return releaseUrl;
+  }
+}
+
+export default async function classicDownload(request: Request) {
+  const destination = await getClassicDownloadDestination(request);
+  if (!destination) return new Response('Not found', { status: 404 });
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Cache-Control': 'public, max-age=300',
+      'Location': destination,
+    },
+  });
+}
+
+export const config: Config = {
+  path: '/downloads/classic/*',
+};

--- a/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
+++ b/apps/networkcanvas.com/netlify/edge-functions/classic-download.ts
@@ -91,6 +91,7 @@ export async function getClassicDownloadDestination(
           'Accept': 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(3_000),
       },
     );
 

--- a/apps/networkcanvas.com/netlify/edge-functions/locale.ts
+++ b/apps/networkcanvas.com/netlify/edge-functions/locale.ts
@@ -88,6 +88,7 @@ function shouldBypass(pathname: string) {
     pathname.startsWith('/_next/') ||
     pathname.startsWith('/api/') ||
     pathname.startsWith('/.netlify/') ||
+    pathname === CLASSIC_DOWNLOAD_PATH_PREFIX ||
     pathname.startsWith(`${CLASSIC_DOWNLOAD_PATH_PREFIX}/`) ||
     /\.[^/]+$/.test(pathname)
   );

--- a/apps/networkcanvas.com/netlify/edge-functions/locale.ts
+++ b/apps/networkcanvas.com/netlify/edge-functions/locale.ts
@@ -8,6 +8,7 @@ import {
   type SiteLocale,
 } from '@codaco/shared-consts';
 
+import { CLASSIC_DOWNLOAD_PATH_PREFIX } from '../../lib/classicDownloads.ts';
 import { localeCookie } from '../../lib/i18n/locales.ts';
 
 type RequestedLocale = {
@@ -87,6 +88,7 @@ function shouldBypass(pathname: string) {
     pathname.startsWith('/_next/') ||
     pathname.startsWith('/api/') ||
     pathname.startsWith('/.netlify/') ||
+    pathname.startsWith(`${CLASSIC_DOWNLOAD_PATH_PREFIX}/`) ||
     /\.[^/]+$/.test(pathname)
   );
 }


### PR DESCRIPTION
## Summary
- route Classic desktop installer buttons through a same-site edge resolver
- resolve the selected version from current GitHub release metadata at click time
- fall back to the matching GitHub release page if the API or asset lookup fails
- add a Website patch changeset

## Root cause
The deployed static page had captured GitHub asset filenames containing spaces. Those assets were subsequently renamed to use dots, leaving every direct desktop installer URL returning 404.

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter networkcanvas.com test` (155 tests)
- [x] `pnpm --filter networkcanvas.com build`
- [x] Resolve all six Classic desktop routes against the live GitHub API and confirm each asset returns a download redirect
- [x] Visual classifier: Architect, Interview, and Interviewer skipped; link routing does not alter rendered pixels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable, versioned download links for Architect Classic and Interviewer Classic on Apple Silicon, Apple Intel, and Windows.
  * Downloads automatically locate the correct release asset and redirect to the release page when an asset is unavailable.
  * Classic download links now bypass locale-based redirects.
* **Bug Fixes**
  * Preserved classic installer links when GitHub release assets change.
  * Invalid download paths now return a 404 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->