### PR TITLE
Keep iPad status bar clear of home and interview content

### DIFF
--- a/.changeset/safe-area-ipad-portrait.md
+++ b/.changeset/safe-area-ipad-portrait.md
@@ -1,0 +1,12 @@
+---
+'@codaco/interview': patch
+'@codaco/interviewer': patch
+---
+
+Keep content clear of the device status bar in the installed app. On iPads and
+other devices with a status bar, the home screen's brand mark, view switcher,
+and settings button — and interview stage content — now start below the system
+status bar instead of sliding underneath the clock and battery indicators,
+while the background still fills the entire screen. The interview navigation
+bar also sits evenly against the bottom edge of the screen in both
+orientations, rather than reserving extra space below its buttons.

--- a/apps/interviewer/src/App.tsx
+++ b/apps/interviewer/src/App.tsx
@@ -77,11 +77,14 @@ export default function App() {
                   initial="hidden"
                   animate="visible"
                   exit="exit"
-                  // Fill the inset #root so the route's full-screen surfaces can
-                  // size to the available space with `h-full` rather than the raw
-                  // viewport (`h-dvh`). The body is padded by the top safe-area
-                  // inset; a viewport-tall child would overflow that inset and
-                  // make the whole page scroll (the iPad-portrait overflow bug).
+                  // Fill #root so the route's full-screen surfaces can size to
+                  // the available space with `h-full` rather than the raw
+                  // viewport (`h-dvh`). #root can be inset by the
+                  // visual-viewport initializer (see globals.css); a
+                  // viewport-tall child would overflow that inset and make the
+                  // whole page scroll (the iPad-portrait overflow bug).
+                  // Safe-area insets are owned per-surface: the Home header and
+                  // the interview shell each pad themselves past the top inset.
                   className="h-full"
                 >
                   <Switch location={location}>

--- a/apps/interviewer/src/routes/Home.tsx
+++ b/apps/interviewer/src/routes/Home.tsx
@@ -174,8 +174,13 @@ export function HomeRoute() {
           z-index so it is visually overlaid, and `inert` keeps its
           controls out of the tab order while the new-session form is up. */}
       <InstallBanner />
+      {/* Top padding measures from the bottom of the device's top safe area
+          (env() is 0 outside an installed PWA on a notched/status-bar device),
+          so the brand mark and action bar clear the clock/battery while the
+          gradient backdrop still shows through behind them (#1186). At laptop:
+          the design's 2.25rem floor wins unless the inset pushes past it. */}
       <header
-        className="laptop:px-11 laptop:pt-9 relative flex items-center justify-between px-6 pt-4"
+        className="laptop:px-11 laptop:pt-[max(2.25rem,calc(1rem+env(safe-area-inset-top)))] relative flex items-center justify-between px-6 pt-[calc(1rem+env(safe-area-inset-top))]"
         inert={newSessionActive}
       >
         <BrandHeader />
@@ -197,7 +202,7 @@ export function HomeRoute() {
             actual ORIENTATION, not a min-width breakpoint: the 13" iPad's
             portrait width (~1024px) would otherwise trip a min-width
             breakpoint and pull the pill up into the header. */}
-        <div className="laptop:px-11 laptop:pt-9 pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-4 landscape:translate-y-0">
+        <div className="laptop:px-11 laptop:pt-[max(2.25rem,calc(1rem+env(safe-area-inset-top)))] pointer-events-none absolute inset-0 z-20 flex translate-y-full items-center justify-center px-6 pt-[calc(1rem+env(safe-area-inset-top))] landscape:translate-y-0">
           <AnimatePresence>
             {showResumePill ? (
               <ResumePill key="resume-pill" sessions={sessions} />

--- a/apps/interviewer/src/routes/Interview.tsx
+++ b/apps/interviewer/src/routes/Interview.tsx
@@ -36,16 +36,16 @@ import type { StoredSession } from '~/lib/db/types';
 import { getInstallationId } from '~/lib/installationId';
 import { useHistoryBackGuard } from '~/lib/pwa/useHistoryBackGuard';
 
-// Inset the interview navigation past the device safe areas so, on an installed
-// PWA, its buttons stay clear of the status bar / iPadOS window controls / home
-// indicator while the rail's background still meets the screen edges. `calc`
+// Inset the vertical navigation rail past the top device safe area so, on an
+// installed PWA, its buttons stay clear of the status bar / iPadOS window
+// controls while the rail's background still meets the screen edge. `calc`
 // keeps the navigation surface's own py-3 (0.75rem); env() insets are 0 off a
-// safe-area device, so browser/desktop are unchanged. The vertical rail meets
-// the top and bottom edges; the horizontal bar only meets the bottom.
+// safe-area device, so browser/desktop are unchanged. The bottom inset is
+// deliberately not added (in either orientation): the home indicator floating
+// over the navigation's base padding reads better than the enlarged bottom
+// band the extra inset produced (#1186).
 const NAVIGATION_SAFE_AREA_CLASSNAMES = {
-  vertical:
-    'pt-[calc(0.75rem_+_env(safe-area-inset-top))] pb-[calc(0.75rem_+_env(safe-area-inset-bottom))]',
-  horizontal: 'pb-[calc(0.75rem_+_env(safe-area-inset-bottom))]',
+  vertical: 'pt-[calc(0.75rem_+_env(safe-area-inset-top))]',
 } as const;
 
 type LoadState =

--- a/apps/interviewer/src/routes/__tests__/Home.test.tsx
+++ b/apps/interviewer/src/routes/__tests__/Home.test.tsx
@@ -142,12 +142,21 @@ describe('HomeRoute resume notification', () => {
     });
   });
 
-  it('uses compact page insets by default and increases them at laptop width', () => {
+  it('uses safe-area-aware page insets that increase at laptop width', () => {
     const { container } = render(<HomeRoute />);
     const header = container.querySelector('header');
 
-    expect(header).toHaveClass('px-6', 'pt-4', 'laptop:px-11', 'laptop:pt-9');
+    // Top padding measures from the bottom of the device's top safe area
+    // (env() is 0 outside an installed PWA), so the header clears the status
+    // bar on iPad while staying unchanged in browsers (#1186).
+    expect(header).toHaveClass(
+      'px-6',
+      'pt-[calc(1rem+env(safe-area-inset-top))]',
+      'laptop:px-11',
+      'laptop:pt-[max(2.25rem,calc(1rem+env(safe-area-inset-top)))]',
+    );
     expect(header).not.toHaveClass(
+      'pt-4',
       'pt-6',
       'tablet-landscape:px-11',
       'tablet-landscape:pt-4',

--- a/packages/interview/src/Shell.tsx
+++ b/packages/interview/src/Shell.tsx
@@ -159,7 +159,12 @@ function Interview({
                   <motion.div
                     key={displayedStep}
                     data-stage-step={displayedStep}
-                    className="flex min-h-0 min-w-0 flex-1"
+                    // pt insets the stage below the device's top safe area
+                    // (status bar/notch) so stage content never slides under
+                    // it in an installed PWA; env() is 0 everywhere else. The
+                    // navigation owns its own inset (via navigationClassnames)
+                    // so its background can still meet the screen edge.
+                    className="flex min-h-0 min-w-0 flex-1 pt-[env(safe-area-inset-top)]"
                     initial="initial"
                     animate="animate"
                     exit="exit"


### PR DESCRIPTION
## Summary

Fixes #1186.

In the installed PWA on iPad, `viewport-fit=cover` renders the app under the status bar and portrait layouts reserved nothing for it — the Home header started 16px from the screen edge inside the 32px top unsafe area (brand mark under the clock, switcher/settings against the battery), and interview stage content scrolled straight under the status bar. Landscape only looked right because the vertical nav rail already insets itself.

- **Home header** (and its resume-pill overlay mirror) now measures its top padding from the bottom of the safe area: `calc(1rem + env(safe-area-inset-top))`, with a `laptop:` floor of `max(2.25rem, …)`.
- **Interview stage viewport** (`@codaco/interview` Shell) pads by `env(safe-area-inset-top)`, so every host (Interviewer, Architect preview, Fresco) benefits.
- **Interview navigation** drops the `env(safe-area-inset-bottom)` additions in both orientations: the home indicator floating over the nav's base padding reads better than the enlarged bottom band it produced. The vertical rail keeps its top inset.
- Refreshed the stale `App.tsx` comment that claimed body-level safe-area padding.

`env()` is 0 outside installed-PWA/safe-area contexts, so browsers, desktop, and CI render byte-identically.

## Test plan

- [x] Verified on the iPad Pro 11" simulator (iOS 26.5) against a production build installed as a localhost PWA (standalone mode): header 48px below screen top, stage content 32px inset, nav bar/rail base padding only — in portrait and landscape. Design was first validated live against production 8.0.0 via Web Inspector CSS injection.
- [x] `pnpm --filter @codaco/interview typecheck && pnpm --filter @codaco/interviewer typecheck`
- [x] `pnpm --filter @codaco/interview test` (1321 passed), `pnpm --filter @codaco/interviewer test` (474 passed; one header-class assertion updated for the intentional change)
- [x] `pnpm lint:fix`, `pnpm knip`, `pnpm check:changesets`
- [x] Visual-baseline classifier flagged all three suites; dismissed after diff inspection — every changed style resolves to identical computed values where `env()` = 0 (the E2E environment), so no PNG regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)