### PR TITLE
fix(test): give Testing Library waits a CI-realistic budget

### DIFF
--- a/apps/documentation/vitest.config.ts
+++ b/apps/documentation/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    // Parallelised with the rest of the workspace's tests in the CI quality
+    // job; give jsdom tests headroom under peak runner load, and room for the
+    // shared setup's 5s Testing Library wait budget to report first.
+    testTimeout: 20_000,
     setupFiles: [disableModernAnimationsSetup, './vitest.setup.ts'],
     include: [
       'components/**/__tests__/**/*.{ts,tsx}',

--- a/apps/fresco/vitest.config.ts
+++ b/apps/fresco/vitest.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
             '**/*.stories.ts',
           ],
           name: 'units',
+          // Parallelised with the rest of the workspace's tests in the CI
+          // quality job; give jsdom tests headroom under peak runner load, and
+          // room for the shared setup's 5s Testing Library wait budget to
+          // report first.
+          testTimeout: 20_000,
           setupFiles: [disableModernAnimationsSetup, './vitest.setup.ts'],
           server: {
             deps: { inline: ['@codaco/interview'] },

--- a/apps/studio/client/vitest.config.ts
+++ b/apps/studio/client/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
+    // Parallelised with the rest of the workspace's tests in the CI quality
+    // job; give jsdom tests headroom under peak runner load, and room for the
+    // shared setup's 5s Testing Library wait budget to report first.
+    testTimeout: 20_000,
     setupFiles: [disableModernAnimationsSetup, './src/test-setup.ts'],
     include: ['src/**/*.test.{ts,tsx}', 'src/**/__tests__/**/*.test.{ts,tsx}'],
     exclude: ['**/node_modules/**', '**/dist/**'],

--- a/packages/art/vitest.config.ts
+++ b/packages/art/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // Parallelised with the rest of the workspace's tests in the CI quality
+    // job; give jsdom tests headroom under peak runner load, and room for the
+    // shared setup's 5s Testing Library wait budget to report first.
+    testTimeout: 20_000,
     setupFiles: [disableModernAnimationsSetup, './src/__tests__/setup.ts'],
   },
 });

--- a/packages/interface-images/package.json
+++ b/packages/interface-images/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@codaco/tsconfig": "workspace:^",
+    "@codaco/vitest-config": "workspace:^",
     "@testing-library/react": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/packages/interface-images/vitest.config.ts
+++ b/packages/interface-images/vitest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vitest/config';
 
+import { disableModernAnimationsSetup } from '@codaco/vitest-config/modern/setup-path';
+
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    // Parallelised with the rest of the workspace's tests in the CI quality
+    // job; give jsdom tests headroom under peak runner load, and room for the
+    // shared setup's 5s Testing Library wait budget to report first.
+    testTimeout: 20_000,
+    setupFiles: [disableModernAnimationsSetup],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ catalogs:
     '@tanstack/react-table':
       specifier: ^8.21.3
       version: 8.21.3
+    '@testing-library/dom':
+      specifier: ^10.4.1
+      version: 10.4.1
     '@testing-library/jest-dom':
       specifier: ^7.0.0
       version: 7.0.0
@@ -2149,6 +2152,9 @@ importers:
       '@codaco/tsconfig':
         specifier: workspace:^
         version: link:../../tooling/typescript
