### PR TITLE
fix(architect): honor reduced motion and speed up e2e

### DIFF
--- a/.changeset/calm-animations-rest.md
+++ b/.changeset/calm-animations-rest.md
@@ -1,0 +1,6 @@
+---
+'@codaco/architect': patch
+'@codaco/fresco-ui': minor
+---
+
+Honor reduced-motion preferences in Architect and expose a shared provider for disabling Motion and Base UI animations together in automated hosts.

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1354,6 +1354,10 @@ jobs:
       # with a spec's own page.evaluate/addStyleTag calls and surfaces as a
       # spurious action failure (the suite's run.sh explains this at length).
       VITE_DISABLE_ANALYTICS: 'true'
+      # Builds the same deterministic app shell as the Docker pixel lane:
+      # Motion and Base UI animation bookkeeping are both disabled before the
+      # application mounts.
+      VITE_DISABLE_ANIMATIONS: 'true'
       # Makes a stray pixel capture throw here rather than silently
       # comparing container-rasterised baselines against this runner's fonts
       # (see the suite's capture helper).

--- a/apps/architect/.storybook/Providers.tsx
+++ b/apps/architect/.storybook/Providers.tsx
@@ -1,15 +1,10 @@
 import { DirectionProvider } from '@base-ui/react/direction-provider';
-import { MotionConfig } from 'motion/react';
 import type { ReactNode } from 'react';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { PortalContainerProvider } from '@codaco/fresco-ui/PortalContainer';
 import { TooltipProvider } from '@codaco/fresco-ui/Tooltip';
-
-declare global {
-  // eslint-disable-next-line no-var
-  var BASE_UI_ANIMATIONS_DISABLED: boolean | undefined;
-}
 
 /**
  * The UI-provider subset shared by Architect and its stories. Connected
@@ -23,12 +18,8 @@ export default function Providers({
   children: ReactNode;
   disableAnimations?: boolean;
 }) {
-  if (disableAnimations) {
-    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
-  }
-
   return (
-    <MotionConfig reducedMotion="user" skipAnimations={disableAnimations}>
+    <AnimationProvider disableAnimations={disableAnimations}>
       <DirectionProvider direction="ltr">
         <PortalContainerProvider>
           <TooltipProvider>
@@ -36,6 +27,6 @@ export default function Providers({
           </TooltipProvider>
         </PortalContainerProvider>
       </DirectionProvider>
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/apps/architect/e2e/helpers/visual.ts
+++ b/apps/architect/e2e/helpers/visual.ts
@@ -1,13 +1,9 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-// Hide non-deterministic chrome so snapshots don't depend on the ambient
-// background's fade-in timing or which element last held focus. Mirrors the
-// interview suite's VISUAL_STYLES.
+// Hide ambient chrome and focus indicators that are outside the snapshot's
+// subject. Mirrors the interview suite's VISUAL_STYLES.
 const VISUAL_STYLES = `
-  /* BackgroundLights (~/components/BackgroundLights.tsx) fades its opacity in
-     via a framer-motion tween that animations:'disabled'/reducedMotion:'reduce'
-     don't stop, so a capture taken mid-fade would be non-deterministic. Hide
-     it so app-chrome snapshots are stable regardless of when the fade lands. */
+  /* BackgroundLights are decorative app chrome, not part of these assertions. */
   [data-testid="background-lights"] { visibility: hidden !important; }
   *:focus-visible, *:has(:focus-visible) { outline: none !important; }
   *:focus-visible { box-shadow: none !important; }
