### PR TITLE
Run affected E2E suites on feature PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,15 +5,11 @@ on:
     branches:
       - main
       - 'changeset-release/**'
-  # Merge groups publish zero-snapshot statuses at the commit that later lands
-  # on main. The subsequent main push must replace that skipped target with a
-  # real build for every project so future PR changesets have snapshots to use.
-  # Once the three `UI Tests: ...` contexts are required on main, every PR and
-  # merge-group SHA must receive them. Normal trusted PRs and merge groups use
-  # Chromatic's zero-snapshot `--skip` path below; release PRs receive the same
-  # contexts from their real release-branch push run.
+  # Normal trusted PRs receive zero-snapshot statuses from Chromatic's `--skip`
+  # path below; release PRs receive the same contexts from their real
+  # release-branch push run. Merge groups deliberately do no Chromatic work.
   pull_request:
-  merge_group:
+    branches: [main]
   # Dependabot and fork PR events cannot read Actions secrets. Wait for the
   # unprivileged CI run, then publish status-only Chromatic results from the
   # trusted default-branch workflow without checking out proposed code.
@@ -42,22 +38,21 @@ concurrency:
   # Main needs one completed target build for every merge commit, so give each
   # push its own group. Other event classes keep only the newest run for a ref;
   # release uploads remain isolated from status-only PR runs.
-  group: chromatic-${{ github.event_name }}-${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && github.sha) || github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.event.workflow_run.pull_requests[0].number || github.ref_name || github.run_id }}
+  group: chromatic-${{ github.event_name }}-${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && github.sha) || github.event.pull_request.head.ref || github.event.workflow_run.pull_requests[0].number || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   # GitHub required contexts apply to every PR targeting main, not only release
   # PRs. Emit all three external UI Test statuses without publishing snapshots
-  # for normal PRs and merge-group commits. `workflow_run` handles Dependabot
-  # and forks only after their unprivileged CI run, checks out trusted
-  # default-branch code, and never executes the proposed head. Generated release
-  # PRs are deliberately excluded: their push run below publishes real or
-  # lane-proven `--skip` results at the same head SHA.
+  # for normal PRs. `workflow_run` handles Dependabot and forks only after their
+  # unprivileged CI run, checks out trusted default-branch code, and never
+  # executes the proposed head. Generated release PRs are deliberately excluded:
+  # their push run below publishes real or lane-proven `--skip` results at the
+  # same head SHA.
   required-statuses:
     name: Required UI Test statuses
     if: >-
-      github.event_name == 'merge_group'
-      || (github.event_name == 'pull_request'
+      (github.event_name == 'pull_request'
       && github.actor != 'dependabot[bot]'
       && github.event.pull_request.head.repo.full_name == github.repository
       && !startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
@@ -73,7 +68,7 @@ jobs:
         with:
           # workflow_run defaults to the trusted default branch. No later step
           # checks out or evaluates the untrusted PR head.
-          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Fetch untrusted status commit without checking it out
@@ -107,8 +102,8 @@ jobs:
       - name: Publish passing UI Test statuses without snapshots
         if: steps.verify-head.outputs.current != 'false'
         env:
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.event.workflow_run.head_sha || github.sha }}
-          CHROMATIC_BRANCH: ${{ (github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label) || github.event.pull_request.head.ref || github.event.merge_group.head_ref || github.event.workflow_run.head_branch || github.ref_name }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
+          CHROMATIC_BRANCH: ${{ (github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.label) || github.event.pull_request.head.ref || github.event.workflow_run.head_branch || github.ref_name }}
           CHROMATIC_SLUG: ${{ github.repository }}
           FRESCO_UI_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_FRESCO_UI }}
           INTERVIEW_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN_INTERVIEW }}

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       force_run:
@@ -185,11 +187,14 @@ jobs:
   # Decides per suite whether E2E must run for this ref. Feature PRs select the
   # suites whose subject package or workspace dependency closure changed.
   # Release lanes select the suites whose subjects ship in their deploy, while
-  # release-PR refreshes and merge groups may reuse an equivalent earlier
-  # verdict. Every path and history guard fails closed; see
+  # release-PR refreshes may reuse an equivalent earlier verdict. Merge groups
+  # deliberately skip the policy and all E2E work. Every path and history guard
+  # fails closed; see
   # scripts/release-e2e-policy.mjs.
   e2e-policy:
-    if: github.event_name != 'push'
+    if: >-
+      github.event_name != 'merge_group'
+      && github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -202,8 +207,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           # Feature-PR selection, app-lane selection, and cross-branch
-          # equivalence all compare commits, so every non-push policy run needs
-          # full history.
+          # equivalence all compare commits, so every policy run needs full
+          # history.
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -215,17 +220,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           # On feature PRs, BASE_SHA and HEAD_SHA define the cumulative
           # merge-base diff. On release PRs, HEAD_SHA is also the branch tip
-          # equivalence reuse compares with prior validated runs. On merge
-          # groups it stays the group's head for release detection. HEAD_REPO
+          # equivalence reuse compares with prior validated runs. HEAD_REPO
           # guards reuse off for fork PRs.
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BENCHMARK_INTERVIEW_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.interview_e2e_benchmark == true }}
-          # Read-only, feeds both the PR-time and merge-queue equivalence
-          # lookups.
+          # Read-only, feeds release-PR equivalence lookups.
           GH_TOKEN: ${{ github.token }}
         run: |
           policy=$(node scripts/release-e2e-policy.mjs)
@@ -402,26 +405,22 @@ jobs:
   # invalidates the packages that use it — listing pnpm-lock.yaml globally
   # would invalidate every task on every bump.
   #
-  # GitHub's cache is branch-scoped: PR and merge-queue runs can restore main's
-  # entries plus their own branch's, but entries written on ephemeral
-  # merge-queue refs die with the ref, and the quality jobs skip `push` — so
-  # without the `seed-turbo-cache` job below, main's tree would never have
-  # cache entries and every run after a merge would re-run everything that
-  # merge changed.
+  # GitHub's cache is branch-scoped: PR runs can restore main's entries plus
+  # their own branch's, and the quality jobs skip `push` — so without the
+  # `seed-turbo-cache` job below, main's tree would never have cache entries and
+  # every run after a merge would re-run everything that merge changed.
   #
   # `quality` is an aggregate over three independent runners: lint, tests, and
   # a support runner that amortises setup across knip, changesets, script tests,
-  # package builds, and typechecking. These jobs deliberately do NOT
-  # `needs: detect` so they still run under `merge_group` (where `detect` is
-  # skipped). Workspace packages are consumed as raw `src` (exports point at
-  # source), so typecheck/test/lint resolve dependency types directly and do
-  # not need built `.d.ts`. This seed job still runs `build` explicitly so the
-  # release and app-deploy jobs find a warm `build` cache on main.
+  # package builds, and typechecking. Workspace packages are consumed as raw
+  # `src` (exports point at source), so typecheck/test/lint resolve dependency
+  # types directly and do not need built `.d.ts`. This seed job still runs
+  # `build` explicitly so the release and app-deploy jobs find a warm `build`
+  # cache on main.
   seed-turbo-cache:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # Cache warming only — the merge queue already validated this identical
-    # tree, so a flake here must not fail the push run (which also carries the
-    # release jobs).
+    # Cache warming only — a flake here must not fail the push run, which also
+    # carries the release jobs.
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -444,7 +443,8 @@ jobs:
 
   lint:
     if: >-
