### PR TITLE
fix(release): pin classic apps' Linux executableName to their pre-monorepo names

### DIFF
--- a/apps/architect-classic/electron-builder.config.js
+++ b/apps/architect-classic/electron-builder.config.js
@@ -141,6 +141,11 @@ module.exports = {
 
   // Linux configuration
   linux: {
+    // Without this, electron-builder derives the Linux executable name from
+    // package.json's name — since the monorepo rename that is the scoped
+    // "@codaco/architect-classic", which AppImage rejects as unsafe for file
+    // paths. Keep the pre-monorepo executable name that 6.6.0 shipped.
+    executableName: 'network-canvas-architect',
     icon: 'build-resources',
     category: 'Education',
     maintainer: 'Complex Data Collective <info@networkcanvas.com>',

--- a/apps/interviewer-classic/electron-builder.config.cjs
+++ b/apps/interviewer-classic/electron-builder.config.cjs
@@ -78,6 +78,11 @@ module.exports = {
     notarize: Boolean(process.env.APPLE_API_KEY || process.env.APPLE_ID),
   },
   linux: {
+    // Without this, electron-builder derives the Linux executable name from
+    // package.json's name — since the monorepo rename that is the scoped
+    // "@codaco/interviewer-classic", which AppImage rejects as unsafe for
+    // file paths. Keep the pre-monorepo executable name that 6.6.0 shipped.
+    executableName: 'network-canvas-interviewer',
     maintainer: 'Joshua Melville <joshmelville@gmail.com>',
     target: [
       { target: 'deb', arch: ['x64', 'arm64'] },


### PR DESCRIPTION
## Summary

Rebased onto #1334, which fixed the macOS signing secrets and the Windows
fresco-postinstall failure from the failed 6.6.1 release run. This PR now
carries only the remaining Linux failure:

electron-builder derives the Linux executable name from `package.json`'s
`name` — since the monorepo rename that's `@codaco/architect-classic` /
`@codaco/interviewer-classic`, and AppImage rejects the sanitized scoped name:

> executableName contains characters that cannot be safely used in file
> paths: @codacoarchitect-classic

The external 6.6.0 binaries predate the rename (hand-assembled from June 18
`legacy-app-build` artifacts), so the failed run was the first release build
to hit it. Pinned `linux.executableName` in both configs to the names 6.6.0
shipped — which also keeps executable-name continuity for existing Linux
installs.

## Test plan

- [x] Reproduced the exact CI failure locally on both apps' AppImage targets,
      then built both AppImages **to completion** with the pinned names
- [x] `oxlint`/`oxfmt` clean; no changeset (release-pipeline fix only,
      classic apps are outside the changesets lane)

## Remaining release blocker (not code)

The mirror jobs still need `LEGACY_RELEASE_GH_TOKEN` re-scoped with contents
write access to the external `architect`/`interviewer` repos (they failed
with `Permission … denied to buckhalt`). Once that's done and this merges,
the next push to `main` re-triggers the 6.6.1 release automatically via the
idempotent release-detect check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)