### PR TITLE
Interviewer: build export archives in a Web Worker

### DIFF
--- a/.changeset/export-worker-offload.md
+++ b/.changeset/export-worker-offload.md
@@ -1,0 +1,8 @@
+---
+'@codaco/interviewer': patch
+---
+
+Export archives are now built in a background worker, so the export dialog's
+progress animations stay smooth during large exports. Interview data is still
+read and decrypted only in the app itself; cancelling an export now also
+releases all partially built archive data immediately.

--- a/apps/interviewer/scripts/assert-pwa-build.mjs
+++ b/apps/interviewer/scripts/assert-pwa-build.mjs
@@ -60,7 +60,9 @@ const critical = jsAssets.filter(
   (f) =>
     f.startsWith('interview-engine') ||
     f.startsWith('main') ||
-    f.startsWith('index'),
+    f.startsWith('index') ||
+    // The export Web Worker chunk: offline data export depends on it.
+    f.startsWith('exportWorker'),
 );
 if (critical.length === 0) {
   fail('no critical chunks (interview-engine / entry) found');

--- a/apps/interviewer/src/lib/export/__tests__/exportSessions.test.ts
+++ b/apps/interviewer/src/lib/export/__tests__/exportSessions.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { runExport } from '../exportSessions';
+import type { ExportWorkerMessage, ExportWorkerStart } from '../exportWorker';
+
+const getSessionsByIds = vi.fn();
+const getProtocolsByHashes = vi.fn();
+const runPipelineWithData = vi.fn();
+
+vi.mock('~/lib/db/api', () => ({
+  getSessionsByIds: (...args: unknown[]) => getSessionsByIds(...args),
+  getProtocolsByHashes: (...args: unknown[]) => getProtocolsByHashes(...args),
+}));
+
+vi.mock('../exportPipelineRunner', () => ({
+  runPipelineWithData: (...args: unknown[]) => runPipelineWithData(...args),
+}));
+
+function seedDb() {
+  getSessionsByIds.mockResolvedValue([
+    {
+      id: 's1',
+      caseId: 'case-1',
+      startedAt: 1722772800000,
+      finishedAt: 1722776400000,
+      network: { nodes: [], edges: [], ego: {} },
+      protocolHash: 'hash-1',
+    },
+  ]);
+  getProtocolsByHashes.mockResolvedValue([
+    { hash: 'hash-1', name: 'Protocol', codebook: {} },
+  ]);
+}
+
+const exportOptions = {
+  exportGraphML: true,
+  exportCSV: false,
+  globalOptions: {
+    useScreenLayoutCoordinates: false,
+    screenLayoutHeight: 0,
+    screenLayoutWidth: 0,
+  },
+  appVersion: 'test',
+  commitHash: 'interviewer',
+};
+
+// Stands in for the export worker: captures the start message and lets tests
+// drive the reply protocol.
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  onmessage: ((message: { data: ExportWorkerMessage }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  posted: ExportWorkerStart[] = [];
+  terminated = false;
+
+  constructor() {
+    FakeWorker.instances.push(this);
+  }
+
+  postMessage(message: ExportWorkerStart) {
+    this.posted.push(message);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  reply(message: ExportWorkerMessage) {
+    this.onmessage?.({ data: message });
+  }
+}
+
+describe('runExport via the export worker', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    FakeWorker.instances = [];
+  });
+
+  it('fetches inputs on the main thread, posts them, and resolves on done', async () => {
+    seedDb();
+    vi.stubGlobal('Worker', FakeWorker);
+    const onEvent = vi.fn();
+
+    const exportPromise = runExport({
+      options: exportOptions,
+      sessionIds: ['s1'],
+      onEvent,
+    });
+    await vi.waitFor(() => {
+      expect(FakeWorker.instances).toHaveLength(1);
+      expect(FakeWorker.instances[0]?.posted).toHaveLength(1);
+    });
+    const worker = FakeWorker.instances[0];
+    if (!worker) throw new Error('worker not constructed');
+
+    const start = worker.posted[0];
+    if (!start) throw new Error('start message not posted');
+    expect(start.type).toBe('start');
+    expect(start.data.sessions.map((s) => s.id)).toEqual(['s1']);
+    expect(Object.keys(start.data.protocols)).toEqual(['hash-1']);
+
+    worker.reply({
+      type: 'event',
+      event: { type: 'stage', stage: 'generating', message: 'Generating…' },
+    });
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'stage', stage: 'generating' }),
+    );
+
+    const blob = new Blob(['zip']);
+    worker.reply({
+      type: 'done',
+      result: {
+        status: 'success',
+        successfulExports: [],
+        failedExports: [],
+        output: {},
+      },
+      blob,
+      fileName: 'export.zip',
+    });
+
+    const run = await exportPromise;
+    expect(run.blob).toBe(blob);
+    expect(run.fileName).toBe('export.zip');
+    expect(worker.terminated).toBe(true);
+    expect(runPipelineWithData).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the worker-reported error, preserving the stack', async () => {
+    seedDb();
+    vi.stubGlobal('Worker', FakeWorker);
+
+    const exportPromise = runExport({
+      options: exportOptions,
+      sessionIds: ['s1'],
+    });
+    await vi.waitFor(() =>
+      expect(FakeWorker.instances[0]?.posted).toHaveLength(1),
+    );
+
+    FakeWorker.instances[0]?.reply({
+      type: 'error',
+      message: 'zip failed',
+      stack: 'Error: zip failed\n    at exportWorker',
+    });
+
+    await expect(exportPromise).rejects.toMatchObject({
+      message: 'zip failed',
+      stack: expect.stringContaining('at exportWorker'),
+    });
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it('aborting terminates the worker and rejects as a cancellation', async () => {
+    seedDb();
+    vi.stubGlobal('Worker', FakeWorker);
+    const controller = new AbortController();
+
+    const exportPromise = runExport({
+      options: exportOptions,
+      sessionIds: ['s1'],
+      signal: controller.signal,
+    });
+    await vi.waitFor(() =>
+      expect(FakeWorker.instances[0]?.posted).toHaveLength(1),
+    );
+
+    controller.abort();
+
+    await expect(exportPromise).rejects.toThrow('Export was cancelled');
+    expect(FakeWorker.instances[0]?.terminated).toBe(true);
+  });
+
+  it('runs the pipeline on the main thread when Worker is unavailable', async () => {
+    seedDb();
+    vi.stubGlobal('Worker', undefined);
+    runPipelineWithData.mockResolvedValue({
+      result: {
+        status: 'success',
+        successfulExports: [],
+        failedExports: [],
+        output: {},
+      },
+      blob: new Blob(['zip']),
+      fileName: 'export.zip',
+    });
+
+    const run = await runExport({
+      options: exportOptions,
+      sessionIds: ['s1'],
+    });
+
+    expect(runPipelineWithData).toHaveBeenCalledOnce();
+    expect(run.fileName).toBe('export.zip');
+  });
+});

