### PR TITLE
test(interview): stabilize Geospatial visual capture

### DIFF
--- a/packages/interview/e2e/specs/matrix/visual.spec.ts
+++ b/packages/interview/e2e/specs/matrix/visual.spec.ts
@@ -28,6 +28,12 @@ for (const suite of ALL_SUITES) {
         const ctx: ScenarioContext = { page, interview, stage, protocol };
         await installScenario(scenario, ctx);
         const mask = scenario.captureMask?.(page);
+        if (
+          suite.interfaceType === 'Geospatial' &&
+          scenario.id === 'core-click-select-and-prompt-panel'
+        ) {
+          await stage.geospatial.waitForMapIdle();
+        }
         await interview.captureInitial(mask);
         await scenario.run(ctx);
         await interview.captureFinal(mask);

--- a/packages/interview/src/interfaces/Sociogram/CollapsablePrompts.tsx
+++ b/packages/interview/src/interfaces/Sociogram/CollapsablePrompts.tsx
@@ -1,8 +1,9 @@
 import { ChevronUp, GripHorizontal } from 'lucide-react';
-import { motion } from 'motion/react';
+import { motion, MotionConfigContext, type BoundingBox } from 'motion/react';
 import {
   type ReactNode,
   type RefObject,
+  useContext,
   useEffect,
   useId,
   useState,
@@ -16,6 +17,18 @@ import Prompts from '../../components/Prompts';
 import { usePrompts } from '../../components/Prompts/usePrompts';
 
 const MotionChevron = motion.create(ChevronUp);
+
+const roundDragConstraints = ({
+  top,
+  right,
+  bottom,
+  left,
+}: BoundingBox): BoundingBox => ({
+  top: Math.round(top),
+  right: Math.round(right),
+  bottom: Math.round(bottom),
+  left: Math.round(left),
+});
 
 /**
  * Floating, draggable panel showing the current prompt. Collapsible via the
@@ -35,6 +48,7 @@ const CollapsablePrompts = (props: {
   const { prompt } = usePrompts();
   const [collapsed, setCollapsed] = useState(false);
   const contentId = useId();
+  const { skipAnimations } = useContext(MotionConfigContext);
 
   const isCollapsed = collapsible && collapsed;
 
@@ -52,9 +66,14 @@ const CollapsablePrompts = (props: {
         'bg-surface/80 absolute top-4 right-4 z-10 flex w-fit max-w-sm cursor-move flex-col items-center overflow-hidden border-b-2 shadow-2xl backdrop-blur-md',
         className,
       )}
-      layout
+      layout={!skipAnimations}
       drag
       dragConstraints={dragConstraints}
+      // Constraint resizes can otherwise leave a fractional drag transform even
+      // when Motion's test mode has disabled every animation.
+      onMeasureDragConstraints={
+        skipAnimations ? roundDragConstraints : undefined
+      }
       noContainer
       spacing="sm"
       shadow="sm"


### PR DESCRIPTION
## Summary
- wait for the target Geospatial map to become idle before its initial visual capture
- prevent Motion's disabled-animation test mode from retaining a fractional drag transform when Mapbox resizes the prompt panel's constraint box
- keep normal and user reduced-motion behavior unchanged; the panel adjustment applies only when the E2E host explicitly sets `skipAnimations`

## Stacking
- temporarily targets PR #1237 (`fix/e2e-release-infrastructure`) so this focused diff can be reviewed while GitHub Actions recovers
- after #1237 merges, this PR will be retargeted to `main`, refreshed from the merged base, and taken through its own merge-group validation after the Architect PR

## Test plan
- [x] target scenario stress: 30/30 across pinned Chromium, Firefox, and WebKit
- [x] full pinned Interview visual matrix: 159 passed, 6 expected skips
- [x] Interviewer visual captures: 5/5
- [x] Interview unit tests: 1,377 passed, 2 todo
- [x] workspace lint/format, knip, typecheck, and changeset policy
- [x] regenerated and inspected affected Interview and Interviewer suites; no PNG baseline changes

## Changeset
- none; normal consumer rendering is unchanged and the behavior is limited to explicit test animation suppression

## Deferred follow-ups
- Architect does not mount `MotionConfig`; fixing its reduced-motion behavior and resulting baselines needs a separate task
- PNG-only snapshot PRs currently receive no pixel verification; adding a non-recursive snapshot-branch gate needs a separate workflow change