-      github.event_name != 'push'
+      github.event_name != 'merge_group'
+      && github.event_name != 'push'
       && !(github.event_name == 'workflow_dispatch'
       && inputs.interview_e2e_benchmark == true)
     runs-on: ubuntu-latest
@@ -453,7 +453,7 @@ jobs:
         with:
           persist-credentials: false
           # Pull requests lint only changed files against their synthetic
-          # merge commit's base parent. Merge groups still run the full check.
+          # merge commit's base parent.
           fetch-depth: 0
       - uses: ./.github/actions/turbo-ci-setup
       # oxlint-tsgolint's type-aware rules resolve workspace types directly from
@@ -478,7 +478,8 @@ jobs:
   # lint and test remain independent jobs on the critical path.
   quality-support:
     if: >-
-      github.event_name != 'push'
+      github.event_name != 'merge_group'
+      && github.event_name != 'push'
       && !(github.event_name == 'workflow_dispatch'
       && inputs.interview_e2e_benchmark == true)
     runs-on: ubuntu-latest
@@ -535,7 +536,8 @@ jobs:
 
   test:
     if: >-
-      github.event_name != 'push'
+      github.event_name != 'merge_group'
+      && github.event_name != 'push'
       && !(github.event_name == 'workflow_dispatch'
       && inputs.interview_e2e_benchmark == true)
     runs-on: ubuntu-latest
@@ -558,16 +560,15 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
-      - name: Run tests (PRs and merge groups run only affected tasks)
+      - name: Run tests (PRs run only affected tasks)
         env:
-          DIFF_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          DIFF_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # PR and merge-group checkouts are synthetic merges. Diff against
-          # the event's base SHA so merge groups that contain multiple PRs
-          # include the whole group's combined change. --affected scopes the
-          # run to tasks whose declared inputs the diff touches, plus their
-          # dependents (turbo.json enables affectedUsingTaskInputs so
-          # selection matches what cache hashing considers an input).
+          # PR checkouts are synthetic merges. Diff against the event's base
+          # SHA, then use --affected to scope the run to tasks whose declared
+          # inputs the diff touches, plus their dependents (turbo.json enables
+          # affectedUsingTaskInputs so selection matches what cache hashing
+          # considers an input).
           #
           # Fail closed: a change outside the workspace package trees (this
           # workflow, composite actions, .nvmrc, pnpm-workspace.yaml, root
@@ -576,20 +577,17 @@ jobs:
           # lockfile stays on the affected path because turbo hashes it
           # granularly per package; docs, changesets, and markdown are inert
           # to tests.
-          case "$GITHUB_EVENT_NAME" in
-            pull_request|merge_group)
-              if [[ -n "$DIFF_BASE_SHA" ]] \
-                && git cat-file -e "$DIFF_BASE_SHA^{commit}" \
-                && git diff --quiet "$DIFF_BASE_SHA" HEAD -- . \
-                  ':(exclude)packages' ':(exclude)apps' ':(exclude)workers' \
-                  ':(exclude)tooling' ':(exclude)docs' ':(exclude).changeset' \
-                  ':(exclude)pnpm-lock.yaml' ':(exclude)*.md'; then
-                echo "Running test tasks affected by $DIFF_BASE_SHA..HEAD"
-                TURBO_SCM_BASE="$DIFF_BASE_SHA" pnpm exec turbo run test --affected
-                exit 0
-              fi
-              ;;
-          esac
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] \
+            && [[ -n "$DIFF_BASE_SHA" ]] \
+            && git cat-file -e "$DIFF_BASE_SHA^{commit}" \
+            && git diff --quiet "$DIFF_BASE_SHA" HEAD -- . \
+              ':(exclude)packages' ':(exclude)apps' ':(exclude)workers' \
+              ':(exclude)tooling' ':(exclude)docs' ':(exclude).changeset' \
+              ':(exclude)pnpm-lock.yaml' ':(exclude)*.md'; then
+            echo "Running test tasks affected by $DIFF_BASE_SHA..HEAD"
+            TURBO_SCM_BASE="$DIFF_BASE_SHA" pnpm exec turbo run test --affected
+            exit 0
+          fi
 
           echo "Running the full test suite for $GITHUB_EVENT_NAME"
           pnpm exec turbo run test