--- a/apps/interviewer/src/lib/export/__tests__/exportSessions.test.ts
+++ b/apps/interviewer/src/lib/export/__tests__/exportSessions.test.ts
@@ -173,6 +173,55 @@ describe('runExport via the export worker', () => {
     expect(FakeWorker.instances[0]?.terminated).toBe(true);
   });
 
+  it('an already-aborted signal starts no database reads', async () => {
+    seedDb();
+    vi.stubGlobal('Worker', FakeWorker);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runExport({
+        options: exportOptions,
+        sessionIds: ['s1'],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('Export was cancelled');
+
+    expect(getSessionsByIds).not.toHaveBeenCalled();
+    expect(getProtocolsByHashes).not.toHaveBeenCalled();
+    expect(FakeWorker.instances).toHaveLength(0);
+  });
+
+  it('aborting during the session read stops before the protocol read', async () => {
+    const controller = new AbortController();
+    // Cancel lands while the session read is in flight.
+    getSessionsByIds.mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve([
+        {
+          id: 's1',
+          caseId: 'case-1',
+          startedAt: 1722772800000,
+          finishedAt: null,
+          network: { nodes: [], edges: [], ego: {} },
+          protocolHash: 'hash-1',
+        },
+      ]);
+    });
+    vi.stubGlobal('Worker', FakeWorker);
+
+    await expect(
+      runExport({
+        options: exportOptions,
+        sessionIds: ['s1'],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow('Export was cancelled');
+
+    expect(getProtocolsByHashes).not.toHaveBeenCalled();
+    expect(FakeWorker.instances).toHaveLength(0);
+  });
+
   it('runs the pipeline on the main thread when Worker is unavailable', async () => {
     seedDb();
     vi.stubGlobal('Worker', undefined);

--- a/apps/interviewer/src/lib/export/exportPipelineRunner.ts
+++ b/apps/interviewer/src/lib/export/exportPipelineRunner.ts
@@ -1,0 +1,119 @@
+import { Effect, Layer, Queue, Stream } from 'effect';
+
+import type { ExportEvent } from '@codaco/network-exporters/events';
+import type {
+  InterviewExportInput,
+  ProtocolExportInput,
+} from '@codaco/network-exporters/input';
+import { makeZipOutput } from '@codaco/network-exporters/layers/ZipOutput';
+import type { ExportOptions } from '@codaco/network-exporters/options';
+import type {
+  ExportReturn,
+  OutputResult,
+} from '@codaco/network-exporters/output';
+import { exportPipeline } from '@codaco/network-exporters/pipeline';
+import { InterviewRepository } from '@codaco/network-exporters/services/InterviewRepository';
+import { ProtocolRepository } from '@codaco/network-exporters/services/ProtocolRepository';
+
+// The decrypted, structured-cloneable inputs the pipeline consumes. Fetched
+// (and decrypted) on the main thread — the vault DEK never crosses a worker
+// boundary — then handed to wherever the pipeline runs.
+export type ExportPipelineData = {
+  sessions: InterviewExportInput[];
+  protocols: Record<string, ProtocolExportInput>;
+};
+
+export type ExportRun = {
+  result: ExportReturn;
+  blob: Blob | null;
+  fileName: string | null;
+};
+
+function makeBlobSink() {
+  let result: { blob: Blob; fileName: string } | null = null;
+  const sink = (iterable: AsyncIterable<Uint8Array>, fileName: string) =>
+    Effect.tryPromise({
+      try: async (): Promise<OutputResult> => {
+        const chunks: BlobPart[] = [];
+        for await (const chunk of iterable) {
+          chunks.push(new Uint8Array(chunk));
+        }
+        const blob = new Blob(chunks, { type: 'application/zip' });
+        result = { blob, fileName };
+        // No object URL: nothing consumes one, and an unrevoked URL would pin
+        // the zip-sized blob in memory for the page lifetime.
+        return { key: fileName };
+      },
+      catch: (cause) => {
+        throw cause;
+      },
+    });
+  return {
+    sink,
+    getResult: () => result,
+  };
+}
+
+// Runs the export pipeline over pre-fetched inputs. Free of database and DOM
+// access, so it executes identically inside the export worker (the normal
+// path) and on the main thread (the no-Worker fallback and unit tests).
+export async function runPipelineWithData({
+  data,
+  options,
+  onEvent,
+  signal,
+}: {
+  data: ExportPipelineData;
+  options: ExportOptions;
+  onEvent?: (event: ExportEvent) => void;
+  signal?: AbortSignal;
+}): Promise<ExportRun> {
+  const interviewRepoLayer = Layer.succeed(InterviewRepository, {
+    getForExport: () => Effect.succeed(data.sessions),
+  });
+  const protocolRepoLayer = Layer.succeed(ProtocolRepository, {
+    getProtocols: () => Effect.succeed(data.protocols),
+  });
+  const { sink, getResult } = makeBlobSink();
+  const outputLayer = makeZipOutput(sink);
+
+  const program = Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<ExportEvent>();
+
+    const drain = Effect.forkScoped(
+      Stream.fromQueue(queue).pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            onEvent?.(event);
+          }),
+        ),
+      ),
+    );
+
+    yield* drain;
+
+    const result = yield* exportPipeline(
+      data.sessions.map((session) => session.id),
+      options,
+      queue,
+    );
+    yield* Queue.shutdown(queue);
+    return result;
+  });
+
+  const result = await Effect.runPromise(
+    Effect.scoped(program).pipe(
+      Effect.provide(
+        Layer.mergeAll(interviewRepoLayer, protocolRepoLayer, outputLayer),
+      ),
+    ),
+    { signal },
+  );
+
+  const sinkResult = getResult();
+  return {
+    result,
+    blob: sinkResult?.blob ?? null,
+    fileName: sinkResult?.fileName ?? null,
+  };
+}

