### PR TITLE
Release Documentation

### DIFF
--- a/.changeset/docs-interview-settings-menu.md
+++ b/.changeset/docs-interview-settings-menu.md
@@ -1,7 +1,0 @@
----
-"@codaco/documentation": patch
----
-
-Update the Interviewer guide's description of the in-interview navigation: the
-standalone exit (door icon) control is now a settings (gear) menu containing
-the Exit interview action and a participant Text size option.

--- a/apps/documentation/CHANGELOG.md
+++ b/apps/documentation/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @codaco/documentation
 
+## 0.3.1
+
+### Patch Changes
+
+- Update the Interviewer guide's description of the in-interview navigation: the
+  standalone exit (door icon) control is now a settings (gear) menu containing
+  the Exit interview action and a participant Text size option.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/documentation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `@codaco/documentation` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `@codaco/documentation` | 0.3.0 | 0.3.1 |

### @codaco/documentation@0.3.1

### Patch Changes

- Update the Interviewer guide's description of the in-interview navigation: the
  standalone exit (door icon) control is now a settings (gear) menu containing
  the Exit interview action and a participant Text size option.
