### PR TITLE
feat(fresco-ui): show full labels for truncated nodes in a tooltip

### DIFF
--- a/.changeset/tidy-moons-brake.md
+++ b/.changeset/tidy-moons-brake.md
@@ -1,0 +1,5 @@
+---
+'@codaco/fresco-ui': minor
+---
+
+Nodes whose names are too long to fit now reveal the full name in a tooltip on mouse hover or keyboard focus — and only when the name is actually cut off. Tapping, selecting, and dragging behave exactly as before, and the tooltip never captures pointer input. Adds the `useIsTruncated` hook (`@codaco/fresco-ui/hooks/useIsTruncated`) for detecting real visual truncation, a `pointerEvents` prop on `TooltipContent` for purely decorative tooltips, and a `tooltipDisabled` prop on `Node` for hosts that need to opt out.

--- a/packages/fresco-ui/package.json
+++ b/packages/fresco-ui/package.json
@@ -64,6 +64,7 @@
     "./utils/composeEventHandlers": "./src/utils/composeEventHandlers.ts",
     "./utils/NoSSRWrapper": "./src/utils/NoSSRWrapper.tsx",
     "./hooks/useSafeAnimate": "./src/hooks/useSafeAnimate.ts",
+    "./hooks/useIsTruncated": "./src/hooks/useIsTruncated.ts",
     "./hooks/useNodeInteractions": "./src/hooks/useNodeInteractions.ts",
     "./hooks/usePrevious": "./src/hooks/usePrevious.ts",
     "./hooks/useResizablePanel": "./src/hooks/useResizablePanel.ts",
