### PR TITLE
Release Website

### DIFF
--- a/.changeset/website-posthog-analytics.md
+++ b/.changeset/website-posthog-analytics.md
@@ -1,8 +1,0 @@
----
-'networkcanvas.com': minor
----
-
-Add privacy-conscious usage analytics, so we can see which pages people find
-useful and be told when a page fails to load. Analytics run only on the live
-site — never on previews or local development — and are sent through the
-project's own relay rather than to a third party directly.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,14 @@
 # networkcanvas.com
 
+## 0.3.0
+
+### Minor Changes
+
+- Add privacy-conscious usage analytics, so we can see which pages people find
+  useful and be told when a page fails to load. Analytics run only on the live
+  site — never on previews or local development — and are sent through the
+  project's own relay rather than to a third party directly.
+
 ## 0.2.4
 
 ### Patch Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.2.4 | 0.3.0 |

### networkcanvas.com@0.3.0

### Minor Changes

- Add privacy-conscious usage analytics, so we can see which pages people find
  useful and be told when a page fails to load. Analytics run only on the live
  site — never on previews or local development — and are sent through the
  project's own relay rather than to a third party directly.