@@ -632,6 +630,11 @@ jobs:
           ARCHITECT_E2E_RESULT: ${{ needs.architect-e2e.result }}
           ARCHITECT_E2E_NATIVE_RESULT: ${{ needs.architect-e2e-native.result }}
         run: |
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            echo "PR quality verdicts are authoritative; merge-group CI is intentionally lightweight"
+            exit 0
+          fi
+
           verify_successes() {
             local gate=$1
             shift

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -182,12 +182,12 @@ jobs:
           echo "docs=$docs" >> "$GITHUB_OUTPUT"
           echo "website=$website" >> "$GITHUB_OUTPUT"
 
-  # Decides per suite whether release E2E must run for this ref: each release
-  # lane requires only the suites whose subject package ships in its deploy,
-  # and both release-PR refreshes and merge-group runs skip suites already
-  # validated by an earlier native PR run whose commit differs only in paths
-  # that cannot affect the suite (equivalence reuse — see
-  # scripts/release-e2e-policy.mjs; every guard fails closed).
+  # Decides per suite whether E2E must run for this ref. Feature PRs select the
+  # suites whose subject package or workspace dependency closure changed.
+  # Release lanes select the suites whose subjects ship in their deploy, while
+  # release-PR refreshes and merge groups may reuse an equivalent earlier
+  # verdict. Every path and history guard fails closed; see
+  # scripts/release-e2e-policy.mjs.
   e2e-policy:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
@@ -201,24 +201,26 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
-          # Combined app-lane suite selection and cross-branch equivalence both
-          # compare commits, so every non-push policy run needs full history.
+          # Feature-PR selection, app-lane selection, and cross-branch
+          # equivalence all compare commits, so every non-push policy run needs
+          # full history.
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version-file: '.nvmrc'
-      - name: Determine which release E2E suites this ref requires
+      - name: Determine which E2E suites this ref requires
         id: policy
         env:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          # On PRs, HEAD_SHA is the branch tip the equivalence reuse diffs
-          # against prior validated runs; on merge groups it stays the
-          # group's head for release detection. HEAD_REPO guards reuse off
-          # for fork PRs.
+          # On feature PRs, BASE_SHA and HEAD_SHA define the cumulative
+          # merge-base diff. On release PRs, HEAD_SHA is also the branch tip
+          # equivalence reuse compares with prior validated runs. On merge
+          # groups it stays the group's head for release detection. HEAD_REPO
+          # guards reuse off for fork PRs.
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BENCHMARK_INTERVIEW_E2E: ${{ github.event_name == 'workflow_dispatch' && inputs.interview_e2e_benchmark == true }}
@@ -235,7 +237,7 @@ jobs:
               | .releaseRef = ""
               | .snapshotBranch = ""' <<< "$policy")
           fi
-          echo "release E2E policy: $policy"
+          echo "E2E policy: $policy"
           {
             echo "interview=$(jq -r '.interview' <<< "$policy")"
             echo "interviewer=$(jq -r '.interviewer' <<< "$policy")"
@@ -664,7 +666,7 @@ jobs:
               return
             fi
             if [[ "$result" != "success" ]]; then
-              echo "::error::release E2E gate failed — $suite concluded '$result'"
+              echo "::error::E2E gate failed — $suite concluded '$result'"
               exit 1
             fi
             echo "$suite passed"
@@ -945,10 +947,9 @@ jobs:
         run: npx --yes @jthrilly/dead-link-checker@^1.1.0 "$WEBSITE_URL/en-US/" -v --yes
 
   interview-e2e:
-    # Runs when the release policy requires the interview suite (the lane
-    # ships @codaco/interview). The Dockerized suite builds its own dependency
-    # graph and cannot consume the host runner's Turbo cache, so start it as
-    # soon as the release policy completes.
+    # Runs when the policy requires the interview suite. The Dockerized suite
+    # builds its own dependency graph and cannot consume the host runner's
+    # Turbo cache, so start it as soon as the policy completes.
     needs: [e2e-policy, pick-e2e-runner]
     if: >-
       ${{ !cancelled() && needs.e2e-policy.outputs.interview == 'true'
@@ -2448,10 +2449,10 @@ jobs:
   # First push on a PR: no prior runs exist, so nothing to carry; the
   # detect logic already runs the relevant jobs at least once because
   # the push diff IS the cumulative PR diff on the first commit.
-  # E2E jobs are deliberately excluded: on release PRs the e2e-policy job
-  # itself decides when a refresh may skip a suite (equivalence reuse) and
-  # the required quality gate checks its decision; non-release PRs must
-  # never inherit an E2E verdict from an earlier commit.
+  # E2E jobs are deliberately excluded: feature PRs select suites from the
+  # cumulative merge-base-to-head diff, while release PRs let e2e-policy
+  # decide when an equivalent earlier verdict may be reused. The required
+  # quality gate checks that current policy decision in both cases.
   carry-forward-statuses:
     needs:
       - detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,18 +348,18 @@ stories.
 #### Affected E2E checks
 
 CI runs the Architect, Interview, and Interviewer E2E suites on feature PRs
-when the cumulative PR diff touches the suite subject or anything in its
-workspace dependency closure. A change to `@codaco/interview`, for example,
-runs all downstream suites; an Architect-only change runs Architect E2E. The
-classifier treats `docs/`, `.changeset/`, and Markdown as inert, and fails
-closed for root configs, workflows, scripts, the lockfile, unrecognised paths,
-or unreadable history.
+targeting `main` when the cumulative PR diff touches the suite subject or
+anything in its workspace dependency closure. A change to `@codaco/interview`,
+for example, runs all downstream suites; an Architect-only change runs
+Architect E2E. The classifier treats `docs/`, `.changeset/`, and Markdown as
+inert, and fails closed for root configs, workflows, scripts, the lockfile,
+unrecognised paths, or unreadable history.
 
-Generated release branches (`changeset-release/*`) and merge groups keep their
-release-aware selection: only suites whose subjects ship in that release lane
-run. The normal Changesets lane (`changeset-release/main`) runs all three
-because it versions libraries, Architect, and Interviewer; the Documentation
-and Website lanes run none. The mapping and feature-PR classifier live in
+Generated release branches (`changeset-release/*`) keep their release-aware
+selection: only suites whose subjects ship in that release lane run. The normal
+Changesets lane (`changeset-release/main`) runs all three because it versions
+libraries, Architect, and Interviewer; the Documentation and Website lanes run
+none. The mapping and feature-PR classifier live in
 `scripts/release-e2e-policy.mjs`, with tests derived from the real package.json
 dependency graph. The required `quality` check requires exactly the suites the
 policy selects.
@@ -383,10 +383,9 @@ Feature PRs never inherit an E2E verdict from an earlier commit: suite
 selection uses the cumulative merge-base-to-current-head diff, so every
 required verdict describes the exact head under review.
 
-Generated release branches and their merge groups use equivalence reuse: a
-suite is skipped when the newest equivalent native pull-request verdict across
-the generated release branches is successful and the diff since that commit
-touches only paths that
+Generated release branches use equivalence reuse: a suite is skipped when the
+newest equivalent native pull-request verdict across the generated release
+branches is successful and the diff since that commit touches only paths that
 provably cannot affect the suite — files in workspace packages outside the
 suite subject's declared workspace dependency closure (dependencies,
 devDependencies, peerDependencies, optionalDependencies), or the inert
@@ -398,6 +397,14 @@ unrelated merges to `main` therefore keep their E2E verdicts without
 re-running, while any change that ships in the lane re-runs as before (see
 `scripts/release-e2e-policy.mjs` and
 `docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md`).
+
+Merge groups run only a lightweight `quality` acknowledgement. The main
+ruleset requires every pull request to pass its full `quality` check before it
+can enter the queue, so merge-group commits deliberately do not repeat lint,
+tests, typechecking, builds, E2E, or Chromatic. GitHub still requires the
+`quality` context to be reported on the merge-group SHA; the acknowledgement
+exists only to satisfy that protocol and does not revalidate the combined
+queue commit.
 
 The release jobs create and update generated branches with the fine-grained PAT
 stored as `RELEASE_PR_TOKEN`. That causes the normal `pull_request` workflow to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,18 +345,24 @@ required for TurboSnap. Keep Interview's `.storybook/static/**` directory in
 its Chromatic externals so static-asset changes invalidate the relevant
 stories.
 
-#### Release-only E2E checks
+#### Affected E2E checks
 
-CI runs the Architect, Interview, and Interviewer E2E suites only for
-generated release branches (`changeset-release/*`) and merge groups whose
-package or product version changes will trigger a release — and only the
-suites whose subjects ship in that release lane: the normal Changesets lane
-(`changeset-release/main`) runs all three because it versions libraries,
-Architect, and Interviewer; the Documentation and Website lanes run none. The
-mapping lives in
-`scripts/release-e2e-policy.mjs`, and its test derives the expected lanes from
-the real package.json dependency graph so the table cannot silently drift.
-The required `quality` check requires exactly the suites the policy selects.
+CI runs the Architect, Interview, and Interviewer E2E suites on feature PRs
+when the cumulative PR diff touches the suite subject or anything in its
+workspace dependency closure. A change to `@codaco/interview`, for example,
+runs all downstream suites; an Architect-only change runs Architect E2E. The
+classifier treats `docs/`, `.changeset/`, and Markdown as inert, and fails
+closed for root configs, workflows, scripts, the lockfile, unrecognised paths,
+or unreadable history.
+
+Generated release branches (`changeset-release/*`) and merge groups keep their
+release-aware selection: only suites whose subjects ship in that release lane
+run. The normal Changesets lane (`changeset-release/main`) runs all three
+because it versions libraries, Architect, and Interviewer; the Documentation
+and Website lanes run none. The mapping and feature-PR classifier live in
+`scripts/release-e2e-policy.mjs`, with tests derived from the real package.json
+dependency graph. The required `quality` check requires exactly the suites the
+policy selects.
 
 Each suite runs as **two jobs**. `<suite>-e2e` runs inside the pinned
 Playwright image and compares the committed PNG baselines; `<suite>-e2e-native`
@@ -373,8 +379,9 @@ regeneration workflow. Both halves are required by `quality`, and
 before a verdict can be reused. The capture helpers throw when
 `E2E_PIXEL_LANE=native` is set, so a mis-tagged visual test fails loudly
 instead of silently comparing container baselines against a runner's fonts.
-Ordinary PRs skip E2E and never inherit an E2E verdict from an earlier
-commit.
+Feature PRs never inherit an E2E verdict from an earlier commit: suite
+selection uses the cumulative merge-base-to-current-head diff, so every
+required verdict describes the exact head under review.
 
 Generated release branches and their merge groups use equivalence reuse: a
 suite is skipped when the newest equivalent native pull-request verdict across
@@ -395,7 +402,7 @@ re-running, while any change that ships in the lane re-runs as before (see
 The release jobs create and update generated branches with the fine-grained PAT
 stored as `RELEASE_PR_TOKEN`. That causes the normal `pull_request` workflow to
 start without manual approval. Do not add a separate workflow dispatch: it would
-duplicate the native CI run and its release-only E2E suites.
+duplicate the native CI run and its selected E2E suites.
 
 #### E2E visual snapshot baselines
 

--- a/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
+++ b/docs/superpowers/specs/2026-07-17-release-e2e-equivalence-reuse-design.md
@@ -1,12 +1,19 @@
 # Release E2E equivalence reuse
 
 **Date:** 2026-07-17
-**Status:** Partially superseded on 2026-08-03
+**Status:** Partially superseded on 2026-08-03 and 2026-08-11
 
 > Architect and Interviewer now share the normal `changeset-release/main` lane
 > with libraries, so cross-branch reuse between a separate apps lane and the
 > library lane is no longer needed. See
 > `2026-08-03-stable-app-release-design.md` for the current topology.
+
+> **2026-08-11 update:** PR `quality` verdicts are now authoritative for the
+> merge queue. Full CI and E2E run on pull requests targeting `main`, including
+> generated release PRs; `merge_group` reports only a lightweight `quality`
+> acknowledgement and never runs E2E. The PR-time equivalence primitive below
+> remains current for refreshed release branches. The queue-time motivation,
+> alternatives, and design sections are retained as historical context.
 
 ## Problem
 

--- a/scripts/chromatic-workflow.test.mjs
+++ b/scripts/chromatic-workflow.test.mjs
@@ -41,9 +41,9 @@ function untraced(script) {
   return [...script.matchAll(/--untraced '([^']+)'/g)].map((match) => match[1]);
 }
 
-test('all required UI Test contexts are emitted for PR and merge queue SHAs', () => {
-  assert.match(workflow, /^  pull_request:$/m);
-  assert.match(workflow, /^  merge_group:$/m);
+test('all UI Test contexts are emitted for PR SHAs without merge-queue work', () => {
+  assert.match(workflow, /^  pull_request:\n    branches: \[main\]$/m);
+  assert.doesNotMatch(workflow, /^  merge_group:/m);
   assert.match(workflow, /^  workflow_run:$/m);
   assert.doesNotMatch(workflow, /pull_request_target/);
   assert.match(workflow, /- CI and Release/);
@@ -54,7 +54,7 @@ test('all required UI Test contexts are emitted for PR and merge queue SHAs', ()
 
   const statuses = job('required-statuses');
   assert.ok(statuses, 'required-statuses job exists');
-  assert.match(statuses, /github\.event_name == 'merge_group'/);
+  assert.doesNotMatch(statuses, /merge_group/);
   assert.match(statuses, /github\.actor != 'dependabot\[bot\]'/);
   assert.match(statuses, /github\.event_name == 'workflow_run'/);
   assert.match(statuses, /workflow_run\.actor\.login == 'dependabot\[bot\]'/);
@@ -68,7 +68,7 @@ test('all required UI Test contexts are emitted for PR and merge queue SHAs', ()
   );
   assert.match(
     statuses,
-    /CHROMATIC_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \|\| github\.event\.workflow_run\.head_sha \|\| github\.sha \}\}/,
+    /CHROMATIC_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.workflow_run\.head_sha \|\| github\.sha \}\}/,
   );
   assert.match(statuses, /refs\/pull\/\$PR_NUMBER\/head/);
   for (const packageName of [
@@ -115,7 +115,7 @@ test('release selection uses the fail-closed lockfile-aware detector', () => {
   assert.match(detect, /GITHUB_STEP_SUMMARY/);
 });
 
-test('default-branch pushes replace merge-queue skip builds with real builds', () => {
+test('default-branch pushes replace release-branch skip builds with real builds', () => {
   const detect = job('detect');
   assert.ok(detect, 'detect job exists');
   assert.match(

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -29,6 +29,32 @@ function job(name) {
   )?.groups?.body;
 }
 
+test('full CI runs on PRs to main while merge groups request only quality', () => {
+  assert.match(workflow, /^  pull_request:\n    branches: \[main\]$/m);
+  assert.match(workflow, /^  merge_group:\n    types: \[checks_requested\]$/m);
+
+  for (const jobName of [
+    'detect',
+    'e2e-policy',
+    'lint',
+    'quality-support',
+    'test',
+  ]) {
+    const body = job(jobName);
+    assert.ok(body, `${jobName} exists`);
+    assert.match(
+      body,
+      /github\.event_name != 'merge_group'/,
+      `${jobName} skips merge groups`,
+    );
+  }
+
+  const quality = job('quality');
+  assert.ok(quality, 'quality job exists');
+  assert.match(quality, /if \[\[ "\$EVENT_NAME" == "merge_group" \]\]; then/);
+  assert.match(quality, /PR quality verdicts are authoritative/);
+});
+
 test('superseded CI runs are cancelled for every pull request', () => {
   assert.ok(
     topLevelConcurrency,
@@ -239,9 +265,10 @@ test('published Classic releases advance latest and rebuild the website', () => 
   );
 });
 
-test('pull requests lint only changed files while merge groups lint fully', () => {
+test('pull requests lint only changed files and merge groups skip lint', () => {
   const lint = job('lint');
   assert.ok(lint, 'lint job exists');
+  assert.match(lint, /github\.event_name != 'merge_group'/);
   assert.match(lint, /fetch-depth: 0/);
   assert.match(lint, /pnpm lint:changed HEAD\^1/);
   assert.match(lint, /pnpm exec turbo run \/\/#lint/);
@@ -290,30 +317,32 @@ test('the quality gate verifies each required E2E suite individually', () => {
   assert.match(qualityJob, /verify_required_e2e architect-e2e/);
 });
 
-test('e2e-policy can query the Actions API for the merge-queue fast path', () => {
+test('e2e-policy can query the Actions API for release-PR reuse', () => {
   const policyJob = job('e2e-policy');
   assert.ok(policyJob, 'e2e-policy job exists');
   assert.match(policyJob, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(policyJob, /fetch-depth: 0/);
   assert.match(
     policyJob,
-    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
+    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/,
   );
+  assert.doesNotMatch(policyJob, /github\.event\.merge_group/);
 });
 
-test('unit tests use affected task selection for PRs and merge groups', () => {
+test('unit tests use affected task selection for PRs and skip merge groups', () => {
   const testJob = job('test');
   assert.ok(testJob, 'test job exists');
   assert.match(
     testJob,
-    /DIFF_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
-    'test job diffs each event against its full base',
+    /DIFF_BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/,
+    'test job diffs the PR against its full base',
   );
+  assert.match(testJob, /github\.event_name != 'merge_group'/);
   assert.match(
     testJob,
-    /pull_request\|merge_group\)/,
-    'both PR and merge-group events enter the affected path',
+    /if \[\[ "\$GITHUB_EVENT_NAME" == "pull_request" \]\] \\/,
   );
+  assert.doesNotMatch(testJob, /pull_request\|merge_group/);
   assert.match(
     testJob,
     /TURBO_SCM_BASE="\$DIFF_BASE_SHA" pnpm exec turbo run test --affected/,
@@ -440,13 +469,13 @@ test('e2e-policy receives affected-PR and equivalence-reuse inputs', () => {
   assert.ok(policyJob, 'e2e-policy job exists');
   assert.match(
     policyJob,
-    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
-    'policy step receives the PR base (or merge-group base) as BASE_SHA',
+    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/,
+    'policy step receives the PR base as BASE_SHA',
   );
   assert.match(
     policyJob,
-    /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \}\}/,
-    'policy step receives the PR tip (or merge-group head) as HEAD_SHA',
+    /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
+    'policy step receives the PR tip as HEAD_SHA',
   );
   assert.match(
     policyJob,

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -122,7 +122,7 @@ test('website dead-link crawl waits for the documentation preview it links to', 
   );
 });
 
-test('each release E2E suite gates on its own policy flag', () => {
+test('each E2E suite gates on its own policy flag', () => {
   for (const [jobName, flag] of [
     ['interview-e2e', 'interview'],
     ['interview-e2e-native', 'interview'],
@@ -435,9 +435,14 @@ test('the informational Pages deploy has a bounded failure window', () => {
   );
 });
 
-test('e2e-policy receives the equivalence-reuse inputs', () => {
+test('e2e-policy receives affected-PR and equivalence-reuse inputs', () => {
   const policyJob = job('e2e-policy');
   assert.ok(policyJob, 'e2e-policy job exists');
+  assert.match(
+    policyJob,
+    /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
+    'policy step receives the PR base (or merge-group base) as BASE_SHA',
+  );
   assert.match(
     policyJob,
     /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \}\}/,

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -376,41 +376,6 @@ export const SUITES_BY_RELEASE_REF = {
   'changeset-release/website': suites(),
 };
 
-// Manifests whose version field moving means the resulting main push will ship
-// the mapped product. Keeping suites on the manifest (rather than only on the
-// combined lane) preserves app-specific E2E selection.
-const VERSIONED_MANIFEST_SUITE_RULES = [
-  {
-    pathspec: 'packages/*/package.json',
-    pattern: /^packages\/[^/]+\/package\.json$/,
-    suites: suites('interview', 'interviewer', 'architect'),
-  },
-  {
-    pathspec: 'apps/architect/package.json',
-    pattern: /^apps\/architect\/package\.json$/,
-    suites: suites('architect', 'interview'),
-  },
-  {
-    pathspec: 'apps/interviewer/package.json',
-    pattern: /^apps\/interviewer\/package\.json$/,
-    suites: suites('interviewer', 'interview'),
-  },
-  {
-    pathspec: 'apps/documentation/package.json',
-    pattern: /^apps\/documentation\/package\.json$/,
-    suites: suites(),
-  },
-  {
-    pathspec: 'apps/networkcanvas.com/package.json',
-    pattern: /^apps\/networkcanvas\.com\/package\.json$/,
-    suites: suites(),
-  },
-];
-
-const ALL_VERSIONED_MANIFESTS = VERSIONED_MANIFEST_SUITE_RULES.map(
-  ({ pathspec }) => pathspec,
-);
-
 export function releaseRefForEvent({ eventName, headRef, refName }) {
   const candidate =
     eventName === 'pull_request'
@@ -455,62 +420,8 @@ export function pullRequestRequiredSuites(baseSha, headSha, cwd) {
   return affectedSuitesForPaths(diff.split('\n').filter(Boolean), cwd);
 }
 
-function readVersionAt(revision, manifest, cwd) {
-  const contents = tryGit(['show', `${revision}:${manifest}`], cwd);
-  if (contents === null) return null;
-  try {
-    const parsed = JSON.parse(contents);
-    return typeof parsed.version === 'string' ? parsed.version : null;
-  } catch {
-    return null;
-  }
-}
-
-function versionChangeRequiredSuites(baseSha, headSha, cwd, manifests) {
-  if (!baseSha || !headSha) {
-    throw new Error('release E2E detection requires base and head SHAs');
-  }
-
-  const changedManifests = execFileSync(
-    'git',
-    ['diff', '--name-only', baseSha, headSha, '--', ...manifests],
-    { cwd, encoding: 'utf8' },
-  )
-    .split('\n')
-    .filter(Boolean);
-
-  const required = suites();
-  for (const manifest of changedManifests) {
-    const baseVersion = readVersionAt(baseSha, manifest, cwd);
-    const headVersion = readVersionAt(headSha, manifest, cwd);
-    if (baseVersion === null || headVersion === null) {
-      throw new Error(`Unable to read release version from ${manifest}`);
-    }
-    if (baseVersion === headVersion) continue;
-    const rule = VERSIONED_MANIFEST_SUITE_RULES.find(({ pattern }) =>
-      pattern.test(manifest),
-    );
-    if (!rule) throw new Error(`No release E2E rule for ${manifest}`);
-    for (const key of SUITE_KEYS) {
-      required[key] ||= rule.suites[key];
-    }
-  }
-  return required;
-}
-
-// Union of suites required by every version manifest moving in a merge group.
-export function mergeGroupRequiredSuites(baseSha, headSha, cwd) {
-  return versionChangeRequiredSuites(
-    baseSha,
-    headSha,
-    cwd,
-    ALL_VERSIONED_MANIFESTS,
-  );
-}
-
 export function releaseE2EPolicy(
   { eventName, headRef = '', refName = '', baseSha = '', headSha = '' },
-  mergeGroupDetector = mergeGroupRequiredSuites,
   pullRequestDetector = pullRequestRequiredSuites,
 ) {
   const releaseRef = releaseRefForEvent({ eventName, headRef, refName });
@@ -519,20 +430,6 @@ export function releaseE2EPolicy(
       ...SUITES_BY_RELEASE_REF[releaseRef],
       releaseRef,
       snapshotBranch: 'e2e-snapshots/main',
-    };
-  }
-
-  if (eventName === 'merge_group') {
-    let required;
-    try {
-      required = mergeGroupDetector(baseSha, headSha, process.cwd());
-    } catch {
-      required = suites('interview', 'interviewer', 'architect');
-    }
-    return {
-      ...required,
-      releaseRef: '',
-      snapshotBranch: '',
     };
   }
 
@@ -551,19 +448,6 @@ export function releaseE2EPolicy(
   }
 
   return { ...suites(), releaseRef: '', snapshotBranch: '' };
-}
-
-// Trust guard for merge-queue reuse: the queued merge's second parent must be
-// the current tip of a generated release branch — never an arbitrary PR that
-// happens to bump a version.
-export function releaseBranchForMergeQueue(cwd) {
-  const prTip = tryGit(['rev-parse', 'HEAD^2'], cwd);
-  if (!prTip) return '';
-  return (
-    Object.keys(SUITES_BY_RELEASE_REF).find(
-      (ref) => tryGit(['rev-parse', `origin/${ref}`], cwd) === prTip,
-    ) ?? ''
-  );
 }
 
 async function main() {
@@ -589,10 +473,6 @@ async function main() {
       ) {
         reuse = { branch: policy.releaseRef, headSha: process.env.HEAD_SHA };
       }
-    } else if (eventName === 'merge_group') {
-      const branch = releaseBranchForMergeQueue(cwd);
-      const headSha = tryGit(['rev-parse', 'HEAD'], cwd);
-      if (branch && headSha) reuse = { branch, headSha };
     }
     if (reuse) {
       const validated = await equivalentValidatedSuites({

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -128,6 +128,29 @@ export function diffIrrelevantToSuite(changedPaths, relevanceDirs, packages) {
   });
 }
 
+// Select each suite whose subject or workspace dependency closure contains a
+// changed path. Unknown paths fail closed for every suite via
+// diffIrrelevantToSuite; a missing subject fails closed for that suite because
+// its relevance closure cannot be trusted.
+export function affectedSuitesForPaths(changedPaths, cwd) {
+  const packages = collectWorkspacePackages(cwd);
+  const required = suites();
+  for (const key of SUITE_KEYS) {
+    const subject = E2E_SUITE_SUBJECTS[key];
+    if (!packages.has(subject)) {
+      required[key] = true;
+      continue;
+    }
+    const relevanceDirs = relevanceDirsForSubject(subject, packages);
+    required[key] = !diffIrrelevantToSuite(
+      changedPaths,
+      relevanceDirs,
+      packages,
+    );
+  }
+  return required;
+}
+
 const CONCLUSIVE = new Set(['success', 'failure', 'timed_out']);
 // One bounded page per generated branch. A verdict older than this is stale
 // enough that re-running is the right call anyway (fail closed past the cap).
@@ -414,6 +437,24 @@ function tryGit(args, cwd) {
   }
 }
 
+// Feature PRs use their cumulative merge-base-to-head diff so every current
+// head is gated by the suites the PR can affect. This deliberately does not
+// use push-to-push carry-forward: an E2E verdict must describe the exact PR
+// head that the required quality check is evaluating.
+export function pullRequestRequiredSuites(baseSha, headSha, cwd) {
+  if (!baseSha || !headSha) {
+    throw new Error('feature PR E2E detection requires base and head SHAs');
+  }
+  const mergeBase = tryGit(['merge-base', baseSha, headSha], cwd);
+  if (!mergeBase) throw new Error('Unable to resolve feature PR merge base');
+  const diff = tryGit(
+    ['diff', '--no-renames', '--name-only', mergeBase, headSha, '--'],
+    cwd,
+  );
+  if (diff === null) throw new Error('Unable to read feature PR diff');
+  return affectedSuitesForPaths(diff.split('\n').filter(Boolean), cwd);
+}
+
 function readVersionAt(revision, manifest, cwd) {
   const contents = tryGit(['show', `${revision}:${manifest}`], cwd);
   if (contents === null) return null;
@@ -470,6 +511,7 @@ export function mergeGroupRequiredSuites(baseSha, headSha, cwd) {
 export function releaseE2EPolicy(
   { eventName, headRef = '', refName = '', baseSha = '', headSha = '' },
   mergeGroupDetector = mergeGroupRequiredSuites,
+  pullRequestDetector = pullRequestRequiredSuites,
 ) {
   const releaseRef = releaseRefForEvent({ eventName, headRef, refName });
   if (releaseRef) {
@@ -484,6 +526,20 @@ export function releaseE2EPolicy(
     let required;
     try {
       required = mergeGroupDetector(baseSha, headSha, process.cwd());
+    } catch {
+      required = suites('interview', 'interviewer', 'architect');
+    }
+    return {
+      ...required,
+      releaseRef: '',
+      snapshotBranch: '',
+    };
+  }
+
+  if (eventName === 'pull_request') {
+    let required;
+    try {
+      required = pullRequestDetector(baseSha, headSha, process.cwd());
     } catch {
       required = suites('interview', 'interviewer', 'architect');
     }

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -18,9 +18,7 @@ import {
   diffIrrelevantToSuite,
   equivalentValidatedSuites,
   E2E_SUITE_SUBJECTS,
-  mergeGroupRequiredSuites,
   pullRequestRequiredSuites,
-  releaseBranchForMergeQueue,
   releaseE2EPolicy,
   releaseRefForEvent,
   relevanceDirsForSubject,
@@ -37,8 +35,8 @@ function git(cwd, ...args) {
 
 function initRepo() {
   const cwd = mkdtempSync(join(tmpdir(), 'release-e2e-'));
-  // -b main: the merge-queue tests check out `main` by name, which must not
-  // depend on the host's init.defaultBranch (CI runners default to master).
+  // -b main keeps fixture branch names independent of the host's
+  // init.defaultBranch (CI runners default to master).
   git(cwd, 'init', '-q', '-b', 'main');
   git(cwd, 'config', 'user.email', 'ci@example.com');
   git(cwd, 'config', 'user.name', 'ci');
@@ -208,159 +206,13 @@ test('all release policies share the central snapshot PR target', () => {
   }
 });
 
-test('merge groups require the suites the detector reports', () => {
-  const detected = {
-    interview: true,
-    interviewer: false,
-    architect: true,
-  };
-  assert.deepEqual(
-    releaseE2EPolicy(
-      { eventName: 'merge_group', baseSha: 'base', headSha: 'head' },
-      () => detected,
-    ),
-    { ...detected, releaseRef: '', snapshotBranch: '' },
-  );
-  assert.deepEqual(
-    releaseE2EPolicy(
-      { eventName: 'merge_group', baseSha: 'base', headSha: 'head' },
-      () => {
-        throw new Error('unreadable merge history');
-      },
-    ),
-    {
-      interview: true,
-      interviewer: true,
-      architect: true,
-      releaseRef: '',
-      snapshotBranch: '',
-    },
-  );
-});
-
-test('merge groups derive suites from the app versions that move', () => {
-  const cwd = initRepo();
-  commitManifest(
-    cwd,
-    'apps/interviewer/package.json',
-    '{"name":"@codaco/interviewer","version":"1.0.0"}\n',
-    'add interviewer',
-  );
-  const baseSha = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.0"}\n',
-    'add architect',
-  );
-  const architectBump = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.1"}\n',
-    'release architect',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(baseSha, architectBump, cwd), {
-    interview: true,
-    interviewer: false,
-    architect: true,
-  });
-
-  const bothBumped = commitManifest(
-    cwd,
-    'apps/interviewer/package.json',
-    '{"name":"@codaco/interviewer","version":"1.0.1"}\n',
-    'release interviewer too',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(baseSha, bothBumped, cwd), {
-    interview: true,
-    interviewer: true,
-    architect: true,
-  });
-
-  const manifestOnly = commitManifest(
-    cwd,
-    'apps/interviewer/package.json',
-    '{"name":"@codaco/interviewer","version":"1.0.1","scripts":{}}\n',
-    'manifest metadata',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(bothBumped, manifestOnly, cwd), {
+test('merge groups never require E2E', () => {
+  assert.deepEqual(releaseE2EPolicy({ eventName: 'merge_group' }), {
     interview: false,
     interviewer: false,
     architect: false,
-  });
-});
-
-test('merge-group version bumps require only the affected lanes', () => {
-  const cwd = initRepo();
-  commitManifest(
-    cwd,
-    'apps/networkcanvas.com/package.json',
-    '{"name":"networkcanvas.com","version":"0.1.1"}\n',
-    'add website',
-  );
-  commitManifest(
-    cwd,
-    'packages/protocol-validation/package.json',
-    '{"name":"@codaco/protocol-validation","version":"9.9.8"}\n',
-    'add library',
-  );
-  const baseSha = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.0"}\n',
-    'base',
-  );
-
-  // A website bump releases nothing the suites test.
-  const websiteBump = commitManifest(
-    cwd,
-    'apps/networkcanvas.com/package.json',
-    '{"name":"networkcanvas.com","version":"0.1.2"}\n',
-    'release website',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(baseSha, websiteBump, cwd), {
-    interview: false,
-    interviewer: false,
-    architect: false,
-  });
-
-  // An architect bump releases the architect app, which ships the interview
-  // runtime.
-  const architectBump = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.1"}\n',
-    'release architect',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(websiteBump, architectBump, cwd), {
-    interview: true,
-    interviewer: false,
-    architect: true,
-  });
-
-  // A library bump can ship in every app.
-  const libraryBump = commitManifest(
-    cwd,
-    'packages/protocol-validation/package.json',
-    '{"name":"@codaco/protocol-validation","version":"9.9.9"}\n',
-    'release library',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(architectBump, libraryBump, cwd), {
-    interview: true,
-    interviewer: true,
-    architect: true,
-  });
-
-  // Content-only manifest changes (no version movement) require nothing.
-  const scriptChange = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.1","scripts":{}}\n',
-    'manifest content change',
-  );
-  assert.deepEqual(mergeGroupRequiredSuites(libraryBump, scriptChange, cwd), {
-    interview: false,
-    interviewer: false,
-    architect: false,
+    releaseRef: '',
+    snapshotBranch: '',
   });
 });
 
@@ -378,7 +230,6 @@ test('feature PRs require the suites the affected-path detector reports', () => 
         baseSha: 'base',
         headSha: 'head',
       },
-      undefined,
       () => detected,
     ),
     { ...detected, releaseRef: '', snapshotBranch: '' },
@@ -391,7 +242,6 @@ test('feature PRs require the suites the affected-path detector reports', () => 
         baseSha: 'base',
         headSha: 'head',
       },
-      undefined,
       () => {
         throw new Error('unreadable PR history');
       },
@@ -526,148 +376,6 @@ test('non-PR ordinary events do not require E2E', () => {
     releaseE2EPolicy({ eventName: 'push', refName: 'main' }),
     none,
   );
-});
-
-// Build a repo shaped like a merge-queue checkout: main, a release branch
-// with a version bump, and a merge commit of the branch into main (HEAD).
-// Returns the branch tip so tests can point origin/changeset-release/* at it.
-function initMergeQueueRepo({ advanceMainWith = '' } = {}) {
-  const cwd = initRepo();
-  // @codaco/interview must be a real discovered package: equivalence reuse
-  // now refuses to trust a relevance judgment about a suite whose subject is
-  // missing from the graph entirely.
-  commitManifest(
-    cwd,
-    'packages/interview/package.json',
-    '{"name":"@codaco/interview","version":"1.0.0"}\n',
-    'add interview',
-  );
-  commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.0"}\n',
-    'base',
-  );
-  git(cwd, 'checkout', '-qb', 'release');
-  const branchTip = commitManifest(
-    cwd,
-    'apps/architect/package.json',
-    '{"name":"@codaco/architect","version":"1.0.1"}\n',
-    'version architect',
-  );
-  git(cwd, 'checkout', '-q', 'main');
-  if (advanceMainWith) {
-    commitManifest(cwd, advanceMainWith, 'moved\n', 'main moved');
-  }
-  git(cwd, 'merge', '-q', '--no-ff', '--no-edit', 'release');
-  return { cwd, branchTip };
-}
-
-function releaseLaneQueueCall(cwd, fetcher) {
-  const branch = releaseBranchForMergeQueue(cwd);
-  return equivalentValidatedSuites({
-    cwd,
-    repository: 'example/repo',
-    token: 'token',
-    branch,
-    headSha: git(cwd, 'rev-parse', 'HEAD'),
-    requiredSuites: { interview: true, interviewer: false, architect: true },
-    fetcher,
-  });
-}
-
-// Each suite reports two halves (Dockerized pixel + native functional), and
-// reuse requires both — see E2E_JOB_NAMES in release-e2e-policy.mjs.
-const RELEASE_LANE_ARCHITECT_SUCCESS_JOBS = [
-  { name: 'architect-e2e', conclusion: 'success' },
-  { name: 'architect-e2e-native', conclusion: 'success' },
-  { name: 'interview-e2e', conclusion: 'success' },
-  { name: 'interview-e2e-native', conclusion: 'success' },
-  { name: 'quality', conclusion: 'success' },
-];
-
-test('merge queue identifies the release lane from the merge second parent', () => {
-  const { cwd, branchTip } = initMergeQueueRepo();
-  assert.equal(releaseBranchForMergeQueue(cwd), '');
-  git(
-    cwd,
-    'update-ref',
-    `refs/remotes/origin/${NORMAL_RELEASE_REF}`,
-    branchTip,
-  );
-  assert.equal(releaseBranchForMergeQueue(cwd), NORMAL_RELEASE_REF);
-});
-
-test('merge-queue reuse skips suites validated at the branch tip', async () => {
-  const { cwd, branchTip } = initMergeQueueRepo();
-  git(
-    cwd,
-    'update-ref',
-    `refs/remotes/origin/${NORMAL_RELEASE_REF}`,
-    branchTip,
-  );
-  // The merge added nothing beyond the branch: empty diff, trivial case.
-  assert.deepEqual(
-    await releaseLaneQueueCall(
-      cwd,
-      fakeActionsApi({
-        runs: [fakeRun(1, branchTip)],
-        jobsByRun: { 1: RELEASE_LANE_ARCHITECT_SUCCESS_JOBS },
-      }),
-    ),
-    { interview: true, interviewer: false, architect: true },
-  );
-});
-
-test('merge-queue reuse classifies batched main movement by relevance', async () => {
-  // Main moved with a file inside the architect subject: the architect suite
-  // re-runs. The interview suite may still skip — apps/architect is outside
-  // the interview package's closure, so its e2e outcome cannot change.
-  const relevant = initMergeQueueRepo({
-    advanceMainWith: 'apps/architect/src/main.tsx',
-  });
-  git(
-    relevant.cwd,
-    'update-ref',
-    `refs/remotes/origin/${NORMAL_RELEASE_REF}`,
-    relevant.branchTip,
-  );
-  assert.deepEqual(
-    await releaseLaneQueueCall(
-      relevant.cwd,
-      fakeActionsApi({
-        runs: [fakeRun(1, relevant.branchTip)],
-        jobsByRun: { 1: RELEASE_LANE_ARCHITECT_SUCCESS_JOBS },
-      }),
-    ),
-    { interview: true, interviewer: false, architect: false },
-  );
-
-  // Main moved with an inert file (README): the batched merge still cannot
-  // affect the suites, so reuse holds. (Old byte-identical semantics re-ran
-  // here; relevance classification is the intended improvement.)
-  const inert = initMergeQueueRepo({ advanceMainWith: 'README.md' });
-  git(
-    inert.cwd,
-    'update-ref',
-    `refs/remotes/origin/${NORMAL_RELEASE_REF}`,
-    inert.branchTip,
-  );
-  assert.deepEqual(
-    await releaseLaneQueueCall(
-      inert.cwd,
-      fakeActionsApi({
-        runs: [fakeRun(1, inert.branchTip)],
-        jobsByRun: { 1: RELEASE_LANE_ARCHITECT_SUCCESS_JOBS },
-      }),
-    ),
-    { interview: true, interviewer: false, architect: true },
-  );
-
-  // An ordinary PR that bumps a version must never satisfy reuse: without a
-  // matching origin/changeset-release/* tip there is no branch to walk.
-  const untrusted = initMergeQueueRepo();
-  assert.equal(releaseBranchForMergeQueue(untrusted.cwd), '');
 });
 
 // Scaffold a repo-shaped directory tree (no git needed for these tests):

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -13,11 +13,13 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  affectedSuitesForPaths,
   collectWorkspacePackages,
   diffIrrelevantToSuite,
   equivalentValidatedSuites,
   E2E_SUITE_SUBJECTS,
   mergeGroupRequiredSuites,
+  pullRequestRequiredSuites,
   releaseBranchForMergeQueue,
   releaseE2EPolicy,
   releaseRefForEvent,
@@ -362,7 +364,157 @@ test('merge-group version bumps require only the affected lanes', () => {
   });
 });
 
-test('ordinary events do not require release E2E', () => {
+test('feature PRs require the suites the affected-path detector reports', () => {
+  const detected = {
+    interview: true,
+    interviewer: false,
+    architect: true,
+  };
+  assert.deepEqual(
+    releaseE2EPolicy(
+      {
+        eventName: 'pull_request',
+        headRef: 'feature/example',
+        baseSha: 'base',
+        headSha: 'head',
+      },
+      undefined,
+      () => detected,
+    ),
+    { ...detected, releaseRef: '', snapshotBranch: '' },
+  );
+  assert.deepEqual(
+    releaseE2EPolicy(
+      {
+        eventName: 'pull_request',
+        headRef: 'feature/example',
+        baseSha: 'base',
+        headSha: 'head',
+      },
+      undefined,
+      () => {
+        throw new Error('unreadable PR history');
+      },
+    ),
+    {
+      interview: true,
+      interviewer: true,
+      architect: true,
+      releaseRef: '',
+      snapshotBranch: '',
+    },
+  );
+});
+
+test('feature PR suite selection follows the workspace dependency graph', () => {
+  const cwd = initRepo();
+  commitManifest(
+    cwd,
+    'packages/interview/package.json',
+    '{"name":"@codaco/interview","version":"1.0.0"}\n',
+    'add interview',
+  );
+  commitManifest(
+    cwd,
+    'apps/interviewer/package.json',
+    '{"name":"@codaco/interviewer","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:^"}}\n',
+    'add interviewer',
+  );
+  commitManifest(
+    cwd,
+    'apps/architect/package.json',
+    '{"name":"@codaco/architect","version":"1.0.0","dependencies":{"@codaco/interview":"workspace:^"}}\n',
+    'add architect',
+  );
+  const commonBase = commitManifest(
+    cwd,
+    'apps/documentation/package.json',
+    '{"name":"@codaco/documentation","version":"1.0.0"}\n',
+    'add documentation',
+  );
+
+  git(cwd, 'checkout', '-qb', 'feature-architect', commonBase);
+  const architectHead = commitManifest(
+    cwd,
+    'apps/architect/src/main.tsx',
+    'export {};\n',
+    'change architect',
+  );
+  git(cwd, 'checkout', '-q', 'main');
+  const advancedBase = commitManifest(
+    cwd,
+    'apps/interviewer/src/main.tsx',
+    'export {};\n',
+    'advance main',
+  );
+  assert.deepEqual(
+    pullRequestRequiredSuites(advancedBase, architectHead, cwd),
+    { interview: false, interviewer: false, architect: true },
+    'merge-base diff excludes unrelated movement on the base branch',
+  );
+
+  git(cwd, 'checkout', '-qb', 'feature-interview', commonBase);
+  const interviewHead = commitManifest(
+    cwd,
+    'packages/interview/src/index.ts',
+    'export {};\n',
+    'change interview',
+  );
+  assert.deepEqual(
+    pullRequestRequiredSuites(advancedBase, interviewHead, cwd),
+    { interview: true, interviewer: true, architect: true },
+    'a shared runtime change selects every downstream suite',
+  );
+
+  git(cwd, 'checkout', '-qb', 'feature-documentation', commonBase);
+  const documentationHead = commitManifest(
+    cwd,
+    'apps/documentation/src/page.tsx',
+    'export {};\n',
+    'change documentation',
+  );
+  assert.deepEqual(
+    pullRequestRequiredSuites(advancedBase, documentationHead, cwd),
+    { interview: false, interviewer: false, architect: false },
+  );
+
+  git(cwd, 'checkout', '-qb', 'feature-root-config', commonBase);
+  const rootConfigHead = commitManifest(
+    cwd,
+    'turbo.json',
+    '{}\n',
+    'change root config',
+  );
+  assert.deepEqual(
+    pullRequestRequiredSuites(advancedBase, rootConfigHead, cwd),
+    { interview: true, interviewer: true, architect: true },
+    'an unrecognised root path fails closed',
+  );
+
+  git(cwd, 'checkout', '-qb', 'feature-docs-only', commonBase);
+  const docsHead = commitManifest(cwd, 'README.md', 'Docs\n', 'change docs');
+  assert.deepEqual(pullRequestRequiredSuites(advancedBase, docsHead, cwd), {
+    interview: false,
+    interviewer: false,
+    architect: false,
+  });
+});
+
+test('affected path selection fails closed when a suite subject is missing', () => {
+  const cwd = writeWorkspaceFixture();
+  const manifest = join(cwd, 'apps/architect/package.json');
+  writeFileSync(
+    manifest,
+    '{"name":"@codaco/not-architect","version":"1.0.0"}\n',
+  );
+  assert.deepEqual(affectedSuitesForPaths(['README.md'], cwd), {
+    interview: false,
+    interviewer: false,
+    architect: true,
+  });
+});
+
+test('non-PR ordinary events do not require E2E', () => {
   const none = {
     interview: false,
     interviewer: false,
@@ -370,10 +522,6 @@ test('ordinary events do not require release E2E', () => {
     releaseRef: '',
     snapshotBranch: '',
   };
-  assert.deepEqual(
-    releaseE2EPolicy({ eventName: 'pull_request', headRef: 'feature/example' }),
-    none,
-  );
   assert.deepEqual(
     releaseE2EPolicy({ eventName: 'push', refName: 'main' }),
     none,


### PR DESCRIPTION
## Summary

- run affected Architect, Interview, and Interviewer E2E suites on feature PRs targeting `main`, selected from the cumulative merge-base diff
- preserve generated changeset release-branch selection and safe release-PR equivalence reuse
- make PR `quality` verdicts authoritative and reduce merge-group CI to the lightweight required `quality` acknowledgement
- remove merge-group E2E, lint, tests, typechecking, builds, and Chromatic work
- document the resulting policy and add workflow/policy regression coverage

## Test plan

- [x] `pnpm test:scripts` (150 tests)
- [x] `pnpm lint:fix`
- [x] `pnpm knip`
- [x] `pnpm typecheck` (17 tasks)
- [x] parse both modified workflows as YAML
- [x] `git diff --check`
- [x] visual-impact audit: CI/tooling only; no baseline regeneration required

## Changeset

Not required: this is a CI/tooling-only change with no consumer-visible release impact.