@@ -355,6 +356,10 @@
       "./hooks/useSafeAnimate": {
         "types": "./dist/hooks/useSafeAnimate.d.ts",
         "default": "./dist/hooks/useSafeAnimate.js"
+      },
+      "./hooks/useIsTruncated": {
+        "types": "./dist/hooks/useIsTruncated.d.ts",
+        "default": "./dist/hooks/useIsTruncated.js"
       },
       "./hooks/useNodeInteractions": {
         "types": "./dist/hooks/useNodeInteractions.d.ts",

--- a/packages/fresco-ui/src/Node.stories.tsx
+++ b/packages/fresco-ui/src/Node.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { expect, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import Node, { NodeColors } from './Node';
+import { withTooltipProvider } from './storybook-support/withTooltipProvider';
+import { TooltipProvider } from './Tooltip';
 import Heading from './typography/Heading';
 import Paragraph from './typography/Paragraph';
 
@@ -10,6 +12,7 @@ const meta: Meta<typeof Node> = {
   title: 'Components/Node',
   component: Node,
   tags: ['autodocs'],
+  decorators: [withTooltipProvider],
   parameters: {
     layout: 'centered',
     docs: {
@@ -33,6 +36,13 @@ Interaction behaviors are automatically inferred from the props you provide:
 
 This design allows the Node to integrate seamlessly with external interaction systems
 without needing explicit mode flags.
+
+## Truncated Labels
+Labels that exceed the available space are line-clamped. When (and only when) a
+label is actually clamped, the complete label is shown in a tooltip on mouse
+hover and keyboard focus. The tooltip never opens from press, click, or touch,
+is suppressed while a pointer button is held or a drag is active, and cannot
+capture pointer events. The full label always remains the accessible name.
         `,
       },
     },
@@ -393,7 +403,12 @@ export const FocusRing: Story = {
   },
 };
 
-const resilientLabelCases = [
+const resilientLabelCases: readonly {
+  caption: string;
+  label: string;
+  lang: string;
+  dir?: 'rtl';
+}[] = [
   {
     caption: 'Short name',
     label: 'Amina',
@@ -415,11 +430,17 @@ const resilientLabelCases = [
     lang: 'ja',
   },
   {
+    caption: 'Right-to-left text',
+    label: 'محمد عبد الرحمن بن عبد العزيز الحسيني',
+    lang: 'ar',
+    dir: 'rtl',
+  },
+  {
     caption: 'No natural break opportunities',
     label: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     lang: 'en',
   },
-] as const;
+];
 
 const resilientLabelShapes = ['circle', 'square', 'diamond'] as const;
 
@@ -429,7 +450,7 @@ const resilientLabelShapes = ['circle', 'square', 'diamond'] as const;
 export const LongLabels: Story = {
   render: () => (
     <div className="flex flex-col gap-10">
-      {resilientLabelCases.map(({ caption, label, lang }, index) => (
+      {resilientLabelCases.map(({ caption, label, lang, dir }, index) => (
         <section key={caption} className="flex flex-col gap-3">
           <Heading level="h3" margin="none" className="text-base">
             {caption}
@@ -443,6 +464,7 @@ export const LongLabels: Story = {
                 <Node
                   label={label}
                   lang={lang}
+                  dir={dir}
                   shape={shape}
                   size="sm"
                   color={
@@ -699,6 +721,212 @@ export const DisabledNodes: Story = {
       description: {
         story:
           'Disabled nodes are desaturated and have `pointer-events: none`. Visual states like selected can still be shown.',
+      },
+    },
+  },
+};
+
+const tooltipLabelCases: readonly {
+  caption: string;
+  label: string;
+  lang: string;
+  dir?: 'rtl';
+  truncates: boolean;
+}[] = [
+  { caption: 'Short name', label: 'Ash', lang: 'en', truncates: false },
+  {
+    caption: 'Natural word boundaries',
+    label: 'Alexandria Montgomery-Fitzgerald von Habsburg III',
+    lang: 'en',
+    truncates: true,
+  },
+  {
+    caption: 'Locale-aware hyphenation',
+    label:
+      'Alexandra Müller-Lüdenscheidt von Donaudampfschifffahrtsgesellschaft',
+    lang: 'de',
+    truncates: true,
+  },
+  {
+    caption: 'CJK text',
+    label: '佐藤アレクサンドラ美咲エリザベス真理子オリビア',
+    lang: 'ja',
+    truncates: true,
+  },
+  {
+    caption: 'Right-to-left text',
+    label: 'محمد عبد الرحمن بن عبد العزيز الحسيني الهاشمي',
+    lang: 'ar',
+    dir: 'rtl',
+    truncates: true,
+  },
+  {
+    caption: 'No natural break opportunities',
+    label: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    lang: 'en',
+    truncates: true,
+  },
+];
+
+const labelOverflows = (labelElement: HTMLElement) =>
+  labelElement.scrollHeight - labelElement.clientHeight > 1 ||
+  labelElement.scrollWidth - labelElement.clientWidth > 1;
+
+const getOpenTooltip = () =>
+  document.querySelector('[data-base-ui-portal] [data-open][role="tooltip"]');
+
+/**
+ * Truncated labels expose their complete value in a tooltip on hover and
+ * keyboard focus. Untruncated labels never show a tooltip, and pressing a
+ * pointer button closes and suppresses it.
+ */
+export const TruncatedLabelTooltip: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-8 p-16">
+      {tooltipLabelCases.map(({ caption, label, lang, dir }) => (
+        <div key={caption} className="flex w-32 flex-col items-center gap-2">
+          <Node label={label} lang={lang} dir={dir} onClick={fn()} />
+          <span className="text-center text-xs text-current/70">{caption}</span>
+        </div>
+      ))}
+    </div>
+  ),
+  decorators: [
+    (StoryComponent) => (
+      <TooltipProvider delay={0} closeDelay={0}>
+        <StoryComponent />
+      </TooltipProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const { label, truncates } of tooltipLabelCases) {
+      const node = canvas.getByRole('button', { name: label });
+      const visibleLabel = within(node).getByText(label);
+      await expect(labelOverflows(visibleLabel)).toBe(truncates);
+
+      await userEvent.hover(node);
+      if (truncates) {
+        await waitFor(() => expect(getOpenTooltip()).toHaveTextContent(label));
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        await expect(getOpenTooltip()).toBeNull();
+      }
+      await userEvent.unhover(node);
+      await waitFor(() => expect(getOpenTooltip()).toBeNull());
+    }
+
+    const truncatedCase = tooltipLabelCases[1]!;
+    const truncatedNode = canvas.getByRole('button', {
+      name: truncatedCase.label,
+    });
+    await userEvent.hover(truncatedNode);
+    await waitFor(() => expect(getOpenTooltip()).not.toBeNull());
+    await userEvent.pointer({ keys: '[MouseLeft>]', target: truncatedNode });
+    await waitFor(() => expect(getOpenTooltip()).toBeNull());
+    await userEvent.pointer({ keys: '[/MouseLeft]', target: truncatedNode });
+    await userEvent.unhover(truncatedNode);
+    await waitFor(() => expect(getOpenTooltip()).toBeNull());
+
+    // Keyboard focus-open can't be driven by synthetic play input
+    // (no focus-visible modality); covered in Node.tooltip.test.tsx.
+  },
+  parameters: {
+    layout: 'padded',
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        story: `
+Overflow is detected from real layout after render — not from character count —
+so only labels that actually clamp get a tooltip. The tooltip opens on mouse
+hover and keyboard focus, never from press, click, or touch; pressing a pointer
+button closes it and keeps it closed while held. The tooltip is rendered with
+\`pointer-events: none\`, so it can never capture a gesture, and its content is
+\`aria-hidden\` because the full label is already the button's accessible name.
+        `,
+      },
+    },
+  },
+};
+
+/**
+ * The truncated-label tooltip in its open state, for visual review.
+ */
+export const TruncatedLabelTooltipOpen: Story = {
+  render: () => (
+    <div className="p-24">
+      <Node
+        label="Alexandria Montgomery-Fitzgerald von Habsburg III"
+        onClick={fn()}
+      />
+    </div>
+  ),
+  decorators: [
+    (StoryComponent) => (
+      <TooltipProvider delay={0} closeDelay={0}>
+        <StoryComponent />
+      </TooltipProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const node = canvas.getByRole('button');
+    await userEvent.hover(node);
+    await waitFor(() => expect(getOpenTooltip()).not.toBeNull());
+  },
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true },
+    docs: {
+      description: {
+        story:
+          'The complete label appears above the node without altering its layout or size.',
+      },
+    },
+  },
+};
+
+/**
+ * Overflow detection holds across every size and shape.
+ */
+export const TruncationAcrossSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      {(['xxs', 'xs', 'sm', 'md', 'lg'] as const).map((size) => (
+        <div key={size} className="flex items-center gap-8">
+          <span className="w-12 text-sm font-medium">{size}</span>
+          <div className="flex items-end gap-6">
+            {(['circle', 'square', 'diamond'] as const).map((shape) => (
+              <Node
+                key={shape}
+                size={size}
+                shape={shape}
+                label="Alexandria Montgomery-Fitzgerald von Habsburg III"
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nodes = canvas.getAllByRole('button');
+    await expect(nodes).toHaveLength(15);
+
+    for (const node of nodes) {
+      const visibleLabel = within(node).getByText(
+        'Alexandria Montgomery-Fitzgerald von Habsburg III',
+      );
+      await expect(labelOverflows(visibleLabel)).toBe(true);
+    }
+  },
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        story:
+          'A label longer than any node can hold is detected as truncated at every size (each size clamps at a different line count) and shape, so the tooltip is available for all of them.',
       },
     },
   },

--- a/packages/fresco-ui/src/Node.tooltip.test.tsx
+++ b/packages/fresco-ui/src/Node.tooltip.test.tsx
@@ -1,0 +1,158 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Node from './Node';
+
+const LONG_LABEL = 'Alexandria Montgomery-Fitzgerald von Habsburg III';
+
+function mockLabelOverflow() {
+  Object.defineProperty(HTMLSpanElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => 60,
+  });
+  Object.defineProperty(HTMLSpanElement.prototype, 'clientHeight', {
+    configurable: true,
+    get: () => 40,
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(HTMLSpanElement.prototype, 'scrollHeight');
+  Reflect.deleteProperty(HTMLSpanElement.prototype, 'clientHeight');
+});
+
+const getPopup = () =>
+  document.querySelector('[data-base-ui-portal] [data-open][role="tooltip"]');
+
+describe('Node truncation tooltip', () => {
+  it('does not show a tooltip for an untruncated label', async () => {
+    const user = userEvent.setup();
+    render(<Node label="Ash" onClick={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Ash' });
+    await user.tab();
+    expect(button).toHaveFocus();
+
+    await act(async () => {});
+    expect(button).not.toHaveAttribute('data-popup-open');
+    expect(getPopup()).toBeNull();
+  });
+
+  it('shows the complete label on keyboard focus when truncated', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: LONG_LABEL });
+    await user.tab();
+    expect(button).toHaveFocus();
+    await waitFor(() => expect(button).toHaveAttribute('data-popup-open'));
+
+    const popup = getPopup();
+    expect(popup).toHaveAttribute('aria-hidden', 'true');
+    expect(popup).toHaveTextContent(LONG_LABEL);
+  });
+
+  it('keeps the full label as the accessible name while the tooltip is open', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} />);
+
+    await user.tab();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: LONG_LABEL })).toHaveAttribute(
+        'data-popup-open',
+      ),
+    );
+  });
+
+  it('never opens from a click alone', async () => {
+    mockLabelOverflow();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: LONG_LABEL });
+    fireEvent.click(button);
+
+    await act(async () => {});
+    expect(button).not.toHaveAttribute('data-popup-open');
+  });
+
+  it('closes on pointerdown, stays suppressed while held, and recovers after release', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    const externalPointerDown = vi.fn((e: React.PointerEvent) =>
+      e.stopPropagation(),
+    );
+    render(
+      <>
+        <Node
+          label={LONG_LABEL}
+          onClick={vi.fn()}
+          onPointerDown={externalPointerDown}
+        />
+        <button type="button">other</button>
+      </>,
+    );
+
+    const button = screen.getByRole('button', { name: LONG_LABEL });
+    await user.tab();
+    await waitFor(() => expect(button).toHaveAttribute('data-popup-open'));
+
+    fireEvent.pointerDown(button);
+    expect(externalPointerDown).toHaveBeenCalledOnce();
+    await waitFor(() => expect(button).not.toHaveAttribute('data-popup-open'));
+
+    await act(async () => {});
+    expect(button).not.toHaveAttribute('data-popup-open');
+
+    fireEvent.pointerUp(window);
+    await user.tab();
+    await user.tab({ shift: true });
+    await waitFor(() => expect(button).toHaveAttribute('data-popup-open'));
+  });
+
+  it('is suppressed during a keyboard drag (aria-grabbed)', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} aria-grabbed={true} />);
+
+    const button = screen.getByRole('button', { name: LONG_LABEL });
+    await user.tab();
+    expect(button).toHaveFocus();
+
+    await act(async () => {});
+    expect(button).not.toHaveAttribute('data-popup-open');
+  });
+
+  it('is suppressed by the tooltipDisabled escape hatch', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} tooltipDisabled />);
+
+    const button = screen.getByRole('button', { name: LONG_LABEL });
+    await user.tab();
+    expect(button).toHaveFocus();
+
+    await act(async () => {});
+    expect(button).not.toHaveAttribute('data-popup-open');
+  });
+
+  it('renders the tooltip popup with pointer events disabled', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    render(<Node label={LONG_LABEL} onClick={vi.fn()} />);
+
+    await user.tab();
+    await waitFor(() => expect(getPopup()).not.toBeNull());
+
+    const positioner = getPopup()!.closest('[data-base-ui-portal] > *');
+    expect(positioner).toHaveClass('pointer-events-none!');
+  });
+});

