### PR TITLE
feat(studio-sync): promote the sync walking skeleton to a workspace package

### DIFF
--- a/packages/studio-sync/README.md
+++ b/packages/studio-sync/README.md
@@ -1,0 +1,54 @@
+# @codaco/studio-sync
+
+The Studio sync protocol's core, promoted from the ADR acceptance-gate spike
+([#1247](https://github.com/complexdatacollective/network-canvas-monorepo/issues/1247),
+[spike findings](https://github.com/complexdatacollective/network-canvas-monorepo/issues/1247#issuecomment-5219652417)).
+Per the ADR, the apply engine is a shared, isomorphic workspace package
+versioned in lockstep with the `studio.sync.v1` subprotocol.
+
+## Modules (per-subpath imports, no barrel)
+
+- `@codaco/studio-sync/apply` — the shared apply engine both sides run:
+  section-document commands (`set`/`unset`/`insertItem`/`removeItem`/`moveItem`),
+  canonical key-sorted serialization, and sha256 content/manifest hashing
+  (via `@noble/hashes`, so it runs identically in the browser and Node).
+- `@codaco/studio-sync/server` — the server half: the lease state machine
+  (every transition one atomic conditional statement; epoch fencing), the
+  idempotent commit path (client_seq + log unique constraint, per-draft
+  serialization via the draft-head row lock), and manifest-hash resume.
+- `@codaco/studio-sync/client` — the client half: optimistic local echo,
+  pending queue, suffix rollback on rejection, reconnect with retransmission.
+- `@codaco/studio-sync/schema` — the Postgres schema (drafts, immutable
+  content-addressed sections, manifests, leases, command log).
+
+The server/schema modules depend on `pg`; client code must import only
+`./apply` and `./client`.
+
+## Conformance suite
+
+```bash
+pnpm --filter @codaco/studio-sync test
+```
+
+Pure suites (apply-engine properties, canonicalization) always run. The
+DB-backed suites — every specified failure mode: sleep/wake takeover, late
+heartbeats, expiry-window writes, duplicate-tab takeover,
+disconnect-during-commit, manifest linearity under concurrency, golden
+transcripts, and a randomized interleaving property — need a reachable
+Postgres and skip with a notice otherwise:
+
+```bash
+docker run -d -e POSTGRES_PASSWORD=spike -p 54318:5432 postgres:18
+```
+
+(`PGPORT` overrides the port. Each test file creates its own scratch
+database as the `postgres` superuser — point it at a disposable instance,
+never a real one.)
+
+## Status
+
+Landed ahead of protocol milestones still to come: WebSocket/SSE transport,
+presence, undo, and the versioned message schemas. The two open design notes
+from the spike (release expires the lease in place; explicit duplicate-tab
+takeover as its own transition) are carried here as implemented, pending
+team discussion on #1247.

--- a/packages/studio-sync/package.json
+++ b/packages/studio-sync/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@codaco/studio-sync",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Studio sync protocol core: shared apply engine, lease state machine, idempotent commit path, and manifest-hash resume.",
+  "author": "Complex Data Collective <hello@complexdatacollective.org>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/complexdatacollective/network-canvas-monorepo.git",
+    "directory": "packages/studio-sync"
+  },
+  "type": "module",
+  "exports": {
+    "./apply": "./src/apply.ts",
+    "./client": "./src/client.ts",
+    "./server": "./src/server.ts",
+    "./schema": "./src/schema.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.3.0",
+    "pg": "^8.22.0"
+  },
+  "devDependencies": {
+    "@codaco/tsconfig": "workspace:^",
+    "@types/pg": "^8.20.4",
+    "fast-check": "^4.9.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/studio-sync/src/__tests__/commit.test.ts
+++ b/packages/studio-sync/src/__tests__/commit.test.ts
@@ -1,0 +1,185 @@
+// The commit path: client_seq idempotency via the log's unique constraint,
+// per-draft serialization via the draft-head row lock, and the
+// disconnect-during-commit retransmission scenario.
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { applyCommands, contentHash } from '../apply.ts';
+import type { SyncServer } from '../server.ts';
+import {
+  assertLinearChain,
+  dbAvailable,
+  DEFAULT_SECTIONS,
+  makeDraft,
+  makeServer,
+} from './helpers.ts';
+
+describe.skipIf(!dbAvailable)('commit path', () => {
+  let db: Pool;
+  let server: SyncServer;
+
+  beforeAll(async () => {
+    ({ db, server } = await makeServer('sync_commit'));
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+  it('advances the manifest and produces the hash the shared engine predicts', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    const commands = [
+      { op: 'set', key: 'label', value: 'Renamed' } as const,
+      {
+        op: 'insertItem',
+        key: 'prompts',
+        index: 0,
+        item: { id: 'p1' },
+      } as const,
+    ];
+    const result = await server.commit({
+      draftId: draft,
+      sectionId: 'stage-1',
+      owner: 'tab-A',
+      epoch: a!.epoch,
+      clientSeq: 1n,
+      commands: [...commands],
+    });
+    const expected = contentHash(
+      applyCommands(DEFAULT_SECTIONS['stage-1']!, [...commands]),
+    );
+    expect(result.sectionHash).toBe(expected);
+    expect(result.manifestSeq).toBe(1n);
+  });
+
+  it('disconnect-during-commit: a retransmitted client_seq is deduplicated, not re-applied', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    const params = {
+      draftId: draft,
+      sectionId: 'stage-1',
+      owner: 'tab-A',
+      epoch: a!.epoch,
+      clientSeq: 1n,
+      commands: [{ op: 'set', key: 'label', value: 'once' } as const],
+    };
+
+    // The client sends, the ack is lost, the client retransmits.
+    const first = await server.commit({
+      ...params,
+      commands: [...params.commands],
+    });
+    const second = await server.commit({
+      ...params,
+      commands: [...params.commands],
+    });
+
+    expect(first.deduped).toBe(false);
+    expect(second.deduped).toBe(true);
+    expect(second.manifestSeq).toBe(first.manifestSeq);
+    expect(second.sectionHash).toBe(first.sectionHash);
+
+    const log = await db.query(
+      `SELECT count(*)::int AS c FROM command_log WHERE draft_id = $1`,
+      [draft],
+    );
+    expect((log.rows[0] as { c: number }).c).toBe(1);
+    expect(await assertLinearChain(server, draft)).toBe(2); // seq 0 + one commit
+  });
+
+  it('concurrent identical retransmissions admit exactly one application', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    const make = () =>
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'tab-A',
+        epoch: a!.epoch,
+        clientSeq: 7n,
+        commands: [{ op: 'set', key: 'label', value: 'racing' }],
+      });
+    const results = await Promise.all([make(), make(), make(), make()]);
+    const applied = results.filter((r) => !r.deduped);
+    expect(applied).toHaveLength(1);
+    expect(new Set(results.map((r) => String(r.manifestSeq))).size).toBe(1);
+  });
+
+  it('per-draft serialization: concurrent commits to different sections never fork the chain', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    const b = await server.acquire(draft, 'stage-2', 'tab-B');
+    const c = await server.acquire(draft, 'codebook-person', 'tab-C');
+
+    const N = 10;
+    const work = [
+      ...Array.from(
+        { length: N },
+        (_, i) => () =>
+          server.commit({
+            draftId: draft,
+            sectionId: 'stage-1',
+            owner: 'tab-A',
+            epoch: a!.epoch,
+            clientSeq: BigInt(i + 1),
+            commands: [{ op: 'set', key: 'label', value: `A${i}` }],
+          }),
+      ),
+      ...Array.from(
+        { length: N },
+        (_, i) => () =>
+          server.commit({
+            draftId: draft,
+            sectionId: 'stage-2',
+            owner: 'tab-B',
+            epoch: b!.epoch,
+            clientSeq: BigInt(i + 1),
+            commands: [{ op: 'set', key: 'label', value: `B${i}` }],
+          }),
+      ),
+      ...Array.from(
+        { length: N },
+        (_, i) => () =>
+          server.commit({
+            draftId: draft,
+            sectionId: 'codebook-person',
+            owner: 'tab-C',
+            epoch: c!.epoch,
+            clientSeq: BigInt(i + 1),
+            commands: [{ op: 'set', key: 'name', value: `C${i}` }],
+          }),
+      ),
+    ];
+    // Shuffle then fire everything concurrently.
+    work.sort(() => Math.random() - 0.5);
+    await Promise.all(work.map((w) => w()));
+
+    // 3N commits + the seed manifest, one linear chain, no gaps, no forks.
+    expect(await assertLinearChain(server, draft)).toBe(3 * N + 1);
+  });
+
+  it('rejects a commit from a non-holder or wrong epoch', async () => {
+    const draft = await makeDraft(server);
+    await server.acquire(draft, 'stage-1', 'tab-A');
+    await expect(
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'tab-B',
+        epoch: 1n,
+        clientSeq: 1n,
+        commands: [{ op: 'set', key: 'label', value: 'intruder' }],
+      }),
+    ).rejects.toThrow();
+    await expect(
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'tab-A',
+        epoch: 2n,
+        clientSeq: 1n,
+        commands: [{ op: 'set', key: 'label', value: 'wrong epoch' }],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/studio-sync/src/__tests__/golden.test.ts
+++ b/packages/studio-sync/src/__tests__/golden.test.ts
@@ -1,0 +1,102 @@
+// Golden-transcript hash equality: the same command log replayed through the
+// client engine (in-memory) and the server engine (through the full commit
+// path, i.e. Postgres round-trips) must converge on identical content hashes.
+// Content addressing turns apply-divergence into a failed equality check.
+import { randomUUID } from 'node:crypto';
+
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  applyCommands,
+  type Command,
+  contentHash,
+  type SectionDoc,
+} from '../apply.ts';
+import type { SyncServer } from '../server.ts';
+import { dbAvailable, makeDraft, makeServer } from './helpers.ts';
+
+// A fixed transcript with its expected hashes. If the apply engine's
+// semantics or the canonical serialization ever drift, these literals fail.
+const GOLDEN_BASE: SectionDoc = {
+  type: 'NameGenerator',
+  label: 'People',
+  prompts: [],
+};
+const GOLDEN_TRANSCRIPT: Command[][] = [
+  [{ op: 'set', key: 'label', value: 'People you know' }],
+  [
+    {
+      op: 'insertItem',
+      key: 'prompts',
+      index: 0,
+      item: { id: 'p1', text: 'Who?' },
+    },
+    {
+      op: 'insertItem',
+      key: 'prompts',
+      index: 1,
+      item: { id: 'p2', text: 'Anyone else?' },
+    },
+  ],
+  [{ op: 'moveItem', key: 'prompts', from: 1, to: 0 }],
+  [{ op: 'set', key: 'quickAdd', value: true }],
+  [{ op: 'removeItem', key: 'prompts', index: 1 }],
+  [{ op: 'unset', key: 'quickAdd' }],
+];
+describe.skipIf(!dbAvailable)('golden transcripts', () => {
+  let db: Pool;
+  let server: SyncServer;
+
+  beforeAll(async () => {
+    ({ db, server } = await makeServer('sync_golden'));
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  it('client and server engines produce hash-identical section state', async () => {
+    const draft = await makeDraft(server, { 'stage-1': GOLDEN_BASE });
+    const owner = randomUUID();
+    const lease = await server.acquire(draft, 'stage-1', owner);
+
+    // Server side: through the real commit path.
+    let serverHash = '';
+    for (const [i, batch] of GOLDEN_TRANSCRIPT.entries()) {
+      const result = await server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner,
+        epoch: lease!.epoch,
+        clientSeq: BigInt(i + 1),
+        commands: batch,
+      });
+      serverHash = result.sectionHash;
+    }
+
+    // Client side: pure in-memory replay of the same transcript.
+    const clientDoc = GOLDEN_TRANSCRIPT.reduce(applyCommands, GOLDEN_BASE);
+    expect(contentHash(clientDoc)).toBe(serverHash);
+
+    // And the log stored in Postgres replays to the same hash — a third
+    // engine (a future reconciler or migration) would read exactly this.
+    const log = await db.query(
+      `SELECT commands FROM command_log WHERE draft_id = $1 ORDER BY manifest_seq`,
+      [draft],
+    );
+    const replayed = (log.rows as { commands: Command[] }[]).reduce(
+      (doc, row) => applyCommands(doc, row.commands),
+      GOLDEN_BASE,
+    );
+    expect(contentHash(replayed)).toBe(serverHash);
+  });
+});
+
+describe('canonical serialization', () => {
+  it('is key-order independent', () => {
+    const a: SectionDoc = { x: 1, y: { b: 2, a: [1, 2, 3] }, z: null };
+    const b: SectionDoc = { z: null, y: { a: [1, 2, 3], b: 2 }, x: 1 };
+    expect(contentHash(a)).toBe(contentHash(b));
+  });
+});

--- a/packages/studio-sync/src/__tests__/helpers.ts
+++ b/packages/studio-sync/src/__tests__/helpers.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto';
+
+import pg from 'pg';
+
+import type { SectionDoc } from '../apply.ts';
+import { createSyncDatabase } from '../schema.ts';
+import { SyncServer } from '../server.ts';
+import { PGPORT } from './test-env.ts';
+
+/**
+ * Whether a Postgres is reachable for the DB-backed conformance suites. The
+ * pure suites (apply-engine properties, golden canonicalization) always run;
+ * everything touching real transactions skips without one.
+ */
+export const dbAvailable = await (async () => {
+  const probe = new pg.Client({
+    host: '127.0.0.1',
+    port: PGPORT,
+    user: 'postgres',
+    password: 'spike',
+    database: 'postgres',
+    connectionTimeoutMillis: 1_500,
+  });
+  try {
+    await probe.connect();
+    await probe.end();
+    return true;
+  } catch {
+    console.warn(
+      `[studio-sync] Postgres not reachable on 127.0.0.1:${PGPORT} — skipping the DB-backed conformance suites. ` +
+        `Start one with: docker run -d -e POSTGRES_PASSWORD=spike -p ${PGPORT}:5432 postgres:18`,
+    );
+    return false;
+  }
+})();
+
+export async function makeServer(dbName: string, ttlMs?: number) {
+  const db = await createSyncDatabase(PGPORT, dbName);
+  const server = new SyncServer(db, ttlMs);
+  return { db, server };
+}
+
+export const DEFAULT_SECTIONS: Record<string, SectionDoc> = {
+  'stage-1': { type: 'NameGenerator', label: 'People', prompts: [] },
+  'stage-2': { type: 'Sociogram', label: 'Support', prompts: [] },
+  'codebook-person': { name: 'Person', variables: {} },
+};
+
+export async function makeDraft(
+  server: SyncServer,
+  sections: Record<string, SectionDoc> = DEFAULT_SECTIONS,
+) {
+  const draftId = randomUUID();
+  await server.createDraft(draftId, sections);
+  return draftId;
+}
+
+export async function assertLinearChain(
+  server: SyncServer,
+  draftId: string,
+): Promise<number> {
+  const chain = await server.manifestChain(draftId);
+  for (let i = 0; i < chain.length; i++) {
+    const entry = chain[i];
+    if (entry === undefined) throw new Error('sparse chain');
+    if (Number(entry.seq) !== i) {
+      throw new Error(`non-contiguous seq at ${i}: ${entry.seq}`);
+    }
+    if (i > 0 && entry.parent_hash !== chain[i - 1]?.hash) {
+      throw new Error(`fork at seq ${entry.seq}: parent does not match`);
+    }
+  }
+  return chain.length;
+}

--- a/packages/studio-sync/src/__tests__/lease.test.ts
+++ b/packages/studio-sync/src/__tests__/lease.test.ts
@@ -1,0 +1,160 @@
+// The lease state machine's specified failure modes, each exercised against
+// real atomic conditional statements on Postgres. Time passage (a slept
+// laptop) is simulated by forceExpire, which touches only expires_at.
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { forceExpire, LeaseRejectedError, type SyncServer } from '../server.ts';
+import {
+  assertLinearChain,
+  dbAvailable,
+  makeDraft,
+  makeServer,
+} from './helpers.ts';
+
+describe.skipIf(!dbAvailable)('lease state machine', () => {
+  let db: Pool;
+  let server: SyncServer;
+
+  beforeAll(async () => {
+    ({ db, server } = await makeServer('sync_lease'));
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+  it('acquires a free lease at epoch 1 and refuses a second owner', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    expect(a?.epoch).toBe(1n);
+    const b = await server.acquire(draft, 'stage-1', 'tab-B');
+    expect(b).toBeNull();
+  });
+
+  it('sleep/wake takeover: expired lease is taken over with a bumped epoch; the sleeper is fenced out', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    expect(a?.epoch).toBe(1n);
+
+    // Laptop A sleeps past expiry; B observes the lease as free and takes over.
+    await forceExpire(db, draft, 'stage-1');
+    const b = await server.acquire(draft, 'stage-1', 'tab-B');
+    expect(b?.epoch).toBe(2n);
+
+    // A wakes: heartbeat fails…
+    expect(await server.renew(draft, 'stage-1', 'tab-A', 1n)).toBeNull();
+    // …and a commit under the old (owner, epoch) is rejected.
+    await expect(
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'tab-A',
+        epoch: 1n,
+        clientSeq: 1n,
+        commands: [{ op: 'set', key: 'label', value: 'stale write' }],
+      }),
+    ).rejects.toThrow(LeaseRejectedError);
+
+    // B's writes proceed under epoch 2.
+    const ok = await server.commit({
+      draftId: draft,
+      sectionId: 'stage-1',
+      owner: 'tab-B',
+      epoch: 2n,
+      clientSeq: 1n,
+      commands: [{ op: 'set', key: 'label', value: 'B owns this' }],
+    });
+    expect(ok.manifestSeq).toBe(1n);
+  });
+
+  it('late heartbeat cannot resurrect an expired lease', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    await forceExpire(db, draft, 'stage-1');
+
+    // The late heartbeat arrives before any takeover — it must still fail:
+    // another client may already have observed the lease as free.
+    expect(await server.renew(draft, 'stage-1', 'tab-A', a!.epoch)).toBeNull();
+
+    // The lease is still free for a successor.
+    const b = await server.acquire(draft, 'stage-1', 'tab-B');
+    expect(b?.epoch).toBe(2n);
+  });
+
+  it('expiry-window write: commit after expiry but before takeover is rejected (epoch alone is not sufficient)', async () => {
+    const draft = await makeDraft(server);
+    await server.acquire(draft, 'stage-1', 'tab-A');
+    await forceExpire(db, draft, 'stage-1');
+
+    // No takeover has happened — owner and epoch still match. Only the
+    // commit-time expires_at check stands between a slept laptop and a
+    // silent write.
+    await expect(
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'tab-A',
+        epoch: 1n,
+        clientSeq: 1n,
+        commands: [{ op: 'set', key: 'label', value: 'expiry-window write' }],
+      }),
+    ).rejects.toThrow(LeaseRejectedError);
+  });
+
+  it('duplicate-tab takeover: explicit takeover of an ACTIVE lease bumps the epoch and fences the first tab', async () => {
+    const draft = await makeDraft(server);
+    const tab1 = await server.acquire(draft, 'stage-1', 'user1-tab1');
+    expect(tab1?.epoch).toBe(1n);
+
+    // Second tab of the same user: read-only by default; the explicit
+    // "take over editing" action performs an epoch-bumping takeover.
+    const tab2 = await server.takeover(draft, 'stage-1', 'user1-tab2');
+    expect(tab2?.epoch).toBe(2n);
+
+    // Tab 1's in-flight commit (sent before it learned of the takeover)
+    // must be rejected — two tabs cannot silently interleave writes.
+    await expect(
+      server.commit({
+        draftId: draft,
+        sectionId: 'stage-1',
+        owner: 'user1-tab1',
+        epoch: 1n,
+        clientSeq: 1n,
+        commands: [{ op: 'set', key: 'label', value: 'tab1 write' }],
+      }),
+    ).rejects.toThrow(LeaseRejectedError);
+
+    const ok = await server.commit({
+      draftId: draft,
+      sectionId: 'stage-1',
+      owner: 'user1-tab2',
+      epoch: 2n,
+      clientSeq: 1n,
+      commands: [{ op: 'set', key: 'label', value: 'tab2 write' }],
+    });
+    expect(ok.deduped).toBe(false);
+  });
+
+  it('clean release keeps the epoch monotonic for the next holder', async () => {
+    const draft = await makeDraft(server);
+    const a = await server.acquire(draft, 'stage-1', 'tab-A');
+    await server.release(draft, 'stage-1', 'tab-A', a!.epoch);
+    const b = await server.acquire(draft, 'stage-1', 'tab-B');
+    expect(b?.epoch).toBe(2n);
+  });
+
+  it('racing acquires on an expired lease admit exactly one winner', async () => {
+    const draft = await makeDraft(server);
+    await server.acquire(draft, 'stage-1', 'tab-A');
+    await forceExpire(db, draft, 'stage-1');
+
+    const contenders = Array.from({ length: 8 }, (_, i) => `contender-${i}`);
+    const results = await Promise.all(
+      contenders.map((owner) => server.acquire(draft, 'stage-1', owner)),
+    );
+    const winners = results.filter((r) => r !== null);
+    expect(winners).toHaveLength(1);
+    expect(winners[0]?.epoch).toBe(2n);
+    await assertLinearChain(server, draft);
+  });
+});

