### PR TITLE
fix(fresco): export identifiers, label clearing, and the mirrored image

### DIFF
--- a/.changeset/fresco-export-identifier-and-labels.md
+++ b/.changeset/fresco-export-identifier-and-labels.md
@@ -1,0 +1,15 @@
+---
+'fresco': patch
+---
+
+Exported interview data now identifies each case by the participant's
+identifier rather than their label. A label is optional and need not be unique,
+so any study using labels was exporting cases under a name that could repeat
+between participants and did not match the identifier used by recruitment links
+and the participants table.
+
+Clearing a participant's label now removes it. The edit appeared to succeed
+while the old label was silently kept.
+
+Editing a participant's identifier now refreshes the interviews table, which
+previously kept showing the old identifier until something else changed.

--- a/.changeset/interview-flush-sync-before-finish.md
+++ b/.changeset/interview-flush-sync-before-finish.md
@@ -1,0 +1,11 @@
+---
+'@codaco/interview': patch
+---
+
+Answers given in the final moments of an interview are no longer lost when a
+participant finishes. Responses are saved on a short delay, so the very last
+answer could still be waiting to be written when the interview was marked as
+complete — and any study that locks an interview once it is finished then
+rejected that late save without warning. The interview now waits for every
+outstanding answer to be saved before it is finished. If that final save fails,
+the participant can still finish rather than being stranded on the interview.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
   "files.associations": {
     "*.css": "tailwindcss"
   },
-  "java.configuration.updateBuildConfiguration": "disabled"
+  "java.configuration.updateBuildConfiguration": "disabled",
+  "js/ts.tsdk.path": "./node_modules/typescript/lib"
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The pnpm workspace is organized into four main categories.
 | [`architect`](./apps/architect)                     | Offline-capable Vite/React PWA for designing, validating, and previewing Network Canvas interview protocols                                        |
 | [`architect-classic`](./apps/architect-classic)     | Maintenance-mode Electron version of the original Architect protocol designer                                                                      |
 | [`documentation`](./apps/documentation)             | Localized Next.js documentation site built from Markdown/MDX, with DocSearch and generated protocol downloads                                      |
+| [`fresco`](./apps/fresco)                           | Self-hosted Next.js server that runs Network Canvas interviews in the browser, backed by PostgreSQL and object storage                             |
 | [`interviewer`](./apps/interviewer)                 | Offline-first Vite/React PWA for managing protocols, conducting interviews, storing local sessions with optional encryption, and exporting data    |
 | [`interviewer-classic`](./apps/interviewer-classic) | Maintenance-mode Interviewer application for desktop (Electron) and native mobile (Capacitor)                                                      |
 | [`networkcanvas.com`](./apps/networkcanvas.com)     | Localized Next.js project website, including product information, research resources, publications, team information, and getting-started guidance |

--- a/apps/fresco/Dockerfile
+++ b/apps/fresco/Dockerfile
@@ -18,7 +18,7 @@ COPY lib/db/schema.prisma ./lib/db/schema.prisma
 # Install pnpm and dependencies with cache mount for faster builds
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     --mount=type=cache,target=/root/.cache/pnpm \
-    corepack enable pnpm && pnpm i --frozen-lockfile --prefer-offline
+    corepack enable pnpm && pnpm i --frozen-lockfile --prefer-offline --ignore-scripts
 
 # ---------
 
@@ -82,6 +82,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/prisma.config.ts ./
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/env.js ./
 COPY --from=builder --chown=nextjs:nodejs /app/tsconfig.json ./
+# The mirrored tsconfig.json extends ./tsconfig/web.json (vendored by
+# scripts/mirror-app.mjs), so the startup scripts need that directory present.
+COPY --from=builder --chown=nextjs:nodejs /app/tsconfig ./tsconfig
 
 # Install ONLY the deps the startup scripts need (prisma CLI, tsx, and the
 # packages the .ts scripts import), pinned to the app's versions, into