@@ -60,52 +56,15 @@ export function makeCapture(page: Page): CaptureFn {
     // silently un-hide the background lights/focus-rings for a later
     // capture() in the same test.
     await page.addStyleTag({ content: VISUAL_STYLES });
-    // Wait for motion to reach REST before sampling. Two problems otherwise:
-    // (1) entrance fades sit at their opacity:0 initial variant until a
-    // useEffect commits, so toHaveScreenshot can stabilise on two identical
-    // PRE-entrance frames; (2) spring-physics surfaces (e.g. the timeline's
-    // drag-and-drop stage cards) drift for several frames after mount and,
-    // mid-transient, land at frame-timing-dependent sub-pixel positions. A
-    // spring's EQUILIBRIUM is deterministic, so we poll element geometry
-    // (rounded to whole px) until it stops changing across consecutive
-    // animation frames — that is rest. reducedMotion/animations:'disabled' do
-    // NOT stop these JS-rAF-driven transitions.
-    await page.evaluate(async () => {
-      const raf = () =>
-        new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-      // Sample from #root (the app mount, apps/architect/index.html) — Base
-      // UI dialogs portal OUTSIDE #root, so keep the explicit [role="dialog"]
-      // clause. Cap generously (#root spans the whole app) so a deep,
-      // still-animating element isn't sampled off the end.
-      const sample = () =>
-        Array.from(document.querySelectorAll('#root *, [role="dialog"] *'))
-          .slice(0, 1500)
-          .map((el) => {
-            const r = el.getBoundingClientRect();
-            return `${Math.round(r.x)},${Math.round(r.y)},${Math.round(r.width)},${Math.round(r.height)}`;
-          })
-          .join('|');
-      // Wait until geometry is identical (whole-pixel) across several
-      // CONSECUTIVE frames — that is spring rest. Requiring more than one
-      // stable pair guards against a janky/dropped frame under CPU load
-      // briefly matching mid-animation. Cap at ~150 frames (~2.5s) so a
-      // perpetually-moving element can't hang the capture; toHaveScreenshot's
-      // own frame-matching guards the fallback.
-      const REQUIRED_STABLE = 4;
-      let prev = '';
-      let stable = 0;
-      for (let i = 0; i < 150; i++) {
-        await raf();
-        const cur = sample();
-        if (cur === prev) {
-          stable += 1;
-          if (stable >= REQUIRED_STABLE) return;
-        } else {
-          stable = 0;
-        }
-        prev = cur;
-      }
-    });
+    // skipAnimations commits Motion's final variants from an effect after the
+    // initial paint. Two animation frames let that effect and its paint land
+    // before Playwright begins looking for identical screenshots.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
     await expect(page).toHaveScreenshot(`${name}.png`, {
       fullPage: options.fullPage ?? false,
       mask: options.mask,

--- a/apps/architect/e2e/pageobjects/editor-sections/form-field-controls.ts
+++ b/apps/architect/e2e/pageobjects/editor-sections/form-field-controls.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page } from '@playwright/test';
 
+import { typeInlineRun } from '../stage-editor.js';
 import {
   createVariableViaSpotlight,
   fillOptionRows,
@@ -59,7 +60,7 @@ async function replaceRichTextContent(
   await editorBox.click();
   await page.keyboard.press('ControlOrMeta+a');
   await page.keyboard.press('Delete');
-  await page.keyboard.type(text);
+  await typeInlineRun(page, text);
 }
 
 async function setBooleanOption(

--- a/apps/architect/e2e/pageobjects/stage-editor.ts
+++ b/apps/architect/e2e/pageobjects/stage-editor.ts
@@ -65,6 +65,30 @@ function parseMarkdownBlocks(markdown: string): MarkdownBlock[] {
     });
 }
 
+// One line of inline markdown. Only the emphasis markers need to arrive as
+// real keystrokes — Tiptap converts `**bold**` / `_italic_` / `*italic*`
+// through ProseMirror input rules, which fire on the closing character and
+// are invisible to bulk insertion. Everything between them is plain prose
+// that `insertText` places in one call.
+//
+// This is the difference between ~15,000 keystroke round trips across the
+// spec and a few hundred: the whole-protocol build types 15kB of canonical
+// copy, of which under 5% carries emphasis. It is also SAFER than typing
+// everything, because bulk-inserted prose cannot trip an input rule it was
+// never meant to (a sentence that happens to start `1. `, say). Correctness
+// is not assumed — the final comparison re-parses every string, so a
+// mis-typed mark fails the run loudly.
+export async function typeInlineRun(page: Page, text: string): Promise<void> {
+  for (const segment of text.split(EMPHASIS_SPLIT)) {
+    if (!segment) continue;
+    if (EMPHASIS_TEST.test(segment)) {
+      await page.keyboard.type(segment);
+    } else {
+      await page.keyboard.insertText(segment);
+    }
+  }
+}
+
 export class StageEditor {
   private readonly page: Page;
 
@@ -150,7 +174,7 @@ export class StageEditor {
         await this.page.keyboard.press('Enter');
       }
       if (block.kind === 'paragraph') {
-        await this.typeInlineRun(block.text);
+        await typeInlineRun(this.page, block.text);
         needsBlockBreak = true;
         continue;
       }
@@ -160,37 +184,13 @@ export class StageEditor {
         } else {
           await this.page.keyboard.press('Enter');
         }
-        await this.typeInlineRun(item);
+        await typeInlineRun(this.page, item);
       }
       // Exit the list: the first Enter opens an empty item, the second lifts
       // it out into a fresh paragraph — so the next block needs no break.
       await this.page.keyboard.press('Enter');
       await this.page.keyboard.press('Enter');
       needsBlockBreak = false;
-    }
-  }
-
-  // One line of inline markdown. Only the emphasis markers need to arrive as
-  // real keystrokes — Tiptap converts `**bold**` / `_italic_` / `*italic*`
-  // through ProseMirror input rules, which fire on the closing character and
-  // are invisible to bulk insertion. Everything between them is plain prose
-  // that `insertText` places in one call.
-  //
-  // This is the difference between ~15,000 keystroke round trips across the
-  // spec and a few hundred: the whole-protocol build types 15kB of canonical
-  // copy, of which under 5% carries emphasis. It is also SAFER than typing
-  // everything, because bulk-inserted prose cannot trip an input rule it was
-  // never meant to (a sentence that happens to start `1. `, say). Correctness
-  // is not assumed — the final comparison re-parses every string, so a
-  // mis-typed mark fails the run loudly.
-  private async typeInlineRun(text: string): Promise<void> {
-    for (const segment of text.split(EMPHASIS_SPLIT)) {
-      if (!segment) continue;
-      if (EMPHASIS_TEST.test(segment)) {
-        await this.page.keyboard.type(segment);
-      } else {
-        await this.page.keyboard.insertText(segment);
-      }
     }
   }
 

