### PR TITLE
fix(classic apps): 6.6.1 hotfixes for launch crashes (missing packaged modules)

### DIFF
--- a/apps/architect-classic/CHANGELOG.md
+++ b/apps/architect-classic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # network-canvas-architect
 
+## 6.6.1
+
+- **Fixed a crash on launch.** Version 6.6.0 could fail to start with a "Cannot find module
+  'readable-stream/passthrough'" error, caused by required dependency files being left out of
+  the packaged app. The app now starts correctly, and protocol import/export functionality
+  affected by the same packaging issue has been restored.
+
 ## 6.6.0
 
 - **Updated core dependencies.** The technology the app is built on has been brought up to

--- a/apps/architect-classic/electron-builder.config.js
+++ b/apps/architect-classic/electron-builder.config.js
@@ -18,7 +18,12 @@ module.exports = {
     'dist/**/*',
     '!dist/main/_dummy.js',
     'node_modules/**/*',
-    '!node_modules/**/node_modules/**',
+    // Nested node_modules MUST be included: electron-builder resolves version
+    // conflicts by nesting the losing version under its dependent (e.g.
+    // lazystream needs readable-stream@2 for its `readable-stream/passthrough`
+    // require, while archiver hoists readable-stream@4 to the root). Excluding
+    // `node_modules/**/node_modules/**` strips those copies and crashes the
+    // packaged app at launch with "Cannot find module".
     '!**/*.{map,ts,md}',
     '!**/test/**',
     '!**/tests/**',

--- a/apps/architect-classic/package.json
+++ b/apps/architect-classic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/architect-classic",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "private": true,
   "description": "A tool for building Network Canvas interviews.",
   "homepage": ".",

--- a/apps/interviewer-classic/CHANGELOG.md
+++ b/apps/interviewer-classic/CHANGELOG.md
@@ -1,5 +1,11 @@
 # network-canvas-interviewer
 
+## 6.6.1
+
+- **Fixed a crash on launch.** Version 6.6.0 could fail to start with a "Cannot find module
+  'lodash/defaults'" error, caused by a required dependency being left out of the packaged
+  app. The app now starts correctly.
+
 ## 6.6.0
 
 - **Updated core dependencies.** The technology the app is built on has been brought up to

--- a/apps/interviewer-classic/electron-builder.config.cjs
+++ b/apps/interviewer-classic/electron-builder.config.cjs
@@ -43,7 +43,10 @@ module.exports = {
     '!node_modules/**/vite/**',
     '!node_modules/**/@babel/core/**',
     '!node_modules/**/@babel/parser/**',
-    '!node_modules/**/lodash/**',
+    // lodash MUST be packaged: it is a runtime dependency of archiver-utils
+    // (require('lodash/defaults') at module load), and the main process
+    // requires archiver at startup. Excluding it crashes the packaged app at
+    // launch with "Cannot find module 'lodash/defaults'".
   ],
   extraResources: ['./build-resources/externals/**'],
   appId: 'Network-Canvas-Interviewer-6',

--- a/apps/interviewer-classic/package.json
+++ b/apps/interviewer-classic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/interviewer-classic",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "private": true,
   "description": "A tool for conducting Network Canvas Interviews.",
   "homepage": ".",


### PR DESCRIPTION
## Summary

Both classic apps' published 6.6.0 builds crash at launch with a main-process
"Cannot find module" uncaught exception, each caused by an electron-builder
`files` exclusion deleting runtime modules from the asar. Both apps require
`archiver` at startup (via their ipcHandlers), and `archiver@7`'s dependency
tree is what exposes each exclusion. (Pre-monorepo releases were built with
`archiver@3` / different packaging, which is why 6.5.x never hit this.)

**Architect Classic** (user-reported):

> Error: Cannot find module 'readable-stream/passthrough'

`'!node_modules/**/node_modules/**'` stripped every *nested* version-conflict
copy electron-builder creates — 26 packages, including the `readable-stream@2`
that `lazystream` needs (`passthrough.js` doesn't exist in the hoisted
`readable-stream@4`) and the `decompress` tree used for protocol import.

**Interviewer Classic** (found while auditing the same defect class):

> Error: Cannot find module 'lodash/defaults'

`'!node_modules/**/lodash/**'` stripped lodash, but `archiver-utils` requires
`lodash/defaults` at module load.

Changes:

- Remove both fatal exclusions (each with a comment explaining why the modules
  must be kept)
- Bump both apps to **6.6.1** so the legacy release pipeline ships fixes on
  merge (classic apps are outside the changesets lane; the version bump is the
  release trigger, and release notes are lifted from each app's CHANGELOG
  `## 6.6.1` section)
- Add user-facing CHANGELOG entries

## Test plan

Architect Classic:

- [x] Reproduced: packing with the old config yields an asar with only
      `readable-stream@4.7.0` and zero nested node_modules
- [x] Fixed asar contains `lazystream/node_modules/readable-stream@2.3.8`
      (with `passthrough.js`) plus the other 25 restored nested packages
- [x] `archiver`, `lazystream`, `decompress` all load from the packed asar
      (`ELECTRON_RUN_AS_NODE`)
- [x] Full launch test of the packaged 6.6.1 app: main process boots, window
      and helper processes run, no exception

Interviewer Classic:

- [x] Reproduced: old config's asar lacks lodash; `require('archiver')` from
      the packed asar fails with "Cannot find module 'lodash/defaults'"; the
      launched app stalls at the exception dialog with **zero** renderer/GPU
      helper processes
- [x] Fixed asar (stamped 6.6.1) contains `lodash/defaults.js`; `archiver`
      loads from the packed asar; the launched app boots to a window with all
      helper processes running

Both:

- [x] `oxlint` / `oxfmt` clean on changed files; `pnpm typecheck` and
      `pnpm knip` pass
- [x] Visual baselines: not applicable — packaging config, changelog, and
      version changes only; classic apps are not subjects of any E2E suite
- [x] Changeset: not needed — both classic apps are in the changesets ignore
      list; the version bumps are the release triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)