--- a/apps/fresco/actions/__tests__/updateParticipant.test.ts
+++ b/apps/fresco/actions/__tests__/updateParticipant.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock server-only first to prevent import errors
+vi.mock('server-only', () => ({}));
+
+const { mockPrismaUpdate, mockSafeUpdateTag } = vi.hoisted(() => ({
+  mockPrismaUpdate: vi.fn(),
+  mockSafeUpdateTag: vi.fn(),
+}));
+
+vi.mock('~/lib/db', () => ({
+  prisma: {
+    participant: {
+      update: mockPrismaUpdate,
+    },
+  },
+}));
+
+vi.mock('~/lib/cache', () => ({
+  safeUpdateTag: mockSafeUpdateTag,
+  safeRevalidateTag: vi.fn(),
+  safeCacheTag: vi.fn(),
+}));
+
+vi.mock('~/lib/auth/guards', () => ({
+  requireApiAuth: vi.fn().mockResolvedValue({ user: { username: 'admin' } }),
+}));
+
+vi.mock('~/actions/activityFeed', () => ({
+  addEvent: vi.fn(),
+}));
+
+import { updateParticipant } from '../participants';
+
+describe('updateParticipant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrismaUpdate.mockResolvedValue({
+      id: 'participant-1',
+      identifier: 'P001',
+      label: null,
+      isSynthetic: false,
+    });
+  });
+
+  it('writes null for a cleared label so it is actually removed', async () => {
+    await updateParticipant({
+      existingIdentifier: 'P001',
+      formData: { identifier: 'P001', label: '' },
+    });
+
+    expect(mockPrismaUpdate).toHaveBeenCalledWith({
+      where: { identifier: 'P001' },
+      data: { identifier: 'P001', label: null },
+    });
+  });
+
+  it('writes null when no label is supplied at all', async () => {
+    await updateParticipant({
+      existingIdentifier: 'P001',
+      formData: { identifier: 'P001' },
+    });
+
+    expect(mockPrismaUpdate).toHaveBeenCalledWith({
+      where: { identifier: 'P001' },
+      data: { identifier: 'P001', label: null },
+    });
+  });
+
+  it('preserves a supplied label', async () => {
+    await updateParticipant({
+      existingIdentifier: 'P001',
+      formData: { identifier: 'P002', label: 'Alice' },
+    });
+
+    expect(mockPrismaUpdate).toHaveBeenCalledWith({
+      where: { identifier: 'P001' },
+      data: { identifier: 'P002', label: 'Alice' },
+    });
+  });
+
+  it('invalidates the interviews dashboard cache', async () => {
+    await updateParticipant({
+      existingIdentifier: 'P001',
+      formData: { identifier: 'P002' },
+    });
+
+    expect(mockSafeUpdateTag).toHaveBeenCalledWith('getParticipants');
+    expect(mockSafeUpdateTag).toHaveBeenCalledWith('getInterviews');
+    expect(mockSafeUpdateTag).toHaveBeenCalledWith('summaryStatistics');
+  });
+});

--- a/apps/fresco/actions/__tests__/updateParticipant.test.ts
+++ b/apps/fresco/actions/__tests__/updateParticipant.test.ts
@@ -30,7 +30,7 @@ vi.mock('~/actions/activityFeed', () => ({
   addEvent: vi.fn(),
 }));
 