--- a/apps/architect/e2e/pageobjects/stage-editor.ts
+++ b/apps/architect/e2e/pageobjects/stage-editor.ts
@@ -136,15 +136,12 @@ export class StageEditor {
   // `ariaLabel` string, so a single role/name locator covers both cases.
   async fillRichText(ariaLabel: string, text: string): Promise<void> {
     const editor = this.page.getByRole('textbox', { name: ariaLabel });
-    await editor.click();
-    try {
-      await editor.fill(text);
-    } catch {
-      // Tiptap intercepts real keystrokes via ProseMirror, not just a generic
-      // `input` event — if `.fill()`'s synthetic event doesn't take, fall
-      // back to genuine keystrokes.
-      await this.page.keyboard.type(text);
-    }
+    // The surrounding field can render before Tiptap has attached its
+    // ProseMirror contenteditable. With animations disabled that gap is easy
+    // to hit; wait for the actual editor instead of swallowing fill failures
+    // and typing into whichever element happens to own focus.
+    await expect(editor).toBeEditable();
+    await editor.fill(text);
   }
 
   // Type canonical markdown into a Tiptap RichText editor the way a user

--- a/apps/architect/e2e/scripts/run.sh
+++ b/apps/architect/e2e/scripts/run.sh
@@ -73,6 +73,7 @@ docker run --rm \
   ${PLATFORM_FLAG} \
   -e CI=true \
   -e VITE_DISABLE_ANALYTICS=true \
+  -e VITE_DISABLE_ANIMATIONS=true \
   -v "$(pwd)":/workspace \
   -v "${VOLUME}":/workspace/node_modules \
   -v "${TURBO_VOLUME}":/workspace/.turbo/cache \

--- a/apps/architect/e2e/specs/00-sample-protocol.spec.ts
+++ b/apps/architect/e2e/specs/00-sample-protocol.spec.ts
@@ -70,6 +70,10 @@ import { StageEditor } from '../pageobjects/stage-editor.js';
 // (later stages reference variables/edge types created by earlier ones —
 // verified: zero forward references in protocol order), so tests cannot run
 // independently, but per-test grouping still isolates which build step broke.
+// Playwright's "Consider running tests from slow files in parallel" hint is
+// intentionally wrong for this harness. Do not parallelise or shard it: every
+// test consumes the IndexedDB protocol authored by the preceding tests, and
+// the final test compares that complete from-scratch document.
 // Long texts, option lists, and parameters are sourced from the canonical
 // JSON itself rather than transcribed, so the spec cannot drift from the
 // fixture it asserts against.
@@ -167,7 +171,7 @@ test.describe.serial('sample protocol built from scratch', () => {
   // there: tests that take 30s standalone take 60s under parallel load, and
   // two of them timed out on the first pass. 120s keeps a 4x margin over
   // observed worst cases without masking a genuine hang.
-  test.describe.configure({ timeout: 120_000 });
+  test.describe.configure({ retries: 1, timeout: 120_000 });
 
   // Undefined until `beforeAll` assigns them, which is what `afterAll` has to
   // tolerate: if setup throws before the assignment, an unguarded teardown

--- a/apps/architect/package.json
+++ b/apps/architect/package.json
@@ -16,7 +16,7 @@
     "test:e2e": "./e2e/scripts/run.sh",
     "test:e2e:update-snapshots": "./e2e/scripts/run.sh --grep @visual --update-snapshots",
     "test:e2e:native": "playwright test --config e2e/playwright.config.ts --grep-invert @visual",
-    "test:e2e:headed": "VITE_DISABLE_ANALYTICS=true pnpm turbo run build --filter=@codaco/architect && playwright test --config e2e/playwright.config.ts --headed"
+    "test:e2e:headed": "VITE_DISABLE_ANALYTICS=true VITE_DISABLE_ANIMATIONS=true pnpm turbo run build --filter=@codaco/architect && playwright test --config e2e/playwright.config.ts --headed"
   },
   "dependencies": {
     "@base-ui/react": "catalog:",

--- a/apps/architect/src/main.tsx
+++ b/apps/architect/src/main.tsx
@@ -4,6 +4,7 @@ import './analytics';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import { applyFreshLoadServiceWorkerUpdate } from '@codaco/fresco-ui/appUpdate/applyFreshLoadServiceWorkerUpdate';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { PortalContainerProvider } from '@codaco/fresco-ui/PortalContainer';
@@ -82,20 +83,24 @@ async function startApp(): Promise<void> {
   }
 
   createRoot(root).render(
-    <AppErrorBoundary>
-      <Provider store={store}>
-        {/* PortalContainerProvider outermost so fresco-ui overlays portal into
-          its viewport layer; the `root` (isolation: isolate) wrapper keeps the
-          app's own stacking contexts from competing with that layer. */}
-        <PortalContainerProvider>
-          <DialogProvider>
-            <div className="root h-full">
-              <AppView />
-            </div>
-          </DialogProvider>
-        </PortalContainerProvider>
-      </Provider>
-    </AppErrorBoundary>,
+    <AnimationProvider
+      disableAnimations={import.meta.env.VITE_DISABLE_ANIMATIONS === 'true'}
+    >
+      <AppErrorBoundary>
+        <Provider store={store}>
+          {/* PortalContainerProvider outermost so fresco-ui overlays portal into
+            its viewport layer; the `root` (isolation: isolate) wrapper keeps the
+            app's own stacking contexts from competing with that layer. */}
+          <PortalContainerProvider>
+            <DialogProvider>
+              <div className="root h-full">
+                <AppView />
+              </div>
+            </DialogProvider>
+          </PortalContainerProvider>
+        </Provider>
+      </AppErrorBoundary>
+    </AnimationProvider>,
   );
 
   // Matches the boot loader's opacity transition in index.html (400ms), plus a

--- a/apps/architect/src/vite-env.d.ts
+++ b/apps/architect/src/vite-env.d.ts
@@ -4,5 +4,6 @@
 declare const __APP_VERSION__: string;
 
 interface ImportMetaEnv {
+  readonly VITE_DISABLE_ANIMATIONS?: string;
   readonly VITE_PROTOCOL_SOURCE_AUTHORING?: string;
 }

--- a/apps/interviewer/.storybook/Providers.tsx
+++ b/apps/interviewer/.storybook/Providers.tsx
@@ -1,17 +1,12 @@
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Toast } from '@base-ui/react/toast';
-import { MotionConfig } from 'motion/react';
 import type { ReactNode } from 'react';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { DndStoreProvider } from '@codaco/fresco-ui/dnd/dnd';
 import { Toaster } from '@codaco/fresco-ui/Toast';
 import { TooltipProvider } from '@codaco/fresco-ui/Tooltip';
-
-declare global {
-  // eslint-disable-next-line no-var
-  var BASE_UI_ANIMATIONS_DISABLED: boolean | undefined;
-}
 
 /**
  * Mounted as a global decorator in preview.tsx so every story sees the same
@@ -27,12 +22,8 @@ export default function Providers({
   children: ReactNode;
   disableAnimations?: boolean;
 }) {
-  if (disableAnimations) {
-    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
-  }
-
   return (
-    <MotionConfig reducedMotion="user" skipAnimations={disableAnimations}>
+    <AnimationProvider disableAnimations={disableAnimations}>
       <DirectionProvider direction="ltr">
         <Toast.Provider limit={7}>
           <TooltipProvider>
@@ -43,6 +34,6 @@ export default function Providers({
           <Toaster />
         </Toast.Provider>
       </DirectionProvider>
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/apps/interviewer/src/providers/AppProviders.tsx
+++ b/apps/interviewer/src/providers/AppProviders.tsx
@@ -1,8 +1,8 @@
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Toast } from '@base-ui/react/toast';
-import { MotionConfig } from 'motion/react';
 import type { ReactNode } from 'react';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { DndStoreProvider } from '@codaco/fresco-ui/dnd/dnd';
 import { Toaster } from '@codaco/fresco-ui/Toast';
@@ -15,7 +15,7 @@ import { OnlineStatusProvider } from '~/lib/net/OnlineStatusProvider';
 
 export function AppProviders({ children }: { children: ReactNode }) {
   return (
-    <MotionConfig reducedMotion="user">
+    <AnimationProvider>
       <DirectionProvider direction="ltr">
         <Toast.Provider limit={7}>
           <TooltipProvider>
@@ -36,6 +36,6 @@ export function AppProviders({ children }: { children: ReactNode }) {
           <Toaster />
         </Toast.Provider>
       </DirectionProvider>
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/knip.json
+++ b/knip.json
@@ -51,7 +51,6 @@
         "e2e/scripts/*.ts",
         "e2e/helpers/assetServer.ts",
         "e2e/fixtures/window-test.d.ts",
-        "e2e/host/src/global-augmentations.d.ts",
         // Resolved by vite.config.ts's inlineWorkerPlugin for the library
         // build, never by an import — see createAutoLayoutWorker.ts.
         "src/canvas/createAutoLayoutWorker.inline.ts"

--- a/packages/fresco-ui/.storybook/Providers.tsx
+++ b/packages/fresco-ui/.storybook/Providers.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { DirectionProvider } from '@base-ui/react/direction-provider';
-import { MotionConfig } from 'motion/react';
 import type { ReactNode } from 'react';
 
-declare global {
-  // eslint-disable-next-line no-var
-  var BASE_UI_ANIMATIONS_DISABLED: boolean | undefined;
-}
+import { AnimationProvider } from '../src/AnimationProvider';
 
 type ProvidersProps = {
   children: ReactNode;
@@ -18,13 +14,9 @@ export default function Providers({
   children,
   disableAnimations,
 }: ProvidersProps) {
-  if (disableAnimations) {
-    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
-  }
-
   return (
-    <MotionConfig reducedMotion="user" skipAnimations={disableAnimations}>
+    <AnimationProvider disableAnimations={disableAnimations}>
       <DirectionProvider direction="ltr">{children}</DirectionProvider>
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -18,6 +18,7 @@
   "exports": {
     "./Accordion": "./src/Accordion.tsx",
     "./Alert": "./src/Alert.tsx",
+    "./AnimationProvider": "./src/AnimationProvider.tsx",
     "./Badge": "./src/Badge.tsx",
     "./Definition": "./src/Definition.tsx",
     "./NativeLink": "./src/NativeLink.tsx",
@@ -170,6 +171,10 @@
       "./Alert": {
         "types": "./dist/Alert.d.ts",
         "default": "./dist/Alert.js"
+      },
+      "./AnimationProvider": {
+        "types": "./dist/AnimationProvider.d.ts",
+        "default": "./dist/AnimationProvider.js"
       },
       "./Badge": {
         "types": "./dist/Badge.d.ts",

--- a/packages/fresco-ui/src/AnimationProvider.test.tsx
+++ b/packages/fresco-ui/src/AnimationProvider.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AnimationProvider } from './AnimationProvider';
+
+describe('AnimationProvider', () => {
+  afterEach(() => {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+  });
+
+  it('disables Base UI before rendering descendants', () => {
+    function AnimationState() {
+      return <span>{String(globalThis.BASE_UI_ANIMATIONS_DISABLED)}</span>;
+    }
+
+    render(
+      <AnimationProvider disableAnimations>
+        <AnimationState />
+      </AnimationProvider>,
+    );
+
+    expect(screen.getByText('true')).toBeTruthy();
+  });
+
+  it('does not disable Base UI by default', () => {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    render(<AnimationProvider>content</AnimationProvider>);
+
+    expect(globalThis.BASE_UI_ANIMATIONS_DISABLED).toBe(false);
+  });
+});

--- a/packages/fresco-ui/src/AnimationProvider.tsx
+++ b/packages/fresco-ui/src/AnimationProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { MotionConfig } from 'motion/react';
+import type { ComponentProps, ReactNode } from 'react';
+
+declare global {
+  // Base UI checks this flag before waiting for CSS animations to finish.
+  // eslint-disable-next-line no-var
+  var BASE_UI_ANIMATIONS_DISABLED: boolean;
+}
+
+type ReducedMotion = ComponentProps<typeof MotionConfig>['reducedMotion'];
+
+export type AnimationProviderProps = {
+  children: ReactNode;
+  /**
+   * Disable both Motion animations and Base UI's animation bookkeeping.
+   * Intended for deterministic automated hosts such as Playwright and
+   * Storybook visual tests.
+   */
+  disableAnimations?: boolean;
+  /** How Motion should respond to the user's reduced-motion preference. */
+  reducedMotion?: ReducedMotion;
+};
+
+/**
+ * Coordinates the animation controls used by Fresco applications.
+ *
+ * Motion owns JavaScript-driven animation while Base UI waits for CSS
+ * animations before completing popup transitions. Automated hosts need both
+ * systems disabled together; setting only one still leaves timing-dependent
+ * work behind.
+ */
+export function AnimationProvider({
+  children,
+  disableAnimations = false,
+  reducedMotion = 'user',
+}: AnimationProviderProps) {
+  // This must happen synchronously, before descendants mount and register Base
+  // UI transition callbacks. Automated hosts are long-lived and only move from
+  // animations enabled to disabled, so intentionally keep the flag sticky.
+  if (disableAnimations) {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+  }
+
+  return (
+    <MotionConfig
+      reducedMotion={reducedMotion}
+      skipAnimations={disableAnimations}
+    >
+      {children}
+    </MotionConfig>
+  );
+}

--- a/packages/fresco-ui/src/Spinner.tsx
+++ b/packages/fresco-ui/src/Spinner.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-import {
-  MotionConfigContext,
-  motion,
-  useAnimationControls,
-  useReducedMotionConfig,
-} from 'motion/react';
-import { useContext, useEffect, useRef } from 'react';
+import { motion, useAnimationControls } from 'motion/react';
+import { useEffect, useRef } from 'react';
 
+import { useShouldSkipAnimations } from './hooks/useSafeAnimate';
 import { cva, cx, type VariantProps } from './utils/cva';
 
 const ANIMATION_DURATION = 1.8;
@@ -139,16 +135,7 @@ export default function Spinner({
   // the tab. Accessibility-wise the right answer is also just "don't
   // animate" in reduced-motion mode, so we bail out entirely.
   //
-  // `useReducedMotionConfig` respects the OS `prefers-reduced-motion`
-  // setting AND an ancestor `MotionConfig`'s `reducedMotion` override.
-  // We ALSO have to check `skipAnimations` from the context directly
-  // because `useReducedMotionConfig` doesn't cover that flag, and it
-  // also causes `controls.start(...)` to resolve synchronously.
-  const reducedMotionFromConfig = useReducedMotionConfig();
-  const { skipAnimations: skipAnimationsFromConfig } =
-    useContext(MotionConfigContext);
-  const shouldReduceMotion =
-    !!reducedMotionFromConfig || !!skipAnimationsFromConfig;
+  const shouldReduceMotion = useShouldSkipAnimations();
 
   const containerControls = useAnimationControls();
   const halfCircleControls = [

--- a/packages/interview/.storybook/Providers.tsx
+++ b/packages/interview/.storybook/Providers.tsx
@@ -2,9 +2,9 @@
 
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Toast } from '@base-ui/react/toast';
-import { MotionConfig } from 'motion/react';
 import type { ReactNode } from 'react';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import { DndStoreProvider } from '@codaco/fresco-ui/dnd/dnd';
 import { Toaster } from '@codaco/fresco-ui/Toast';
@@ -51,12 +51,8 @@ export default function Providers({
   children: ReactNode;
   disableAnimations?: boolean;
 }) {
-  if (disableAnimations) {
-    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
-  }
-
   return (
-    <MotionConfig reducedMotion="user" skipAnimations={disableAnimations}>
+    <AnimationProvider disableAnimations={disableAnimations}>
       <DirectionProvider direction="ltr">
         <Toast.Provider limit={7}>
           <TooltipProvider>
@@ -75,6 +71,6 @@ export default function Providers({
           <Toaster />
         </Toast.Provider>
       </DirectionProvider>
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/packages/interview/e2e/host/src/App.tsx
+++ b/packages/interview/e2e/host/src/App.tsx
@@ -1,4 +1,3 @@
-import { MotionConfig } from 'motion/react';
 import {
   useCallback,
   useEffect,
@@ -8,6 +7,7 @@ import {
   useSyncExternalStore,
 } from 'react';
 
+import { AnimationProvider } from '@codaco/fresco-ui/AnimationProvider';
 import type {
   AssetRequestHandler,
   InterviewPayload,
@@ -51,8 +51,6 @@ async function autoBootstrap(slug: string): Promise<string | null> {
     return null;
   }
 }
-
-globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
 
 const mockAssetReq: AssetRequestHandler = async (assetId: string) => {
   const url = getTestState().assetUrls.get(assetId);
@@ -151,7 +149,7 @@ export default function App() {
   }
 
   return (
-    <MotionConfig reducedMotion="always" skipAnimations>
+    <AnimationProvider disableAnimations reducedMotion="always">
       <Shell
         payload={payload}
         onSync={mockSync}
@@ -164,6 +162,6 @@ export default function App() {
         analytics={{ installationId: 'e2e', hostApp: 'e2e' }}
         disableAnalytics={true}
       />
-    </MotionConfig>
+    </AnimationProvider>
   );
 }

--- a/packages/interview/e2e/host/src/global-augmentations.d.ts
+++ b/packages/interview/e2e/host/src/global-augmentations.d.ts
@@ -1,6 +1,0 @@
-// Set by the e2e host (App.tsx) before mounting Shell, to suppress Base UI's
-// CSS-animation waits during Playwright runs. Read by base-ui's runtime; we
-// only assign it. Declared with a top-level `declare var` (not a
-// `declare global` block, which needs an `export {}` module marker that
-// oxlint --fix strips from .d.ts files) so it surfaces on `globalThis`.
-declare var BASE_UI_ANIMATIONS_DISABLED: boolean | undefined;

--- a/packages/interview/src/types/build-globals.d.ts
+++ b/packages/interview/src/types/build-globals.d.ts
@@ -1,6 +1,0 @@
-// Set by Storybook and the e2e host before mounting Shell, to suppress
-// Base UI's CSS-animation waits during automated runs (Chromatic /
-// Playwright). Read by base-ui's runtime; we only assign it. Declared
-// with `var` (not `let`/`const`) so it surfaces on `globalThis`, which is
-// how it's actually written from the consumer side.
-declare var BASE_UI_ANIMATIONS_DISABLED: boolean | undefined;

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -509,3 +509,23 @@ test('the native E2E lane cannot touch pixel baselines', () => {
     );
   }
 });
+
+test('Architect E2E builds disable both animation systems', () => {
+  const nativeJob = job('architect-e2e-native');
+  assert.ok(nativeJob, 'architect-e2e-native job exists');
+  assert.match(
+    nativeJob,
+    /VITE_DISABLE_ANIMATIONS: 'true'/,
+    'the native build disables Motion and Base UI animations',
+  );
+
+  const dockerRunner = readFileSync(
+    new URL('../apps/architect/e2e/scripts/run.sh', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    dockerRunner,
+    /-e VITE_DISABLE_ANIMATIONS=true/,
+    'the Docker build disables Motion and Base UI animations',
+  );
+});

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "NEXT_PUBLIC_NETWORK_CANVAS_URL",
     "VITE_FRESCO_PREVIEW_URL",
     "VITE_FRESCO_PREVIEW_API_TOKEN",
-    "VITE_DISABLE_ANALYTICS"
+    "VITE_DISABLE_ANALYTICS",
+    "VITE_DISABLE_ANIMATIONS"
   ],
   "tasks": {
     "topo": {
@@ -106,7 +107,8 @@
       "env": [
         "VITE_FRESCO_PREVIEW_URL",
         "VITE_FRESCO_PREVIEW_API_TOKEN",
-        "VITE_DISABLE_ANALYTICS"
+        "VITE_DISABLE_ANALYTICS",
+        "VITE_DISABLE_ANIMATIONS"
       ],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
## Summary
- mount a shared animation provider in Architect so the app honors OS reduced-motion preferences
- disable Motion and Base UI animation bookkeeping together in Architect E2E builds, cutting the full native suite from minutes to seconds
- expose the provider from Fresco UI and reuse it across the existing Interview, Interviewer, and Storybook hosts; reuse the shared reduced-motion hook in Spinner
- retain the serial-suite scheduling and rich-text bulk insertion improvements, while waiting explicitly for ProseMirror instead of swallowing readiness races

## Stacking
- temporarily targets PR #1237 (`fix/e2e-release-infrastructure`) so this focused diff can be reviewed while GitHub Actions recovers
- after #1237 merges, this PR will be retargeted to `main`, refreshed from the merged base without rewriting published history, and taken through its own merge-group validation

## Test plan
- [x] full native Architect E2E suite: 60/60 in 42.6 seconds
- [x] pinned amd64 Architect visual regeneration: 2/2, with no PNG changes
- [x] Fresco UI unit suite: 1,009/1,009
- [x] Architect and Fresco UI production builds
- [x] Architect, Interviewer, Interview, and Fresco UI Storybook builds
- [x] workspace lint/format, knip, typecheck, changeset policy, and 151/151 script tests

## Changeset
- `@codaco/architect`: patch
- `@codaco/fresco-ui`: minor
