### PR TITLE
Fresco UI: render TimeAgo in the first commit (data-table flicker)

### DIFF
--- a/.changeset/time-ago-first-paint.md
+++ b/.changeset/time-ago-first-paint.md
@@ -1,0 +1,9 @@
+---
+'@codaco/fresco-ui': patch
+---
+
+TimeAgo now renders its relative timestamp in the very first frame. It
+previously mounted empty and filled in a moment later (both its own state and
+the SSR wrapper resolved in effects), so any re-render that recreated the
+element — selecting a data-table row, for example — made the value's width
+visibly collapse and re-expand.

--- a/packages/fresco-ui/src/TimeAgo.test.tsx
+++ b/packages/fresco-ui/src/TimeAgo.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Profiler } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import TimeAgo from './TimeAgo';
+
+const DAY_MS = 86400000;
+
+// Captures the rendered text at every React commit: the flicker this guards
+// against was the first committed frame being empty (NoSSRWrapper's mount
+// gate, then TimeAgo's effect-derived state), which made the element's width
+// jump on every mount — visibly, whenever a table cell re-rendered.
+function renderCapturingCommits(ui: React.ReactElement) {
+  const commits: (string | null)[] = [];
+  render(
+    <Profiler
+      id="time-ago-commits"
+      onRender={() => {
+        commits.push(screen.queryByTestId('time-ago')?.textContent ?? null);
+      }}
+    >
+      {ui}
+    </Profiler>,
+  );
+  return commits;
+}
+
+describe('TimeAgo', () => {
+  it('renders the relative time in the very first commit', () => {
+    const commits = renderCapturingCommits(
+      <TimeAgo date={new Date(Date.now() - 2 * DAY_MS)} />,
+    );
+
+    expect(commits[0]).toBe('2 days ago');
+    // No commit ever showed an empty or missing element.
+    expect(commits).not.toContain(null);
+    expect(commits).not.toContain('');
+  });
+
+  it.each([
+    { offsetMs: 30000, expected: 'just now' },
+    { offsetMs: 60000, expected: '1 minute ago' },
+    { offsetMs: 25 * 60000, expected: '25 minutes ago' },
+    { offsetMs: 3600000, expected: '1 hour ago' },
+    { offsetMs: 5 * 3600000, expected: '5 hours ago' },
+    { offsetMs: DAY_MS, expected: '1 day ago' },
+    { offsetMs: 6 * DAY_MS, expected: '6 days ago' },
+  ])(
+    'renders "$expected" for an offset of $offsetMs ms',
+    ({ offsetMs, expected }) => {
+      render(<TimeAgo date={new Date(Date.now() - offsetMs)} />);
+      expect(screen.getByTestId('time-ago')).toHaveTextContent(expected);
+    },
+  );
+
+  it('falls back to the locale-formatted date beyond a week', () => {
+    const date = new Date(Date.now() - 8 * DAY_MS);
+    render(<TimeAgo date={date} />);
+    const element = screen.getByTestId('time-ago');
+    // The exact string is locale-dependent; it must match the title, which
+    // always carries the locale-formatted timestamp.
+    expect(element.textContent).toBe(element.getAttribute('title'));
+  });
+
+  it('toggles to the raw timestamp on click', async () => {
+    const user = userEvent.setup();
+    render(<TimeAgo date={new Date(Date.now() - 2 * DAY_MS)} />);
+    const element = screen.getByTestId('time-ago');
+
+    await user.click(element);
+    expect(element.textContent).toBe(element.getAttribute('title'));
+
+    await user.click(element);
+    expect(element).toHaveTextContent('2 days ago');
+  });
+});

--- a/packages/fresco-ui/src/TimeAgo.tsx
+++ b/packages/fresco-ui/src/TimeAgo.tsx
@@ -12,6 +12,32 @@ const DEFAULT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   minute: 'numeric',
 };
 
