### PR TITLE
fix(interview): clamp canvas nodes by their measured radius

### DIFF
--- a/.changeset/canvas-clamp-real-radius.md
+++ b/.changeset/canvas-clamp-real-radius.md
@@ -1,0 +1,9 @@
+---
+'@codaco/interview': patch
+---
+
+Keep canvas nodes fully visible at the canvas edge on every screen size. The
+boundary that stops a dragged or auto-laid-out node at the edge of the
+Sociogram, Narrative, and Network Composer canvases now uses the node's real
+rendered size instead of a fixed estimate, so larger nodes on wide displays are
+no longer partially cut off when moved to the edge of the canvas.

--- a/packages/interview/src/canvas/__tests__/useCanvasStore.test.ts
+++ b/packages/interview/src/canvas/__tests__/useCanvasStore.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { edgeInsetForNode, FALLBACK_NODE_RADIUS } from '../layoutGeometry';
+import { createCanvasStore } from '../useCanvasStore';
+
+const DIMS = { width: 1000, height: 500 };
+
+// The measured radius at the largest type scale (viewport ramp cap x the
+// participant text-size control) exceeds the fallback — the case the
+// radius-aware clamp exists for.
+const MEASURED_RADIUS = 78;
+
+describe('useCanvasStore boundary clamp', () => {
+  it('insets by the fallback radius until a measurement arrives', () => {
+    const store = createCanvasStore();
+    store.getState().setCanvasDimensions(DIMS);
+    store.getState().setPosition('a', { x: 1, y: 1 });
+
+    const inset = edgeInsetForNode(FALLBACK_NODE_RADIUS);
+    const pos = store.getState().positions.get('a')!;
+    expect(pos.x).toBeCloseTo(1 - inset / DIMS.width, 10);
+    expect(pos.y).toBeCloseTo(1 - inset / DIMS.height, 10);
+  });
+
+  it('clamps placements by the measured radius once set', () => {
+    const store = createCanvasStore();
+    store.getState().setCanvasDimensions(DIMS);
+    store.getState().setNodeRadius(MEASURED_RADIUS);
+    store.getState().setPosition('a', { x: 0, y: 0 });
+
+    const inset = edgeInsetForNode(MEASURED_RADIUS);
+    const pos = store.getState().positions.get('a')!;
+    expect(pos.x).toBeCloseTo(inset / DIMS.width, 10);
+    expect(pos.y).toBeCloseTo(inset / DIMS.height, 10);
+  });
+
+  it('re-clamps existing positions when the measured radius grows', () => {
+    const store = createCanvasStore();
+    store.getState().setCanvasDimensions(DIMS);
+    // Placed while only the fallback radius was known: sits at the old edge.
+    store.getState().setPosition('a', { x: 1, y: 1 });
+
+    store.getState().setNodeRadius(MEASURED_RADIUS);
+
+    const inset = edgeInsetForNode(MEASURED_RADIUS);
+    const pos = store.getState().positions.get('a')!;
+    expect(pos.x).toBeCloseTo(1 - inset / DIMS.width, 10);
+    expect(pos.y).toBeCloseTo(1 - inset / DIMS.height, 10);
+  });
+
+  it('falls back for a non-positive (unmeasured) radius', () => {
+    const store = createCanvasStore();
+    store.getState().setNodeRadius(MEASURED_RADIUS);
+    store.getState().setNodeRadius(0);
+    expect(store.getState().nodeRadius).toBe(FALLBACK_NODE_RADIUS);
+  });
+
+  it('does not rebuild positions when the radius is unchanged', () => {
+    const store = createCanvasStore();
+    store.getState().setCanvasDimensions(DIMS);
+    store.getState().setPosition('a', { x: 0.5, y: 0.5 });
+
+    const before = store.getState().positions;
+    store.getState().setNodeRadius(FALLBACK_NODE_RADIUS);
+    expect(store.getState().positions).toBe(before);
+  });
+});

--- a/packages/interview/src/canvas/layoutGeometry.ts
+++ b/packages/interview/src/canvas/layoutGeometry.ts
@@ -22,13 +22,15 @@
 export type Position = { x: number; y: number };
 export type CanvasDimensions = { width: number; height: number };
 
-// Fallback rendered node radius (px) used until `useNodeMeasurement` reports the
-// real measured size (e.g. on the first render, or under jsdom where layout is
-// not computed). Matches `useCanvasStore`'s NODE_RADIUS: size="sm" is size-24 =
-// 6 * --theme-root-size. The interview theme root is fluid (0.9rem floor,
-// ramping up on wider viewports via the Shell), so the real diameter varies;
-// 48px (a 1rem-root, 96px-diameter value) is a representative fallback that
-// useNodeMeasurement corrects on the first real layout.
+// Fallback rendered node radius (px) used until `useNodeMeasurement` reports
+// the real measured size (e.g. on the first render, or under jsdom where
+// layout is not computed): size="sm" is size-24 = 6 * --theme-root-size. The
+// interview theme root is fluid (0.9rem floor, ramping up on wider viewports
+// via the Shell, and further scaled by the participant text-size control), so
+// the real diameter varies; 48px (a 1rem-root, 96px-diameter value) is a
+// representative fallback. It seeds both `useCanvasStore`'s clamp radius and
+// `useAutoLayout`'s collision/bounds radius until the measurement lands, at
+// which point both are corrected to the live radius.
 export const FALLBACK_NODE_RADIUS = 48;
 
 // Extra spacing between a node's visible EDGE and a neighbour's edge, expressed