--- a/packages/fresco-ui/src/Node.tooltip.test.tsx
+++ b/packages/fresco-ui/src/Node.tooltip.test.tsx
@@ -155,4 +155,17 @@ describe('Node truncation tooltip', () => {
     const positioner = getPopup()!.closest('[data-base-ui-portal] > *');
     expect(positioner).toHaveClass('pointer-events-none!');
   });
+
+  it('wraps labels with no break opportunities inside the popup', async () => {
+    mockLabelOverflow();
+    const user = userEvent.setup();
+    const unbrokenLabel = 'a'.repeat(48);
+    render(<Node label={unbrokenLabel} onClick={vi.fn()} />);
+
+    await user.tab();
+    await waitFor(() => expect(getPopup()).not.toBeNull());
+
+    expect(getPopup()).toHaveTextContent(unbrokenLabel);
+    expect(getPopup()).toHaveClass('wrap-anywhere', 'whitespace-pre-line');
+  });
 });

--- a/packages/fresco-ui/src/Node.tsx
+++ b/packages/fresco-ui/src/Node.tsx
@@ -7,12 +7,15 @@ import {
   type CSSProperties,
   type Ref,
   useEffect,
+  useState,
 } from 'react';
 import { useMergeRefs } from 'react-best-merge-refs';
 
