### PR TITLE
Release Website

### DIFF
--- a/.changeset/quick-cats-download.md
+++ b/.changeset/quick-cats-download.md
@@ -1,5 +1,0 @@
----
-'networkcanvas.com': patch
----
-
-Keep Architect Classic and Interviewer Classic installer links working when GitHub release assets change.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,11 @@
 # networkcanvas.com
 
+## 0.2.3
+
+### Patch Changes
+
+- Keep Architect Classic and Interviewer Classic installer links working when GitHub release assets change.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.2.2 | 0.2.3 |

### networkcanvas.com@0.2.3

### Patch Changes

- Keep Architect Classic and Interviewer Classic installer links working when GitHub release assets change.
