### PR TITLE
fix(release): give the classic apps rpm-legal Linux package names

### DIFF
--- a/apps/architect-classic/electron-builder.config.js
+++ b/apps/architect-classic/electron-builder.config.js
@@ -169,6 +169,19 @@ module.exports = {
     ],
   },
 
+  // Linux package identity. Without these, electron-builder derives the deb
+  // and rpm package name from package.json's name; since the monorepo rename
+  // that is scoped ("@codaco/architect-classic"), so it falls back to the
+  // sanitized productName — "Network Canvas Architect", which rpmbuild
+  // rejects because a Name may not contain spaces. Keep the pre-monorepo
+  // package name that 6.6.0 shipped, so existing installs upgrade in place.
+  deb: {
+    packageName: 'network-canvas-architect',
+  },
+  rpm: {
+    packageName: 'network-canvas-architect',
+  },
+
   // AppImage configuration
   appImage: {
     artifactName: '${productName}-${version}-${arch}.${ext}',

--- a/apps/interviewer-classic/electron-builder.config.cjs
+++ b/apps/interviewer-classic/electron-builder.config.cjs
@@ -84,12 +84,36 @@ module.exports = {
     // file paths. Keep the pre-monorepo executable name that 6.6.0 shipped.
     executableName: 'network-canvas-interviewer',
     maintainer: 'Joshua Melville <joshmelville@gmail.com>',
+    // Archive targets (tar.gz) take their artifact name from here, and the
+    // default pattern is `${name}`-based — since the monorepo rename that
+    // expands to "@codaco/interviewer-classic", whose slash writes the
+    // artifact into a `release-builds/@codaco/` subdirectory that the release
+    // job's flat `release-builds/*` upload then misses. Spell out the
+    // pre-monorepo name instead. This is also the fallback for every other
+    // Linux target, so deb, rpm and AppImage each restate their own below.
+    artifactName: 'network-canvas-interviewer-${version}-${arch}.${ext}',
     target: [
       { target: 'deb', arch: ['x64', 'arm64'] },
       { target: 'rpm', arch: ['x64', 'arm64'] },
       { target: 'AppImage', arch: ['x64', 'arm64'] },
       { target: 'tar.gz', arch: ['x64', 'arm64'] },
     ],
+  },
+  // `packageName` keeps the deb/rpm package identity on the pre-monorepo name
+  // that 6.6.0 shipped, so existing installs upgrade in place. Without it
+  // electron-builder falls back to the sanitized productName for a scoped
+  // package.json name — "Network Canvas Interviewer", which rpmbuild rejects
+  // because a Name may not contain spaces.
+  deb: {
+    packageName: 'network-canvas-interviewer',
+    artifactName: 'network-canvas-interviewer_${version}_${arch}.${ext}',
+  },
+  rpm: {
+    packageName: 'network-canvas-interviewer',
+    artifactName: 'network-canvas-interviewer-${version}.${arch}.${ext}',
+  },
+  appImage: {
+    artifactName: '${productName}-${version}-${arch}.${ext}',
   },
   publish: [
     {


### PR DESCRIPTION
## Problem

The Ubuntu `architect-release-build` and `interviewer-release-build` jobs both fail ([run 31487310280](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/31487310280)). Every AppImage/deb/tar.gz target builds fine; the rpm targets fail in `rpmbuild`:

```
Command failed: .../fpm -s dir --force -t rpm ... --name Network Canvas Architect
Process failed: rpmbuild failed (exit code 1)
```

Since the monorepo rename, `package.json`'s `name` is scoped, and electron-builder falls back to the sanitized `productName` for the deb/rpm package name when it is ([`appInfo.linuxPackageName`](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/appInfo.ts)). rpm rejects a `Name:` containing spaces, so all four rpm builds fail and take the job down. Same root cause as the recent `executableName` pin.

## Fix

- Pin `packageName` on each app's `deb` and `rpm` targets to the pre-monorepo names 6.6.0 shipped (`network-canvas-architect`, `network-canvas-interviewer`), so existing installs still upgrade in place.
- Interviewer additionally had its deb/rpm/tar.gz artifact names default to a `${name}`-based pattern, expanding to `@codaco/interviewer-classic` — the slash wrote those artifacts into a `release-builds/@codaco/` subdirectory that the release job's flat `release-builds/*` upload would have missed. Those patterns are now spelled out, and AppImage restates its own so the new `linux.artifactName` fallback does not change it.

Both configs validate against electron-builder's own `scheme.json` (`packageName` is only legal inside the `deb`/`rpm` blocks, not `linux`).

## Not addressed here

The macOS `architect-release-build` job fails for an unrelated, non-code reason — notarytool returns HTTP 403, *"A required agreement is missing or has expired"*. That needs an App Store Connect agreement accepted by the account holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)