### PR TITLE
test(architect): exercise Narrative preset layout-variable creation

### DIFF
--- a/apps/architect/e2e/specs/interfaces/narrative.spec.ts
+++ b/apps/architect/e2e/specs/interfaces/narrative.spec.ts
@@ -6,61 +6,15 @@ import { stageSnapshotJson } from '../../helpers/normalize-stage.js';
 import { readStageJson } from '../../helpers/read-store.js';
 import { selectOrCreateNodeType } from '../../pageobjects/editor-sections/entity-types.js';
 import { addPrompt } from '../../pageobjects/editor-sections/prompts.js';
+import { createVariableViaSpotlight } from '../../pageobjects/editor-sections/variables.js';
 import { StageEditor } from '../../pageobjects/stage-editor.js';
 
-// KNOWN APP BUG, worked around below — NarrativePresets/withPresetProps.tsx's
-// `handleCreateLayoutVariable` (wired to the "Layout Variable" `VariablePicker`'s
-// `onCreateOption`) destructures `dispatch` straight from its own props:
-//
-//   handleCreateLayoutVariable:
-//     ({ form, changeForm, createVariable, dispatch, entity, type }) =>
-//     async (name) => {
-//       const result = await dispatch(createVariable({ ... })).unwrap();
-//       ...
-//
-// but this component's `connect(mapStateToProps, mapDispatchToProps)` passes
-// `mapDispatchToProps` as a plain OBJECT (`{ createVariable: ..., deleteVariable:
-// ..., changeForm: change }`), not a function — react-redux's object shorthand
-// wraps each entry with `bindActionCreators(mapDispatchToProps, dispatch)` and
-// deliberately does NOT also inject a raw `dispatch` prop (that only happens
-// when `mapDispatchToProps` is omitted entirely, or a function form explicitly
-// returns one). So `dispatch` here is always `undefined`, and every attempt to
-// CREATE a new layout variable from a Narrative preset throws `TypeError:
-// dispatch is not a function` inside an unhandled promise rejection — silently,
-// with no chance for `changeForm(form, 'layoutVariable', variable)` to ever run.
-// The dialog's own "Layout Variable" field is correctly left blank + `Required`
-// (no corrupted data — this is a broken/unusable feature, not a data-integrity
-// bug), but "Add" can never succeed for a *brand-new* layout variable.
-//
-// Reproduced deterministically, twice: once against the production build via
-// `page.on('pageerror')` (minified: "r is not a function"), and again against
-// the unminified Vite dev server (unminified stack trace resolves to
-// `withPresetProps.tsx:29`, `const result = await dispatch(createVariable(...`)
-// — driven live via the browser MCP + `getBoundingClientRect`/native-value-setter
-// DOM calls rather than trusted from source reading alone. Confirmed this is
-// isolated to `NarrativePresets/withPresetProps.tsx`'s old-style class-component
-// `connect + withHandlers` pattern: every other canvas-family layout-variable
-// creation path in this suite (Sociogram's prompt "Layout" section,
-// NetworkComposer's NodeConfiguration) instead goes through
-// `withCreateVariableHandler.tsx`, which gets `dispatch` correctly via the
-// `useAppDispatch()` hook — so those two ARE the "simple creation path"
-// (`createVariableViaSpotlight` unmodified) and are exercised as such in
-// sociogram.spec.ts / network-composer.spec.ts.
-//
-// Not app-fixed here, per this task's "flag, don't silently app-fix" instruction
-// — this is a two-line production fix (thread a real `dispatch` prop through,
-// or switch to the hook-based handler like the other two interfaces already
-// do), but out of scope for an e2e-authoring task. Worked around at the TEST
-// level in a way that mirrors a real author action: SociogramPrompts'
-// PromptFieldsLayout.tsx's own UI copy encourages reusing one shared layout
-// variable across multiple canvas-family stages/prompts ("If you use the same
-// layout variable across all prompts, the position of nodes will be
-// automatically set..."), so a protocol already having a `layout`-type variable
-// defined for the `person` node type before a Narrative preset needs one is a
-// completely ordinary starting state — not a test-only fiction. The seeded
-// variable is only ever SELECTED here (the spotlight's non-"create" list-item
-// path, which never touches `handleCreateLayoutVariable`), never created.
-function protocolWithPersonLayoutVariable(): CurrentProtocol {
+// Only the background image asset is seeded: the Background section's picker
+// selects from resources the protocol already has, and driving a real upload
+// through the file-chooser is resources.spec.ts's job. Everything else this
+// stage needs (node type, layout variable, preset) is authored live through
+// the editor UI below.
+function protocolWithBackgroundAsset(): CurrentProtocol {
   return {
     ...emptyProtocol(),
     assetManifest: {
@@ -68,23 +22,6 @@ function protocolWithPersonLayoutVariable(): CurrentProtocol {
         name: 'Narrative Background',
         type: 'image',
         source: 'narrative-background.svg',
-      },
-    },
-    codebook: {
-      node: {
-        // uuid-shaped so `normalize-stage.ts`'s `UUID_RE` placeholder-maps
-        // these the same way live-created ids would be.
-        '11111111-1111-4111-8111-111111111111': {
-          name: 'person',
-          color: 'node-color-seq-1',
-          shape: { default: 'circle' },
-          variables: {
-            '22222222-2222-4222-8222-222222222222': {
-              name: 'layout',
-              type: 'layout',
-            },
-          },
-        },
       },
     },
   };
@@ -99,7 +36,7 @@ test('creates a valid Narrative stage from scratch', async ({
   architectPage,
   seed,
 }) => {
-  await seed(protocolWithPersonLayoutVariable(), {
+  await seed(protocolWithBackgroundAsset(), {
     assets: [
       {
         assetId: 'narrative_background',
@@ -116,10 +53,11 @@ test('creates a valid Narrative stage from scratch', async ({
 
   // StageEditor/Interfaces.tsx: `Narrative.sections = [FilteredNodeType,
   // Background, NarrativePresets, NarrativeBehaviours, SkipLogic,
-  // InterviewScript]`. `selectOrCreateEntityType` (entity-types.ts) SELECTS
-  // the seeded "person" type (its radio already exists) rather than creating
-  // a second one — real authors reuse an existing node type across stages
-  // just as readily as they reuse a layout variable.
+  // InterviewScript]`. FilteredNodeType renders the same radio-pill/"Create
+  // new node type" structure as the plain `NodeType` (entity-types.ts: "Both
+  // node ... sections are structurally identical"), so
+  // `selectOrCreateNodeType` creates "person" from the empty codebook here,
+  // exactly as sociogram.spec.ts does.
   await selectOrCreateNodeType(architectPage, 'person');
 
   // Narrative uses the shared canvas Background section, including the same
@@ -163,31 +101,19 @@ test('creates a valid Narrative stage from scratch', async ({
   // Layout Variable `VariablePicker` is the only "Select variable" button
   // visible — no `scope` needed, unlike NetworkComposer's NodeConfiguration.
   //
-  // The picker's options list (`layoutVariablesForSubject`,
-  // NarrativePresets/selectors.ts's `getNarrativeVariables`) already contains
-  // the seeded "layout" variable, so typing its exact name leaves
-  // `hasExactFilterMatch` true and VariableSpotlight never renders a "Create
-  // new variable called…" row at all — only the existing variable's own
-  // `spotlight-list-item`, which this clicks. That routes through
-  // `VariablePickerControl.handleSelectVariable` -> the field's own
-  // `onChange`, never through the broken `handleCreateLayoutVariable` above.
+  // The fresh codebook has no variables yet, so typing a name renders the
+  // spotlight's "Create new variable called…" row and this exercises real
+  // creation through the picker's `onCreateOption`:
+  // NarrativePresets/withPresetProps.tsx's `handleCreateLayoutVariable`
+  // delegates to withCreateVariableHandler's `handleCreateVariable(name,
+  // 'layout', 'layoutVariable')` — the same simple creation path as
+  // Sociogram's prompt "Layout" section, with the type pre-supplied by the
+  // call site (no NewVariableWindow opens).
   await addPrompt(editor.section('Narrative Presets'), async () => {
     await architectPage
       .getByPlaceholder('Enter a label for the preset...')
       .fill('Default view');
-
-    await architectPage
-      .getByRole('button', { name: 'Select variable' })
-      .click();
-    const search = architectPage.getByRole('searchbox', {
-      name: 'Find or create a variable',
-    });
-    await search.fill('layout');
-    await architectPage
-      .getByTestId('spotlight-list-item')
-      .filter({ hasText: 'layout' })
-      .first()
-      .click();
+    await createVariableViaSpotlight(architectPage, { variableName: 'layout' });
   });
 
   await editor.expectNoIssues();


### PR DESCRIPTION
## Summary
- The Narrative e2e spec carried a ~50-line "KNOWN APP BUG, worked around below" comment documenting that creating a layout variable from a Narrative preset threw `dispatch is not a function`. That bug was fixed in 387e7b2fb / 7414214ff (`withPresetProps` now composes `withCreateVariableHandler`, which gets `dispatch` from the `useAppDispatch()` hook), so the commentary and the workaround are stale.
- Remove the stale comment block and the seeded person/layout codebook workaround, and drive the real creation path instead: the preset dialog's Layout Variable picker now goes through `createVariableViaSpotlight`, exercising `handleCreateLayoutVariable` → `handleCreateVariable(name, 'layout', 'layoutVariable')` end to end. This makes narrative.spec.ts the e2e regression guard for the exact wiring that was broken — no other spec covers withPresetProps' composed handler (Sociogram/NetworkComposer cover `withCreateVariableHandler`'s direct call sites).
- The background image asset stays seeded (the Background section picks from existing resources; real uploads are resources.spec.ts's job), and the node type is now created from an empty codebook exactly as sociogram.spec.ts does.
- `narrative-stage.json` is unchanged: the snapshot normalizer maps UUIDs positionally, so live-created ids normalize identically to the previously seeded uuid-shaped ids.

## Test plan
- [x] Verified the app fix is present (`withPresetProps.tsx` composes `withCreateVariableHandler`; handler delegates with type `'layout'` and field `'layoutVariable'`)
- [x] `pnpm turbo run build --filter=@codaco/architect` + `playwright test --config e2e/playwright.config.ts specs/interfaces/narrative.spec.ts` — 1 passed against the fresh production build; existing `narrative-stage.json` snapshot matched without `--update-snapshots`
- [x] `pnpm --filter @codaco/architect typecheck` (app + e2e tsconfig), `pnpm lint:fix`, `pnpm knip` — clean
- [x] Visual-baseline classifier: Architect flagged for review only because a file under its `e2e/` changed; dismissed — the spec takes no PNG captures and no app source changed, so no suite regeneration is required
- [x] No changeset: test-only change, no consumer-visible effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)