### PR TITLE
Fix false dirty state in Sociogram editor

### DIFF
--- a/.changeset/calm-sociograms-rest.md
+++ b/.changeset/calm-sociograms-rest.md
@@ -1,0 +1,5 @@
+---
+"@codaco/architect": patch
+---
+
+Prevent the Sociogram editor from showing Finished Editing until the stage has actually changed.

--- a/apps/architect/e2e/specs/interfaces/sociogram.spec.ts
+++ b/apps/architect/e2e/specs/interfaces/sociogram.spec.ts
@@ -45,6 +45,10 @@ test('opens an existing Sociogram without reporting unsaved changes', async ({
   await gotoProtocol(architectPage);
   await architectPage.goto(`/protocol/stage/${sociogram.id}`);
 
+  const editor = new StageEditor(architectPage);
+  await expect(
+    editor.field('background.concentricCircles').getByRole('spinbutton'),
+  ).toBeVisible();
   await expect(
     architectPage.getByRole('button', { name: 'Finished Editing' }),
   ).toHaveCount(0);

--- a/apps/architect/e2e/specs/interfaces/sociogram.spec.ts
+++ b/apps/architect/e2e/specs/interfaces/sociogram.spec.ts
@@ -1,11 +1,54 @@
 import { expect, gotoProtocol, test } from '../../fixtures/architect-test.js';
 import { emptyProtocol } from '../../fixtures/seed.js';
+import { loadAllInterfacesFixture } from '../../helpers/load-fixture.js';
 import { stageSnapshotJson } from '../../helpers/normalize-stage.js';
 import { readStageJson } from '../../helpers/read-store.js';
 import { selectOrCreateNodeType } from '../../pageobjects/editor-sections/entity-types.js';
 import { addPrompt } from '../../pageobjects/editor-sections/prompts.js';
 import { createVariableViaSpotlight } from '../../pageobjects/editor-sections/variables.js';
 import { StageEditor } from '../../pageobjects/stage-editor.js';
+
+test('opens a new Sociogram without reporting unsaved changes', async ({
+  architectPage,
+  seed,
+}) => {
+  await seed(emptyProtocol());
+  await gotoProtocol(architectPage);
+
+  const editor = new StageEditor(architectPage);
+  await editor.createNew('Sociogram');
+
+  await expect(
+    architectPage.getByRole('button', { name: 'Finished Editing' }),
+  ).toHaveCount(0);
+});
+
+test('opens an existing Sociogram without reporting unsaved changes', async ({
+  architectPage,
+  seed,
+}) => {
+  const { protocol, assets } = loadAllInterfacesFixture();
+  const sociogram = protocol.stages.find((stage) => stage.type === 'Sociogram');
+  if (!sociogram || sociogram.type !== 'Sociogram') {
+    throw new Error('all-interfaces fixture has no Sociogram stage');
+  }
+  if (!sociogram.background || !('concentricCircles' in sociogram.background)) {
+    throw new Error('fixture Sociogram does not use concentric circles');
+  }
+
+  // Older valid protocols may omit this optional false-valued property. The
+  // editor toggle supplies `false` on mount, which must be part of the form's
+  // baseline rather than a user edit.
+  delete sociogram.background.skewedTowardCenter;
+
+  await seed(protocol, { assets });
+  await gotoProtocol(architectPage);
+  await architectPage.goto(`/protocol/stage/${sociogram.id}`);
+
+  await expect(
+    architectPage.getByRole('button', { name: 'Finished Editing' }),
+  ).toHaveCount(0);
+});
 
 test('creates a valid Sociogram stage from scratch', async ({
   architectPage,

--- a/apps/architect/src/components/StageEditor/StageEditor.tsx
+++ b/apps/architect/src/components/StageEditor/StageEditor.tsx
@@ -36,6 +36,7 @@ import {
   shouldOverridePreviewStage,
 } from './buildProtocolWithStage';
 import { formName } from './configuration';
+import { getStageEditorInitialValues } from './getStageEditorInitialValues';
 import type { SectionComponent } from './Interfaces';
 import { getInterface } from './Interfaces';
 import StageHeading from './StageHeading';
@@ -89,7 +90,11 @@ const StageEditor = (props: StageEditorProps) => {
   const stagePath = stageIndex !== -1 ? `stages[${stageIndex}]` : null;
   const interfaceType = (stage?.type || type || 'Information') as StageType;
   const template = getInterface(interfaceType).template;
-  const initialValues = stage || { ...template, type: interfaceType };
+  const initialValues = getStageEditorInitialValues({
+    interfaceType,
+    stage,
+    template,
+  });
 
   // Get form state
   const hasUnsavedChanges = useSelector(getStageDraftDirty);

--- a/apps/architect/src/components/StageEditor/getStageEditorInitialValues.ts
+++ b/apps/architect/src/components/StageEditor/getStageEditorInitialValues.ts
@@ -1,0 +1,43 @@
+import type { Stage, StageType } from '@codaco/protocol-validation';
+
+type GetStageEditorInitialValuesOptions = {
+  interfaceType: StageType;
+  stage?: Stage | null;
+  template: Record<string, unknown>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const getStageEditorInitialValues = ({
+  interfaceType,
+  stage,
+  template,
+}: GetStageEditorInitialValuesOptions): Record<string, unknown> => {
+  const values = stage ?? { ...template, type: interfaceType };
+
+  if (interfaceType !== 'Sociogram') {
+    return values;
+  }
+
+  const sociogramValues: Record<string, unknown> = { ...values };
+  const background = isRecord(sociogramValues.background)
+    ? sociogramValues.background
+    : {};
+
+  // The concentric-circles editor renders an optional toggle whose established
+  // form default is `false`. Include that default in redux-form's initial
+  // values so mounting the field does not look like a user edit. Image-backed
+  // Sociograms do not render the toggle, so their persisted shape stays intact.
+  if (background.image || typeof background.skewedTowardCenter === 'boolean') {
+    return sociogramValues;
+  }
+
+  return {
+    ...sociogramValues,
+    background: {
+      ...background,
+      skewedTowardCenter: false,
+    },
+  };
+};

--- a/apps/architect/src/components/sections/Background/__tests__/Background.test.tsx
+++ b/apps/architect/src/components/sections/Background/__tests__/Background.test.tsx
@@ -1,6 +1,69 @@
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import {
+  reducer as formReducer,
+  reduxForm,
+  type InjectedFormProps,
+} from 'redux-form';
 import { describe, expect, it } from 'vitest';
 
-import { allowsBackgroundImage } from '../Background';
+import {
+  asEntityAttributeReference,
+  type Stage,
+} from '@codaco/protocol-validation';
+import { getStageEditorInitialValues } from '~/components/StageEditor/getStageEditorInitialValues';
+import { stageEditorDraftListenerMiddleware } from '~/ducks/middleware/stageEditorDraftListener';
+import stageEditorDraft from '~/ducks/modules/stageEditorDraft';
+import type { RootState } from '~/ducks/store';
+import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
+
+import Background, { allowsBackgroundImage } from '../Background';
+
+type FormValues = {
+  type: 'Sociogram';
+  background: {
+    concentricCircles: number;
+    skewedTowardCenter?: boolean;
+  };
+};
+
+const BackgroundHarness = (_props: InjectedFormProps<FormValues>) => (
+  <Background
+    form="edit-stage"
+    stagePath="stages[0]"
+    stagePosition={0}
+    interfaceType="Sociogram"
+  />
+);
+
+const BackgroundForm = reduxForm<FormValues>({ form: 'edit-stage' })(
+  BackgroundHarness,
+);
+
+const renderExistingSociogram = (stage: Stage) => {
+  const reducer = combineReducers({ form: formReducer, stageEditorDraft });
+  const store = configureStore({
+    reducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({ serializableCheck: false }).prepend(
+        stageEditorDraftListenerMiddleware.middleware,
+      ),
+  });
+  const initialValues = getStageEditorInitialValues({
+    interfaceType: 'Sociogram',
+    stage,
+    template: {},
+  }) as FormValues;
+
+  render(
+    <Provider store={store}>
+      <BackgroundForm initialValues={initialValues} />
+    </Provider>,
+  );
+
+  return store;
+};
 
 describe('allowsBackgroundImage', () => {
   it('allows a background image for Narrative stages', () => {
@@ -17,5 +80,34 @@ describe('allowsBackgroundImage', () => {
 
   it('does not enable background images for unrelated stages', () => {
     expect(allowsBackgroundImage('Information')).toBe(false);
+  });
+
+  it('does not mark a legacy Sociogram dirty when the toggle supplies its false default', async () => {
+    const stage = {
+      id: 'sociogram-1',
+      label: 'Sociogram',
+      type: 'Sociogram',
+      subject: { entity: 'node', type: 'person' },
+      background: { concentricCircles: 4 },
+      prompts: [
+        {
+          id: 'prompt-1',
+          text: 'Place the people you named.',
+          layout: {
+            layoutVariable: asEntityAttributeReference('layout'),
+          },
+        },
+      ],
+    } satisfies Stage;
+    const store = renderExistingSociogram(stage);
+
+    await waitFor(() => {
+      expect(
+        store.getState().form['edit-stage']?.values?.background
+          ?.skewedTowardCenter,
+      ).toBe(false);
+    });
+
+    expect(getStageDraftDirty(store.getState() as RootState)).toBe(false);
   });
 });

--- a/apps/architect/src/components/sections/Background/__tests__/Background.test.tsx
+++ b/apps/architect/src/components/sections/Background/__tests__/Background.test.tsx
@@ -20,15 +20,9 @@ import { getStageDraftDirty } from '~/selectors/stageEditorDraft';
 
 import Background, { allowsBackgroundImage } from '../Background';
 
-type FormValues = {
-  type: 'Sociogram';
-  background: {
-    concentricCircles: number;
-    skewedTowardCenter?: boolean;
-  };
-};
-
-const BackgroundHarness = (_props: InjectedFormProps<FormValues>) => (
+const BackgroundHarness = (
+  _props: InjectedFormProps<Record<string, unknown>>,
+) => (
   <Background
     form="edit-stage"
     stagePath="stages[0]"
@@ -37,9 +31,9 @@ const BackgroundHarness = (_props: InjectedFormProps<FormValues>) => (
   />
 );
 
-const BackgroundForm = reduxForm<FormValues>({ form: 'edit-stage' })(
-  BackgroundHarness,
-);
+const BackgroundForm = reduxForm<Record<string, unknown>>({
+  form: 'edit-stage',
+})(BackgroundHarness);
 
 const renderExistingSociogram = (stage: Stage) => {
   const reducer = combineReducers({ form: formReducer, stageEditorDraft });
@@ -54,7 +48,7 @@ const renderExistingSociogram = (stage: Stage) => {
     interfaceType: 'Sociogram',
     stage,
     template: {},
-  }) as FormValues;
+  });
 
   render(
     <Provider store={store}>


### PR DESCRIPTION
## Summary

- seed the Sociogram background toggle default into the Redux Form baseline
- keep new and existing Sociogram editors pristine until a real edit occurs
- add unit and Playwright regressions plus an Architect patch changeset

## Test plan

- [x] `pnpm --filter @codaco/architect test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts e2e/specs/interfaces/sociogram.spec.ts`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts --workers=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sociogram stages no longer incorrectly show unsaved-change warnings when opened.
  * The “Finished Editing” state now updates correctly after changing stages.
  * Existing Sociogram backgrounds and legacy stage settings are preserved during editing.
  * New stages receive consistent default background settings.

* **Tests**
  * Added end-to-end and regression coverage for Sociogram stage loading, backgrounds, and clean editor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->