+const MINUTE_MS = 60000;
+const HOUR_MS = 3600000;
+const DAY_MS = 86400000;
+const WEEK_MS = 604800000;
+
+function formatTimeAgo(date: Date, localisedDate: string): string {
+  const distance = Date.now() - date.getTime();
+  if (distance < MINUTE_MS) {
+    return 'just now';
+  }
+  if (distance < HOUR_MS) {
+    const minutes = Math.floor(distance / MINUTE_MS);
+    return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`;
+  }
+  if (distance < DAY_MS) {
+    const hours = Math.floor(distance / HOUR_MS);
+    return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
+  }
+  if (distance < WEEK_MS) {
+    const days = Math.floor(distance / DAY_MS);
+    return `${days} ${days === 1 ? 'day' : 'days'} ago`;
+  }
+  // More than a week ago, fall back to the locale-formatted timestamp.
+  return localisedDate;
+}
+
 type TimeAgoProps = Omit<
   React.TimeHTMLAttributes<HTMLTimeElement>,
   'onClick'
@@ -30,45 +56,31 @@ const TimeAgo: React.FC<TimeAgoProps> = ({
 }) => {
   const date = useMemo(() => new Date(dateProp), [dateProp]);
   const opts = dateOptions ?? DEFAULT_DATE_OPTIONS;
-  const localisedDate = new Intl.DateTimeFormat(
-    navigator.language,
-    opts,
-  ).format(date);
+  const localisedDate = useMemo(
+    () => new Intl.DateTimeFormat(navigator.language, opts).format(date),
+    [date, opts],
+  );
 
-  const [timeAgo, setTimeAgo] = useState<string>('');
+  // Computed synchronously for the very first paint: deriving this in an
+  // effect rendered an empty element whose width then jumped — a visible
+  // flicker on every mount (and table cells remount on unrelated re-renders).
+  const [timeAgo, setTimeAgo] = useState(() =>
+    formatTimeAgo(date, localisedDate),
+  );
   // Click anywhere on the time element to flip between the relative
   // ("2 days ago") rendering and the raw locale-formatted timestamp.
   const [showRaw, setShowRaw] = useState(false);
 
   useEffect(() => {
-    const calculateTimeAgo = () => {
-      const now = new Date();
-      const distance = now.getTime() - date.getTime();
-
-      if (distance < 60000) {
-        setTimeAgo('just now');
-      } else if (distance < 3600000) {
-        const singleOrPlural =
-          Math.floor(distance / 60000) === 1 ? 'minute' : 'minutes';
-        setTimeAgo(`${Math.floor(distance / 60000)} ${singleOrPlural} ago`);
-      } else if (distance < 86400000) {
-        const singleOrPlural =
-          Math.floor(distance / 3600000) === 1 ? 'hour' : 'hours';
-        setTimeAgo(`${Math.floor(distance / 3600000)} ${singleOrPlural} ago`);
-      } else if (distance < 604800000) {
-        const singleOrPlural =
-          Math.floor(distance / 86400000) === 1 ? 'day' : 'days';
-        setTimeAgo(`${Math.floor(distance / 86400000)} ${singleOrPlural} ago`);
-      } else {
-        // More than a week ago, fall back to Intl.DateTimeFormat
-        setTimeAgo(localisedDate);
-      }
+    const update = () => {
+      // Setting an unchanged string is a no-op render-wise; React bails out.
+      setTimeAgo(formatTimeAgo(date, localisedDate));
     };
 
-    calculateTimeAgo();
+    update();
 
     // Update time ago every minute
-    const interval = setInterval(calculateTimeAgo, 60000);
+    const interval = setInterval(update, MINUTE_MS);
 
     return () => clearInterval(interval);
   }, [date, localisedDate]);

--- a/packages/fresco-ui/src/utils/NoSSRWrapper.tsx
+++ b/packages/fresco-ui/src/utils/NoSSRWrapper.tsx
@@ -2,23 +2,31 @@ import {
   type ComponentProps,
   type ComponentType,
   type ReactNode,
-  useEffect,
-  useState,
+  useSyncExternalStore,
 } from 'react';
 
+// The snapshot never changes within an environment, so there is nothing to
+// subscribe to.
+const emptySubscribe = () => () => {};
+
 /**
- * SSR-safe wrapper. The wrapped tree is mounted only after hydration —
- * useful for components that depend on browser-only APIs (`document`, `window`,
- * Web Workers, layout measurement, etc.).
+ * SSR-safe wrapper. The wrapped tree renders `null` on the server and during
+ * the hydration pass, but is present from the very first commit in a
+ * client-only render.
  *
- * Implementation note: we use a mount-detection pattern (useEffect + useState)
- * rather than Next's `dynamic({ ssr: false })` so the package works in any
- * React environment, not just Next.js.
+ * Implementation note: `useSyncExternalStore` with divergent client/server
+ * snapshots is the canonical hydration-safe environment check. The previous
+ * useEffect mount-gate blanked the first client frame on *every* mount —
+ * a table cell remounting a wrapped component (e.g. TimeAgo) visibly
+ * collapsed to zero width and re-expanded a frame later.
  */
 const NoSSRWrapper = ({ children }: { children: ReactNode }) => {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  return mounted ? children : null;
+  const hydrated = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+  return hydrated ? children : null;
 };
 
 export const withNoSSRWrapper = <P extends object>(


### PR DESCRIPTION
## Summary

Selecting a row in the Interviewer data table visibly flickered the Started/Updated columns: the `TimeAgo` cell collapsed to zero width and re-expanded a frame later. Two compounding causes, both in fresco-ui:

- `withNoSSRWrapper` gated its children behind a `useEffect` mount flag, so every mount rendered `null` for the first commit. It now uses the canonical `useSyncExternalStore` environment check — the server/hydration pass still renders `null` (the SSR contract external consumers rely on), but client-only renders mount the children in the very first commit.
- `TimeAgo` derived its relative string in an effect from `useState('')`, adding a second empty-width commit. The string is now computed in a lazy state initializer (the interval-driven minute refresh is unchanged), and the repeated `Intl.DateTimeFormat` construction is memoized.

Table cells remount whenever the column defs' inline `cell` renderers change identity (e.g. the selection-dependent `useMemo` in `useDataViewColumns`), which is why unrelated interactions replayed the mount flicker.

New `TimeAgo.test.tsx` locks the behavior with a `Profiler`-based assertion that the text is present in the **first** committed frame and that no commit ever renders empty, plus coverage of the relative ranges, the >1-week locale fallback, and the click-to-toggle raw timestamp.

## Test plan

- [x] `pnpm --filter @codaco/fresco-ui test` (988 tests, including the 10 new)
- [x] `pnpm --filter @codaco/fresco-ui typecheck`, `pnpm lint:fix`, `pnpm knip`, `pnpm check:changesets`
- [x] Visual baselines: settled rendering is pixel-identical (the change removes transient empty frames only); no e2e screenshots capture mid-mount frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)