### PR TITLE
Fix production Dependabot vulnerabilities

### DIFF
--- a/.changeset/plenty-swans-thank.md
+++ b/.changeset/plenty-swans-thank.md
@@ -1,0 +1,7 @@
+---
+"@codaco/architect": patch
+"fresco": patch
+"@codaco/interviewer": patch
+---
+
+Update runtime dependencies to resolve security vulnerabilities in analytics sanitization, uploads, and form state handling.

--- a/.changeset/plenty-swans-thank.md
+++ b/.changeset/plenty-swans-thank.md
@@ -1,6 +1,7 @@
 ---
 "@codaco/architect": patch
 "fresco": patch
+"@codaco/interview": patch
 "@codaco/interviewer": patch
 ---
 

--- a/.changeset/secure-analytics-rest.md
+++ b/.changeset/secure-analytics-rest.md
@@ -1,0 +1,5 @@
+---
+"@codaco/documentation": patch
+---
+
+Update analytics sanitization dependencies to resolve security vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ catalogs:
       specifier: ^17.4.2
       version: 17.4.2
     effect:
-      specifier: ^3.22.0
+      specifier: ^3.22.1
       version: 3.22.1
     electron:
       specifier: ^43.0.0
@@ -247,7 +247,7 @@ overrides:
   slate>immer: ^5.3.0
   slate-history>immer: ^5.3.0
   dompurify@3.4.7: ^3.4.12
-  effect@3.17.7: 3.20.0
+  effect@3.17.7: ^3.22.1
   fast-uri: ^3.1.4
   find-my-way: ^9.7.0
   immutable@4.3.8: 4.3.9
@@ -3826,7 +3826,7 @@ packages:
   '@effect/platform@0.90.3':
     resolution: {integrity: sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA==}
     peerDependencies:
-      effect: 3.20.0
+      effect: ^3.22.1
 
   '@electric-sql/pglite-socket@0.1.3':
     resolution: {integrity: sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==}
@@ -17873,10 +17873,10 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@effect/platform@0.90.3(effect@3.20.0)':
+  '@effect/platform@0.90.3(effect@3.22.1)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.41.1
-      effect: 3.20.0
+      effect: 3.22.1
       find-my-way-ts: 0.1.6
       msgpackr: 1.12.1
       multipasta: 0.2.8
@@ -21423,7 +21423,7 @@ snapshots:
   '@uploadthing/shared@7.1.10':
     dependencies:
       '@uploadthing/mime-types': 0.3.6
-      effect: 3.20.0
+      effect: 3.22.1
       sqids: 0.3.0
 
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@7.0.2))':
@@ -30321,11 +30321,11 @@ snapshots:
 
   uploadthing@7.7.4(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(tailwindcss@4.3.3):
     dependencies:
-      '@effect/platform': 0.90.3(effect@3.20.0)
+      '@effect/platform': 0.90.3(effect@3.22.1)
       '@standard-schema/spec': 1.0.0-beta.4
       '@uploadthing/mime-types': 0.3.6
       '@uploadthing/shared': 7.1.10
-      effect: 3.20.0
+      effect: 3.22.1
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0)
       tailwindcss: 4.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,11 @@ overrides:
   '@microsoft/api-extractor>typescript': npm:@typescript/typescript6@^6.0.2
   slate>immer: ^5.3.0
   slate-history>immer: ^5.3.0
+  dompurify@3.4.7: ^3.4.12
+  effect@3.17.7: 3.20.0
   fast-uri: ^3.1.4
   find-my-way: ^9.7.0
+  immutable@4.3.8: 4.3.9
   postcss: ^8.5.23
   sharp: ^0.35.3
   valibot: ^1.4.2
@@ -399,7 +402,7 @@ importers:
         version: 5.0.1
       redux-form:
         specifier: 'catalog:'
-        version: 8.3.10(immutable@4.3.8)(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)(redux@5.0.1)
+        version: 8.3.10(immutable@4.3.9)(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)(redux@5.0.1)
       redux-logger:
         specifier: 'catalog:'
         version: 3.0.6
@@ -674,7 +677,7 @@ importers:
         version: 4.2.1
       redux-form:
         specifier: 'catalog:'
-        version: 8.3.10(immutable@4.3.8)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1)
+        version: 8.3.10(immutable@4.3.9)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1)
       redux-logger:
         specifier: ^2.10.2
         version: 2.10.2
@@ -1548,7 +1551,7 @@ importers:
         version: 4.2.1
       redux-form:
         specifier: 'catalog:'
