### PR TITLE
Fix roster scroll reset after dragging a node

### DIFF
--- a/.changeset/calm-rosters-stay-put.md
+++ b/.changeset/calm-rosters-stay-put.md
@@ -1,0 +1,6 @@
+---
+'@codaco/fresco-ui': patch
+'@codaco/interview': patch
+---
+
+Keep a scrolled roster near the dragged item after it is added instead of resetting the source list to the top.

--- a/packages/fresco-ui/src/collection/__tests__/store.test.ts
+++ b/packages/fresco-ui/src/collection/__tests__/store.test.ts
@@ -88,3 +88,31 @@ describe('collection store — focus after filtering (resortItems)', () => {
     expect(selected.size).toBe(1);
   });
 });
+
+describe('collection store — focus after items are removed (setItems)', () => {
+  it('moves focus to the next surviving item instead of the collection start', () => {
+    const store = makeStore();
+    store.getState().setFocusedKey('b');
+
+    // A successful roster drag removes its focused source card. Virtualized
+    // collections scroll the focused key into view, so falling back to the
+    // first key here would reset a scrolled roster to the top.
+    store
+      .getState()
+      .setItems([items[0]!, items[2]!], keyExtractor, textValueExtractor);
+
+    expect(store.getState().orderedKeys).toEqual(['a', 'c']);
+    expect(store.getState().focusedKey).toBe('c');
+  });
+
+  it('moves focus to the previous item when the final item is removed', () => {
+    const store = makeStore();
+    store.getState().setFocusedKey('c');
+
+    store
+      .getState()
+      .setItems([items[0]!, items[1]!], keyExtractor, textValueExtractor);
+
+    expect(store.getState().focusedKey).toBe('b');
+  });
+});