+import { useIsTruncated } from './hooks/useIsTruncated';
 import { useNodeInteractions } from './hooks/useNodeInteractions';
 import usePrevious from './hooks/usePrevious';
 import { useSafeAnimate } from './hooks/useSafeAnimate';
+import { Tooltip, TooltipContent, TooltipTrigger } from './Tooltip';
 import { composeEventHandlers } from './utils/composeEventHandlers';
 import { cva, type VariantProps } from './utils/cva';
 
@@ -154,6 +157,8 @@ type UINodeProps = {
   onPointerDown?: (e: React.PointerEvent) => void;
   /** External pointer up handler (composes with internal behavior) */
   onPointerUp?: (e: React.PointerEvent) => void;
+  /** Suppresses the truncated-label tooltip */
+  tooltipDisabled?: boolean;
   ref?: Ref<HTMLButtonElement>;
 } & VariantProps<typeof nodeVariants> &
   Omit<
@@ -202,6 +207,8 @@ export default function Node(props: UINodeProps) {
     className,
     style,
     ref,
+    id,
+    tooltipDisabled = false,
     onPointerDown: externalPointerDown,
     onPointerUp: externalPointerUp,
     onKeyDown: externalKeyDown,
@@ -232,6 +239,33 @@ export default function Node(props: UINodeProps) {
     hasClickHandler,
     disabled,
   });
