### PR TITLE
fix(fresco-ui): resolve late node label review feedback

### DIFF
--- a/.changeset/neat-labels-settle.md
+++ b/.changeset/neat-labels-settle.md
@@ -1,0 +1,6 @@
+---
+"@codaco/fresco-ui": patch
+"@codaco/interview": patch
+---
+
+Keep fitted node labels accurate as fluid type changes, make long labels scroll within the available viewport when revealed, and release keyboard press feedback when activation moves focus into an opened form.

--- a/packages/fresco-ui/src/Node.labelReveal.test.tsx
+++ b/packages/fresco-ui/src/Node.labelReveal.test.tsx
@@ -176,13 +176,22 @@ describe('Node label reveal', () => {
     expect(getPopup()).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('renders the popup transparent to the pointer', async () => {
+  it('keeps the popup within the viewport and lets the participant scroll it', async () => {
     await renderNode(<Node label={CLIPPED_LABEL} onClick={vi.fn()} />);
 
     await pressAndHold(node(CLIPPED_LABEL));
     await waitFor(() => expect(getPopup()).not.toBeNull());
 
-    expect(getPopup()!.closest('[data-base-ui-portal] > *')).toHaveClass(
+    expect(getPopup()).toHaveClass(
+      'max-h-(--available-height)',
+      'flex',
+      'flex-col',
+    );
+    expect(getPopup()!.querySelector('[data-node-label-reveal]')).toHaveClass(
+      'overflow-y-auto',
+      'overscroll-contain',
+    );
+    expect(getPopup()!.closest('[data-base-ui-portal] > *')).not.toHaveClass(
       'pointer-events-none!',
     );
   });

--- a/packages/fresco-ui/src/Node.tsx
+++ b/packages/fresco-ui/src/Node.tsx
@@ -360,6 +360,7 @@ export default function Node(props: UINodeProps) {
     onPointerUp: externalPointerUp,
     onKeyDown: externalKeyDown,
     onKeyUp: externalKeyUp,
+    onBlur: externalBlur,
     onClick,
     onLongPress,
     onDragStart,
@@ -622,6 +623,7 @@ export default function Node(props: UINodeProps) {
       onPointerLeave={nodeProps.onPointerLeave}
       onKeyDown={composeEventHandlers(externalKeyDown, nodeProps.onKeyDown)}
       onKeyUp={composeEventHandlers(externalKeyUp, nodeProps.onKeyUp)}
+      onBlur={composeEventHandlers(nodeProps.onBlur, externalBlur)}
       onClick={handleClick}
     >
       {/* Shape layer - carries the background, state box-shadows, and (for
@@ -712,10 +714,17 @@ export default function Node(props: UINodeProps) {
         // The full label is already the button's accessible name, so announcing
         // the popup as well would read it twice.
         aria-hidden="true"
-        pointerEvents="none"
-        className="wrap-anywhere whitespace-pre-line"
+        // A short viewport may not have enough room for the entire label at
+        // once. Keep it inside Base UI's available space and let touch,
+        // pointer, and wheel users scroll the rest.
+        className="flex max-h-(--available-height) flex-col"
       >
-        {label}
+        <span
+          data-node-label-reveal
+          className="min-h-0 touch-pan-y overflow-y-auto overscroll-contain wrap-anywhere whitespace-pre-line"
+        >
+          {label}
+        </span>
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/fresco-ui/src/hooks/__tests__/useFitText.test.tsx
+++ b/packages/fresco-ui/src/hooks/__tests__/useFitText.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -79,6 +79,38 @@ describe('useFitText', () => {
 
     rerender(<Probe text={'a'.repeat(20)} />);
     await waitFor(() => expect(state()).toBe('0:false'));
+  });
+
+  it('re-fits when fluid type changes without resizing the container', async () => {
+    uninstallLabelMetrics();
+    let fluidTypeHasGrown = false;
+    const defineMetric = (
+      metric: string,
+      get: (this: HTMLElement) => number,
+    ) => {
+      Object.defineProperty(HTMLSpanElement.prototype, metric, {
+        configurable: true,
+        get,
+      });
+    };
+    defineMetric('clientWidth', () => 100);
+    defineMetric('scrollWidth', function (this: HTMLElement) {
+      return fluidTypeHasGrown && this.className.includes('text-base')
+        ? 101
+        : 100;
+    });
+    defineMetric('clientHeight', () => 20);
+    defineMetric('scrollHeight', () => 20);
+
+    render(<Probe text="Fluid label" />);
+    await waitFor(() => expect(state()).toBe('0:false'));
+
+    // The node box stays fixed while a viewport-based text token grows.
+    // ResizeObserver therefore has nothing to report from the container.
+    fluidTypeHasGrown = true;
+    fireEvent.resize(window);
+
+    await waitFor(() => expect(state()).toBe('1:false'));
   });
 
   it('still reports truncation for a single-rung ladder', async () => {

--- a/packages/fresco-ui/src/hooks/__tests__/useNodeInteractions.test.tsx
+++ b/packages/fresco-ui/src/hooks/__tests__/useNodeInteractions.test.tsx
@@ -19,7 +19,7 @@ function Probe() {
   );
 }
 
-const node = () => screen.getByRole('button');
+const node = () => screen.getByRole('button', { name: 'Node' });
 const pressed = () => node().getAttribute('data-pressed');
 
 beforeEach(() => {
@@ -85,6 +85,30 @@ describe('useNodeInteractions: minimum visible key press', () => {
     fireEvent.keyDown(node(), { key: 'Enter' });
     fireEvent.keyUp(node(), { key: 'Enter' });
     fireEvent.blur(window);
+
+    expect(pressed()).toBe('false');
+  });
+
+  it('lifts a key press when activation moves focus before keyup', () => {
+    render(
+      <>
+        <Probe />
+        <button type="button">Dialog field</button>
+      </>,
+    );
+
+    const button = node();
+    const dialogField = screen.getByRole('button', { name: 'Dialog field' });
+    button.focus();
+    act(() => {
+      button.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+      // Enter can synchronously open a form whose autofocus target receives
+      // the eventual keyup. Blur therefore happens before the key-down state
+      // has committed a render.
+      dialogField.focus();
+    });
 
     expect(pressed()).toBe('false');
   });

--- a/packages/fresco-ui/src/hooks/useFitText.ts
+++ b/packages/fresco-ui/src/hooks/useFitText.ts
@@ -165,19 +165,26 @@ export function useFitText<T extends HTMLElement = HTMLElement>({
     // against the fallback font can fit — or stop fitting — once they load.
     void document.fonts?.ready.then(fit);
 
+    // ResizeObserver only notices the fixed box. Fluid type tokens can change
+    // with the viewport while that box stays the same size, so the text still
+    // needs measuring on a viewport resize.
+    window.addEventListener('resize', fit);
+
+    const cleanup = () => {
+      cancelled = true;
+      pending.delete(fitter);
+      window.removeEventListener('resize', fit);
+    };
+
     if (typeof ResizeObserver === 'undefined' || !container) {
-      return () => {
-        cancelled = true;
-        pending.delete(fitter);
-      };
+      return cleanup;
     }
 
     const observer = new ResizeObserver(fit);
     observer.observe(container);
 
     return () => {
-      cancelled = true;
-      pending.delete(fitter);
+      cleanup();
       observer.disconnect();
     };
   }, [steps, containerRef, watch, enabled]);

--- a/packages/fresco-ui/src/hooks/useNodeInteractions.ts
+++ b/packages/fresco-ui/src/hooks/useNodeInteractions.ts
@@ -38,6 +38,7 @@ type UseNodeInteractionsReturn = {
     onPointerLeave: (e: React.PointerEvent) => void;
     onKeyDown: (e: React.KeyboardEvent) => void;
     onKeyUp: (e: React.KeyboardEvent) => void;
+    onBlur: (e: React.FocusEvent) => void;
     style: CSSProperties;
   };
   /** Whether the node is currently being pressed */
@@ -75,6 +76,10 @@ export function useNodeInteractions(
 
   const [scope, animate] = useSafeAnimate<HTMLElement>();
   const [isPressed, setIsPressed] = useState(false);
+  // Event sequences can move focus before React commits the key-down render.
+  // Keep the live ownership synchronously as well as in render state so a
+  // blur in that same sequence can still settle the press.
+  const isPressedRef = useRef(false);
 
   // A key tap can be over in well under the time the press spring needs to
   // become visible, so the release is held back until the press has been on
@@ -103,6 +108,7 @@ export function useNodeInteractions(
       // A held-back key release must not pop a press the pointer now owns.
       cancelPendingKeyRelease();
       if (enablePressAnimation && scope.current) {
+        isPressedRef.current = true;
         setIsPressed(true);
         animate(scope.current, { scale: 0.92 });
       }
@@ -111,7 +117,8 @@ export function useNodeInteractions(
   );
 
   const resetPress = useCallback(() => {
-    if (!isPressed) return;
+    if (!isPressedRef.current) return;
+    isPressedRef.current = false;
     setIsPressed(false);
 
     if (scope.current) {
@@ -121,7 +128,7 @@ export function useNodeInteractions(
         { type: 'spring', stiffness: 700, damping: 20 },
       );
     }
-  }, [isPressed, animate, scope]);
+  }, [animate, scope]);
 
   // Losing the window ends the press without any of the events that normally
   // would: no pointerup, no pointercancel, no keyup. Left alone the node stays
@@ -135,6 +142,14 @@ export function useNodeInteractions(
     window.addEventListener('blur', handleWindowBlur);
     return () => window.removeEventListener('blur', handleWindowBlur);
   }, [cancelPendingKeyRelease, resetPress]);
+
+  const handleBlur = useCallback(
+    (_e: React.FocusEvent) => {
+      cancelPendingKeyRelease();
+      resetPress();
+    },
+    [cancelPendingKeyRelease, resetPress],
+  );
 
   const handlePointerUp = useCallback(
     (_e: React.PointerEvent) => {
@@ -168,6 +183,7 @@ export function useNodeInteractions(
       cancelPendingKeyRelease();
       keyPressedAtRef.current = performance.now();
       if (enablePressAnimation && scope.current) {
+        isPressedRef.current = true;
         setIsPressed(true);
         animate(
           scope.current,
@@ -206,6 +222,7 @@ export function useNodeInteractions(
       onPointerLeave: handlePointerLeave,
       onKeyDown: handleKeyDown,
       onKeyUp: handleKeyUp,
+      onBlur: handleBlur,
       style: {
         touchAction: 'manipulation',
         userSelect: 'none',


### PR DESCRIPTION
## Summary
- re-fit node labels when viewport-fluid typography changes without resizing the node box
- constrain revealed labels to Base UI's available viewport height and make overflow scrollable by touch, pointer, and wheel
- settle keyboard press feedback when activation moves focus before keyup
- add causal regressions for all three findings posted after #1329 merged

Follow-up to #1329.

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm --filter @codaco/fresco-ui test` (1,246 tests)
- [x] `pnpm --filter @codaco/fresco-ui test:storybook` (1,078 tests)
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `git diff --check`
- [x] Reviewed E2E visual classification; no canonical snapshots capture an open label reveal or active focus transition, and initial fitting output is unchanged