-        version: 8.3.10(immutable@4.3.8)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1)
+        version: 8.3.10(immutable@4.3.9)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1)
       redux-logger:
         specifier: ^2.10.2
         version: 2.10.2
@@ -3823,7 +3826,7 @@ packages:
   '@effect/platform@0.90.3':
     resolution: {integrity: sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA==}
     peerDependencies:
-      effect: ^3.17.7
+      effect: 3.20.0
 
   '@electric-sql/pglite-socket@0.1.3':
     resolution: {integrity: sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==}
@@ -9800,8 +9803,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.7:
-    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -9848,9 +9851,6 @@ packages:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
     engines: {node: '>=14'}
     hasBin: true
-
-  effect@3.17.7:
-    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
 
   effect@3.20.0:
     resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
@@ -11026,8 +11026,8 @@ packages:
   immer@5.3.6:
     resolution: {integrity: sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==}
 
-  immutable@4.3.8:
-    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
+  immutable@4.3.9:
+    resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
 
   immutable@5.1.9:
     resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
@@ -13813,7 +13813,7 @@ packages:
     resolution: {integrity: sha512-Eeog8dJYUxCSZI/oBoy7VkprvMjj1lpUnHa3LwjVNZvYDNeiRZMoZoaAT+6nlK2YQ4aiBopKUMiLe4ihUOHCGg==}
     engines: {node: '>=8.10'}
     peerDependencies:
-      immutable: ^3.8.2 || ^4.0.0
+      immutable: 4.3.9
       react: ^16.4.2 || ^17.0.0 || ^18.0.0
       react-redux: ^6.0.1 || ^7.0.0 || ^8.0.0
       redux: ^3.7.2 || ^4.0.0
@@ -17873,10 +17873,10 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@effect/platform@0.90.3(effect@3.17.7)':
+  '@effect/platform@0.90.3(effect@3.20.0)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.41.1
-      effect: 3.17.7
+      effect: 3.20.0
       find-my-way-ts: 0.1.6
       msgpackr: 1.12.1
       multipasta: 0.2.8
@@ -21423,7 +21423,7 @@ snapshots:
   '@uploadthing/shared@7.1.10':
     dependencies:
       '@uploadthing/mime-types': 0.3.6
-      effect: 3.17.7
+      effect: 3.20.0
       sqids: 0.3.0
 
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@7.0.2))':
@@ -22802,7 +22802,7 @@ snapshots:
       react-router: 5.3.4(react@16.14.0)
       redux: 4.2.1
     optionalDependencies:
-      immutable: 4.3.8
+      immutable: 4.3.9
       seamless-immutable: 7.1.4
 
   consola@3.4.2: {}
@@ -23381,7 +23381,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.7:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -23441,11 +23441,6 @@ snapshots:
       commander: 10.0.1
       minimatch: 9.0.9
       semver: 7.8.5
-
-  effect@3.17.7:
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      fast-check: 3.23.2
 
   effect@3.20.0:
     dependencies:
@@ -25004,7 +24999,7 @@ snapshots:
 
   immer@5.3.6: {}
 
-  immutable@4.3.8:
+  immutable@4.3.9:
     optional: true
 
   immutable@5.1.9: {}
@@ -27665,7 +27660,7 @@ snapshots:
       '@posthog/core': 1.46.6
       '@posthog/types': 1.400.0
       core-js: 3.49.0
-      dompurify: 3.4.7
+      dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.29.8
       query-selector-shadow-dom: 1.0.1