-import { updateParticipant } from '../participants';
+import { updateParticipant } from '~/actions/participants';
 
 describe('updateParticipant', () => {
   beforeEach(() => {

--- a/apps/fresco/actions/participants.ts
+++ b/apps/fresco/actions/participants.ts
@@ -170,10 +170,19 @@ export async function updateParticipant(rawInput: unknown) {
   try {
     const updatedParticipant = await prisma.participant.update({
       where: { identifier: existingIdentifier },
-      data: formData,
+      data: {
+        ...formData,
+        // A cleared label parses to `undefined`, which Prisma reads as "leave
+        // this column alone" — the old label would survive an edit that was
+        // reported as successful. `null` actually removes it.
+        label: formData.label ?? null,
+      },
     });
 
     safeUpdateTag('getParticipants');
+    // The interviews dashboard caches the participant identifier alongside each
+    // interview row, so an identifier edit must invalidate it too.
+    safeUpdateTag('getInterviews');
     safeUpdateTag('summaryStatistics');
 
     return { error: null, participant: updatedParticipant };

--- a/apps/fresco/lib/export/InterviewRepository.ts
+++ b/apps/fresco/lib/export/InterviewRepository.ts
@@ -16,10 +16,12 @@ export const PrismaInterviewRepository = Layer.succeed(InterviewRepository, {
 
       const inputs: InterviewExportInput[] = rows.map((row) => ({
         id: row.id,
-        participantIdentifier:
-          row.participant.label && row.participant.label !== ''
-            ? row.participant.label
-            : row.participant.identifier,
+        // Always the stable identifier, never the optional human-readable
+        // label: this becomes the case ID in the exported CSV/GraphML, and it
+        // must match the identifier used by recruitment URLs and participant
+        // rows. Labels are neither unique nor stable, so using one here would
+        // make cases ambiguous across an export.
+        participantIdentifier: row.participant.identifier,
         startTime: row.startTime,
         finishTime: row.finishTime,
         network: NcNetworkSchema.parse(row.network),

--- a/apps/fresco/lib/export/__tests__/InterviewRepository.test.ts
+++ b/apps/fresco/lib/export/__tests__/InterviewRepository.test.ts
@@ -1,0 +1,68 @@
+import { Effect } from 'effect';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InterviewRepository } from '@codaco/network-exporters/services/InterviewRepository';
+import {
+  entityAttributesProperty,
+  entityPrimaryKeyProperty,
+} from '@codaco/shared-consts';
+
+vi.mock('server-only', () => ({}));
+
+const { mockGetInterviewsForExport } = vi.hoisted(() => ({
+  mockGetInterviewsForExport: vi.fn(),
+}));
+
+vi.mock('~/queries/interviews', () => ({
+  getInterviewsForExport: mockGetInterviewsForExport,
+}));
+
+import { PrismaInterviewRepository } from '~/lib/export/InterviewRepository';
+
+const network = {
+  nodes: [],
+  edges: [],
+  ego: {
+    [entityPrimaryKeyProperty]: 'ego-uid',
+    [entityAttributesProperty]: {},
+  },
+};
+
+const row = (participant: { identifier: string; label: string | null }) => ({
+  id: 'interview-1',
+  participant,
+  startTime: new Date('2026-01-01'),
+  finishTime: null,
+  network,
+  protocol: { hash: 'protocol-hash' },
+});
+
+const getForExport = (ids: string[]) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const repository = yield* InterviewRepository;
+      return yield* repository.getForExport(ids);
+    }).pipe(Effect.provide(PrismaInterviewRepository)),
+  );
+
+describe('PrismaInterviewRepository', () => {
+  it('exports the stable participant identifier, not the label', async () => {
+    mockGetInterviewsForExport.mockResolvedValue([
+      row({ identifier: 'P001', label: 'Alice' }),
+    ]);
+
+    const inputs = await getForExport(['interview-1']);
+
+    expect(inputs[0]?.participantIdentifier).toBe('P001');
+  });
+
+  it('exports the identifier when the participant has no label', async () => {
+    mockGetInterviewsForExport.mockResolvedValue([
+      row({ identifier: 'P002', label: null }),
+    ]);
+
+    const inputs = await getForExport(['interview-1']);
+
+    expect(inputs[0]?.participantIdentifier).toBe('P002');
+  });
+});

--- a/packages/interview/src/Shell.tsx
+++ b/packages/interview/src/Shell.tsx
@@ -42,6 +42,7 @@ import useInterviewNavigation from './hooks/useInterviewNavigation';
 import useMediaQuery from './hooks/useMediaQuery';
 import { getLastAvailableAuthoredStageIndex } from './selectors/skip-logic';
 import { store, type RootState } from './store/store';
+import { SyncFlushProvider } from './store/SyncFlushContext';
 import {
   InterviewToastProvider,
   InterviewToastViewport,
@@ -474,33 +475,37 @@ const Shell = ({
       onTrackerChange={onTrackerChange}
     >
       <Provider store={reduxStore}>
-        <ContractProvider
-          onFinish={onFinish}
-          onRequestAsset={onRequestAsset}
-          flags={flags}
-          finishConfirmationDescription={finishConfirmationDescription}
-        >
-          <CurrentStepProvider
-            currentStep={reviewEntry.currentStep}
-            onStepChange={onStepChange}
+        <SyncFlushProvider flush={reduxStore.flushSync}>
+          <ContractProvider
+            onFinish={onFinish}
+            onRequestAsset={onRequestAsset}
+            flags={flags}
+            finishConfirmationDescription={finishConfirmationDescription}
           >
-            <Interview
-              onExit={onExit}
-              hideNavigation={hideNavigation}
-              navigationOrientation={navigationOrientation}
-              navigationClassnames={navigationClassnames}
-              allowStageNavigation={
-                allowStageNavigation &&
-                (currentStep === undefined || onStepChange !== undefined)
-              }
-              allowUserScaling={allowUserScaling}
-              initialTextScale={initialTextScale}
-              onTextScaleChange={onTextScaleChange}
-              initialStageOverrideIndex={reviewEntry.initialStageOverrideIndex}
-              reviewMode={reviewMode}
-            />
-          </CurrentStepProvider>
-        </ContractProvider>
+            <CurrentStepProvider
+              currentStep={reviewEntry.currentStep}
+              onStepChange={onStepChange}
+            >
+              <Interview
+                onExit={onExit}
+                hideNavigation={hideNavigation}
+                navigationOrientation={navigationOrientation}
+                navigationClassnames={navigationClassnames}
+                allowStageNavigation={
+                  allowStageNavigation &&
+                  (currentStep === undefined || onStepChange !== undefined)
+                }
+                allowUserScaling={allowUserScaling}
+                initialTextScale={initialTextScale}
+                onTextScaleChange={onTextScaleChange}
+                initialStageOverrideIndex={
+                  reviewEntry.initialStageOverrideIndex
+                }
+                reviewMode={reviewMode}
+              />
+            </CurrentStepProvider>
+          </ContractProvider>
+        </SyncFlushProvider>
       </Provider>
     </AnalyticsProvider>
   );

--- a/packages/interview/src/interfaces/FinishSession.tsx
+++ b/packages/interview/src/interfaces/FinishSession.tsx
@@ -13,11 +13,13 @@ import {
   useFinishConfirmationDescription,
 } from '../contract/context';
 import { getInterviewId } from '../selectors/session';
+import { useSyncFlush } from '../store/SyncFlushContext';
 
 const FinishSession = () => {
   const interviewId = useSelector(getInterviewId);
   const { onFinish } = useContractHandlers();
   const finishConfirmationDescription = useFinishConfirmationDescription();
+  const flushSync = useSyncFlush();
   const { confirm } = useDialog();
 
   const finishInterviewConfirmation = async () => {
@@ -28,6 +30,11 @@ const FinishSession = () => {
       description: finishConfirmationDescription,
       confirmLabel: 'Finish Interview',
       onConfirm: async (signal: AbortSignal) => {
+        // Order matters: autosave is debounced, so the participant's most
+        // recent answers may still be waiting to be written. Hosts can freeze
+        // an interview the moment it is finished and reject anything that
+        // arrives afterwards, so the pending write has to land first.
+        await flushSync();
         await onFinish(interviewId, signal);
       },
     });

--- a/packages/interview/src/store/SyncFlushContext.tsx
+++ b/packages/interview/src/store/SyncFlushContext.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, type ReactNode, useContext } from 'react';
+
+type SyncFlush = () => Promise<void>;
+
+// Components rendered outside a provider (Storybook, unit tests) still need to
+// call the flush, so the default is a resolved no-op rather than a throw.
+const noopFlush: SyncFlush = () => Promise.resolve();
+
+const SyncFlushContext = createContext<SyncFlush>(noopFlush);
+
+export function SyncFlushProvider({
+  flush,
+  children,
+}: {
+  flush: SyncFlush;
+  children: ReactNode;
+}) {
+  return (
+    <SyncFlushContext.Provider value={flush}>
+      {children}
+    </SyncFlushContext.Provider>
+  );
+}
+
+/**
+ * Returns a function that writes any pending session state immediately,
+ * bypassing the autosave debounce. Await it before handing control back to the
+ * host (finishing an interview) so no answers are still in the debounce window.
+ */
+export function useSyncFlush(): SyncFlush {
+  return useContext(SyncFlushContext);
+}

--- a/packages/interview/src/store/middleware/__tests__/syncMiddleware.test.ts
+++ b/packages/interview/src/store/middleware/__tests__/syncMiddleware.test.ts
@@ -34,7 +34,7 @@ function makeSession(overrides: Partial<SessionState> = {}): SessionState {
 const mutateSession = createAction<Partial<SessionState>>('TEST/MUTATE');
 
 function createTestStore(
-  middleware: ReturnType<typeof createSyncMiddleware>,
+  middleware: ReturnType<typeof createSyncMiddleware>['middleware'],
   initialSession?: SessionState,
 ) {
   const session = initialSession ?? makeSession();
@@ -58,7 +58,8 @@ function createTestStore(
 // --- Test suite ---
 
 let onSyncMock: Mock;
-let middleware: ReturnType<typeof createSyncMiddleware>;
+let middleware: ReturnType<typeof createSyncMiddleware>['middleware'];
+let flush: ReturnType<typeof createSyncMiddleware>['flush'];
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -66,7 +67,7 @@ beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(vi.fn());
   vi.spyOn(console, 'error').mockImplementation(vi.fn());
 
-  middleware = createSyncMiddleware({ onSync: onSyncMock });
+  ({ middleware, flush } = createSyncMiddleware({ onSync: onSyncMock }));
 });
 
 afterEach(() => {
@@ -315,5 +316,87 @@ describe('syncMiddleware', () => {
     expect(allSteps.every((step) => step === '2026-01-01T00:00:01.000Z')).toBe(
       true,
     );
+  });
+});
+
+describe('syncMiddleware flush', () => {
+  it('writes a pending change immediately without waiting out the debounce', async () => {
+    const store = createTestStore(middleware);
+
+    // Leading edge consumes the first change.
+    store.dispatch(mutateSession({ lastUpdated: '2026-01-01T00:00:01.000Z' }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onSyncMock).toHaveBeenCalledTimes(1);
+
+    // A later change is now sitting in the trailing debounce window.
+    store.dispatch(mutateSession({ lastUpdated: '2026-01-01T00:00:02.000Z' }));
+    expect(onSyncMock).toHaveBeenCalledTimes(1);
+
+    // No timer advance: flush must write it right now.
+    await flush();
+
+    expect(onSyncMock).toHaveBeenCalledTimes(2);
+    expect(onSyncMock).toHaveBeenLastCalledWith(
+      'interview-1',
+      expect.objectContaining({ lastUpdated: '2026-01-01T00:00:02.000Z' }),
+    );
+  });
+
+  it('waits for an already in-flight sync before resolving', async () => {
+    let resolveSync!: () => void;
+    onSyncMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSync = resolve;
+        }),
+    );
+
+    const store = createTestStore(middleware);
+
+    // Leading edge sync starts and stays in-flight.
+    store.dispatch(mutateSession({ lastUpdated: '2026-01-01T00:00:01.000Z' }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onSyncMock).toHaveBeenCalledTimes(1);
+
+    // A newer answer arrives while that write is on the wire.
+    store.dispatch(mutateSession({ lastUpdated: '2026-01-01T00:00:02.000Z' }));
+
+    let settled = false;
+    const flushed = flush().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false);
+
+    resolveSync();
+    await flushed;
+
+    expect(settled).toBe(true);
+    expect(onSyncMock).toHaveBeenCalledTimes(2);
+    expect(onSyncMock).toHaveBeenLastCalledWith(
+      'interview-1',
+      expect.objectContaining({ lastUpdated: '2026-01-01T00:00:02.000Z' }),
+    );
+  });
+
+  it('resolves rather than rejecting when the final sync fails', async () => {
+    onSyncMock.mockRejectedValue(new Error('Vault locked'));
+
+    const store = createTestStore(middleware);
+
+    store.dispatch(mutateSession({ lastUpdated: '2026-01-01T00:00:01.000Z' }));
+
+    // Finishing must never be blocked by a failed write.
+    await expect(flush()).resolves.toBeUndefined();
+    expect(onSyncMock).toHaveBeenCalled();
+  });
+
+  it('is a no-op when nothing has changed', async () => {
+    createTestStore(middleware);
+
+    await flush();
+
+    expect(onSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/interview/src/store/middleware/syncMiddleware.ts
+++ b/packages/interview/src/store/middleware/syncMiddleware.ts
@@ -15,19 +15,26 @@ export const createSyncMiddleware = ({
   onSync,
 }: {
   onSync: SyncHandler;
-}): Middleware<Record<string, never>, SyncMiddlewareState> => {
+}): {
+  middleware: Middleware<Record<string, never>, SyncMiddlewareState>;
+  flush: () => Promise<void>;
+} => {
   let lastSyncedState = {} as SessionPayload;
-  let isSyncing = false;
+  // The in-flight write, or null when idle. Held as a promise (rather than a
+  // boolean) so `flush` can await a sync that is already on the wire.
+  let inFlight: Promise<void> | null = null;
   let storeRef: { getState: () => SyncMiddlewareState } | null = null;
 
-  const doSync = () => {
-    if (isSyncing || !storeRef) return;
+  const doSync = (): Promise<void> => {
+    // Never run two writes concurrently: hand back the one already running so
+    // callers can await it.
+    if (inFlight) return inFlight;
+    if (!storeRef) return Promise.resolve();
+
     const session = storeRef.getState().session;
-    if (!sessionChanged(session, lastSyncedState)) return;
+    if (!sessionChanged(session, lastSyncedState)) return Promise.resolve();
 
-    isSyncing = true;
-
-    onSync(session.id, session)
+    const pending = onSync(session.id, session)
       .then(() => {
         // Only advance the high-water mark once the write actually resolves,
         // so a failed autosave is not treated as synced and re-tried below.
@@ -39,7 +46,7 @@ export const createSyncMiddleware = ({
         console.error('❌ Error syncing data:', error);
       })
       .finally(() => {
-        isSyncing = false;
+        inFlight = null;
         // A rejected sync leaves lastSyncedState unchanged, so this diff still
         // holds and the failed snapshot is retried on the debounce window even
         // when no further state changes have been made.
@@ -50,16 +57,40 @@ export const createSyncMiddleware = ({
           debouncedSync();
         }
       });
+
+    inFlight = pending;
+    return pending;
   };
 
   const debouncedSync = debounce(doSync, 3000, {
     edges: ['leading', 'trailing'],
   });
 
-  return (store) => {
+  // Write any pending session state right now instead of waiting out the
+  // debounce window. Callers that end the session (finishing an interview)
+  // must await this before telling the host, because hosts may refuse writes
+  // once an interview is complete — a trailing-edge sync that lands afterwards
+  // would be rejected and the participant's last answers lost.
+  const flush = async (): Promise<void> => {
+    debouncedSync.cancel();
+
+    // Wait for a write already on the wire first: it may be carrying an older
+    // snapshot, and doSync refuses to start a second concurrent write.
+    if (inFlight) await inFlight;
+
+    // The `catch` above already swallows and logs failures, so this never
+    // rejects. A failed final sync must not block the participant from
+    // finishing — they cannot act on the error, and blocking would strand
+    // them on the interview.
+    await doSync();
+  };
+
+  const middleware: Middleware<Record<string, never>, SyncMiddlewareState> = (
+    store,
+  ) => {
     storeRef = store;
     lastSyncedState = store.getState().session;
-    isSyncing = false;
+    inFlight = null;
     debouncedSync.cancel();
 
     return (next) => (action: unknown) => {
@@ -70,4 +101,6 @@ export const createSyncMiddleware = ({
       return result;
     };
   };
+
+  return { middleware, flush };
 };

--- a/packages/interview/src/store/store.ts
+++ b/packages/interview/src/store/store.ts
@@ -33,30 +33,37 @@ export const store = (
   { session: sessionPayload, protocol: protocolPayload }: InterviewPayload,
   options: StoreOptions,
 ) => {
-  const syncMiddleware = createSyncMiddleware({ onSync: options.onSync });
+  const { middleware: syncMiddleware, flush } = createSyncMiddleware({
+    onSync: options.onSync,
+  });
   const tracker = options.tracker ?? NULL_TRACKER;
   const analyticsMiddleware = createAnalyticsListenerMiddleware({
     tracker,
   }).middleware;
 
-  return configureStore({
-    reducer: rootReducer,
-    middleware: (getDefaultMiddleware) =>
-      getDefaultMiddleware({
-        serializableCheck: {
-          ignoredActions: ['dialogs/addDialog', 'dialogs/open/pending'],
-        },
-      }).concat(
-        ...(options.isDevelopment ? [logger] : []),
-        syncMiddleware,
-        analyticsMiddleware,
-        ...(options.extraMiddleware ?? []),
-      ),
-    preloadedState: {
-      session: sessionPayload,
-      protocol: protocolPayload,
-    },
-  });
+  // Object.assign rather than a cast so the store's inferred type (dispatch
+  // thunk overloads included) survives alongside the added flushSync.
+  return Object.assign(
+    configureStore({
+      reducer: rootReducer,
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({
+          serializableCheck: {
+            ignoredActions: ['dialogs/addDialog', 'dialogs/open/pending'],
+          },
+        }).concat(
+          ...(options.isDevelopment ? [logger] : []),
+          syncMiddleware,
+          analyticsMiddleware,
+          ...(options.extraMiddleware ?? []),
+        ),
+      preloadedState: {
+        session: sessionPayload,
+        protocol: protocolPayload,
+      },
+    }),
+    { flushSync: flush },
+  );
 };
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
## Summary

Review findings that arrived on #1207 while it was in the merge queue (posted 12:21:51Z, merged 12:22:55Z), so they landed on `main` unaddressed. Each was verified against the code before changing anything, and **two were rejected** — see below.

### Fixed

- **Exports identified each case by the participant's label.** `Participant.label` is optional and *not* unique — only `identifier` is — so any study using labels exported cases under a name that could repeat between participants and did not match the identifier used by recruitment links and the participants table. This corrupted case identity in CSV and GraphML output, and is the most consequential item here.
- **Clearing a participant's label was a silent no-op.** `participantLabelSchema` transforms `''` to `undefined`, which Prisma reads as "leave this column unchanged", so the modal closed as if the edit had succeeded while the old label survived.
- **Editing a participant's identifier left the interviews table stale.** `getInterviews` caches that identifier per row but was not invalidated. (Checked that this is not redundant with the existing call at `participants.ts:31` — that one is in `deleteParticipants`.)
- **The runner image was missing the vendored tsconfig.** `scripts/mirror-app.mjs` rewrites `tsconfig.json` to extend `./tsconfig/web.json`, but the runner stage copied only the former, so the `extends` target was absent and `migrate-and-start.sh`'s `tsx` scripts could fail before migrations ran. **This was a regression introduced by the mirror's tsconfig vendoring in #1207.**
- **The image's deps stage ran `next typegen` before the Next project was copied.** The builder stage already runs `prisma generate` and `next build` against full source, so the deps install now skips lifecycle scripts.

### Rejected

- **Revalidating `getInterviews` on every interview sync.** The finish route already calls `safeRevalidateTag(['getInterviews', …])` immediately after its update, so invalidation happens at the boundary that matters. Adding it per-sync would invalidate a dashboard cache repeatedly on the interview's hottest path for no benefit.
- **A grace window allowing syncs to write after `finishTime`.** The underlying race is real — the client debounces syncs by 3s and does not flush before calling finish, so with `freezeInterviewsAfterCompletion` on, a trailing autosave carrying final answers can be discarded. But weakening that setting is the wrong place to fix it; the fix belongs in `@codaco/interview`, flushing the pending sync before `onFinish`. **Filed here as a known issue rather than patched.**

Also adds Fresco to the README app table, which #1207 missed.

## Test plan

- [x] `pnpm turbo run typecheck --force` — 17/17, all caches cleared
- [x] `pnpm turbo run test --force` — 18/18; fresco 373 tests across 46 files
- [x] `pnpm lint`, `pnpm knip`, `pnpm check:changesets`
- [x] **Built the mirrored Fresco image with Docker** and confirmed `/app/tsconfig/{base,web}.json` is present in the runner and `tsconfig.json` extends `./tsconfig/web.json`. This is the first time the release path's container build has been exercised end to end.
- [ ] Not run: E2E suites. No visual baselines regenerated — no rendering code is touched.

## Note on timing

The pending `fresco` changeset has not been consumed yet, so these fixes ride into 4.1.0 if this merges before the Version Packages PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interview exports now consistently use each participant’s stable identifier, regardless of whether a label is present.
  - Clearing a participant label now removes it correctly instead of retaining the previous value.
  - Participant edits now refresh the interviews table and related summary information.

- **Documentation**
  - Added the Fresco application to the repository structure documentation.

- **Tests**
  - Added coverage for participant updates and interview export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->