### PR TITLE
fix(ci): wait for docs preview before website dead-link crawl

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -772,7 +772,9 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       needs.detect.outputs.website == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Budgets two sequential 15-minute Netlify status polls (website, then
+    # documentation) plus the reachability probes and the crawl itself.
+    timeout-minutes: 40
     permissions:
       contents: read
       statuses: read

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -843,6 +843,80 @@ jobs:
           done
           echo "::error::Netlify website preview is not reachable at $WEBSITE_URL"
           exit 1
+      # In a deploy-preview context the website rewrites its documentation
+      # links to this PR's documentation preview
+      # (apps/networkcanvas.com/next.config.ts, documentationUrl). The two
+      # Netlify builds race, so wait for the documentation preview before
+      # crawling — otherwise every docs link 404s whenever the website
+      # preview deploys first.
+      - id: docs-preview
+        name: Wait for Netlify documentation preview
+        if: needs.detect.outputs.docs == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const siteName = 'documentation-dev';
+            const statusContext = `netlify/${siteName}/deploy-preview`;
+            const headSha = context.payload.pull_request.head.sha;
+            const expectedHost = `deploy-preview-${context.issue.number}--${siteName}.netlify.app`;
+            const deadline = Date.now() + 15 * 60 * 1000;
+
+            while (Date.now() < deadline) {
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: headSha,
+                  per_page: 100,
+                },
+              );
+              const status = statuses.find(({ context }) => context === statusContext);
+
+              if (status?.state === 'success') {
+                let previewUrl;
+                try {
+                  previewUrl = new URL(status.target_url);
+                } catch {
+                  core.setFailed(`${statusContext} did not provide a valid preview URL`);
+                  return;
+                }
+
+                if (previewUrl.protocol !== 'https:' || previewUrl.hostname !== expectedHost) {
+                  core.setFailed(
+                    `${statusContext} pointed to unexpected URL ${previewUrl.toString()}`,
+                  );
+                  return;
+                }
+
+                core.setOutput('url', previewUrl.origin);
+                return;
+              }
+
+              if (status && ['error', 'failure'].includes(status.state)) {
+                core.setFailed(`${statusContext} concluded ${status.state}`);
+                return;
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, 15_000));
+            }
+
+            core.setFailed(`Timed out waiting for ${statusContext}`);
+      - name: Confirm documentation preview is reachable
+        if: needs.detect.outputs.docs == 'true'
+        env:
+          DOCS_URL: ${{ steps.docs-preview.outputs.url }}
+        run: |
+          for i in 1 2 3 4 5 6; do
+            if curl -fsSL --max-time 10 -o /dev/null "$DOCS_URL/en"; then
+              echo "deploy is reachable; proceeding"
+              exit 0
+            fi
+            echo "attempt $i: not yet, sleeping 5s"
+            sleep 5
+          done
+          echo "::error::Netlify documentation preview is not reachable at $DOCS_URL"
+          exit 1
       - name: Dead-link check
         env:
           WEBSITE_URL: ${{ steps.netlify-preview.outputs.url }}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -97,6 +97,29 @@ test('both public sites crawl their matching Netlify deploy previews', () => {
   assert.match(carryForward, /FLAG_WEBSITE: \["website-preview-checks"\]/);
 });
 
+test('website dead-link crawl waits for the documentation preview it links to', () => {
+  // The website preview rewrites docs links to the documentation deploy
+  // preview (apps/networkcanvas.com/next.config.ts), so the crawl must not
+  // start until that preview is live too.
+  const previewJob = job('website-preview-checks');
+  assert.ok(previewJob, 'website-preview-checks job exists');
+  assert.match(
+    previewJob,
+    /- id: docs-preview\n\s+name: Wait for Netlify documentation preview\n\s+if: needs\.detect\.outputs\.docs == 'true'/,
+    'the documentation deploy-preview wait exists and is gated on the docs flag',
+  );
+  assert.match(previewJob, /const siteName = 'documentation-dev'/);
+  assert.match(previewJob, /Confirm documentation preview is reachable/);
+
+  const docsWaitIndex = previewJob.indexOf('- id: docs-preview');
+  const crawlIndex = previewJob.indexOf('Dead-link check');
+  assert.ok(crawlIndex !== -1, 'website dead-link check exists');
+  assert.ok(
+    docsWaitIndex < crawlIndex,
+    'the documentation wait runs before the dead-link crawl',
+  );
+});
+
 test('each release E2E suite gates on its own policy flag', () => {
   for (const [jobName, flag] of [
     ['interview-e2e', 'interview'],


### PR DESCRIPTION
## Summary

`website-preview-checks` and `docs-preview-checks` run in parallel, but the website deploy preview rewrites its documentation links to `https://deploy-preview-<PR>--documentation-dev.netlify.app` whenever it builds in a deploy-preview context (`apps/networkcanvas.com/next.config.ts`, `documentationUrl`). When the website preview deploys before the documentation preview, the website dead-link crawl 404s on every docs link and fails the PR even though the docs preview comes up moments later — observed on PR #1197 (run 30901294651), where a plain rerun passed.

- `website-preview-checks` now also waits for the `netlify/documentation-dev/deploy-preview` commit status before its dead-link crawl, using the same polling/URL-validation script its own `netlify-preview` step uses, and then confirms the docs preview origin is reachable (mirroring the existing "Confirm Netlify preview is reachable" step).
- Both new steps are gated on `needs.detect.outputs.docs == 'true'`. `detect` currently forces both site flags true together, so the guard is future-proofing rather than a behavioural branch today.
- Added a wiring test to `scripts/ci-workflow.test.mjs` asserting the docs wait exists in `website-preview-checks`, is gated on the docs flag, and runs before the dead-link check.

No changeset: CI/tooling-only. Nonvisual (workflow YAML + test script), so no E2E baseline impact. Note this workflow file is on the release-e2e-policy "unrecognised path fails closed" list, which is fine for ordinary PRs.

## Test plan

- [x] `pnpm test:scripts` — 145 pass, including the new wiring assertion
- [x] Workflow YAML parses; `website-preview-checks` step order verified: website wait → website reachable → docs wait → docs reachable → dead-link check
- [x] `oxfmt --check` / `oxlint` clean on the edited test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)