### PR TITLE
Reset residual iOS input auto-zoom in the installed PWA

### DIFF
--- a/.changeset/standalone-keyboard-zoom-reset.md
+++ b/.changeset/standalone-keyboard-zoom-reset.md
@@ -1,0 +1,10 @@
+---
+'@codaco/interviewer': patch
+---
+
+Fixed the installed app on iPhone being left zoomed and shifted under the
+status bar after the keyboard closed. iOS zooms in slightly when a text field
+is focused and could fail to zoom back out when typing finished, leaving the
+whole interview stuck partly off screen until the device was rotated. The app
+now detects this leftover zoom after typing ends and restores the normal view
+automatically, without affecting pinch-to-zoom.

--- a/apps/interviewer/src/lib/pwa/__tests__/visualViewportSizing.test.ts
+++ b/apps/interviewer/src/lib/pwa/__tests__/visualViewportSizing.test.ts
@@ -197,4 +197,162 @@ describe('initVisualViewportSizing', () => {
 
     cleanup();
   });
+
+  it('compensates while a closed keyboard leaves the standalone viewport displaced', () => {
+    // iOS standalone can fail to restore the layout viewport it scrolled for
+    // the software keyboard: after dismissal the window stays shorter than
+    // the screen with a pinned page offset (the iPhone measurement was
+    // 874 -> 786 with pageTop 88). The frame must stay active over that
+    // resting displacement so #root aligns with the visible region, and must
+    // clear once the viewport truly recovers.
+    setInstalled(true);
+    vi.stubGlobal('innerWidth', 402);
+    vi.stubGlobal('innerHeight', 874);
+    const viewport = installViewport({
+      width: 402,
+      height: 874,
+      offsetTop: 0,
+      pageTop: 0,
+    });
+
+    const cleanup = initVisualViewportSizing();
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.append(input);
+    input.focus();
+    viewport.update({ height: 725, offsetTop: 87, pageTop: 149 }, 'resize');
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+
+    // Keyboard dismissed, but WebKit restores only part of the height and
+    // keeps the page pinned at a nonzero offset.
+    input.blur();
+    vi.stubGlobal('innerHeight', 786);
+    viewport.update({ height: 786, offsetTop: 26, pageTop: 88 }, 'resize');
+
+    expect(root()).toHaveAttribute('data-visual-viewport', 'active');
+    expect(root().style.getPropertyValue('--app-viewport-height')).toBe(
+      '786px',
+    );
+    expect(root().style.getPropertyValue('--app-viewport-top')).toBe('88px');
+
+    // A real recovery (e.g. a rotation cycle) returns the offset to zero; the
+    // compensation must stand down with it.
+    vi.stubGlobal('innerHeight', 874);
+    viewport.update({ height: 874, offsetTop: 0, pageTop: 0 }, 'resize');
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+    expect(root().getAttribute('style')).toBeNull();
+
+    cleanup();
+  });
+
+  it('resets residual input auto-zoom after a standalone text-entry session', () => {
+    // iOS auto-zooms to a focused control and can fail to zoom back out on
+    // dismissal, stranding the viewport scaled + scroll-pinned (measured
+    // scale 1.112, 874 -> 786 on the iPhone). Once the session ends, the
+    // module reasserts scale 1 via a momentary maximum-scale clamp, then
+    // restores the authored viewport meta so pinch zoom stays available.
+    vi.useFakeTimers();
+    setInstalled(true);
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    const meta = document.createElement('meta');
+    meta.name = 'viewport';
+    meta.content = 'width=device-width, initial-scale=1.0, viewport-fit=cover';
+    document.head.append(meta);
+    vi.stubGlobal('innerWidth', 402);
+    vi.stubGlobal('innerHeight', 874);
+    const viewport = installViewport({
+      width: 402,
+      height: 874,
+      offsetTop: 0,
+      pageTop: 0,
+    });
+
+    const cleanup = initVisualViewportSizing();
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.append(input);
+    input.focus();
+    // Focus auto-zoom engages during the session…
+    viewport.update(
+      { scale: 1.112, width: 362, height: 725, pageTop: 149 },
+      'resize',
+    );
+    // …and survives the dismissal.
+    input.blur();
+    vi.stubGlobal('innerHeight', 786);
+    viewport.update({ height: 786, offsetTop: 26, pageTop: 88 }, 'resize');
+
+    vi.advanceTimersByTime(300);
+    expect(meta.content).toContain('maximum-scale=1');
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+
+    vi.advanceTimersByTime(300);
+    expect(meta.content).toBe(
+      'width=device-width, initial-scale=1.0, viewport-fit=cover',
+    );
+
+    cleanup();
+    meta.remove();
+    vi.useRealTimers();
+  });
+
+  it('leaves deliberate pinch zoom outside a text-entry session alone', () => {
+    vi.useFakeTimers();
+    setInstalled(true);
+    const meta = document.createElement('meta');
+    meta.name = 'viewport';
+    meta.content = 'width=device-width, initial-scale=1.0, viewport-fit=cover';
+    document.head.append(meta);
+    const viewport = installViewport({
+      width: 402,
+      height: 874,
+      offsetTop: 0,
+      pageTop: 0,
+      scale: 1,
+    });
+
+    const cleanup = initVisualViewportSizing();
+
+    // A participant pinch-zooms with no field focused.
+    viewport.update(
+      { scale: 2, width: 201, height: 437, pageTop: 40 },
+      'resize',
+    );
+    vi.advanceTimersByTime(600);
+
+    expect(meta.content).toBe(
+      'width=device-width, initial-scale=1.0, viewport-fit=cover',
+    );
+
+    cleanup();
+    meta.remove();
+    vi.useRealTimers();
+  });
+
+  it('keeps the keyboard-session gate for a displaced viewport during text entry', () => {
+    // While a field is focused, activation still requires the material
+    // height reduction — a small scroll-induced page offset alone must not
+    // flip an installed PWA off its static 100vh frame mid-entry.
+    setInstalled(true);
+    vi.stubGlobal('innerHeight', 1_368);
+    installViewport({
+      height: 1_360,
+      offsetTop: 0,
+      pageTop: 8,
+    });
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    document.body.append(input);
+    input.focus();
+
+    const cleanup = initVisualViewportSizing();
+    expect(root()).not.toHaveAttribute('data-visual-viewport');
+
+    cleanup();
+  });
 });