--- a/apps/interviewer/src/lib/export/exportSessions.ts
+++ b/apps/interviewer/src/lib/export/exportSessions.ts
@@ -1,146 +1,143 @@
-import { Effect, Layer, Queue, Stream } from 'effect';
-
-import { DatabaseError } from '@codaco/network-exporters/errors';
 import type { ExportEvent } from '@codaco/network-exporters/events';
 import type {
   InterviewExportInput,
   ProtocolExportInput,
 } from '@codaco/network-exporters/input';
-import { makeZipOutput } from '@codaco/network-exporters/layers/ZipOutput';
 import type { ExportOptions } from '@codaco/network-exporters/options';
-import type {
-  ExportReturn,
-  OutputResult,
-} from '@codaco/network-exporters/output';
-import { exportPipeline } from '@codaco/network-exporters/pipeline';
-import { InterviewRepository } from '@codaco/network-exporters/services/InterviewRepository';
-import { ProtocolRepository } from '@codaco/network-exporters/services/ProtocolRepository';
 
 import { APP_VERSION } from '../appVersion';
 import { getProtocolsByHashes, getSessionsByIds } from '../db/api';
-
-const interviewRepoLayer = Layer.succeed(InterviewRepository, {
-  getForExport: (ids) =>
-    Effect.tryPromise({
-      try: async () => {
-        const records = await getSessionsByIds(ids);
-        const inputs: InterviewExportInput[] = records.map((record) => ({
-          id: record.id,
-          participantIdentifier: record.caseId,
-          startTime: new Date(record.startedAt),
-          finishTime: record.finishedAt ? new Date(record.finishedAt) : null,
-          network: record.network,
-          protocolHash: record.protocolHash,
-        }));
-        return inputs;
-      },
-      catch: (cause) => new DatabaseError({ cause }),
-    }),
-});
-
-const protocolRepoLayer = Layer.succeed(ProtocolRepository, {
-  getProtocols: (hashes) =>
-    Effect.tryPromise({
-      try: async () => {
-        const protocols = await getProtocolsByHashes(hashes);
-        const out: Record<string, ProtocolExportInput> = {};
-        for (const stored of protocols) {
-          out[stored.hash] = {
-            hash: stored.hash,
-            name: stored.name,
-            codebook: stored.codebook,
-          };
-        }
-        return out;
-      },
-      catch: (cause) => new DatabaseError({ cause }),
-    }),
-});
-
-function makeBlobSink() {
-  let result: { blob: Blob; fileName: string } | null = null;
-  const sink = (iterable: AsyncIterable<Uint8Array>, fileName: string) =>
-    Effect.tryPromise({
-      try: async (): Promise<OutputResult> => {
-        const chunks: BlobPart[] = [];
-        for await (const chunk of iterable) {
-          chunks.push(new Uint8Array(chunk));
-        }
-        const blob = new Blob(chunks, { type: 'application/zip' });
-        result = { blob, fileName };
-        // No object URL: nothing consumes one, and an unrevoked URL would pin
-        // the zip-sized blob in memory for the page lifetime.
-        return { key: fileName };
-      },
-      catch: (cause) => {
-        throw cause;
-      },
-    });
-  return {
-    sink,
-    getResult: () => result,
-  };
-}
+import {
+  type ExportPipelineData,
+  type ExportRun,
+  runPipelineWithData,
+} from './exportPipelineRunner';
+import type { ExportWorkerMessage, ExportWorkerStart } from './exportWorker';
 
 export type ExportInvocation = {
   options: ExportOptions;
   sessionIds: string[];
   onEvent?: (event: ExportEvent) => void;
-  // Aborting interrupts the Effect pipeline; runExport rejects. Callers that
-  // abort should treat that rejection as a cancellation, not an error.
+  // Aborting cancels the export: the worker (which holds all pipeline state)
+  // is terminated, or the fallback pipeline's Effect fiber is interrupted.
+  // Callers that abort should treat the rejection as a cancellation.
   signal?: AbortSignal;
 };
 