--- a/packages/fresco-ui/src/collection/store.ts
+++ b/packages/fresco-ui/src/collection/store.ts
@@ -184,6 +184,39 @@ function buildNodes<T>(
 }
 
 /**
+ * Find the item that should receive focus when an item is removed from the
+ * collection. Prefer the next surviving item in the previous ordering, then
+ * the previous surviving item. This keeps focus near the removed item instead
+ * of sending virtualized collections back to their first row.
+ */
+function getFocusAfterRemoval<T>(
+  removedKey: Key,
+  previousOrderedKeys: Key[],
+  nextItems: Map<Key, Node<T>>,
+  nextOrderedKeys: Key[],
+): Key | null {
+  const removedIndex = previousOrderedKeys.indexOf(removedKey);
+
+  if (removedIndex !== -1) {
+    for (
+      let index = removedIndex + 1;
+      index < previousOrderedKeys.length;
+      index++
+    ) {
+      const key = previousOrderedKeys[index];
+      if (key !== undefined && nextItems.has(key)) return key;
+    }
+
+    for (let index = removedIndex - 1; index >= 0; index--) {
+      const key = previousOrderedKeys[index];
+      if (key !== undefined && nextItems.has(key)) return key;
+    }
+  }
+
+  return nextOrderedKeys[0] ?? null;
+}
+
+/**
  * Filter items by matching keys, then sort with optional relevance prefix.
  * Relevance comparator (from filter scores) is chained before user sort rules,
  * so it acts as the primary sort key with user rules as tiebreakers.
@@ -297,7 +330,12 @@ export const createCollectionStore = <T>(
         }
 
         if (newFocusedKey !== null && !itemsMap.has(newFocusedKey)) {
-          newFocusedKey = orderedKeys[0] ?? null;
+          newFocusedKey = getFocusAfterRemoval(
+            newFocusedKey,
+            state.orderedKeys,
+            itemsMap,
+            orderedKeys,
+          );
         }
 
         set({

--- a/packages/interview/e2e/matrix/name-generator-roster.scenarios.ts
+++ b/packages/interview/e2e/matrix/name-generator-roster.scenarios.ts
@@ -206,6 +206,73 @@ export const nameGeneratorRosterScenarios: InterfaceScenarios = {
       run: async ({ page, stage, interview }) => {
         const roster = new NameGeneratorRosterFixture(page);
 
+        // A focused source card is removed after a successful keyboard drag.
+        // Keep the virtualized roster near that card instead of moving focus
+        // to the first item and scrolling the source list back to the top.
+        await expect
+          .poll(() =>
+            roster.sourceListbox.evaluate(
+              (element) => element.scrollHeight > element.clientHeight,
+            ),
+          )
+          .toBe(true);
+        const scrollTopBeforeDrag = await roster.sourceListbox.evaluate(
+          (element) => {
+            element.scrollTop = Math.min(
+              1200,
+              element.scrollHeight - element.clientHeight,
+            );
+            element.dispatchEvent(new Event('scroll'));
+            return element.scrollTop;
+          },
+        );
+        expect(scrollTopBeforeDrag).toBeGreaterThan(0);
+
+        await expect
+          .poll(() =>
+            roster.sourceListbox.evaluate((element) => {
+              const listboxRect = element.getBoundingClientRect();
+              return Array.from(
+                element.querySelectorAll<HTMLElement>('[role="option"]'),
+              ).some((option) => {
+                const optionRect = option.getBoundingClientRect();
+                return (
+                  option.getAttribute('aria-label') !== 'Charles' &&
+                  optionRect.top >= listboxRect.top &&
+                  optionRect.bottom <= listboxRect.bottom
+                );
+              });
+            }),
+          )
+          .toBe(true);
+
+        const visibleRosterLabel = await roster.sourceListbox.evaluate(
+          (element) => {
+            const listboxRect = element.getBoundingClientRect();
+            const option = Array.from(
+              element.querySelectorAll<HTMLElement>('[role="option"]'),
+            ).find((candidate) => {
+              const candidateRect = candidate.getBoundingClientRect();
+              return (
+                candidate.getAttribute('aria-label') !== 'Charles' &&
+                candidateRect.top >= listboxRect.top &&
+                candidateRect.bottom <= listboxRect.bottom
+              );
+            });
+            return option?.getAttribute('aria-label') ?? null;
+          },
+        );
+        if (!visibleRosterLabel) {
+          throw new Error('Could not find a visible roster card to drag');
+        }
+
+        await roster.addNode(visibleRosterLabel);
+        await expect
+          .poll(() =>
+            roster.sourceListbox.evaluate((element) => element.scrollTop),
+          )
+          .toBeGreaterThan(scrollTopBeforeDrag / 2);
+
         // Stage A: narrow the 98-row CSV to one match via search, then add it —
         // avoids asserting exact counts against a virtualized list.
         await roster.search('Charles');


### PR DESCRIPTION
## Summary

- Preserve collection focus near a removed item so a virtualized roster does not jump to its first row after a drag.
- Add a collection-store regression that fails against the previous first-item fallback.
- Add an Interview browser regression covering a scrolled, focused roster item.
- Record patch releases for Fresco UI and Interview.

## Root cause

A successful roster drag removes the focused source card. The shared collection store previously moved focus to its first item whenever the focused key disappeared. The virtualized renderer then scrolled that first item into view, resetting the roster to the top.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @codaco/fresco-ui test`
- [x] `pnpm --filter @codaco/interview test`
- [x] `pnpm turbo build --filter @codaco/interview`
- [x] Chromium Name Generator Roster matrix (13 scenarios)
- [x] Firefox and WebKit Name Generator Roster smoke scenarios
- [x] Manual Playwright WebKit reproduction with an iPad-sized context
- [x] `pnpm check:changesets`
- [x] Visual-baseline assessment: no captured resting-state changes

Closes #1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug fixes**
  - Adding an item to a scrolled roster now keeps the list positioned near the dragged item instead of returning to the top.
  - Removing a focused item now preserves focus by moving to the next available item, or the previous item when appropriate.
- **Tests**
  - Added coverage for focus retention and roster scrolling during keyboard drag-and-drop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->