### PR TITLE
Stabilize Interviewer StatusRow Storybook version

### DIFF
--- a/apps/interviewer/src/components/StatusRow.stories.tsx
+++ b/apps/interviewer/src/components/StatusRow.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect } from 'storybook/test';
 
 import type { AuthMode } from '~/lib/auth/api';
 
@@ -16,6 +17,7 @@ type StoryArgs = {
   persisted: boolean;
   installed: boolean;
   usage: number;
+  version: string;
 };
 
 const meta: Meta<StoryArgs> = {
@@ -27,6 +29,7 @@ const meta: Meta<StoryArgs> = {
     persisted: true,
     installed: false,
     usage: 4.2 * 1024 * 1024,
+    version: '0.0.0',
   },
   argTypes: {
     mode: {
@@ -45,6 +48,10 @@ const meta: Meta<StoryArgs> = {
         'calm "best effort" state — there is no install action left to take.',
     },
     usage: { control: 'number', description: 'Bytes reported by estimate()' },
+    version: {
+      control: 'text',
+      description: 'Fixed story fixture; production reads the package version',
+    },
   },
   render: ({
     protocolCount,
@@ -53,6 +60,7 @@ const meta: Meta<StoryArgs> = {
     persisted,
     installed,
     usage,
+    version,
   }) => (
     <StatusRowView
       protocolCount={protocolCount}
@@ -60,6 +68,7 @@ const meta: Meta<StoryArgs> = {
       mode={mode}
       durability={{ persisted, usage }}
       installed={installed}
+      versionSlot={<span>Interviewer {version}</span>}
     />
   ),
 };
@@ -67,7 +76,11 @@ const meta: Meta<StoryArgs> = {
 export default meta;
 type Story = StoryObj<StoryArgs>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Interviewer 0.0.0')).toBeVisible();
+  },
+};
 
 export const NotEncryptedNotPersisted: Story = {
   args: { mode: 'none', persisted: false },


### PR DESCRIPTION
## Summary

- replace the release-derived StatusRow story version with a fixed `0.0.0` fixture
- preserve production version behavior through the existing `versionSlot` presentation seam
- add a Storybook play assertion that prevents the fixture from regressing to the package version

## Test plan

- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/interviewer test:storybook -- StatusRow.stories.tsx` (96 tests)
- [x] `pnpm --filter @codaco/interviewer build-storybook`

## Visual baselines

- The visual classifier conservatively flags Interviewer because this is an Interviewer story.
- No Playwright PNG baseline is affected: the production component and E2E-captured state are unchanged.
- Chromatic will receive one intentional StatusRow text update to the fixed fixture; subsequent app releases will no longer churn this snapshot.

## Changeset

Not required: this is a Storybook-only test fixture with no consumer-visible application change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Storybook coverage to verify that the default status row displays the expected version text.
* **Documentation**
  * Enhanced the status row story with a configurable version field and formatted version display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->