@@ -28478,7 +28473,7 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redux-form@8.3.10(immutable@4.3.8)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1):
+  redux-form@8.3.10(immutable@4.3.9)(react-redux@7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(react@16.14.0)(redux@4.2.1):
     dependencies:
       '@babel/runtime': 7.29.7
       es6-error: 4.1.1
@@ -28492,9 +28487,9 @@ snapshots:
       react-redux: 7.2.9(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       redux: 4.2.1
     optionalDependencies:
-      immutable: 4.3.8
+      immutable: 4.3.9
 
-  redux-form@8.3.10(immutable@4.3.8)(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)(redux@5.0.1):
+  redux-form@8.3.10(immutable@4.3.9)(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)(redux@5.0.1):
     dependencies:
       '@babel/runtime': 7.29.7
       es6-error: 4.1.1
@@ -28508,7 +28503,7 @@ snapshots:
       react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
       redux: 5.0.1
     optionalDependencies:
-      immutable: 4.3.8
+      immutable: 4.3.9
 
   redux-logger@2.10.2:
     dependencies:
@@ -30326,11 +30321,11 @@ snapshots:
 
   uploadthing@7.7.4(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(tailwindcss@4.3.3):
     dependencies:
-      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@effect/platform': 0.90.3(effect@3.20.0)
       '@standard-schema/spec': 1.0.0-beta.4
       '@uploadthing/mime-types': 0.3.6
       '@uploadthing/shared': 7.1.10
-      effect: 3.17.7
+      effect: 3.20.0
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0)
       tailwindcss: 4.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: ^1.62.1
       version: 1.62.1
     posthog-js:
-      specifier: ^1.409.5
-      version: 1.410.7
+      specifier: ^1.413.2
+      version: 1.413.2
     react:
       specifier: ^19.2.8
       version: 19.2.8
@@ -246,7 +246,6 @@ overrides:
   '@microsoft/api-extractor>typescript': npm:@typescript/typescript6@^6.0.2
   slate>immer: ^5.3.0
   slate-history>immer: ^5.3.0
-  dompurify@3.4.7: ^3.4.12
   effect@3.17.7: ^3.22.1
   fast-uri: ^3.1.4
   find-my-way: ^9.7.0
@@ -381,7 +380,7 @@ importers:
         version: 12.43.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       posthog-js:
         specifier: 'catalog:'
-        version: 1.410.7
+        version: 1.413.2
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -752,7 +751,7 @@ importers:
         version: 16.3.0(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(react@19.2.8)
       '@posthog/react':
         specifier: 'catalog:'
-        version: 1.10.3(@types/react@19.2.18)(posthog-js@1.410.7)(react@19.2.8)
+        version: 1.10.3(@types/react@19.2.18)(posthog-js@1.413.2)(react@19.2.8)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -782,7 +781,7 @@ importers:
         version: 8.5.25
       posthog-js:
         specifier: 'catalog:'
-        version: 1.410.7
+        version: 1.413.2
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1008,7 +1007,7 @@ importers:
         version: 8.5.25
       posthog-js:
         specifier: 'catalog:'
-        version: 1.410.7
+        version: 1.413.2
       posthog-node:
         specifier: ^5.47.3
         version: 5.47.8(rxjs@7.8.2)
@@ -1222,7 +1221,7 @@ importers:
         version: 12.43.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       posthog-js:
         specifier: 'catalog:'
-        version: 1.410.7
+        version: 1.413.2
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -2058,7 +2057,7 @@ importers:
         version: 2.0.11
       posthog-js:
         specifier: 'catalog:'
-        version: 1.410.7
+        version: 1.413.2
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -6299,8 +6298,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@posthog/browser-common@0.3.1':
-    resolution: {integrity: sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ==}
+  '@posthog/browser-common@0.4.0':
+    resolution: {integrity: sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ==}
 
   '@posthog/cli@0.7.34':
     resolution: {integrity: sha512-wrRwj0FhbypW01TLpFRo1HkPBrwZHKP2tFE9xI4NTb84yMKZnXy49ibBdbImktJ5NbW7ndeWidOCZx+2Lkk7/Q==}
@@ -6309,6 +6308,9 @@ packages:
 
   '@posthog/core@1.46.6':
     resolution: {integrity: sha512-m7iLFU7Cx4IjsUG6wQE3AJRzCFW/tUDCMIWhifvogLCxRAD6pELnqWHqshUB83KcTpxKnFACOQVMxmzzeO98dg==}
+
+  '@posthog/core@1.46.8':
+    resolution: {integrity: sha512-WQTSwlFhsWk09xngTimHiTyhFU8QZHFZEGSm+6brY3acwYdvTLcTxpIhgl/qOCgn/XoqlCFTZqU1ldWLxNntfA==}
 
   '@posthog/nextjs-config@1.9.68':
     resolution: {integrity: sha512-MmzSrompIThnnrDArCKIOBZuD/b3RErH48ZJyzAuX+WfJTiHBjjTMvGWzr+qlIn8jCyJoglSygAwYVG8lJXybg==}
@@ -6329,8 +6331,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@posthog/types@1.400.0':
-    resolution: {integrity: sha512-0VVOXFrkh0TEAfmptoUqFGbhEzygQyWYQZYPlw0v0QYJfXTYlnlhr/QMMF3NAGKakFwOAn9ZZnlpEFeaLhZ/Cg==}
+  '@posthog/types@1.402.1':
+    resolution: {integrity: sha512-4PZ9wMYI8m8AqJuZ9YR1IAHGVtSnYbBVBgTevrKpzZbcSe/OUwhEV2Ks//rJh/L8eMTU8R5DrD4D/hlrOwaAiQ==}
 
   '@posthog/webpack-plugin@1.5.26':
     resolution: {integrity: sha512-NAsTb81f8QQai7Uzd3IT2Kjt7o9lPxccVfWqD30HyACCEL3NVMTXed5hRYdtY5DkrdCejxhcA80ldXGiUsiGrQ==}
@@ -13230,8 +13232,8 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
-  posthog-js@1.410.7:
-    resolution: {integrity: sha512-86w0Q6g+iUCMIOsg+X0j9SXIfXyD5N0mwpo9Q96SmrqEQLTQ398I/xzn4skE/v7xA5QUz/AK+uukzNOy4wy5/A==}
+  posthog-js@1.413.2:
+    resolution: {integrity: sha512-LddTVMdYFd0jB+p5h3ZHcho9mWNjgKn9QySCQt74iISKrmC3b7KzW2Q7W7aOF6m/NwK7NubIHqLujCER64gSRw==}
 
   posthog-node@5.47.8:
     resolution: {integrity: sha512-NJqjGu4O0Nxi9FHuAIAarPKGtPdThh6eY1/BCY/jK/Y9btnW9NhXe8l9K0NlpUw7LF3q67ab4p8bDy6pZV881A==}
@@ -15702,6 +15704,9 @@ packages:
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
@@ -19770,10 +19775,10 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@posthog/browser-common@0.3.1':
+  '@posthog/browser-common@0.4.0':
     dependencies:
-      '@posthog/core': 1.46.6
-      '@posthog/types': 1.400.0
+      '@posthog/core': 1.46.8
+      '@posthog/types': 1.402.1
 
   '@posthog/cli@0.7.34':
     dependencies:
@@ -19781,7 +19786,11 @@ snapshots:
 
   '@posthog/core@1.46.6':
     dependencies:
-      '@posthog/types': 1.400.0
+      '@posthog/types': 1.402.1
+
+  '@posthog/core@1.46.8':
+    dependencies:
+      '@posthog/types': 1.402.1
 
   '@posthog/nextjs-config@1.9.68(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))':
     dependencies:
@@ -19797,19 +19806,19 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/react@1.10.3(@types/react@19.2.18)(posthog-js@1.410.7)(react@19.2.8)':
+  '@posthog/react@1.10.3(@types/react@19.2.18)(posthog-js@1.413.2)(react@19.2.8)':
     dependencies:
-      posthog-js: 1.410.7
+      posthog-js: 1.413.2
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@posthog/types@1.400.0': {}
+  '@posthog/types@1.402.1': {}
 
   '@posthog/webpack-plugin@1.5.26(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))':
     dependencies:
       '@posthog/cli': 0.7.34
-      '@posthog/core': 1.46.6
+      '@posthog/core': 1.46.8
       '@posthog/plugin-utils': 1.1.2
       webpack: 5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3)
 
@@ -27654,17 +27663,18 @@ snapshots:
 
   postgres@3.4.7: {}
 
-  posthog-js@1.410.7:
+  posthog-js@1.413.2:
     dependencies:
-      '@posthog/browser-common': 0.3.1
-      '@posthog/core': 1.46.6
-      '@posthog/types': 1.400.0
+      '@posthog/browser-common': 0.4.0
+      '@posthog/core': 1.46.8
+      '@posthog/types': 1.402.1
       core-js: 3.49.0
       dompurify: 3.4.13
       fflate: 0.4.8
       preact: 10.29.8
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
     transitivePeerDependencies:
       - preact-render-to-string
 
@@ -30545,6 +30555,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webcrypto-core@1.9.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalog:
   # Keep in lock-step with `@playwright/test` above (grouped in dependabot); a
   # mismatch crashes interview-e2e with "two different versions of @playwright/test".
   playwright: ^1.62.1
-  posthog-js: ^1.409.5
+  posthog-js: ^1.413.2
   react: ^19.2.8
   react-dom: ^19.2.8
   react-dropzone: ^15.0.0
@@ -140,7 +140,6 @@ overrides:
   'slate-history>immer': '^5.3.0'
   # Keep security-sensitive transitives on patched versions when upstream
   # manifests still pin vulnerable releases (inherited from fresco).
-  'dompurify@3.4.7': '^3.4.12'
   'effect@3.17.7': 'catalog:'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -140,8 +140,11 @@ overrides:
   'slate-history>immer': '^5.3.0'
   # Keep security-sensitive transitives on patched versions when upstream
   # manifests still pin vulnerable releases (inherited from fresco).
+  'dompurify@3.4.7': '^3.4.12'
+  'effect@3.17.7': '3.20.0'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'
+  'immutable@4.3.8': '4.3.9'
   postcss: '^8.5.23'
   sharp: '^0.35.3'
   valibot: '^1.4.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,7 +81,7 @@ catalog:
   class-variance-authority: 0.7.1
   csvtojson: ^2.0.14
   dotenv: ^17.4.2
-  effect: ^3.22.0
+  effect: ^3.22.1
   electron: ^43.0.0
   electron-builder: ^26.15.2
   electron-vite: ^6.0.0-beta.1
@@ -141,7 +141,7 @@ overrides:
   # Keep security-sensitive transitives on patched versions when upstream
   # manifests still pin vulnerable releases (inherited from fresco).
   'dompurify@3.4.7': '^3.4.12'
-  'effect@3.17.7': '3.20.0'
+  'effect@3.17.7': 'catalog:'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'
   'immutable@4.3.8': '4.3.9'

--- a/scripts/mirror-app.mjs
+++ b/scripts/mirror-app.mjs
@@ -197,7 +197,6 @@ allowBuilds:
 # Keep security-sensitive transitives on patched versions when upstream
 # manifests still pin vulnerable releases.
 overrides:
-  'dompurify@3.4.7': '^3.4.12'
   'effect@3.17.7': '${effectVersion}'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'

--- a/scripts/mirror-app.mjs
+++ b/scripts/mirror-app.mjs
@@ -37,6 +37,19 @@ import { fileURLToPath } from 'node:url';
 import { parseCatalog, resolveManifest } from './resolve-manifest.mjs';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const workspaceCatalog = parseCatalog(
+  readFileSync(join(repoRoot, 'pnpm-workspace.yaml'), 'utf8'),
+);
+
+function requireCatalogVersion(name) {
+  const version = workspaceCatalog[name];
+  if (!version) {
+    throw new Error(`No default catalog entry for "${name}".`);
+  }
+  return version;
+}
+
+const effectVersion = requireCatalogVersion('effect');
 
 const GITIGNORE = `node_modules/
 dist/
@@ -184,6 +197,8 @@ allowBuilds:
 # Keep security-sensitive transitives on patched versions when upstream
 # manifests still pin vulnerable releases.
 overrides:
+  'dompurify@3.4.7': '^3.4.12'
+  'effect@3.17.7': '${effectVersion}'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'
   postcss: '^8.5.23'
@@ -220,15 +235,7 @@ function vendorSharedTsconfig(staging, manifest) {
     original.replace(shared, '"./tsconfig/web.json"'),
   );
 
-  const catalog = parseCatalog(
-    readFileSync(join(repoRoot, 'pnpm-workspace.yaml'), 'utf8'),
-  );
-  const tsResetVersion = catalog['@total-typescript/ts-reset'];
-  if (!tsResetVersion) {
-    throw new Error(
-      'No catalog entry for @total-typescript/ts-reset; the vendored tsconfig names it in `types`.',
-    );
-  }
+  const tsResetVersion = requireCatalogVersion('@total-typescript/ts-reset');
   manifest.devDependencies ??= {};
   manifest.devDependencies['@total-typescript/ts-reset'] = tsResetVersion;
 }


### PR DESCRIPTION
## Summary
- resolve the seven runtime-relevant Dependabot alerts with patched DOMPurify 3.4.13, Effect 3.22.1, and Immutable 4.3.9 dependency paths
- update the shared PostHog catalog dependency so published `@codaco/interview` consumers receive the patched DOMPurify range without a workspace-only override
- keep Effect shared through the workspace catalog and carry its transitive override into Fresco's generated standalone mirror
- add patch release entries for `@codaco/interview`, Architect, Interviewer, Fresco, and the separately gated Documentation app
- dismiss 64 Classic-only or non-production alerts as accepted risk under the repository security policy

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm test:scripts` (151 passed)
- [x] `pnpm --filter @codaco/interview test` (1,377 passed, 2 todo)
- [x] `pnpm --filter @codaco/architect test` (1,344 passed, 4 todo)
- [x] `pnpm --filter @codaco/interviewer test` (496 passed)
- [x] `pnpm --filter fresco test` (373 passed)
- [x] `pnpm --filter @codaco/documentation test` (14 passed)
- [x] production builds for Interview, Architect, Interviewer, Fresco, and Documentation
- [x] packed `@codaco/interview` manifest contains `posthog-js: ^1.413.2`
- [x] Fresco mirror dry run with generated standalone lockfile
- [x] `pnpm audit --json` no longer reports DOMPurify, Effect, or Immutable advisories
- [x] visual baseline classifier reviewed; no regeneration needed because these dependency patches do not alter rendered UI