--- a/packages/interview/src/canvas/useAutoLayout.ts
+++ b/packages/interview/src/canvas/useAutoLayout.ts
@@ -216,6 +216,17 @@ export function useAutoLayout({
     );
   }, [store]);
 
+  // Push the measured radius into the store so its boundary clamp insets by
+  // the SAME radius the worker's bounds force uses (the seeding effect below
+  // resolves <= 0 to the fallback exactly as the store does). Runs even when
+  // the layout is disabled (e.g. manual-mode Sociogram) so plain drags clamp
+  // against the real rendered radius too. Declared before the seeding effect
+  // so a radius change re-clamps stored positions before the worker re-seeds
+  // from them.
+  useEffect(() => {
+    store.getState().setNodeRadius(nodeRadius);
+  }, [store, nodeRadius]);
+
   useEffect(() => {
     if (!enabled) return;
     // Defer until the canvas has been measured: seeding against a 0-size canvas
@@ -239,10 +250,11 @@ export function useAutoLayout({
     // connected nodes onto the floor — the closest spacing in the layout — while
     // charge spreads unconnected nodes beyond it. Tune visually.
     const linkDistance = 1.9 * collideRadius;
-    // Bounds inset is keyed to FALLBACK_NODE_RADIUS (px) so it EXACTLY matches the
-    // store clamp's fixed inset, then divided by height into sim units — that
-    // equality is what makes the store clamp a no-op on settled positions.
-    const boundsInset = edgeInsetForNode(FALLBACK_NODE_RADIUS) / dims.height;
+    // Bounds inset is keyed to the SAME resolved radius the setNodeRadius
+    // effect above pushed into the store's clamp, then divided by height into
+    // sim units — that equality is what makes the store clamp a no-op on
+    // settled positions.
+    const boundsInset = edgeInsetForNode(resolvedRadius) / dims.height;
 
     // In e2e tests, swap in a deterministic worker so visual snapshots aren't
     // sensitive to simulation randomness.

--- a/packages/interview/src/canvas/useCanvasStore.ts
+++ b/packages/interview/src/canvas/useCanvasStore.ts
@@ -19,12 +19,20 @@ type CanvasState = {
   positions: Map<string, Position>;
   selectedNodeId: string | null;
   canvasDimensions: CanvasDimensions | null;
+  // Rendered node radius (px) the boundary clamp insets by. Starts at
+  // FALLBACK_NODE_RADIUS and is corrected via setNodeRadius once
+  // `useNodeMeasurement` reports the live size (useAutoLayout pushes it), so
+  // the clamp tracks the real radius — which varies with the Shell's viewport
+  // ramp and the participant text-size control — instead of clipping larger
+  // nodes against a fixed inset.
+  nodeRadius: number;
 };
 
 type CanvasActions = {
   setPosition: (nodeId: string, position: Position) => void;
   setBatchPositions: (entries: [string, Position][]) => void;
   setCanvasDimensions: (dimensions: CanvasDimensions) => void;
+  setNodeRadius: (radius: number) => void;
   syncFromNodes: (nodes: NcNode[], layoutVariable: string) => void;
   syncNewFromNodes: (nodes: NcNode[], layoutVariable: string) => void;
   selectNode: (nodeId: string | null) => void;
@@ -40,12 +48,13 @@ type CanvasStore = CanvasState & CanvasActions;
 const clampPosition = (
   pos: Position,
   dimensions: CanvasDimensions | null,
+  nodeRadius: number,
 ): Position => {
   if (!dimensions || dimensions.width === 0 || dimensions.height === 0) {
     return { x: clamp(pos.x, 0, 1), y: clamp(pos.y, 0, 1) };
   }
 
-  const inset = edgeInsetForNode(FALLBACK_NODE_RADIUS);
+  const inset = edgeInsetForNode(nodeRadius);
   const marginX = Math.min(inset / dimensions.width, 0.5);
   const marginY = Math.min(inset / dimensions.height, 0.5);
 
@@ -61,11 +70,15 @@ export const createCanvasStore = () =>
       positions: new Map(),
       selectedNodeId: null,
       canvasDimensions: null,
+      nodeRadius: FALLBACK_NODE_RADIUS,
 
       setPosition: (nodeId, position) => {
         set((state) => {
           const next = new Map(state.positions);
-          next.set(nodeId, clampPosition(position, state.canvasDimensions));
+          next.set(
+            nodeId,
+            clampPosition(position, state.canvasDimensions, state.nodeRadius),
+          );
           return { positions: next };
         });
       },
@@ -74,7 +87,10 @@ export const createCanvasStore = () =>
         set((state) => {
           const next = new Map(state.positions);
           for (const [nodeId, position] of entries) {
-            next.set(nodeId, clampPosition(position, state.canvasDimensions));
+            next.set(
+              nodeId,
+              clampPosition(position, state.canvasDimensions, state.nodeRadius),
+            );
           }
           return { positions: next };
         });
@@ -84,14 +100,30 @@ export const createCanvasStore = () =>
         set((state) => {
           const next = new Map<string, Position>();
           for (const [nodeId, pos] of state.positions) {
-            next.set(nodeId, clampPosition(pos, dimensions));
+            next.set(nodeId, clampPosition(pos, dimensions, state.nodeRadius));
           }
           return { canvasDimensions: dimensions, positions: next };
         });
       },
 
+      setNodeRadius: (radius) => {
+        // <= 0 (unmeasured) falls back so the clamp always has a usable inset.
+        const resolved = radius > 0 ? radius : FALLBACK_NODE_RADIUS;
+        if (resolved === get().nodeRadius) return;
+        set((state) => {
+          const next = new Map<string, Position>();
+          for (const [nodeId, pos] of state.positions) {
+            next.set(
+              nodeId,
+              clampPosition(pos, state.canvasDimensions, resolved),
+            );
+          }
+          return { nodeRadius: resolved, positions: next };
+        });
+      },
+
       syncFromNodes: (nodes, layoutVariable) => {
-        const dims = get().canvasDimensions;
+        const { canvasDimensions: dims, nodeRadius } = get();
         const next = new Map<string, Position>();
         for (const node of nodes) {
           const attrs = node[entityAttributesProperty];
@@ -106,7 +138,7 @@ export const createCanvasStore = () =>
           ) {
             next.set(
               node[entityPrimaryKeyProperty],
-              clampPosition(layoutValue, dims),
+              clampPosition(layoutValue, dims, nodeRadius),
             );
           }
         }
@@ -143,7 +175,11 @@ export const createCanvasStore = () =>
               ) {
                 next.set(
                   nodeId,
-                  clampPosition(layoutValue, state.canvasDimensions),
+                  clampPosition(
+                    layoutValue,
+                    state.canvasDimensions,
+                    state.nodeRadius,
+                  ),
                 );
               }
             }


### PR DESCRIPTION
## Summary

- The canvas boundary clamp (`useCanvasStore`'s `clampPosition`) and the auto-layout worker's bounds force both inset by a fixed `edgeInsetForNode(FALLBACK_NODE_RADIUS)` = 64px, while the real rendered node radius varies with the interview type scale — the Shell's viewport ramp alone reaches a 60px radius at 2560px wide (and the upcoming participant text-size control multiplies further, up to ~78px). A node dragged to the edge of the overflow-hidden Sociogram, Narrative, or Network Composer canvas could therefore be clipped by up to ~14px.
- The canvas store now owns a `nodeRadius` (defaulting to `FALLBACK_NODE_RADIUS`) and clamps by `edgeInsetForNode(nodeRadius)`. `useAutoLayout` pushes the live `useNodeMeasurement` radius into the store — in an effect that runs even while the simulation is disabled, so manual-mode Sociogram drags clamp correctly too — and keys the worker's `boundsInset` to the same resolved value, preserving the existing "store clamp is a no-op on settled positions" exact-match invariant with a single writer.
- `setNodeRadius` re-clamps existing positions, so a node already resting at the old (too-tight) edge pulls in once the measurement lands.

Origin: Codex review finding on PR #1193 (thread on `Shell.tsx` about scaling canvas boundary insets).

## Test plan

- [x] New unit tests for the radius-aware clamp (`packages/interview/src/canvas/__tests__/useCanvasStore.test.ts`): fallback inset before measurement, measured-radius clamping, re-clamp on radius growth, non-positive fallback, no-op churn guard.
- [x] Full `@codaco/interview` unit suite: 150 files / 1326 tests pass; typecheck, lint, and knip clean.
- [x] Visual baselines assessed per `preparing-e2e-visual-baselines`: Interview and Interviewer suites regenerated in pinned Docker (Architect dismissed — its two baselines are the printable summary/codebook, which never render the canvas runtime). **Zero canvas baselines changed** — at the 1920×1080 e2e viewport the inset moves 64→70px and no captured node sits inside that band (the e2e mock worker's grid keeps nodes ≥10% from the edges). The only diffs were sub-threshold webkit Geospatial Mapbox noise, which was reverted per the skill.