### PR TITLE
fix(deps): keep transitive nanoid v3 on patched releases

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,7 @@ overrides:
   fast-uri: ^3.1.4
   find-my-way: ^9.7.0
   immutable@4.3.8: 4.3.9
+  nanoid@<4: ^3.3.17
   postcss: ^8.5.23
   sharp: ^0.35.3
   valibot: ^1.4.2
@@ -12392,8 +12393,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -26565,7 +26566,7 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@6.0.0: {}
 
@@ -27663,7 +27664,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,6 +144,9 @@ overrides:
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'
   'immutable@4.3.8': '4.3.9'
+  # Scoped to v3 so fresco-ui's direct nanoid@6 keeps its own range
+  # (CVE-2026-67213: infinite loop in customAlphabet/customRandom with size 0).
+  'nanoid@<4': '^3.3.17'
   postcss: '^8.5.23'
   sharp: '^0.35.3'
   valibot: '^1.4.2'

--- a/scripts/mirror-app.mjs
+++ b/scripts/mirror-app.mjs
@@ -200,6 +200,7 @@ overrides:
   'effect@3.17.7': '${effectVersion}'
   fast-uri: '^3.1.4'
   find-my-way: '^9.7.0'
+  'nanoid@<4': '^3.3.17'
   postcss: '^8.5.23'
   sharp: '^0.35.3'
   valibot: '^1.4.2'


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert 429](https://github.com/complexdatacollective/network-canvas-monorepo/security/dependabot/429) — GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (high): nanoid before 3.3.17 loops forever in `customAlphabet`/`customRandom` when configured with a size of 0.
- The only vulnerable copy in the tree is postcss's transitive `nanoid@3.3.16`. Adds a v3-scoped entry to the existing "security-sensitive transitives" overrides block in `pnpm-workspace.yaml` (`'nanoid@<4': '^3.3.17'`), which re-resolves it to 3.3.18. Scoping to `<4` leaves fresco-ui's direct (non-vulnerable) `nanoid@^6` on its own range.
- Mirrors the same override into the generated Fresco workspace manifest in `scripts/mirror-app.mjs`, matching the parallel security-overrides block there, so the standalone mirrored tree can never resolve a pinned vulnerable nanoid@3.
- No changeset: lockfile/tooling-only, no consumer-visible change in any released package or app. No Dependabot PR exists for this alert (it can't bump a transitive held only by postcss's range).

## Test plan
- [x] `pnpm typecheck` — 17/17 tasks pass
- [x] `pnpm lint` — exit 0
- [x] `pnpm knip` — clean
- [x] `pnpm test` — 18/18 tasks pass
- [x] `pnpm test:scripts` — 152/152 pass (covers `mirror-app.mjs`)
- [x] Visual-baseline assessment: classifier fails closed on lockfile/root-config paths as designed; the sole resolution change (nanoid 3.3.16 → 3.3.18, consumed only by postcss for internal source-map input IDs at build time) provably cannot alter rendered pixels, so no baselines regenerated. CI's fail-closed E2E policy will still run all three suites against existing baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)