+
+  const { ref: labelRef, isTruncated } = useIsTruncated<HTMLSpanElement>({
+    watch: label,
+    enabled: !loading,
+  });
+
+  const [pointerHeld, setPointerHeld] = useState(false);
+  useEffect(() => {
+    if (!pointerHeld) return undefined;
+    const release = () => setPointerHeld(false);
+    window.addEventListener('pointerup', release);
+    window.addEventListener('pointercancel', release);
+    return () => {
+      window.removeEventListener('pointerup', release);
+      window.removeEventListener('pointercancel', release);
+    };
+  }, [pointerHeld]);
+
+  const grabbed = buttonProps['aria-grabbed'];
+  const tooltipEnabled =
+    isTruncated &&
+    !loading &&
+    !disabled &&
+    !pointerHeld &&
+    grabbed !== true &&
+    grabbed !== 'true' &&
+    !tooltipDisabled;
 
   // Scope for selected state animation (box-shadow on the shape layer, so
   // the ring follows the shape's border radius and rotation)
@@ -283,11 +317,15 @@ export default function Node(props: UINodeProps) {
   const nodeContent = (
     <>
       {loading && <Loader2 className="animate-spin" size={24} />}
-      {!loading && <span className={labelVariants({ size })}>{label}</span>}
+      {!loading && (
+        <span ref={labelRef} className={labelVariants({ size })}>
+          {label}
+        </span>
+      )}
     </>
   );
 
-  return (
+  const button = (
     <motion.button
       {...buttonProps}
       tabIndex={
@@ -295,6 +333,7 @@ export default function Node(props: UINodeProps) {
       }
       ref={useMergeRefs({ ref, scope })}
       type="button"
+      id={id}
       disabled={disabled}
       aria-label={ariaLabel ?? label}
       aria-pressed={
@@ -316,8 +355,8 @@ export default function Node(props: UINodeProps) {
       data-node-linking={linking || undefined}
       data-node-highlighted={highlighted || undefined}
       onPointerDown={composeEventHandlers(
-        nodeProps.onPointerDown,
-        externalPointerDown,
+        composeEventHandlers(nodeProps.onPointerDown, externalPointerDown),
+        () => setPointerHeld(true),
       )}
       onPointerUp={composeEventHandlers(
         nodeProps.onPointerUp,
@@ -370,5 +409,14 @@ export default function Node(props: UINodeProps) {
         {props.children}
       </span>
     </motion.button>
+  );
+
+  return (
+    <Tooltip disabled={!tooltipEnabled}>
+      <TooltipTrigger id={id} render={button} />
+      <TooltipContent aria-hidden="true" pointerEvents="none">
+        {label}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/fresco-ui/src/Node.tsx
+++ b/packages/fresco-ui/src/Node.tsx
@@ -414,7 +414,11 @@ export default function Node(props: UINodeProps) {
   return (
     <Tooltip disabled={!tooltipEnabled}>
       <TooltipTrigger id={id} render={button} />
-      <TooltipContent aria-hidden="true" pointerEvents="none">
+      <TooltipContent
+        aria-hidden="true"
+        pointerEvents="none"
+        className="wrap-anywhere whitespace-pre-line"
+      >
         {label}
       </TooltipContent>
     </Tooltip>

--- a/packages/fresco-ui/src/Tooltip.test.tsx
+++ b/packages/fresco-ui/src/Tooltip.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from './Tooltip';
+
+async function openTooltip(pointerEvents?: 'auto' | 'none') {
+  const user = userEvent.setup();
+  render(
+    <Tooltip>
+      <TooltipTrigger render={<button type="button">Trigger</button>} />
+      <TooltipContent aria-hidden="true" pointerEvents={pointerEvents}>
+        Tooltip text
+      </TooltipContent>
+    </Tooltip>,
+  );
+
+  const trigger = screen.getByRole('button', { name: 'Trigger' });
+  await user.tab();
+  expect(trigger).toHaveFocus();
+  await waitFor(() => expect(trigger).toHaveAttribute('data-popup-open'));
+
+  const popup = document.querySelector(
+    '[data-base-ui-portal] [data-open][aria-hidden="true"]',
+  );
+  expect(popup).toBeInTheDocument();
+  // The Positioner is the portaled root the container's
+  // [&>*]:pointer-events-auto rule targets.
+  return popup!.closest('[data-base-ui-portal] > *')!;
+}
+
+describe('Tooltip', () => {
+  it('leaves the positioner interactive by default', async () => {
+    const positioner = await openTooltip();
+    expect(positioner).not.toHaveClass('pointer-events-none!');
+  });
+
+  it('disables pointer events on the positioner when pointerEvents="none"', async () => {
+    const positioner = await openTooltip('none');
+    expect(positioner).toHaveClass('pointer-events-none!');
+  });
+});

--- a/packages/fresco-ui/src/Tooltip.tsx
+++ b/packages/fresco-ui/src/Tooltip.tsx
@@ -27,6 +27,7 @@ type TooltipContentProps = Omit<
   side?: 'top' | 'bottom' | 'left' | 'right';
   align?: 'start' | 'center' | 'end';
   showArrow?: boolean;
+  pointerEvents?: 'auto' | 'none';
   children?: React.ReactNode;
 };
 
@@ -41,6 +42,7 @@ const TooltipContent = React.forwardRef<
       side = 'top',
       align = 'center',
       showArrow = true,
+      pointerEvents = 'auto',
       children,
       ...props
     },
@@ -54,6 +56,7 @@ const TooltipContent = React.forwardRef<
           sideOffset={sideOffset}
           align={align}
           arrowPadding={POPOVER_ARROW_PADDING}
+          className={cx(pointerEvents === 'none' && 'pointer-events-none!')}
         >
           <AnimatePresence>
             <BaseTooltip.Popup

--- a/packages/fresco-ui/src/hooks/__tests__/useIsTruncated.test.tsx
+++ b/packages/fresco-ui/src/hooks/__tests__/useIsTruncated.test.tsx
@@ -1,0 +1,160 @@
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useIsTruncated } from '../useIsTruncated';
+
+function Probe({
+  watch,
+  enabled,
+  scrollHeight,
+  clientHeight,
+}: {
+  watch?: string;
+  enabled?: boolean;
+  scrollHeight: number;
+  clientHeight: number;
+}) {
+  const { ref, isTruncated } = useIsTruncated<HTMLSpanElement>({
+    watch,
+    enabled,
+  });
+  return (
+    <span
+      data-testid="probe"
+      data-truncated={isTruncated}
+      ref={(el) => {
+        if (el) {
+          Object.defineProperty(el, 'scrollHeight', {
+            configurable: true,
+            get: () => scrollHeight,
+          });
+          Object.defineProperty(el, 'clientHeight', {
+            configurable: true,
+            get: () => clientHeight,
+          });
+        }
+        ref.current = el;
+      }}
+    >
+      {watch}
+    </span>
+  );
+}
+
+const isTruncated = () =>
+  screen.getByTestId('probe').getAttribute('data-truncated') === 'true';
+
+describe('useIsTruncated', () => {
+  it('measures on mount and reports overflow beyond the 1px tolerance', () => {
+    render(<Probe watch="long label" scrollHeight={60} clientHeight={40} />);
+    expect(isTruncated()).toBe(true);
+  });
+
+  it('reports false when content fits', () => {
+    render(<Probe watch="short" scrollHeight={40} clientHeight={40} />);
+    expect(isTruncated()).toBe(false);
+  });
+
+  it('treats sub-pixel overflow as not truncated', () => {
+    render(<Probe watch="edge" scrollHeight={41} clientHeight={40} />);
+    expect(isTruncated()).toBe(false);
+  });
+
+  it('re-measures when watch changes', () => {
+    const { rerender } = render(
+      <Probe watch="short" scrollHeight={40} clientHeight={40} />,
+    );
+    expect(isTruncated()).toBe(false);
+
+    rerender(
+      <Probe watch="a much longer label" scrollHeight={60} clientHeight={40} />,
+    );
+    expect(isTruncated()).toBe(true);
+  });
+
+  it('re-measures when the ResizeObserver fires', async () => {
+    let scrollHeight = 40;
+    function ResizingProbe() {
+      const { ref, isTruncated: truncated } = useIsTruncated<HTMLSpanElement>();
+      return (
+        <span
+          data-testid="probe"
+          data-truncated={truncated}
+          ref={(el) => {
+            if (el) {
+              Object.defineProperty(el, 'scrollHeight', {
+                configurable: true,
+                get: () => scrollHeight,
+              });
+              Object.defineProperty(el, 'clientHeight', {
+                configurable: true,
+                get: () => 40,
+              });
+            }
+            ref.current = el;
+          }}
+        />
+      );
+    }
+
+    render(<ResizingProbe />);
+    expect(isTruncated()).toBe(false);
+
+    scrollHeight = 60;
+    await act(async () => {});
+    expect(isTruncated()).toBe(true);
+  });
+
+  it('returns false when disabled, even if the element overflows', () => {
+    render(
+      <Probe
+        watch="long"
+        enabled={false}
+        scrollHeight={60}
+        clientHeight={40}
+      />,
+    );
+    expect(isTruncated()).toBe(false);
+  });
+
+  it('resets when enabled flips to false', () => {
+    const { rerender } = render(
+      <Probe watch="long" enabled scrollHeight={60} clientHeight={40} />,
+    );
+    expect(isTruncated()).toBe(true);
+
+    rerender(
+      <Probe
+        watch="long"
+        enabled={false}
+        scrollHeight={60}
+        clientHeight={40}
+      />,
+    );
+    expect(isTruncated()).toBe(false);
+  });
+
+  it('does not set state after unmount from the fonts-ready path', async () => {
+    let resolveFonts: () => void = () => undefined;
+    const ready = new Promise<void>((resolve) => {
+      resolveFonts = resolve;
+    });
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { ready },
+    });
+
+    try {
+      const { unmount } = render(
+        <Probe watch="long" scrollHeight={60} clientHeight={40} />,
+      );
+      unmount();
+      await act(async () => {
+        resolveFonts();
+        await ready;
+      });
+    } finally {
+      Reflect.deleteProperty(document, 'fonts');
+    }
+  });
+});

--- a/packages/fresco-ui/src/hooks/useIsTruncated.ts
+++ b/packages/fresco-ui/src/hooks/useIsTruncated.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { type RefObject, useLayoutEffect, useRef, useState } from 'react';
+
+type UseIsTruncatedOptions = {
+  /** Primitive whose change forces a re-measure (e.g. the rendered text). */
+  watch?: string | number | boolean | null;
+  /** Skip measurement entirely (e.g. while the element isn't rendered). */
+  enabled?: boolean;
+};
+
+/** Reports whether the element carrying `ref` visually truncates its content */
+export function useIsTruncated<T extends HTMLElement = HTMLElement>({
+  watch,
+  enabled = true,
+}: UseIsTruncatedOptions = {}): {
+  ref: RefObject<T | null>;
+  isTruncated: boolean;
+} {
+  const ref = useRef<T>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) {
+      setIsTruncated(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const measure = () => {
+      if (cancelled) return;
+      const next =
+        el.scrollHeight - el.clientHeight > 1 ||
+        el.scrollWidth - el.clientWidth > 1;
+      setIsTruncated((prev) => (prev === next ? prev : next));
+    };
+
+    measure();
+
+    void document.fonts?.ready.then(measure);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [watch, enabled]);
+
+  return { ref, isTruncated };
+}


### PR DESCRIPTION
Addresses issue #1151.

## Handwritten Feature summary:

Node labels are wrapped and clipped by line-clamp to preserve size when the label is long. `aria-label` preserves the full accessible name, but there was no visual way to see the full truncated label. This PR adds a visual disclosure mechanism via a Fresco UI tooltip on mouse hover and keyboard focus.

All changes are in `fresco-ui`. Adds a new `useIsTruncated` hook, connects tooltip into `Node` which has an optional `tooltipDisabled` prop, and a new `pointerEvents` prop on `TooltipContent`. Key aspects of the behavior, and how it's implemented:

**Detects actual visual truncation after layout rather than inferring it from character count.**
Accomplished by implementing a fresco-ui hook `useIsTruncated`, which uses `scrollHeight`/`clientHeight` (line-clamp) and `scrollWidth`/`clientWidth` (unbreakable strings) to measure actual truncation. The initial measurement runs in `useLayoutEffect` so that it happens before paint. Remeasure happens on a couple triggers: the `watch` option (content changed), a `ResizeObserver`, and `document.fonts.ready`.

**Renders the existing Node button as the tooltip trigger without adding a layout wrapper.**
Base UI's `render` prop takes an element and merges the trigger into it using `React.cloneElement`, and does not create a wrapper. This is accomplished by changing the way the `Node` returns. Instead of returning the Node directly, we assign it to a `button` const and pass it to `TooltipTrigger` like this:

```tsx
const button = (
  <motion.button {...buttonProps} …>…</motion.button>
);

return (
  <Tooltip disabled={!tooltipEnabled}>
    <TooltipTrigger id={id} render={button} />
    <TooltipContent …>{label}</TooltipContent>
  </Tooltip>
);
```

**Doesn't open the tooltip from pointerdown, click, or touch events:**
Accomplished by setting a `tooltipEnabled` const which is used in `Tooltip`'s `disabled` prop. Protects against each case.

Tap, selection, drag initiation, dragging, and dropping behave exactly as before. Demonstrated through test coverage and stories. PR adds a changeset and typecheck & knip pass.

<img width="481" height="292" alt="Screenshot 2026-08-07 at 1 52 35 PM" src="https://github.com/user-attachments/assets/c1ed9047-ec66-412b-b511-e66cddb60290" />

---
Claude summary:

## Changes

- `src/hooks/useIsTruncated.ts` — new hook (exported as `@codaco/fresco-ui/hooks/useIsTruncated`, added to both the source and `publishConfig` export maps).
- `src/Node.tsx` — labels get a measured ref; the button becomes a `TooltipTrigger` `render` target; `tooltipEnabled` gates on truncation and on `loading`, `disabled`, a held pointer, `aria-grabbed`, and the new `tooltipDisabled` prop. The pointer-held flag is released from `window` `pointerup`/`pointercancel` so a release outside the node still clears it.
- `src/Tooltip.tsx` — `pointerEvents` prop on `TooltipContent`; `"none"` applies `pointer-events-none!` to the positioner so the popup can never intercept a drag or a hover.
- Stories and tests for all of the above, plus a changeset (`@codaco/fresco-ui` minor).

## Test plan

- [x] `pnpm --filter @codaco/fresco-ui test` — 1035 tests pass, including 18 new ones:
  - `Node.tooltip.test.tsx` — no tooltip when the label fits; opens on keyboard focus when truncated; full label stays the accessible name while open; never opens from a click alone; closes on pointerdown and stays suppressed until release; suppressed during a keyboard drag (`aria-grabbed`); suppressed by `tooltipDisabled`; popup renders with pointer events disabled.
  - `useIsTruncated.test.tsx` — measures on mount, 1px tolerance, re-measures on `watch` change and `ResizeObserver`, honours `enabled`, and no state update after unmount from the `document.fonts.ready` path.
  - `Tooltip.test.tsx` — positioner interactive by default, non-interactive with `pointerEvents="none"`.
- [x] `pnpm typecheck` and `pnpm knip` pass.
- [x] No E2E visual baselines regenerated: the rendered tree at rest is unchanged (Base UI's `render` prop clones the existing button rather than wrapping it, and the popup is portalled only while open), and no Playwright spec hovers or focuses a node.