-export type ExportRun = {
-  result: ExportReturn;
-  blob: Blob | null;
-  fileName: string | null;
-};
+// The fetch (and field-level decryption) stage stays on the main thread: the
+// vault DEK never crosses the worker boundary; only decrypted, cloneable
+// export inputs do.
+async function fetchExportInputs(
+  sessionIds: string[],
+): Promise<ExportPipelineData> {
+  const records = await getSessionsByIds(sessionIds);
+  const sessions: InterviewExportInput[] = records.map((record) => ({
+    id: record.id,
+    participantIdentifier: record.caseId,
+    startTime: new Date(record.startedAt),
+    finishTime: record.finishedAt ? new Date(record.finishedAt) : null,
+    network: record.network,
+    protocolHash: record.protocolHash,
+  }));
+  const hashes = [...new Set(records.map((record) => record.protocolHash))];
+  const stored = await getProtocolsByHashes(hashes);
+  const protocols: Record<string, ProtocolExportInput> = {};
+  for (const protocol of stored) {
+    protocols[protocol.hash] = {
+      hash: protocol.hash,
+      name: protocol.name,
+      codebook: protocol.codebook,
+    };
+  }
+  return { sessions, protocols };
+}
 
+function runOnWorker({
+  worker,
+  data,
+  options,
+  onEvent,
+  signal,
+}: {
+  worker: Worker;
+  data: ExportPipelineData;
+  options: ExportOptions;
+  onEvent?: (event: ExportEvent) => void;
+  signal?: AbortSignal;
+}): Promise<ExportRun> {
+  return new Promise<ExportRun>((resolve, reject) => {
+    // Terminating the worker frees the pipeline and everything it buffered in
+    // one step — there is no in-band cancellation message.
+    const onAbort = () => {
+      worker.terminate();
+      reject(new Error('Export was cancelled'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    const settle = () => {
+      signal?.removeEventListener('abort', onAbort);
+      worker.terminate();
+    };
+    worker.onmessage = (message: MessageEvent<ExportWorkerMessage>) => {
+      const payload = message.data;
+      if (payload.type === 'event') {
+        onEvent?.(payload.event);
+        return;
+      }
+      settle();
+      if (payload.type === 'done') {
+        resolve({
+          result: payload.result,
+          blob: payload.blob,
+          fileName: payload.fileName,
+        });
+        return;
+      }
+      const error = new Error(payload.message);
+      error.stack = payload.stack;
+      reject(error);
+    };
+    worker.onerror = (event) => {
+      settle();
+      reject(
+        new Error(
+          event.message.length > 0 ? event.message : 'Export worker failed',
+        ),
+      );
+    };
+    const start: ExportWorkerStart = { type: 'start', data, options };
+    worker.postMessage(start);
+  });
+}
+
+// The CPU-heavy generation and ZIP stages run in a dedicated Web Worker so
+// the export dialog's progress UI stays smooth; environments without Worker
+// (jsdom, unit tests) run the same pipeline on the main thread.
 export async function runExport({
   options,
   sessionIds,
   onEvent,
   signal,
 }: ExportInvocation): Promise<ExportRun> {
-  const { sink, getResult } = makeBlobSink();
-  const outputLayer = makeZipOutput(sink);
+  const data = await fetchExportInputs(sessionIds);
+  if (signal?.aborted) throw new Error('Export was cancelled');
 
-  const program = Effect.gen(function* () {
-    const queue = yield* Queue.unbounded<ExportEvent>();
+  if (typeof Worker === 'function') {
+    let worker: Worker | null = null;
+    try {
+      worker = new Worker(new URL('./exportWorker.ts', import.meta.url), {
+        type: 'module',
+      });
+    } catch {
+      // Construction can fail under restrictive embedding; fall through to
+      // the main-thread pipeline rather than failing the export.
+      worker = null;
+    }
+    if (worker) {
+      return runOnWorker({ worker, data, options, onEvent, signal });
+    }
+  }
 
-    const drain = Effect.forkScoped(
-      Stream.fromQueue(queue).pipe(
-        Stream.runForEach((event) =>
-          Effect.sync(() => {
-            onEvent?.(event);
-          }),
-        ),
-      ),
-    );
-
-    yield* drain;
-
-    const result = yield* exportPipeline(sessionIds, options, queue);
-    yield* Queue.shutdown(queue);
-    return result;
-  });
-
-  const result = await Effect.runPromise(
-    Effect.scoped(program).pipe(
-      Effect.provide(
-        Layer.mergeAll(interviewRepoLayer, protocolRepoLayer, outputLayer),
-      ),
-    ),
-    { signal },
-  );
-
-  const sinkResult = getResult();
-  return {
-    result,
-    blob: sinkResult?.blob ?? null,
-    fileName: sinkResult?.fileName ?? null,
-  };
+  return runPipelineWithData({ data, options, onEvent, signal });
 }
 
 export function buildExportOptions(args: {

--- a/apps/interviewer/src/lib/export/exportSessions.ts
+++ b/apps/interviewer/src/lib/export/exportSessions.ts
@@ -24,13 +24,18 @@ export type ExportInvocation = {
   signal?: AbortSignal;
 };
 
+const CANCELLED_MESSAGE = 'Export was cancelled';
+
 // The fetch (and field-level decryption) stage stays on the main thread: the
 // vault DEK never crosses the worker boundary; only decrypted, cloneable
-// export inputs do.
+// export inputs do. Checks the signal between the two reads so cancelling
+// mid-fetch stops before the protocol lookup/decryption begins.
 async function fetchExportInputs(
   sessionIds: string[],
+  signal?: AbortSignal,
 ): Promise<ExportPipelineData> {
   const records = await getSessionsByIds(sessionIds);
+  if (signal?.aborted) throw new Error(CANCELLED_MESSAGE);
   const sessions: InterviewExportInput[] = records.map((record) => ({
     id: record.id,
     participantIdentifier: record.caseId,
@@ -70,7 +75,7 @@ function runOnWorker({
     // one step — there is no in-band cancellation message.
     const onAbort = () => {
       worker.terminate();
-      reject(new Error('Export was cancelled'));
+      reject(new Error(CANCELLED_MESSAGE));
     };
     signal?.addEventListener('abort', onAbort, { once: true });
     const settle = () => {
@@ -118,8 +123,10 @@ export async function runExport({
   onEvent,
   signal,
 }: ExportInvocation): Promise<ExportRun> {
-  const data = await fetchExportInputs(sessionIds);
-  if (signal?.aborted) throw new Error('Export was cancelled');
+  // An already-cancelled export must not start the database reads at all.
+  if (signal?.aborted) throw new Error(CANCELLED_MESSAGE);
+  const data = await fetchExportInputs(sessionIds, signal);
+  if (signal?.aborted) throw new Error(CANCELLED_MESSAGE);
 
   if (typeof Worker === 'function') {
     let worker: Worker | null = null;

--- a/apps/interviewer/src/lib/export/exportWorker.ts
+++ b/apps/interviewer/src/lib/export/exportWorker.ts
@@ -1,0 +1,67 @@
+import type { ExportEvent } from '@codaco/network-exporters/events';
+import type { ExportOptions } from '@codaco/network-exporters/options';
+import type { ExportReturn } from '@codaco/network-exporters/output';
+
+import {
+  type ExportPipelineData,
+  runPipelineWithData,
+} from './exportPipelineRunner';
+
+// The message protocol between runExport (client) and this worker. Both sides
+// import these types from here; only the client constructs the Worker.
+export type ExportWorkerStart = {
+  type: 'start';
+  data: ExportPipelineData;
+  options: ExportOptions;
+};
+
+export type ExportWorkerMessage =
+  | { type: 'event'; event: ExportEvent }
+  | {
+      type: 'done';
+      result: ExportReturn;
+      blob: Blob | null;
+      fileName: string | null;
+    }
+  | { type: 'error'; message: string; stack: string };
+
+// Shadows the DOM lib's `self: Window` with the worker-shaped surface this
+// module actually runs against, keeping the file type-checkable inside the
+// app's DOM-lib TS program without `as` assertions.
+declare const self: {
+  onmessage: ((message: MessageEvent<ExportWorkerStart>) => void) | null;
+  postMessage: (message: ExportWorkerMessage) => void;
+};
+
+// Cancellation has no in-band message: the client simply terminates the
+// worker, which frees the pipeline and everything it buffered outright.
+self.onmessage = (message) => {
+  const payload = message.data;
+  if (payload.type !== 'start') return;
+  void (async () => {
+    try {
+      const run = await runPipelineWithData({
+        data: payload.data,
+        options: payload.options,
+        onEvent: (event) => {
+          self.postMessage({ type: 'event', event });
+        },
+      });
+      self.postMessage({
+        type: 'done',
+        result: run.result,
+        blob: run.blob,
+        fileName: run.fileName,
+      });
+    } catch (cause) {
+      self.postMessage({
+        type: 'error',
+        message: cause instanceof Error ? cause.message : String(cause),
+        stack:
+          cause instanceof Error
+            ? (cause.stack ?? cause.message)
+            : String(cause),
+      });
+    }
+  })();
+};

--- a/docs/superpowers/specs/2026-08-04-interviewer-export-dialog-design.md
+++ b/docs/superpowers/specs/2026-08-04-interviewer-export-dialog-design.md
@@ -283,6 +283,25 @@ From live testing on desktop Chrome and PR #1191 review:
   implemented by `makeZipOutput` and invoked via `Effect.onInterrupt`
   (`@codaco/network-exporters` patch).
 
+## Worker offload (2026-08-04, follow-up)
+
+The generation and ZIP stages move into a dedicated Web Worker
+(`src/lib/export/exportWorker.ts`), keeping the dialog's progress UI smooth
+during large exports:
+
+- The fetch/decrypt stage stays on the main thread — the vault DEK never
+  crosses the worker boundary; `runExport` resolves the decrypted
+  `InterviewExportInput[]` + protocol map and posts them (structured clone)
+  to the worker, which runs the pipeline via data-backed repository layers
+  (`exportPipelineRunner.ts`, shared with the main-thread fallback).
+- Progress events stream back as messages; cancellation is
+  `worker.terminate()`, which frees the pipeline and everything it buffered
+  in one step (no in-band abort protocol).
+- Environments without `Worker` (jsdom/unit tests), or where construction
+  fails, run the identical pipeline on the main thread.
+- The worker chunk is precached (offline export) and asserted critical in
+  `scripts/assert-pwa-build.mjs`.
+
 ## Shipping
 
 Single PR. App-lane changeset, `minor`, researcher-facing notes ("Exporting


### PR DESCRIPTION
## Summary

Stacked on #1191 (retarget to `main` once that merges). Follow-up to the export-dialog work: even with the periodic event-loop yields added there, the synchronous GraphML/CSV generation and per-byte CRC32 zipping blocked the main thread between yields, so the dialog's spinner and progress bar jittered during large exports.

This moves the CPU-heavy stages into a dedicated module worker:

- **Main thread keeps the keys.** `runExport` resolves the decrypted `InterviewExportInput[]` + protocol map via the existing db api (the vault DEK never crosses the worker boundary), then posts them to the worker via structured clone.
- **The worker runs the identical pipeline** (`exportPipelineRunner.ts`, shared) with data-backed repository layers; progress events stream back as messages and drive the dialog exactly as before.
- **Cancellation is `worker.terminate()`** — the pipeline and everything it buffered are freed in one step, with no in-band abort protocol to get wrong.
- **Fallback:** environments without `Worker` (jsdom/unit tests) or where construction fails run the same pipeline on the main thread, preserving the previous behavior including `Effect.runPromise` signal interruption.
- **PWA:** the worker chunk is precached (offline export keeps working) and added to `assert-pwa-build.mjs`'s critical-chunk assertion so a size regression can't silently drop it.

No `@codaco/network-exporters` API changes; app-lane patch changeset. Design notes added to the 2026-08-04 export-dialog spec ("Worker offload").

## Test plan

- [x] `pnpm --filter @codaco/interviewer typecheck`, `pnpm lint:fix`, `pnpm knip`, `pnpm check:changesets`
- [x] Unit: 494 tests pass, including a new suite for the worker client protocol (start payload, event streaming, error propagation with stack, abort-terminates, no-Worker fallback) against a fake Worker
- [x] Storybook: 96 tests pass
- [x] Production build: worker chunk emitted, precached, and asserted critical (`PWA build ok … 3 critical chunk(s) precached`)
- [x] E2E: `data-management.spec.ts` (8 tests) in the pinned Playwright Docker image — the export test exercises the real worker in Chromium through to a captured, unzipped archive
- [x] Live verification in the dev server: 25-interview export through the worker to the ready dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export archive generation now runs in the background when supported, keeping the app more responsive.
  * Export progress updates are smoother, with cancellation immediately removing partial archive data.
  * Exports automatically fall back to the standard process if background processing is unavailable.
* **Bug Fixes**
  * Improved export error handling and cancellation behavior.
* **Documentation**
  * Added design documentation for background export processing and data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->