### PR TITLE
ci: skip Fresco env validation in the turbo cache seed job

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -439,7 +439,15 @@ jobs:
             echo "PROTOCOL_ENCRYPTION_IV=$PROTOCOL_ENCRYPTION_IV"
             echo "GITHUB_TOKEN=$TEST_PROTOCOL_TOKEN"
           } > packages/protocol-validation/.env
+      # Fresco's `build` script is a bare `next build`, whose env.js validates
+      # the full deployment env at config load; this job has no Fresco
+      # deployment secrets. The variable reaches the task through
+      # `fresco#build`'s `passThroughEnv` (strict env mode strips undeclared
+      # variables), which keeps it out of the task hash so the seeded cache
+      # stays valid for runs that don't set it.
       - run: pnpm exec turbo run build test typecheck
+        env:
+          SKIP_ENV_VALIDATION: 'true'
 
   lint:
     if: >-

--- a/turbo.json
+++ b/turbo.json
@@ -479,6 +479,7 @@
     },
     "fresco#build": {
       "dependsOn": ["^topo", "fresco#codegen"],
+      "passThroughEnv": ["SKIP_ENV_VALIDATION"],
       "inputs": [
         "app/**",
         "actions/**",


### PR DESCRIPTION
## Summary

- `seed-turbo-cache` (every push to `main`, `continue-on-error`) fails on `fresco#build`: the unfiltered `turbo run build` reaches Fresco, whose `build` script is a bare `next build`, and `env.js` validates the full deployment env at config load — the job has no Fresco deployment secrets. Failing examples: runs [31482402133](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/31482402133) and [31483051494](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/31483051494).
- Fix: set `SKIP_ENV_VALIDATION: 'true'` on the seed job's turbo step, and declare the variable in `fresco#build`'s `passThroughEnv` in `turbo.json`. The declaration is required — turbo runs tasks in **strict env mode**, so an undeclared variable is stripped before `next build` sees it (setting it only in the workflow env would not have fixed anything).
- Deliberate choices:
  - Not added inline to Fresco's `build` script: the Fresco `Dockerfile` runs `pnpm run build` for the production image, where env validation must stay on. (Every other Fresco script already sets the flag inline, which is why only `build` failed.)
  - `passThroughEnv` rather than `env`: passthrough variables are excluded from the task hash, verified by dry-run — `fresco#build` hashes to `cf2fb83e1e29726f` with and without the flag — so the seeded cache entry stays valid for any run that doesn't set it.

## Test plan

- [x] Reproduced locally: `node apps/fresco/env.js` fails with "Invalid environment variables"; passes with `SKIP_ENV_VALIDATION=true`.
- [x] End-to-end through the exact seed-job path: `SKIP_ENV_VALIDATION=true pnpm exec turbo run build --filter=fresco` completes (`next build` emits the full route table, exit 0) under strict env mode.
- [x] `turbo run build --filter=fresco --dry=json` hash identical with/without the variable; the variable appears in the task's passthrough set.
- [x] `node --test scripts/ci-workflow.test.mjs` — 26/26 pass; `oxfmt --check` clean on both files.
- [ ] Confirm `seed-turbo-cache` goes green on the next push to `main` after merge.

No changeset: root CI configuration only (same lane as #1331). Nonvisual: no app source, theme, asset, or lockfile touched, so no E2E baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)