### PR TITLE
Fix Classic release titles for update checks

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -2311,7 +2311,7 @@ jobs:
           token: ${{ secrets.LEGACY_RELEASE_GH_TOKEN }}
           tag_name: v${{ needs.legacy-release-detect.outputs.interviewer_version }}
           target_commitish: ${{ steps.mirror.outputs.mirror_sha }}
-          name: Network Canvas Interviewer v${{ needs.legacy-release-detect.outputs.interviewer_version }}
+          name: ${{ needs.legacy-release-detect.outputs.interviewer_version }}
           body_path: ${{ runner.temp }}/notes.md
           draft: true
           make_latest: 'false'
@@ -2390,7 +2390,7 @@ jobs:
           token: ${{ secrets.LEGACY_RELEASE_GH_TOKEN }}
           tag_name: v${{ needs.legacy-release-detect.outputs.architect_version }}
           target_commitish: ${{ steps.mirror.outputs.mirror_sha }}
-          name: Network Canvas Architect v${{ needs.legacy-release-detect.outputs.architect_version }}
+          name: ${{ needs.legacy-release-detect.outputs.architect_version }}
           body_path: ${{ runner.temp }}/notes.md
           draft: true
           make_latest: 'false'

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -239,6 +239,23 @@ test('classic release builds use the proven macOS signing secrets', () => {
   }
 });
 
+test('Classic release names remain bare semver for legacy update checks', () => {
+  for (const [jobName, app] of [
+    ['interviewer-mirror', 'interviewer'],
+    ['architect-mirror', 'architect'],
+  ]) {
+    const mirrorJob = job(jobName);
+    assert.ok(mirrorJob, `${jobName} exists`);
+    assert.match(
+      mirrorJob,
+      new RegExp(
+        `name: \\$\\{\\{ needs\\.legacy-release-detect\\.outputs\\.${app}_version \\}\\}`,
+      ),
+    );
+    assert.doesNotMatch(mirrorJob, /name: Network Canvas/);
+  }
+});
+
 test('Fresco postinstall is portable to Windows release runners', () => {
   assert.equal(
     frescoPackage.scripts.postinstall,


### PR DESCRIPTION
## Summary
- publish Classic Architect and Interviewer GitHub releases with bare semver titles so their legacy update checks can compare versions
- add a workflow regression test covering both external release jobs
- existing `v6.6.0` and `v6.6.1` release titles were corrected in both standalone repositories

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm test:scripts` (153 tests)
- [x] `pnpm knip`
- [x] `pnpm typecheck` (17 tasks)
- [x] visual-baseline classifier: Architect, Interview, and Interviewer skipped as nonvisual
- [x] verified both live `releases/latest` endpoints return the bare `6.6.1` title and all existing release titles are semver

## Changeset
- Not required: CI/tooling-only change
