### PR TITLE
chore: enforce catalog dependency checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "turbo run typecheck --continue",
     "generate:interface-images": "pnpm --filter @codaco/interface-images generate",
     "prepare": "husky",
-    "knip": "SKIP_ENV_VALIDATION=true knip --exclude catalog"
+    "knip": "SKIP_ENV_VALIDATION=true knip"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,6 @@ catalog:
   '@posthog/nextjs-config': ^1.9.68
   '@posthog/react': ^1.10.3
   '@posthog/rollup-plugin': ^1.4.7
-  '@radix-ui/react-dialog': ^1.1.15
   '@radix-ui/react-slot': ^1.2.4
   '@reduxjs/toolkit': ^2.12.0
   '@storybook/addon-a11y': ^10.5.6
@@ -64,7 +63,6 @@ catalog:
   '@storybook/nextjs-vite': ^10.5.5
   '@storybook/react-vite': ^10.5.6
   '@tailwindcss/cli': ^4.3.3
-  '@tailwindcss/container-queries': ^0.1.1
   '@tailwindcss/postcss': ^4.3.3
   '@tailwindcss/typography': ^0.5.20
   '@tailwindcss/vite': ^4.3.3
@@ -83,7 +81,6 @@ catalog:
   '@vitest/browser-playwright': ^4.1.10
   '@vitest/coverage-v8': ^4.1.10
   chromatic: ^18.1.0
-  class-variance-authority: 0.7.1
   csvtojson: ^2.0.14
   dotenv: ^17.4.2
   effect: ^3.22.1


### PR DESCRIPTION
## Summary
- remove three unused workspace catalog entries
- enable Knip's catalog analysis so future orphaned catalog entries fail the standard dependency check
- preserve all Capacitor catalog entries and Interviewer Classic native build dependencies

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `SKIP_ENV_VALIDATION=true pnpm exec knip --include catalog`
- [x] `pnpm check:changesets`
- [x] `git diff --check`

No changeset is needed because this is repository tooling only. Visual baselines were not regenerated because the manifest-only diff does not change rendered dependencies or pixels, and the lockfile is unchanged.