### PR TITLE
ci: bound e2e reporting infrastructure failures

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1535,7 +1535,10 @@ jobs:
             commit -q -m "interview-e2e report site (run ${{ github.run_id }})"
           git --git-dir="$RUNNER_TEMP/pages-state/.git" push -q --force \
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" gh-pages
-      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Deploy report to Pages
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        timeout-minutes: 3
+        continue-on-error: true
       - name: Comment on PR
         # always(): still post the E2E result even if the Pages publish above
         # failed — the report link may be stale but the pass/fail signal is the

--- a/.github/workflows/open-e2e-snapshot-update-pr.yml
+++ b/.github/workflows/open-e2e-snapshot-update-pr.yml
@@ -122,28 +122,45 @@ jobs:
             echo 'current=true' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Restore already-proposed central baseline changes
+      - name: Find the open central snapshot PR
+        id: snapshot_source
         if: steps.release_base.outputs.current == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
+        with:
+          script: |
+            const snapshotBranch = process.env.SNAPSHOT_BRANCH;
+            const head = `${context.repo.owner}:${snapshotBranch}`;
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+              head,
+              per_page: 10,
+            });
+            const source = pulls.find(
+              (pull) =>
+                pull.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` &&
+                pull.head.ref === snapshotBranch,
+            );
+            core.setOutput('open', source ? 'true' : 'false');
+            if (!source) {
+              core.notice('No open central snapshot PR exists yet.');
+            }
+
+      - name: Restore already-proposed central baseline changes
+        if: >-
+          ${{ steps.release_base.outputs.current == 'true'
+          && steps.snapshot_source.outputs.open == 'true' }}
+        env:
           SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
         run: |
           architect='^apps/architect/e2e/visual-snapshots/chromium/[A-Za-z0-9._-]+\.png$'
           interview='^packages/interview/e2e/visual-snapshots/(chromium|firefox|webkit)-matrix/[A-Za-z0-9._-]+\.png$'
           interviewer='^apps/interviewer/e2e/visual-snapshots/chromium/[A-Za-z0-9._-]+\.png$'
           snapshot_ref="refs/remotes/origin/$SNAPSHOT_BRANCH"
-
-          open_pr_count=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state open \
-            --base main \
-            --head "$SNAPSHOT_BRANCH" \
-            --json number \
-            --jq 'length')
-          if [[ "$open_pr_count" == '0' ]]; then
-            echo 'No open central snapshot PR exists yet.'
-            exit 0
-          fi
 
           git fetch --no-tags origin "+refs/heads/$SNAPSHOT_BRANCH:$snapshot_ref"
           merge_base=$(git merge-base origin/main "$snapshot_ref")

--- a/.github/workflows/open-e2e-snapshot-update-pr.yml
+++ b/.github/workflows/open-e2e-snapshot-update-pr.yml
@@ -125,6 +125,7 @@ jobs:
       - name: Restore already-proposed central baseline changes
         if: steps.release_base.outputs.current == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPSHOT_BRANCH: ${{ inputs.snapshot_branch }}
         run: |
           architect='^apps/architect/e2e/visual-snapshots/chromium/[A-Za-z0-9._-]+\.png$'
@@ -132,8 +133,15 @@ jobs:
           interviewer='^apps/interviewer/e2e/visual-snapshots/chromium/[A-Za-z0-9._-]+\.png$'
           snapshot_ref="refs/remotes/origin/$SNAPSHOT_BRANCH"
 
-          if ! git ls-remote --exit-code --heads origin "refs/heads/$SNAPSHOT_BRANCH" >/dev/null 2>&1; then
-            echo 'No central snapshot branch exists yet.'
+          open_pr_count=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --base main \
+            --head "$SNAPSHOT_BRANCH" \
+            --json number \
+            --jq 'length')
+          if [[ "$open_pr_count" == '0' ]]; then
+            echo 'No open central snapshot PR exists yet.'
             exit 0
           fi
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -410,11 +410,15 @@ test('snapshot update workflow accepts only current release branches', () => {
 test('closed snapshot PRs cannot leave permanent pending state', () => {
   assert.match(
     snapshotWorkflow,
-    /open_pr_count=\$\(gh pr list[\s\S]*?--state open[\s\S]*?--head "\$SNAPSHOT_BRANCH"[\s\S]*?--jq 'length'\)/,
+    /id: snapshot_source[\s\S]*?state: 'open'[\s\S]*?base: 'main'[\s\S]*?head,/,
   );
   assert.match(
     snapshotWorkflow,
-    /if \[\[ "\$open_pr_count" == '0' \]\]; then\n\s+echo 'No open central snapshot PR exists yet\.'/,
+    /pull\.head\.repo\?\.full_name === `\$\{context\.repo\.owner\}\/\$\{context\.repo\.repo\}` &&\n\s+pull\.head\.ref === snapshotBranch/,
+  );
+  assert.match(
+    snapshotWorkflow,
+    /steps\.snapshot_source\.outputs\.open == 'true'/,
   );
   assert.doesNotMatch(
     snapshotWorkflow,

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -407,6 +407,30 @@ test('snapshot update workflow accepts only current release branches', () => {
   assert.doesNotMatch(snapshotWorkflow, /'changeset-release\/interviewer'/);
 });
 
+test('closed snapshot PRs cannot leave permanent pending state', () => {
+  assert.match(
+    snapshotWorkflow,
+    /open_pr_count=\$\(gh pr list[\s\S]*?--state open[\s\S]*?--head "\$SNAPSHOT_BRANCH"[\s\S]*?--jq 'length'\)/,
+  );
+  assert.match(
+    snapshotWorkflow,
+    /if \[\[ "\$open_pr_count" == '0' \]\]; then\n\s+echo 'No open central snapshot PR exists yet\.'/,
+  );
+  assert.doesNotMatch(
+    snapshotWorkflow,
+    /git ls-remote --exit-code --heads origin/,
+  );
+});
+
+test('the informational Pages deploy has a bounded failure window', () => {
+  const reportJob = job('interview-e2e-report');
+  assert.ok(reportJob, 'interview-e2e-report job exists');
+  assert.match(
+    reportJob,
+    /- name: Deploy report to Pages\n\s+uses: actions\/deploy-pages@[^\n]+\n\s+timeout-minutes: 3\n\s+continue-on-error: true/,
+  );
+});
+
 test('e2e-policy receives the equivalence-reuse inputs', () => {
   const policyJob = job('e2e-policy');
   assert.ok(policyJob, 'e2e-policy job exists');


### PR DESCRIPTION
## Summary
- stop the informational Interview Playwright Pages deploy after three minutes without failing the reporting step
- restore accumulated snapshot baselines only when an open first-party central snapshot PR exists
- remove the three orphaned `e2e-snapshots/*` remote refs after explicit approval and exact-SHA validation
- cover both infrastructure guards with workflow regression tests

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm test:scripts` (150/150)
- [x] `pnpm knip`
- [x] `pnpm typecheck`
- [x] `pnpm check:changesets`
- [x] `pnpm format:check`
- [x] parse both changed workflows with `yaml`
- [x] `git diff --check`
- [x] visual-change classifier: all suites skipped (CI/test-only)
- [x] closed PR #1179 is ignored while exact first-party open PRs remain eligible
- [x] verify the three approved orphaned refs no longer exist on `origin`

## Release notes
No changeset: this is CI/test infrastructure only.