--- a/apps/interviewer/src/lib/pwa/visualViewportSizing.ts
+++ b/apps/interviewer/src/lib/pwa/visualViewportSizing.ts
@@ -16,6 +16,15 @@ const VIEWPORT_PROPERTIES = [
 // bottom edge on iPad.
 const MIN_KEYBOARD_REDUCTION = 120;
 const SCALE_EPSILON = 0.01;
+// A resting page offset beyond this is a wedged layout viewport, not rounding.
+const DISPLACEMENT_EPSILON = 1;
+// Wait for WebKit's keyboard-close event burst (which finishes within a few
+// frames) before judging whether a text-entry session left residual zoom.
+const RESIDUAL_ZOOM_SETTLE_MS = 250;
+// How long the maximum-scale clamp stays applied. The zoom reset itself is
+// immediate; the clamp must simply outlive a paint so WebKit commits it
+// before pinch-zoom is re-permitted.
+const ZOOM_CLAMP_RELEASE_MS = 250;
 
 function isEditableElement(element: Element | null): boolean {
   return (
@@ -61,7 +70,11 @@ function clearVisualViewportFrame(root: HTMLElement): void {
  *
  * The static 100vh root remains the fallback and the resting installed-PWA
  * size. Browser tabs always follow VisualViewport; an installed PWA opts in
- * only during a focused text-entry session with a material height reduction.
+ * during a focused text-entry session with a material height reduction, and
+ * stays opted in while a closed keyboard leaves the layout viewport displaced
+ * (the iOS standalone restore bug — see displacedAtRest below). Residual
+ * focus auto-zoom that outlives its text-entry session is actively reset via
+ * a momentary maximum-scale clamp (see resetResidualSessionZoom below).
  */
 export function initVisualViewportSizing(): () => void {
   const root = document.getElementById(ROOT_ID);
@@ -72,18 +85,31 @@ export function initVisualViewportSizing(): () => void {
   }
 
   const installed = isRunningInstalled();
+  const viewportMeta = document.querySelector('meta[name="viewport"]');
+  const viewportMetaContent =
+    viewportMeta instanceof HTMLMetaElement ? viewportMeta.content : undefined;
   let textEntrySession = isEditableElement(document.activeElement);
+  // Scale left away from 1 by a text-entry session — iOS's focus auto-zoom —
+  // as opposed to a deliberate pinch, which is never touched.
+  let sessionZoom = false;
   let firstFrame: number | undefined;
   let secondFrame: number | undefined;
+  let residualZoomTimer: number | undefined;
+  let clampReleaseTimer: number | undefined;
 
   const applyViewportFrame = () => {
+    const editableActive = isEditableElement(document.activeElement);
+
     // Resizing the layout in response to pinch zoom causes a reflow feedback
     // loop. Keep the most recent scale-1 frame until zoom returns to 100%.
     if (Math.abs(viewport.scale - 1) > SCALE_EPSILON) {
+      if (editableActive || textEntrySession) {
+        sessionZoom = true;
+      }
       return;
     }
+    sessionZoom = false;
 
-    const editableActive = isEditableElement(document.activeElement);
     if (editableActive) {
       textEntrySession = true;
     }
@@ -94,11 +120,6 @@ export function initVisualViewportSizing(): () => void {
 
     if (!editableActive && !materiallyShrunken) {
       textEntrySession = false;
-    }
-
-    if (installed && !(textEntrySession && materiallyShrunken)) {
-      clearVisualViewportFrame(root);
-      return;
     }
 
     const width = positiveMetric(viewport.width, window.innerWidth);
@@ -118,6 +139,27 @@ export function initVisualViewportSizing(): () => void {
       ),
     );
 
+    // iOS standalone can fail to restore the layout viewport it scrolled and
+    // shrank for the software keyboard: after dismissal the window stays
+    // shorter than the screen with a pinned page offset (scrollTo(0, 0) is
+    // re-clamped, so no page-side action can undo it — only a device rotation
+    // resizes it back). The page then renders shifted under the status bar.
+    // While that resting displacement persists, keep the visual-viewport frame
+    // active so #root aligns with the region WebKit actually shows; the frame
+    // clears itself the moment the viewport truly recovers (top returns to 0).
+    const displacedAtRest =
+      !textEntrySession &&
+      (top >= DISPLACEMENT_EPSILON || left >= DISPLACEMENT_EPSILON);
+
+    if (
+      installed &&
+      !(textEntrySession && materiallyShrunken) &&
+      !displacedAtRest
+    ) {
+      clearVisualViewportFrame(root);
+      return;
+    }
+
     root.style.setProperty('--app-viewport-width', `${String(width)}px`);
     root.style.setProperty('--app-viewport-height', `${String(height)}px`);
     root.style.setProperty('--app-viewport-left', `${String(left)}px`);
@@ -136,6 +178,45 @@ export function initVisualViewportSizing(): () => void {
     }
   };
 
+  // Installed iOS PWAs auto-zoom to a focused control and can fail to zoom
+  // back out on dismissal, stranding the layout viewport scaled, shrunken,
+  // and scroll-pinned under the status bar — with no later event to recover
+  // it, and scrollTo re-clamped by WebKit so no scripted scroll can help.
+  // Once the text-entry session that engaged the zoom has ended, reassert the
+  // authored scale by briefly clamping maximum-scale, then restore the
+  // original meta so pinch zoom stays available. A pinch performed outside a
+  // text-entry session never sets sessionZoom, so deliberate accessibility
+  // zoom is left alone.
+  const resetResidualSessionZoom = () => {
+    residualZoomTimer = undefined;
+    if (!installed || !sessionZoom) {
+      return;
+    }
+    if (isEditableElement(document.activeElement)) {
+      return;
+    }
+    if (Math.abs(viewport.scale - 1) <= SCALE_EPSILON) {
+      sessionZoom = false;
+      return;
+    }
+    if (
+      !(viewportMeta instanceof HTMLMetaElement) ||
+      viewportMetaContent === undefined
+    ) {
+      return;
+    }
+    sessionZoom = false;
+    viewportMeta.content = `${viewportMetaContent}, maximum-scale=1`;
+    window.scrollTo(0, 0);
+    if (clampReleaseTimer !== undefined) {
+      window.clearTimeout(clampReleaseTimer);
+    }
+    clampReleaseTimer = window.setTimeout(() => {
+      clampReleaseTimer = undefined;
+      viewportMeta.content = viewportMetaContent;
+    }, ZOOM_CLAMP_RELEASE_MS);
+  };
+
   const handleViewportChange = () => {
     // Apply immediately, then sample again after two paints. WebKit can emit a
     // viewport event before its keyboard animation has committed final metrics.
@@ -148,6 +229,13 @@ export function initVisualViewportSizing(): () => void {
         applyViewportFrame();
       });
     });
+    if (residualZoomTimer !== undefined) {
+      window.clearTimeout(residualZoomTimer);
+    }
+    residualZoomTimer = window.setTimeout(
+      resetResidualSessionZoom,
+      RESIDUAL_ZOOM_SETTLE_MS,
+    );
   };
 
   handleViewportChange();
@@ -165,6 +253,17 @@ export function initVisualViewportSizing(): () => void {
 
   return () => {
     cancelScheduledFrames();
+    if (residualZoomTimer !== undefined) {
+      window.clearTimeout(residualZoomTimer);
+      residualZoomTimer = undefined;
+    }
+    if (clampReleaseTimer !== undefined) {
+      window.clearTimeout(clampReleaseTimer);
+      clampReleaseTimer = undefined;
+      if (viewportMeta instanceof HTMLMetaElement && viewportMetaContent) {
+        viewportMeta.content = viewportMetaContent;
+      }
+    }
     viewport.removeEventListener('resize', handleViewportChange);
     viewport.removeEventListener('scroll', handleViewportChange);
     viewport.removeEventListener('scrollend', handleViewportChange);


### PR DESCRIPTION
## Summary

In the installed standalone PWA on iOS, focusing a text field triggers iOS's input auto-zoom (measured scale 1.112 on an iPhone 17 / iOS 26.5 simulator), and WebKit can fail to zoom back out on blur. The layout viewport is left scaled, shrunken (`innerHeight` 874 → 786), and scroll-pinned (`pageTop` 88, with `scrollTo(0,0)` re-clamped by WebKit) — the whole app renders shifted under the status bar, the participant cannot scroll it back (`overflow: hidden` body), and only a device rotation recovered it. The existing visual-viewport machinery could not act: its scale guard deliberately freezes while `scale != 1`.

The fix, in `visualViewportSizing.ts`:

- Track when a text-entry session engages zoom (`sessionZoom`). A pinch performed outside a text-entry session never arms it, so **deliberate accessibility pinch-zoom is untouched**.
- After the session ends (trailing 250ms settle, so WebKit's keyboard-close event burst finishes), if the zoom is still stuck, reassert the authored scale by momentarily clamping the viewport meta with `maximum-scale=1`, then restore the original meta content so pinch zoom stays available. This clamp/release was probed live via Web Inspector against the wedged state before writing the code — meta rewrites, scroll pinning during close, focus cycles, and document-height perturbation all failed; the scale clamp restores everything instantly.
- Keep the visual-viewport compensation frame active over a displaced-at-rest layout viewport (defense in depth for non-zoom displacement).

## Test plan

- [x] Reproduced the wedge deterministically on the iPhone 17 simulator (standalone localhost PWA, interview ego-form stage, accessory-bar keyboard mode) and verified the fixed build self-heals within ~250ms of keyboard dismissal — scale 1, 402×874, offset 0, meta restored — across repeated cycles, with no rotation.
- [x] 4 new unit tests (residual-zoom reset, deliberate-pinch untouched, displaced-at-rest compensation on/off) + all existing pass: `pnpm --filter @codaco/interviewer test` (478 passed).
- [x] `pnpm --filter @codaco/interviewer typecheck`, `pnpm lint:fix`, `pnpm knip`, `pnpm check:changesets`.
- [x] No visual-baseline impact: the new code only acts at runtime when `visualViewport.scale != 1` after a text-entry session, which never occurs in the desktop-Chromium E2E environment.

Pre-existing bug observed while verifying #1186 (PR #1192); independent of that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)