+      '@codaco/vitest-config':
+        specifier: workspace:^
+        version: link:../../tooling/vitest
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2719,6 +2725,9 @@ importers:
 
   tooling/vitest:
     dependencies:
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
       motion:
         specifier: 'catalog:'
         version: 12.43.0(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,10 @@ catalog:
   '@tailwindcss/typography': ^0.5.20
   '@tailwindcss/vite': ^4.3.3
   '@tanstack/react-table': ^8.21.3
+  # Declared so the shared Vitest setup can call `configure()` on the very same
+  # module instance the suites' own queries read. React Testing Library depends
+  # on this range, so the catalog pin keeps it a single copy.
+  '@testing-library/dom': ^10.4.1
   '@testing-library/jest-dom': ^7.0.0
   '@testing-library/react': ^16.3.2
   '@total-typescript/ts-reset': ^0.6.1

--- a/scripts/mirror-app.mjs
+++ b/scripts/mirror-app.mjs
@@ -267,6 +267,9 @@ export function vendorSharedVitestConfig(staging, manifest, dropped) {
     delete vendoredManifest.exports['./modern/disable-animations'];
     delete vendoredManifest.exports['./modern/setup-path'];
     delete vendoredManifest.dependencies.motion;
+    // Only the modern setup configures Testing Library; the legacy one does not
+    // import it.
+    delete vendoredManifest.dependencies['@testing-library/dom'];
   }
   if (!usesDependency('framer-motion')) {
     vendoredManifest.files = vendoredManifest.files.filter(

--- a/scripts/vitest-animation-setup.test.mjs
+++ b/scripts/vitest-animation-setup.test.mjs
@@ -161,6 +161,105 @@ test('the shared Vitest setup widens the Testing Library wait budget', () => {
   );
 });
 
+/**
+ * The chain of `{ … }` blocks enclosing `offset`, innermost first, as
+ * `[start, end]` pairs. Strings and comments are skipped, so neither a brace
+ * inside a glob nor an apostrophe inside prose can shift the nesting.
+ *
+ * A whole-file scan is not good enough here: a config's projects each carry
+ * their own `testTimeout`, and a Storybook project's generous one must not be
+ * read as cover for a unit project that declares none.
+ */
+function enclosingBlocks(source, offset) {
+  const open = [];
+  const blocks = [];
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    const pair = source.slice(index, index + 2);
+
+    if (pair === '//') {
+      const newline = source.indexOf('\n', index);
+      index = newline === -1 ? source.length : newline;
+      continue;
+    }
+
+    if (pair === '/*') {
+      const close = source.indexOf('*/', index + 2);
+      index = close === -1 ? source.length : close + 1;
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      index += 1;
+      while (index < source.length && source[index] !== character) {
+        if (source[index] === '\\') index += 1;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (character === '{') {
+      open.push(index);
+    } else if (character === '}') {
+      const start = open.pop();
+      if (start !== undefined && start < offset && index > offset) {
+        blocks.push([start, index]);
+      }
+    }
+  }
+
+  // Blocks are recorded as they close, and an enclosing block cannot close
+  // before the block it encloses — so this is already innermost-first.
+  return blocks;
+}
+
+/**
+ * A block's own properties, with every nested `{ … }` blanked out. Without
+ * this, the root `test` block of a config whose `projects` array holds a
+ * 60-second Storybook project would appear to declare that timeout itself.
+ */
+function ownProperties(source, [start, end]) {
+  let own = '';
+  let depth = 0;
+
+  for (let index = start + 1; index < end; index += 1) {
+    const character = source[index];
+    const pair = source.slice(index, index + 2);
+
+    if (pair === '//') {
+      const newline = source.indexOf('\n', index);
+      index = newline === -1 ? end : newline;
+      continue;
+    }
+
+    if (pair === '/*') {
+      const close = source.indexOf('*/', index + 2);
+      index = close === -1 ? end : close + 1;
+      continue;
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      // Consumed whole so a brace inside cannot shift the depth, but kept
+      // verbatim so string-valued properties such as `name` survive.
+      const opened = index;
+      index += 1;
+      while (index < end && source[index] !== character) {
+        if (source[index] === '\\') index += 1;
+        index += 1;
+      }
+      if (depth === 0) own += source.slice(opened, index + 1);
+      continue;
+    }
+
+    if (character === '{') depth += 1;
+    else if (character === '}') depth -= 1;
+    else if (depth === 0) own += character;
+  }
+
+  return own;
+}
+
 test('every jsdom project loading the shared setup outlasts its wait budget', () => {
   // A `testTimeout` at or below the wait budget cuts `waitFor` short, so the
   // failure arrives as a bare timeout instead of the DOM the wait gave up on.
@@ -171,13 +270,30 @@ test('every jsdom project loading the shared setup outlasts its wait budget', ()
 
     for (const configPath of findVitestConfigs(workspaceDirectory)) {
       const config = readFileSync(configPath, 'utf8');
-      if (!config.includes(sharedSetupFilename)) continue;
 
-      const timeouts = [...config.matchAll(/testTimeout:\s*([\d_]+)/g)].map(
-        (match) => Number(match[1].replaceAll('_', '')),
-      );
-      if (timeouts.length === 0 || timeouts.some((value) => value < 20_000)) {
-        tooTight.push(path.relative(repoRoot, configPath));
+      // Every use in `setupFiles` is one project loading the shared setup; the
+      // bare import specifier at the top of the file is not.
+      const uses = [...config.matchAll(/disableModernAnimationsSetup/g)]
+        .map((match) => match.index)
+        .filter((index) => !/^\s*import\b/.test(lineAt(config, index)));
+
+      for (const use of uses) {
+        // Projects here all use `extends: true`, so a `testTimeout` on an
+        // enclosing block still governs; take the nearest one declared.
+        const nearest = enclosingBlocks(config, use)
+          .map((block) =>
+            /testTimeout:\s*([\d_]+)/.exec(ownProperties(config, block)),
+          )
+          .find(Boolean);
+
+        const timeout = nearest
+          ? Number(nearest[1].replaceAll('_', ''))
+          : undefined;
+        if (timeout === undefined || timeout < 20_000) {
+          tooTight.push(
+            `${path.relative(repoRoot, configPath)} (${projectNameAt(config, use) ?? 'root'}: ${timeout ?? 'unset'})`,
+          );
+        }
       }
     }
   }
@@ -185,9 +301,24 @@ test('every jsdom project loading the shared setup outlasts its wait budget', ()
   assert.deepEqual(
     tooTight,
     [],
-    `Vitest projects loading ${sharedSetupPath} must set testTimeout to at least 20s on every project: ${tooTight.join(', ')}`,
+    `Every Vitest project loading ${sharedSetupPath} must set testTimeout to at least 20s: ${tooTight.join(', ')}`,
   );
 });
+
+function lineAt(source, offset) {
+  const start = source.lastIndexOf('\n', offset) + 1;
+  const end = source.indexOf('\n', offset);
+  return source.slice(start, end === -1 ? undefined : end);
+}
+
+/** The `name:` of the project block that loads the setup, for the failure text. */
+function projectNameAt(source, offset) {
+  for (const block of enclosingBlocks(source, offset)) {
+    const named = /name:\s*'([^']+)'/.exec(ownProperties(source, block));
+    if (named) return named[1];
+  }
+  return undefined;
+}
 
 test('every Testing Library Vitest workspace loads the shared setup', () => {
   // Motion is the usual reason to need the shared setup, but the wait budget it

--- a/scripts/vitest-animation-setup.test.mjs
+++ b/scripts/vitest-animation-setup.test.mjs
@@ -148,6 +148,77 @@ test('the shared Vitest setup disables Motion and Base UI animations', () => {
   assert.match(setup, /globalThis\.BASE_UI_ANIMATIONS_DISABLED\s*=\s*true/);
 });
 
+test('the shared Vitest setup widens the Testing Library wait budget', () => {
+  const setup = readFileSync(path.join(repoRoot, sharedSetupPath), 'utf8');
+
+  // Testing Library's own default is one second, which a loaded CI runner
+  // exceeds on renders that take tens of milliseconds locally.
+  const configured = setup.match(/asyncUtilTimeout:\s*([\d_]+)/);
+  assert.ok(configured, `${sharedSetupPath} must configure asyncUtilTimeout`);
+  assert.ok(
+    Number(configured[1].replaceAll('_', '')) >= 5000,
+    `${sharedSetupPath} must give waitFor/findBy at least 5s, got ${configured[1]}`,
+  );
+});
+
+test('every jsdom project loading the shared setup outlasts its wait budget', () => {
+  // A `testTimeout` at or below the wait budget cuts `waitFor` short, so the
+  // failure arrives as a bare timeout instead of the DOM the wait gave up on.
+  const tooTight = [];
+
+  for (const manifestPath of workspaceManifests) {
+    const workspaceDirectory = path.dirname(manifestPath);
+
+    for (const configPath of findVitestConfigs(workspaceDirectory)) {
+      const config = readFileSync(configPath, 'utf8');
+      if (!config.includes(sharedSetupFilename)) continue;
+
+      const timeouts = [...config.matchAll(/testTimeout:\s*([\d_]+)/g)].map(
+        (match) => Number(match[1].replaceAll('_', '')),
+      );
+      if (timeouts.length === 0 || timeouts.some((value) => value < 20_000)) {
+        tooTight.push(path.relative(repoRoot, configPath));
+      }
+    }
+  }
+
+  assert.deepEqual(
+    tooTight,
+    [],
+    `Vitest projects loading ${sharedSetupPath} must set testTimeout to at least 20s on every project: ${tooTight.join(', ')}`,
+  );
+});
+
+test('every Testing Library Vitest workspace loads the shared setup', () => {
+  // Motion is the usual reason to need the shared setup, but the wait budget it
+  // configures matters to any workspace that queries the DOM asynchronously.
+  const uncoveredWorkspaces = findUnconfiguredWorkspaces({
+    dependencyName: '@testing-library/react',
+    setupFilename: sharedSetupFilename,
+    workspaceManifests,
+  });
+
+  assert.deepEqual(
+    uncoveredWorkspaces,
+    [],
+    `Testing Library Vitest workspaces must load ${sharedSetupPath} in their unit or browser setupFiles: ${uncoveredWorkspaces.join(', ')}`,
+  );
+});
+
+test('Testing Library Vitest consumers inherit setup changes through Vitest tooling', () => {
+  const missingDependency = findConsumersMissingWorkspaceDependency({
+    consumerDependency: '@testing-library/react',
+    requiredDependency: '@codaco/vitest-config',
+    workspaceManifests,
+  });
+
+  assert.deepEqual(
+    missingDependency,
+    [],
+    `Testing Library Vitest consumers must declare @codaco/vitest-config as a workspace dependency so Turbo selects them when ${sharedSetupPath} changes: ${missingDependency.join(', ')}`,
+  );
+});
+
 test('every modern Motion Vitest workspace loads the shared animation setup', () => {
   const uncoveredWorkspaces = findUnconfiguredWorkspaces({
     dependencyName: 'motion',

--- a/tooling/vitest/modern/disable-animations.js
+++ b/tooling/vitest/modern/disable-animations.js
@@ -1,7 +1,41 @@
+import { configure } from '@testing-library/dom';
 import { MotionGlobalConfig } from 'motion/react';
+import { afterAll, vi } from 'vitest';
 
 // Keep the real Motion implementation in unit tests, but make every animation
 // finish immediately. This covers components rendered without the app-level
 // AnimationProvider, including AnimatePresence exit bookkeeping.
 MotionGlobalConfig.skipAnimations = true;
 globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+
+// Testing Library gives every `waitFor`/`findBy*` one second, a budget whose
+// only calibration is a developer's idle machine. CI runs the whole workspace's
+// suites concurrently on a four-core runner: Architect's jsdom project alone
+// takes ~30s locally and ~10min there. Waits that resolve in tens of
+// milliseconds locally land either side of that one-second cliff under load, so
+// the suite fails on a half-rendered DOM rather than on any assertion. Each
+// project's `testTimeout` was already raised for exactly this reason; this is
+// its Testing Library counterpart. It stays well under the 20s test timeout so
+// a genuinely stuck wait still reports its own DOM rather than being cut short,
+// and it costs nothing when a wait succeeds — `waitFor` polls and returns as
+// soon as the condition holds.
+configure({ asyncUtilTimeout: 5_000 });
+
+// @tiptap/react defers `editor.destroy()` onto a 1ms timer so that remounting
+// does not tear down an editor that is in fact still mounted. Vitest disposes
+// the jsdom environment as soon as a file's hooks finish, so under load that
+// timer can land in the gap between one file's teardown and the next file's
+// setup, where `window` no longer exists. Tiptap's drag-handling plugin
+// dereferences it unconditionally, so the run dies with `ReferenceError: window
+// is not defined` as an unhandled error — failing the job with every test
+// passing. Give the file's deferred unmount work a real tick while the DOM is
+// still there.
+afterAll(async () => {
+  // The file is over; restoring real timers here cannot disturb a test, and
+  // without it a suite that left fake timers installed would hang below.
+  if (vi.isFakeTimers()) vi.useRealTimers();
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 5);
+  });
+});

--- a/tooling/vitest/package.json
+++ b/tooling/vitest/package.json
@@ -14,6 +14,7 @@
     "./modern/setup-path": "./modern/setup-path.js"
   },
   "dependencies": {
+    "@testing-library/dom": "catalog:",
     "motion": "catalog:"
   },
   "peerDependencies": {


### PR DESCRIPTION
## The failure

Since [#1236](https://github.com/complexdatacollective/network-canvas-monorepo/pull/1236) (the Architect Redux-form migration) merged at 17:07 on 11 Aug, the `test` job has failed intermittently on essentially every open PR — including dependency bumps that touch nothing Architect renders. Every failure is `@codaco/architect#test`, but a *different* test each time:

| Run | Branch | Failing test |
| --- | --- | --- |
| 17:20 11 Aug | `feat/1151-node-label-autofit-longpress` | `additionalAttributes.test.tsx` |
| 18:38 11 Aug | `changeset-release/main` | `additionalAttributes.test.tsx` |
| 22:18 11 Aug | `feat/studio-auth` | `additionalAttributes.test.tsx` |
| 09:34 12 Aug | `codex/fix-fresco-form-prototype-pollution` | `additionalAttributes.test.tsx` |
| 11:28 12 Aug | `dependabot/storybook` | `NodePanels.identity.test.tsx` |
| 11:29 12 Aug | `dependabot/capacitor/app` | tiptap unhandled error |

The runs immediately before #1236 fail only on `interview-e2e` — no `test` failures at all.

## Cause

**All of them are `waitFor`/`findBy*` giving up, not assertions disagreeing.** Testing Library gives every wait one second, a budget whose only calibration is an idle developer machine. CI runs the whole workspace's suites concurrently on a four-core runner: Architect's jsdom project takes **~30s locally and ~585s there**. Waits that resolve in tens of milliseconds locally land either side of that one-second cliff under load, and the failure reports a half-rendered DOM — the `NodePanels` dump shows a Base UI switch caught mid-update, `aria-checked="false"` on the button while its hidden input already reads `checked`.

#1236 moved Architect's stage-form sections onto `fresco-ui`'s `ArrayField`, which is exactly where the async waits are. That is why the flakiness starts there and why it keeps landing on a different test.

Each project's `testTimeout` was already raised to 20s with the comment *"give jsdom tests headroom under peak runner load"*. Its Testing Library counterpart was never configured anywhere in the repo.

A second, independent cross-PR failure arrived with the tiptap 3.30 bump ([#1351](https://github.com/complexdatacollective/network-canvas-monorepo/pull/1351)): `@tiptap/react` defers `editor.destroy()` onto a 1ms timer, and Vitest disposes the jsdom environment as soon as a file's hooks finish. Under load that timer lands in the gap between one file's teardown and the next file's setup, where `window` no longer exists; tiptap's drag plugin dereferences it unconditionally. The job dies with an unhandled `ReferenceError: window is not defined` **with all 1681 tests passing**.

## The fix

- Configure `asyncUtilTimeout: 5_000` in the shared modern Vitest setup, so every jsdom suite in the workspace gets it at once. It costs nothing when a wait succeeds — `waitFor` polls and returns as soon as the condition holds — and it stays well under the 20s `testTimeout` so a genuinely stuck wait still reports its own DOM instead of being cut short.
- Give the four jsdom projects still on the default 5s `testTimeout` (`art`, `documentation`, `studio-client`, `interface-images`) the same 20s headroom the rest already have, so that ordering holds everywhere.
- `@codaco/interface-images` was the one Testing Library suite the shared setup never reached — wire it up, and widen the guard tests in `scripts/vitest-animation-setup.test.mjs` from "Motion consumers" to "Testing Library consumers" so the next one cannot be missed. The guards also now assert the wait budget exists and that no project's `testTimeout` undercuts it.
- Flush deferred unmount work in an `afterAll` so tiptap's 1ms destroy runs while the DOM is still there, instead of racing environment teardown.

`@testing-library/dom` becomes a catalog entry and a dependency of `@codaco/vitest-config` so `configure()` runs against the very same module instance the suites' own queries read (verified: both resolve to `.pnpm/@testing-library+dom@10.4.1`).

## Verification

- Confirmed the config reaches test queries: a scratch test in Architect read back `getConfig().asyncUtilTimeout === 5000` and completed a `waitFor` that resolves at 2000ms — one that fails under the old default.
- Confirmed the `afterAll` flush runs before teardown: a 1ms timer scheduled during a file's teardown observed a live `window`.
- `turbo run test` green across architect, fresco-ui, interview, interviewer, art, interface-images, documentation, studio-client (Architect: 216 files / 1681 tests).
- `pnpm typecheck`, `pnpm lint:fix`, `pnpm knip`, and `node --test scripts/vitest-animation-setup.test.mjs` (14/14) all pass.

No changeset: test infrastructure only, with no consumer-visible effect in any released package.

## Not fixed here

Three failures in that sample are each PR's own doing, not this class:

- [#1361](https://github.com/complexdatacollective/network-canvas-monorepo/pull/1361) (motion 13) has a broken lockfile — `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`, which fails every job at install.
- The immer 11 bump genuinely breaks `fresco-ui`'s `formStore`.
- `PreviewHost.test.tsx` fails only on `codex/non-null-variable-values`, which changes what synthetic data it asserts on.

The underlying condition — `turbo run test` at concurrency 10, each Vitest spawning its own worker pool on a four-core runner — is left alone deliberately; capping it is a separate call about CI wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)