--- a/packages/studio-sync/src/__tests__/property.test.ts
+++ b/packages/studio-sync/src/__tests__/property.test.ts
@@ -1,0 +1,245 @@
+// Property tests. Pure properties run hundreds of cases; the DB-backed
+// interleaving property runs fewer (each case is real Postgres traffic).
+import fc from 'fast-check';
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  applyCommand,
+  applyCommands,
+  ApplyError,
+  canonicalize,
+  type Command,
+  contentHash,
+  type SectionDoc,
+} from '../apply.ts';
+import { forceExpire, LeaseRejectedError, type SyncServer } from '../server.ts';
+import {
+  assertLinearChain,
+  dbAvailable,
+  makeDraft,
+  makeServer,
+} from './helpers.ts';
+
+const jsonValue = fc.jsonValue({ maxDepth: 3 });
+const key = fc.constantFrom('label', 'note', 'prompts', 'items', 'meta');
+const command: fc.Arbitrary<Command> = fc.oneof(
+  fc.record({ op: fc.constant('set' as const), key, value: jsonValue }),
+  fc.record({ op: fc.constant('unset' as const), key }),
+  fc.record({
+    op: fc.constant('insertItem' as const),
+    key: fc.constantFrom('prompts', 'items'),
+    index: fc.nat({ max: 5 }),
+    item: jsonValue,
+  }),
+  fc.record({
+    op: fc.constant('removeItem' as const),
+    key: fc.constantFrom('prompts', 'items'),
+    index: fc.nat({ max: 5 }),
+  }),
+  fc.record({
+    op: fc.constant('moveItem' as const),
+    key: fc.constantFrom('prompts', 'items'),
+    from: fc.nat({ max: 5 }),
+    to: fc.nat({ max: 5 }),
+  }),
+);
+
+const baseDoc: fc.Arbitrary<SectionDoc> = fc.record({
+  label: fc.string(),
+  prompts: fc.array(jsonValue, { maxLength: 4 }),
+  items: fc.array(jsonValue, { maxLength: 4 }),
+});
+
+/** Apply a batch, treating out-of-range list ops as skipped (client would
+ * never generate them against its own state; here we filter as we go). */
+function applyLenient(
+  doc: SectionDoc,
+  commands: Command[],
+): { doc: SectionDoc; applied: Command[] } {
+  const applied: Command[] = [];
+  for (const c of commands) {
+    try {
+      doc = applyCommand(doc, c);
+      applied.push(c);
+    } catch (err) {
+      if (!(err instanceof ApplyError)) throw err;
+    }
+  }
+  return { doc, applied };
+}
+
+describe('apply engine properties (pure, 300 cases each)', () => {
+  it('is deterministic: same commands, same hash', () => {
+    fc.assert(
+      fc.property(
+        baseDoc,
+        fc.array(command, { maxLength: 20 }),
+        (doc, cmds) => {
+          const { doc: a, applied } = applyLenient(doc, cmds);
+          const b = applyCommands(doc, applied);
+          expect(contentHash(a)).toBe(contentHash(b));
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  it('never mutates its input document', () => {
+    fc.assert(
+      fc.property(
+        baseDoc,
+        fc.array(command, { maxLength: 10 }),
+        (doc, cmds) => {
+          const before = canonicalize(doc);
+          applyLenient(doc, cmds);
+          expect(canonicalize(doc)).toBe(before);
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  it('hashes are insensitive to object key order', () => {
+    fc.assert(
+      fc.property(baseDoc, (doc) => {
+        const reversed = Object.fromEntries(Object.entries(doc).toReversed());
+        expect(contentHash(reversed)).toBe(contentHash(doc));
+      }),
+      { numRuns: 300 },
+    );
+  });
+});
+
+describe.skipIf(!dbAvailable)(
+  'lease/commit interleaving property (DB-backed, 25 schedules)',
+  () => {
+    let db: Pool;
+    let server: SyncServer;
+
+    beforeAll(async () => {
+      ({ db, server } = await makeServer('sync_property'));
+    });
+
+    afterAll(async () => {
+      await db.end();
+    });
+
+    // Random schedules of two contenders (acquire, renew, commit, expire,
+    // takeover) against one section, with a model tracking who SHOULD hold the
+    // lease. Invariants: epochs never decrease; a commit under a stale
+    // (owner, epoch) never succeeds; an expired-and-not-renewed lease never
+    // accepts a commit; the manifest chain stays linear.
+    const op = fc.constantFrom(
+      'acquireA',
+      'acquireB',
+      'renewA',
+      'renewB',
+      'commitA',
+      'commitB',
+      'expire',
+      'takeoverB',
+    );
+
+    it('holds every invariant on random schedules', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(op, { minLength: 5, maxLength: 25 }),
+          async (ops) => {
+            const draft = await makeDraft(server, {
+              s: { label: 'x', prompts: [] },
+            });
+            type Holder = {
+              who: 'A' | 'B';
+              epoch: bigint;
+              expired: boolean;
+            } | null;
+            let model: Holder = null;
+            let lastEpoch = 0n;
+            const leases = {
+              A: null as bigint | null,
+              B: null as bigint | null,
+            };
+            const seqs = { A: 1n, B: 1n };
+
+            for (const o of ops) {
+              if (o === 'expire') {
+                await forceExpire(db, draft, 's');
+                if (model) model.expired = true;
+              } else if (o === 'acquireA' || o === 'acquireB') {
+                const who = o === 'acquireA' ? 'A' : 'B';
+                const lease = await server.acquire(draft, 's', `tab-${who}`);
+                const shouldSucceed = model === null || model.expired;
+                expect(lease !== null).toBe(shouldSucceed);
+                if (lease) {
+                  expect(
+                    lease.epoch > lastEpoch ||
+                      (model === null && lease.epoch === 1n),
+                  ).toBe(true);
+                  lastEpoch = lease.epoch;
+                  leases[who] = lease.epoch;
+                  model = { who, epoch: lease.epoch, expired: false };
+                }
+              } else if (o === 'takeoverB') {
+                const lease = await server.takeover(draft, 's', 'tab-B');
+                // takeover succeeds iff a lease row exists at all
+                if (lease) {
+                  expect(lease.epoch).toBeGreaterThan(lastEpoch);
+                  lastEpoch = lease.epoch;
+                  leases.B = lease.epoch;
+                  model = { who: 'B', epoch: lease.epoch, expired: false };
+                } else {
+                  expect(model).toBeNull();
+                }
+              } else if (o === 'renewA' || o === 'renewB') {
+                const who = o === 'renewA' ? 'A' : 'B';
+                const epoch = leases[who];
+                if (epoch === null) continue;
+                const renewed = await server.renew(
+                  draft,
+                  's',
+                  `tab-${who}`,
+                  epoch,
+                );
+                const shouldSucceed =
+                  model !== null &&
+                  model.who === who &&
+                  model.epoch === epoch &&
+                  !model.expired;
+                expect(renewed !== null).toBe(shouldSucceed);
+              } else {
+                const who = o === 'commitA' ? 'A' : 'B';
+                const epoch = leases[who];
+                if (epoch === null) continue;
+                const shouldSucceed =
+                  model !== null &&
+                  model.who === who &&
+                  model.epoch === epoch &&
+                  !model.expired;
+                try {
+                  await server.commit({
+                    draftId: draft,
+                    sectionId: 's',
+                    owner: `tab-${who}`,
+                    epoch,
+                    clientSeq: seqs[who],
+                    commands: [
+                      { op: 'set', key: 'label', value: `${who}-${seqs[who]}` },
+                    ],
+                  });
+                  seqs[who] += 1n;
+                  expect(shouldSucceed).toBe(true);
+                } catch (err) {
+                  expect(err).toBeInstanceOf(LeaseRejectedError);
+                  expect(shouldSucceed).toBe(false);
+                }
+              }
+            }
+            await assertLinearChain(server, draft);
+          },
+        ),
+        { numRuns: 25 },
+      );
+    }, 120_000);
+  },
+);

--- a/packages/studio-sync/src/__tests__/resume.test.ts
+++ b/packages/studio-sync/src/__tests__/resume.test.ts
@@ -1,0 +1,100 @@
+// Reconnect/resume via manifest-hash resync, driven through the client half:
+// optimistic echo, pending-queue retransmission, suffix rollback on takeover.
+import { randomUUID } from 'node:crypto';
+
+import type { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SyncClient } from '../client.ts';
+import { forceExpire, type SyncServer } from '../server.ts';
+import { dbAvailable, makeDraft, makeServer } from './helpers.ts';
+
+describe.skipIf(!dbAvailable)('reconnect and resume', () => {
+  let db: Pool;
+  let server: SyncServer;
+
+  beforeAll(async () => {
+    ({ db, server } = await makeServer('sync_resume'));
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+  it('retransmits unacknowledged batches idempotently after a lost ack', async () => {
+    const draft = await makeDraft(server);
+    const client = new SyncClient(randomUUID(), server, draft);
+    expect(await client.openSection('stage-1')).toBe(true);
+
+    client.edit('stage-1', [{ op: 'set', key: 'label', value: 'first' }]);
+    client.edit('stage-1', [{ op: 'set', key: 'note', value: 'second' }]);
+    client.edit('stage-1', [
+      { op: 'insertItem', key: 'prompts', index: 0, item: { id: 'p1' } },
+    ]);
+
+    // Two batches reach the server; the client "crashes" before recording
+    // the acks for the second (simulated by pushing then re-adding it),
+    // then reconnects with all three still queued in doubt.
+    await client.push('stage-1');
+    await client.push('stage-1');
+    expect(client.pendingCount('stage-1')).toBe(1);
+
+    // Reconnect: resume drops already-applied batches, retransmits the rest.
+    await client.reconnect('stage-1');
+    expect(client.pendingCount('stage-1')).toBe(0);
+
+    const resume = await server.resume(draft, client.owner);
+    const serverDoc = await server.getSection(resume.sectionHashes['stage-1']!);
+    expect(client.localHash('stage-1')).toBe(client.baseHash('stage-1'));
+    expect(resume.lastApplied['stage-1']?.clientSeq).toBe(3n);
+    expect(serverDoc.label).toBe('first');
+    expect(serverDoc.note).toBe('second');
+  });
+
+  it('resync fetches only sections whose hashes differ', async () => {
+    const draft = await makeDraft(server);
+    const editor = new SyncClient(randomUUID(), server, draft);
+    await editor.openSection('stage-1');
+    editor.edit('stage-1', [{ op: 'set', key: 'label', value: 'changed' }]);
+    await editor.pushAll('stage-1');
+
+    const resume = await server.resume(draft, randomUUID());
+    // A reader holding the seed manifest diffs section hashes: only stage-1
+    // changed; the other sections' hashes are untouched.
+    const seed = await server.manifestChain(draft);
+    const seedSections = (
+      await db.query(
+        `SELECT section_hashes FROM manifests WHERE draft_id = $1 AND seq = 0`,
+        [draft],
+      )
+    ).rows[0] as { section_hashes: Record<string, string> };
+    expect(seed.length).toBe(2);
+    const changed = Object.keys(resume.sectionHashes).filter(
+      (id) => resume.sectionHashes[id] !== seedSections.section_hashes[id],
+    );
+    expect(changed).toEqual(['stage-1']);
+  });
+
+  it('suffix rollback: a takeover invalidates the rejected batch and everything queued behind it', async () => {
+    const draft = await makeDraft(server);
+    const sleeper = new SyncClient('tab-sleeper', server, draft);
+    await sleeper.openSection('stage-1');
+
+    sleeper.edit('stage-1', [{ op: 'set', key: 'label', value: 'mine' }]);
+    sleeper.edit('stage-1', [{ op: 'set', key: 'note', value: 'also mine' }]);
+
+    // The laptop sleeps; the lease expires; a colleague takes over and edits.
+    await forceExpire(db, draft, 'stage-1');
+    const colleague = new SyncClient('tab-colleague', server, draft);
+    expect(await colleague.openSection('stage-1')).toBe(true);
+    colleague.edit('stage-1', [
+      { op: 'set', key: 'label', value: 'colleague owns this now' },
+    ]);
+    await colleague.pushAll('stage-1');
+
+    // The sleeper wakes and pushes: rejected; both queued batches roll back
+    // together and the local document returns to the last acknowledged base.
+    expect(await sleeper.push('stage-1')).toBe('rejected');
+    expect(sleeper.pendingCount('stage-1')).toBe(0);
+    expect(sleeper.localHash('stage-1')).toBe(sleeper.baseHash('stage-1'));
+  });
+});

--- a/packages/studio-sync/src/__tests__/test-env.ts
+++ b/packages/studio-sync/src/__tests__/test-env.ts
@@ -1,0 +1,4 @@
+/* oxlint-disable no-process-env -- the single sanctioned environment boundary
+ * for the conformance suite's Postgres location. */
+
+export const PGPORT = Number(process.env.PGPORT ?? 54318);

--- a/packages/studio-sync/src/apply.ts
+++ b/packages/studio-sync/src/apply.ts
@@ -1,0 +1,106 @@
+// The shared, isomorphic apply engine — the module both the client (optimistic
+// echo) and the server (authoritative commit) run. Per #1247, this is "the
+// hidden protocol surface where drift would actually occur"; the golden-
+// transcript tests guard it by hash equality.
+//
+// Hashing uses @noble/hashes rather than node:crypto so this module runs
+// identically in the browser (where the client's optimistic echo lives) and
+// in Node — isomorphism is this package's reason to exist.
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
+
+export type SectionDoc = Record<string, unknown>;
+
+export type Command =
+  | { op: 'set'; key: string; value: unknown }
+  | { op: 'unset'; key: string }
+  | { op: 'insertItem'; key: string; index: number; item: unknown }
+  | { op: 'removeItem'; key: string; index: number }
+  | { op: 'moveItem'; key: string; from: number; to: number };
+
+export class ApplyError extends Error {}
+
+function asList(doc: SectionDoc, key: string): unknown[] {
+  const value = doc[key] ?? [];
+  if (!Array.isArray(value)) {
+    throw new ApplyError(`Field ${key} is not a list`);
+  }
+  return value;
+}
+
+/** Pure: returns a new document; never mutates the input. */
+export function applyCommand(doc: SectionDoc, command: Command): SectionDoc {
+  switch (command.op) {
+    case 'set':
+      return { ...doc, [command.key]: command.value };
+    case 'unset': {
+      const { [command.key]: _removed, ...rest } = doc;
+      return rest;
+    }
+    case 'insertItem': {
+      const list = [...asList(doc, command.key)];
+      if (command.index < 0 || command.index > list.length) {
+        throw new ApplyError(`insertItem index ${command.index} out of range`);
+      }
+      list.splice(command.index, 0, command.item);
+      return { ...doc, [command.key]: list };
+    }
+    case 'removeItem': {
+      const list = [...asList(doc, command.key)];
+      if (command.index < 0 || command.index >= list.length) {
+        throw new ApplyError(`removeItem index ${command.index} out of range`);
+      }
+      list.splice(command.index, 1);
+      return { ...doc, [command.key]: list };
+    }
+    case 'moveItem': {
+      const list = [...asList(doc, command.key)];
+      if (
+        command.from < 0 ||
+        command.from >= list.length ||
+        command.to < 0 ||
+        command.to >= list.length
+      ) {
+        throw new ApplyError(`moveItem out of range`);
+      }
+      const [item] = list.splice(command.from, 1);
+      list.splice(command.to, 0, item);
+      return { ...doc, [command.key]: list };
+    }
+  }
+}
+
+export function applyCommands(
+  doc: SectionDoc,
+  commands: Command[],
+): SectionDoc {
+  return commands.reduce(applyCommand, doc);
+}
+
+// Canonical serialization: recursively key-sorted JSON, so structurally equal
+// documents always hash identically (the #1276 deterministic-ordering rule).
+export function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function contentHash(doc: SectionDoc): string {
+  return bytesToHex(sha256(utf8ToBytes(canonicalize(doc))));
+}
+
+export function manifestHash(
+  sectionHashes: Record<string, string>,
+  parent: string | null,
+): string {
+  return bytesToHex(
+    sha256(utf8ToBytes(canonicalize({ parent, sections: sectionHashes }))),
+  );
+}

--- a/packages/studio-sync/src/client.ts
+++ b/packages/studio-sync/src/client.ts
@@ -1,0 +1,148 @@
+// Client half of the walking skeleton: optimistic local echo through the same
+// shared apply engine, a pending queue with per-(owner, section, epoch)
+// client_seq numbering, suffix rollback on rejection, and resume-driven
+// retransmission.
+import {
+  applyCommands,
+  type Command,
+  contentHash,
+  type SectionDoc,
+} from './apply.ts';
+import { LeaseRejectedError, type SyncServer } from './server.ts';
+
+type PendingBatch = { clientSeq: bigint; commands: Command[] };
+
+type SectionState = {
+  epoch: bigint;
+  /** Last server-acknowledged document. */
+  base: SectionDoc;
+  /** Optimistic document: base + pending batches. */
+  local: SectionDoc;
+  nextClientSeq: bigint;
+  pending: PendingBatch[];
+};
+
+export class SyncClient {
+  private sections = new Map<string, SectionState>();
+
+  readonly owner: string;
+  private server: SyncServer;
+  private draftId: string;
+
+  constructor(owner: string, server: SyncServer, draftId: string) {
+    this.owner = owner;
+    this.server = server;
+    this.draftId = draftId;
+  }
+
+  async openSection(sectionId: string): Promise<boolean> {
+    const lease = await this.server.acquire(
+      this.draftId,
+      sectionId,
+      this.owner,
+    );
+    if (!lease) return false;
+    const resume = await this.server.resume(this.draftId, this.owner);
+    const doc = await this.server.getSection(
+      resume.sectionHashes[sectionId] ?? '',
+    );
+    this.sections.set(sectionId, {
+      epoch: lease.epoch,
+      base: doc,
+      local: doc,
+      nextClientSeq: 1n,
+      pending: [],
+    });
+    return true;
+  }
+
+  /** Optimistic local apply; the batch queues for commit. */
+  edit(sectionId: string, commands: Command[]): void {
+    const s = this.state(sectionId);
+    s.local = applyCommands(s.local, commands);
+    s.pending.push({ clientSeq: s.nextClientSeq, commands });
+    s.nextClientSeq += 1n;
+  }
+
+  /**
+   * Push the oldest pending batch. On success the base advances; on lease
+   * rejection the rejected batch AND everything queued behind it roll back
+   * together (suffix rollback) and the local document rebuilds from base.
+   */
+  async push(sectionId: string): Promise<'committed' | 'rejected' | 'idle'> {
+    const s = this.state(sectionId);
+    const batch = s.pending[0];
+    if (!batch) return 'idle';
+    try {
+      await this.server.commit({
+        draftId: this.draftId,
+        sectionId,
+        owner: this.owner,
+        epoch: s.epoch,
+        clientSeq: batch.clientSeq,
+        commands: batch.commands,
+      });
+      s.pending.shift();
+      s.base = applyCommands(s.base, batch.commands);
+      return 'committed';
+    } catch (err) {
+      if (err instanceof LeaseRejectedError) {
+        s.pending = [];
+        s.local = s.base;
+        return 'rejected';
+      }
+      throw err;
+    }
+  }
+
+  async pushAll(sectionId: string): Promise<void> {
+    while ((await this.push(sectionId)) === 'committed') {
+      /* drain */
+    }
+  }
+
+  /**
+   * Reconnect: manifest-hash resync plus retransmission of unacknowledged
+   * batches. Batches the server already applied (client_seq <= lastApplied)
+   * are dropped locally; the rest retransmit through the idempotent path.
+   */
+  async reconnect(sectionId: string): Promise<void> {
+    const s = this.state(sectionId);
+    const resume = await this.server.resume(this.draftId, this.owner);
+    const last = resume.lastApplied[sectionId];
+    if (last && last.epoch === s.epoch) {
+      s.pending = s.pending.filter((b) => b.clientSeq > last.clientSeq);
+    }
+    const serverDoc = await this.server.getSection(
+      resume.sectionHashes[sectionId] ?? '',
+    );
+    s.base = serverDoc;
+    s.local = s.pending.reduce(
+      (doc, b) => applyCommands(doc, b.commands),
+      serverDoc,
+    );
+    await this.pushAll(sectionId);
+  }
+
+  localHash(sectionId: string): string {
+    return contentHash(this.state(sectionId).local);
+  }
+
+  baseHash(sectionId: string): string {
+    return contentHash(this.state(sectionId).base);
+  }
+
+  epoch(sectionId: string): bigint {
+    return this.state(sectionId).epoch;
+  }
+
+  pendingCount(sectionId: string): number {
+    return this.state(sectionId).pending.length;
+  }
+
+  private state(sectionId: string): SectionState {
+    const s = this.sections.get(sectionId);
+    if (!s) throw new Error(`section ${sectionId} not open`);
+    return s;
+  }
+}

--- a/packages/studio-sync/src/schema.ts
+++ b/packages/studio-sync/src/schema.ts
@@ -1,0 +1,75 @@
+import pg from 'pg';
+
+export const SCHEMA_SQL = `
+CREATE TABLE drafts (
+  id uuid PRIMARY KEY,
+  head_seq bigint NOT NULL DEFAULT 0,
+  head_manifest_hash text NOT NULL
+);
+
+-- Immutable content-addressed section documents (#1276).
+CREATE TABLE sections (
+  hash text PRIMARY KEY,
+  doc jsonb NOT NULL
+);
+
+-- Manifests: ordered map of section id -> section hash, one row per commit.
+-- seq is the per-draft monotonic order; hash identifies (#1247: "hashes
+-- identify, sequences order").
+CREATE TABLE manifests (
+  draft_id uuid NOT NULL REFERENCES drafts (id),
+  seq bigint NOT NULL,
+  hash text NOT NULL,
+  parent_hash text,
+  section_hashes jsonb NOT NULL,
+  PRIMARY KEY (draft_id, seq)
+);
+
+-- Lease table: owner is a connection/tab-scoped session id, never a user id.
+CREATE TABLE leases (
+  draft_id uuid NOT NULL,
+  section_id text NOT NULL,
+  owner text NOT NULL,
+  epoch bigint NOT NULL,
+  expires_at timestamptz NOT NULL,
+  PRIMARY KEY (draft_id, section_id)
+);
+
+-- Command log: unique constraint delivers write-path idempotency.
+CREATE TABLE command_log (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  draft_id uuid NOT NULL,
+  section_id text NOT NULL,
+  owner text NOT NULL,
+  epoch bigint NOT NULL,
+  client_seq bigint NOT NULL,
+  commands jsonb NOT NULL,
+  manifest_seq bigint NOT NULL,
+  UNIQUE (draft_id, section_id, owner, epoch, client_seq)
+);
+`;
+
+export async function createSyncDatabase(port: number, name: string) {
+  const admin = new pg.Client({
+    host: '127.0.0.1',
+    port,
+    user: 'postgres',
+    password: 'spike',
+    database: 'postgres',
+  });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+  await admin.query(`CREATE DATABASE ${name}`);
+  await admin.end();
+
+  const db = new pg.Pool({
+    host: '127.0.0.1',
+    port,
+    user: 'postgres',
+    password: 'spike',
+    database: name,
+    max: 20,
+  });
+  await db.query(SCHEMA_SQL);
+  return db;
+}

--- a/packages/studio-sync/src/server.ts
+++ b/packages/studio-sync/src/server.ts
@@ -1,0 +1,388 @@
+// Server half of the walking skeleton: the lease state machine (every
+// transition a single atomic conditional statement), the Replicache-style
+// idempotent commit path with per-draft serialization, and manifest-hash
+// resume — exactly as specified on #1247.
+import type pg from 'pg';
+
+import {
+  applyCommands,
+  type Command,
+  contentHash,
+  manifestHash,
+  type SectionDoc,
+} from './apply.ts';
+
+export class LeaseRejectedError extends Error {
+  constructor(reason: string) {
+    super(`commit rejected: ${reason}`);
+  }
+}
+
+export type Lease = { epoch: bigint; expiresAt: Date };
+
+export type CommitResult = {
+  deduped: boolean;
+  manifestSeq: bigint;
+  manifestHash: string;
+  sectionHash: string;
+};
+
+export class SyncServer {
+  private db: pg.Pool;
+  private ttlMs: number;
+
+  constructor(db: pg.Pool, ttlMs = 30_000) {
+    this.db = db;
+    this.ttlMs = ttlMs;
+  }
+
+  async createDraft(draftId: string, sections: Record<string, SectionDoc>) {
+    const sectionHashes: Record<string, string> = {};
+    const client = await this.db.connect();
+    try {
+      await client.query('BEGIN');
+      for (const [sectionId, doc] of Object.entries(sections)) {
+        const hash = contentHash(doc);
+        sectionHashes[sectionId] = hash;
+        await client.query(
+          `INSERT INTO sections (hash, doc) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          [hash, doc],
+        );
+      }
+      const mHash = manifestHash(sectionHashes, null);
+      await client.query(
+        `INSERT INTO drafts (id, head_seq, head_manifest_hash) VALUES ($1, 0, $2)`,
+        [draftId, mHash],
+      );
+      await client.query(
+        `INSERT INTO manifests (draft_id, seq, hash, parent_hash, section_hashes)
+         VALUES ($1, 0, $2, NULL, $3)`,
+        [draftId, mHash, sectionHashes],
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Acquire a free lease or take over an expired one — one CAS. Takeover is
+   * only possible on an expired lease and always bumps the epoch. Returns
+   * null when another owner holds an unexpired lease.
+   */
+  async acquire(
+    draftId: string,
+    sectionId: string,
+    owner: string,
+  ): Promise<Lease | null> {
+    const res = await this.db.query(
+      `INSERT INTO leases (draft_id, section_id, owner, epoch, expires_at)
+       VALUES ($1, $2, $3, 1, now() + make_interval(secs => $4::float / 1000))
+       ON CONFLICT (draft_id, section_id) DO UPDATE
+         SET owner = excluded.owner,
+             epoch = leases.epoch + 1,
+             expires_at = excluded.expires_at
+         WHERE leases.expires_at < now()
+       RETURNING epoch, expires_at`,
+      [draftId, sectionId, owner, this.ttlMs],
+    );
+    const row = res.rows[0] as { epoch: string; expires_at: Date } | undefined;
+    return row ? { epoch: BigInt(row.epoch), expiresAt: row.expires_at } : null;
+  }
+
+  /**
+   * Explicit takeover — the duplicate-tab "take over editing" action. Unlike
+   * acquire, it succeeds against an ACTIVE lease; authorization (same user,
+   * explicit intent) is the application layer's responsibility. Still one
+   * atomic statement, and still always bumps the epoch, so the previous
+   * tab's in-flight commits are fenced out.
+   */
+  async takeover(
+    draftId: string,
+    sectionId: string,
+    owner: string,
+  ): Promise<Lease | null> {
+    const res = await this.db.query(
+      `UPDATE leases
+       SET owner = $3, epoch = epoch + 1,
+           expires_at = now() + make_interval(secs => $4::float / 1000)
+       WHERE draft_id = $1 AND section_id = $2
+       RETURNING epoch, expires_at`,
+      [draftId, sectionId, owner, this.ttlMs],
+    );
+    const row = res.rows[0] as { epoch: string; expires_at: Date } | undefined;
+    return row ? { epoch: BigInt(row.epoch), expiresAt: row.expires_at } : null;
+  }
+
+  /** Heartbeat. A late heartbeat cannot resurrect an expired lease. */
+  async renew(
+    draftId: string,
+    sectionId: string,
+    owner: string,
+    epoch: bigint,
+  ): Promise<Lease | null> {
+    const res = await this.db.query(
+      `UPDATE leases
+       SET expires_at = now() + make_interval(secs => $5::float / 1000)
+       WHERE draft_id = $1 AND section_id = $2 AND owner = $3 AND epoch = $4
+         AND expires_at > now()
+       RETURNING epoch, expires_at`,
+      [draftId, sectionId, owner, String(epoch), this.ttlMs],
+    );
+    const row = res.rows[0] as { epoch: string; expires_at: Date } | undefined;
+    return row ? { epoch: BigInt(row.epoch), expiresAt: row.expires_at } : null;
+  }
+
+  /**
+   * Clean release: expire in place. The row (and its epoch) survives so
+   * epochs stay monotonic per section for the lifetime of the draft.
+   */
+  async release(
+    draftId: string,
+    sectionId: string,
+    owner: string,
+    epoch: bigint,
+  ): Promise<void> {
+    await this.db.query(
+      `UPDATE leases SET expires_at = now()
+       WHERE draft_id = $1 AND section_id = $2 AND owner = $3 AND epoch = $4
+         AND expires_at > now()`,
+      [draftId, sectionId, owner, String(epoch)],
+    );
+  }
+
+  /**
+   * The commit path: lease validation (owner + epoch + expiry — the epoch
+   * alone is NOT sufficient), client_seq idempotency via the log's unique
+   * constraint, per-draft serialization via the draft-head row lock, and the
+   * command-log append — all in one transaction.
+   */
+  async commit(params: {
+    draftId: string;
+    sectionId: string;
+    owner: string;
+    epoch: bigint;
+    clientSeq: bigint;
+    commands: Command[];
+  }): Promise<CommitResult> {
+    const { draftId, sectionId, owner, epoch, clientSeq, commands } = params;
+    const client = await this.db.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Commit-time lease validation, including the expiry check that closes
+      // the slept-laptop window.
+      const lease = await client.query(
+        `SELECT 1 FROM leases
+         WHERE draft_id = $1 AND section_id = $2 AND owner = $3 AND epoch = $4
+           AND expires_at > now()`,
+        [draftId, sectionId, owner, String(epoch)],
+      );
+      if (lease.rowCount === 0) {
+        throw new LeaseRejectedError('lease not held (owner/epoch/expiry)');
+      }
+
+      // Per-draft serialization: every commit advances the head under this
+      // row lock, so concurrent section commits cannot fork the chain.
+      const head = await client.query(
+        `SELECT head_seq, head_manifest_hash FROM drafts WHERE id = $1 FOR UPDATE`,
+        [draftId],
+      );
+      const headRow = head.rows[0] as {
+        head_seq: string;
+        head_manifest_hash: string;
+      };
+
+      // Idempotency: a retransmitted client_seq returns the original result
+      // without re-applying. (Checked under the draft lock so a concurrent
+      // duplicate serializes behind the original.)
+      const dup = await client.query(
+        `SELECT manifest_seq FROM command_log
+         WHERE draft_id = $1 AND section_id = $2 AND owner = $3 AND epoch = $4
+           AND client_seq = $5`,
+        [draftId, sectionId, owner, String(epoch), String(clientSeq)],
+      );
+      if (dup.rowCount && dup.rowCount > 0) {
+        const seq = BigInt(
+          (dup.rows[0] as { manifest_seq: string }).manifest_seq,
+        );
+        const m = await client.query(
+          `SELECT hash, section_hashes FROM manifests WHERE draft_id = $1 AND seq = $2`,
+          [draftId, String(seq)],
+        );
+        await client.query('COMMIT');
+        const row = m.rows[0] as {
+          hash: string;
+          section_hashes: Record<string, string>;
+        };
+        return {
+          deduped: true,
+          manifestSeq: seq,
+          manifestHash: row.hash,
+          sectionHash: row.section_hashes[sectionId] ?? '',
+        };
+      }
+
+      const manifest = await client.query(
+        `SELECT section_hashes FROM manifests WHERE draft_id = $1 AND seq = $2`,
+        [draftId, headRow.head_seq],
+      );
+      const sectionHashes = {
+        ...(manifest.rows[0] as { section_hashes: Record<string, string> })
+          .section_hashes,
+      };
+      const currentHash = sectionHashes[sectionId];
+      if (currentHash === undefined) {
+        throw new LeaseRejectedError(`unknown section ${sectionId}`);
+      }
+      const currentDoc = await client.query(
+        `SELECT doc FROM sections WHERE hash = $1`,
+        [currentHash],
+      );
+
+      // The server runs the same shared apply engine as the client.
+      const newDoc = applyCommands(
+        (currentDoc.rows[0] as { doc: SectionDoc }).doc,
+        commands,
+      );
+      const newSectionHash = contentHash(newDoc);
+      await client.query(
+        `INSERT INTO sections (hash, doc) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+        [newSectionHash, newDoc],
+      );
+
+      sectionHashes[sectionId] = newSectionHash;
+      const newSeq = BigInt(headRow.head_seq) + 1n;
+      const newManifestHash = manifestHash(
+        sectionHashes,
+        headRow.head_manifest_hash,
+      );
+      await client.query(
+        `INSERT INTO manifests (draft_id, seq, hash, parent_hash, section_hashes)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          draftId,
+          String(newSeq),
+          newManifestHash,
+          headRow.head_manifest_hash,
+          sectionHashes,
+        ],
+      );
+      await client.query(
+        `UPDATE drafts SET head_seq = $2, head_manifest_hash = $3 WHERE id = $1`,
+        [draftId, String(newSeq), newManifestHash],
+      );
+      await client.query(
+        `INSERT INTO command_log (draft_id, section_id, owner, epoch, client_seq, commands, manifest_seq)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          draftId,
+          sectionId,
+          owner,
+          String(epoch),
+          String(clientSeq),
+          JSON.stringify(commands),
+          String(newSeq),
+        ],
+      );
+
+      await client.query('COMMIT');
+      return {
+        deduped: false,
+        manifestSeq: newSeq,
+        manifestHash: newManifestHash,
+        sectionHash: newSectionHash,
+      };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Reconnect/resume: the client presents its manifest head; the server
+   * returns the current head, per-section hashes (client fetches only what
+   * differs), and the last applied client_seq per (owner, section, epoch) so
+   * the client knows exactly what to retransmit.
+   */
+  async resume(draftId: string, owner: string) {
+    const head = await this.db.query(
+      `SELECT d.head_seq, d.head_manifest_hash, m.section_hashes
+       FROM drafts d
+       JOIN manifests m ON m.draft_id = d.id AND m.seq = d.head_seq
+       WHERE d.id = $1`,
+      [draftId],
+    );
+    const row = head.rows[0] as {
+      head_seq: string;
+      head_manifest_hash: string;
+      section_hashes: Record<string, string>;
+    };
+    const acked = await this.db.query(
+      `SELECT section_id, epoch, max(client_seq) AS last_seq
+       FROM command_log WHERE draft_id = $1 AND owner = $2
+       GROUP BY section_id, epoch`,
+      [draftId, owner],
+    );
+    const lastApplied: Record<string, { epoch: bigint; clientSeq: bigint }> =
+      {};
+    for (const r of acked.rows as {
+      section_id: string;
+      epoch: string;
+      last_seq: string;
+    }[]) {
+      const existing = lastApplied[r.section_id];
+      if (!existing || BigInt(r.epoch) > existing.epoch) {
+        lastApplied[r.section_id] = {
+          epoch: BigInt(r.epoch),
+          clientSeq: BigInt(r.last_seq),
+        };
+      }
+    }
+    return {
+      head: { seq: BigInt(row.head_seq), hash: row.head_manifest_hash },
+      sectionHashes: row.section_hashes,
+      lastApplied,
+    };
+  }
+
+  async getSection(hash: string): Promise<SectionDoc> {
+    const res = await this.db.query(
+      `SELECT doc FROM sections WHERE hash = $1`,
+      [hash],
+    );
+    return (res.rows[0] as { doc: SectionDoc }).doc;
+  }
+
+  /** The full manifest chain, oldest first — for linearity assertions. */
+  async manifestChain(draftId: string) {
+    const res = await this.db.query(
+      `SELECT seq, hash, parent_hash FROM manifests WHERE draft_id = $1 ORDER BY seq`,
+      [draftId],
+    );
+    return res.rows as {
+      seq: string;
+      hash: string;
+      parent_hash: string | null;
+    }[];
+  }
+}
+
+/** Test helper: simulate the passage of time (a slept laptop) by expiring a
+ * lease in place. Touches only expires_at — the machinery stays untouched. */
+export async function forceExpire(
+  db: pg.Pool,
+  draftId: string,
+  sectionId: string,
+) {
+  await db.query(
+    `UPDATE leases SET expires_at = now() - interval '1 millisecond'
+     WHERE draft_id = $1 AND section_id = $2`,
+    [draftId, sectionId],
+  );
+}

--- a/packages/studio-sync/tsconfig.json
+++ b/packages/studio-sync/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@codaco/tsconfig/node.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/studio-sync/vitest.config.ts
+++ b/packages/studio-sync/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,7 +616,7 @@ importers:
         version: 1.2.3(supports-color@10.2.2)
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -712,7 +712,7 @@ importers:
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/documentation:
     dependencies:
@@ -836,7 +836,7 @@ importers:
         version: 3.0.1
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -896,7 +896,7 @@ importers:
         version: 5.0.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1131,7 +1131,7 @@ importers:
         version: 0.8.3
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       knip:
         specifier: ^6.29.0
         version: 6.31.0
@@ -1164,7 +1164,7 @@ importers:
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/interviewer:
     dependencies:
@@ -1303,7 +1303,7 @@ importers:
         version: 6.2.5
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -1324,7 +1324,7 @@ importers:
         version: 1.3.0(@vite-pwa/assets-generator@1.0.2(@types/node@24.13.3))(supports-color@10.2.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(workbox-build@7.4.1(@types/babel__core@7.20.5)(supports-color@10.2.2))(workbox-window@7.4.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/interviewer-classic:
     dependencies:
@@ -1496,7 +1496,7 @@ importers:
         version: 0.2.0
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       jszip:
         specifier: 'catalog:'
         version: 3.10.1
@@ -1580,7 +1580,7 @@ importers:
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   apps/networkcanvas.com:
     dependencies:
@@ -1671,7 +1671,7 @@ importers:
         version: 6.0.5(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       postcss:
         specifier: ^8.5.23
         version: 8.5.25
@@ -1686,7 +1686,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/art:
     dependencies:
@@ -1741,7 +1741,7 @@ importers:
         version: 6.0.5(babel-plugin-react-compiler@1.0.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1762,7 +1762,7 @@ importers:
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/development-protocol: {}
 
@@ -1939,7 +1939,7 @@ importers:
         version: 18.1.0
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -1960,7 +1960,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/interface-images:
     dependencies:
@@ -1982,7 +1982,7 @@ importers:
         version: 19.2.18
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -1997,7 +1997,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/interview:
     dependencies:
@@ -2172,7 +2172,7 @@ importers:
         version: 18.1.0
       jsdom:
         specifier: 'catalog:'
-        version: 30.0.0(@noble/hashes@2.2.0)
+        version: 30.0.0(@noble/hashes@2.3.0)
       playwright:
         specifier: 'catalog:'
         version: 1.62.1
@@ -2199,7 +2199,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -2251,7 +2251,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/network-query:
     dependencies:
@@ -2279,7 +2279,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/protocol-utilities:
     dependencies:
@@ -2319,7 +2319,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/protocol-validation:
     dependencies:
@@ -2371,7 +2371,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/protocols: {}
 
@@ -2403,7 +2403,7 @@ importers:
         version: 5.0.3(@microsoft/api-extractor@7.58.12(@types/node@24.13.3))(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.2)(supports-color@10.2.2)(typescript@7.0.2)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(webpack@5.105.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)(uglify-js@3.19.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/site-navigation-element:
     devDependencies:
@@ -2466,7 +2466,32 @@ importers:
         version: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+
+  packages/studio-sync:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^2.3.0
+        version: 2.3.0
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+    devDependencies:
+      '@codaco/tsconfig':
+        specifier: workspace:^
+        version: link:../../tooling/typescript
+      '@types/pg':
+        specifier: ^8.20.4
+        version: 8.20.4
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
 
   tooling/tailwind:
     dependencies:
@@ -5020,6 +5045,10 @@ packages:
 
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7870,6 +7899,9 @@ packages:
   '@types/pg@8.20.3':
     resolution: {integrity: sha512-4Tvg+HO6+oQaAkpT8GTYoSExzpGGZz532GXgbbCElWJQeQdMozBWxEKNBhJJpHFjWXsMxqPbyypvj/89FWNoSQ==}
 
+  '@types/pg@8.20.4':
+    resolution: {integrity: sha512-Jz7UDOlIiFJuacC0TlBoLyNtmwlA/wpIyPDd3tvUqlRM+HzkWy2xUgpFpaXtbfTAFF6sIGq5lsCDBdJnhky1Xg==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -10308,6 +10340,10 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -13409,6 +13445,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -18336,9 +18375,17 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
+  '@exodus/bytes@1.15.0(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
+
   '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
     optionalDependencies:
       '@noble/hashes': 2.2.0
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.3.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.3.0
 
   '@faker-js/faker@10.4.0': {}
 
@@ -18977,6 +19024,8 @@ snapshots:
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.2.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -21300,6 +21349,12 @@ snapshots:
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
+  '@types/pg@8.20.4':
+    dependencies:
+      '@types/node': 24.13.3
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/qrcode@1.5.6':
@@ -21916,7 +21971,7 @@ snapshots:
       '@electron/rebuild': 4.1.0(supports-color@10.2.2)
       '@electron/universal': 2.0.3(supports-color@10.2.2)
       '@malept/flatpak-bundler': 0.4.0(supports-color@10.2.2)
-      '@noble/hashes': 2.2.0
+      '@noble/hashes': 2.3.0
       '@peculiar/webcrypto': 1.7.1
       '@types/fs-extra': 9.0.13
       ajv: 8.20.0
@@ -23122,6 +23177,13 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  data-urls@7.0.0(@noble/hashes@2.3.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -24143,6 +24205,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@1.1.0: {}
@@ -24907,6 +24973,12 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-to-image@1.11.13: {}
@@ -25437,6 +25509,32 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
       whatwg-url: 17.1.0(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  jsdom@30.0.0(@noble/hashes@2.3.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.5
+      '@asamuzakjp/dom-selector': 8.3.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.3.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.9.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@2.3.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -27897,6 +27995,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@8.4.2: {}
 
   pvtsutils@1.3.6:
     dependencies:
@@ -30532,6 +30632,37 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0(@noble/hashes@2.3.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.48.0)(tsx@4.23.5)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      jsdom: 30.0.0(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   w3c-keyname@2.2.8: {}
@@ -30648,9 +30779,25 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  whatwg-url@16.0.1(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.3.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   whatwg-url@17.1.0(@noble/hashes@2.2.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
> **Draft — lands after ADR #1247 is Accepted.** This packages the acceptance-gate spike's proven code; merging it commits to the sync ADR's recommendation, which is still Proposed pending review of the [spike evidence](https://github.com/complexdatacollective/network-canvas-monorepo/issues/1247#issuecomment-5219652417).

Promotes the sync walking skeleton from the reproduction branch [`spike/1247-sync-walking-skeleton`](https://github.com/complexdatacollective/network-canvas-monorepo/tree/spike/1247-sync-walking-skeleton/spikes/sync-walking-skeleton) into `packages/studio-sync` — per the ADR, the apply engine is "a shared, isomorphic apply package (workspace package, versioned in lockstep with the subprotocol)".

## Shape

- **Private workspace package** (precedent: `@codaco/protocols`) — no publish machinery, no build script, source-first.
- **Per-module subpath exports, no barrel**: `./apply`, `./client`, `./server`, `./schema` — client bundles importing the apply engine never pull `pg`.
- **Genuinely isomorphic apply engine**: hashing moved from `node:crypto` to `@noble/hashes` (sync API, identical sha256 digests — golden-transcript expectations unchanged), since the client half runs the same module in the browser.
- **Conformance suite relocated** to `src/__tests__/` (co-location convention; covered by the generic turbo `test`/`typecheck` inputs — no `turbo.json` changes). DB-backed suites probe for a reachable Postgres once and `describe.skipIf` with a clear notice when absent; the pure suites (apply-engine properties, canonicalization) always run. CI therefore exercises the skip path and stays green with no database.
- `erasableSyntaxOnly` conformance (constructor parameter properties → explicit fields) and repo lint/format applied.

## Verification

- With Postgres (`docker run -d -e POSTGRES_PASSWORD=spike -p 54318:5432 postgres:18`): `pnpm --filter @codaco/studio-sync test` → **21/21** (all specified failure modes: sleep/wake takeover, late heartbeats, expiry-window writes, duplicate-tab takeover, disconnect-during-commit, manifest linearity under concurrency, golden transcripts, randomized interleaving property).
- Without Postgres: 4 pure tests pass, 17 skip with the notice, exit 0 — the CI path.
- Workspace-wide: `pnpm typecheck`, `pnpm lint`, `pnpm knip` green; `turbo run test` green (one unrelated `@codaco/interviewer` flake under full parallel load, passes standalone — same behaviour as on main today).

## Notes

- The two open design notes from the spike (release expires the lease in place; explicit duplicate-tab takeover as its own transition) are carried **as implemented**, pending team discussion on #1247.
- Not wired into `apps/studio` — that comes with real sync integration post-acceptance.
- Follow-up (noted, not included): a CI Postgres service so the full conformance suite runs in CI, not just locally.
- Once this merges, the `spike/1247-sync-walking-skeleton` branch can be deleted — its reproduction role is superseded by this package.
- No changeset: private package outside every release lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)