### PR TITLE
ci: add a hotfix release lane for Architect and Interviewer

### DIFF
--- a/.github/scripts/app-release-guard.sh
+++ b/.github/scripts/app-release-guard.sh
@@ -9,9 +9,17 @@
 #      no longer arrive from main alone: hotfix-release.yml can move an app's
 #      released version out of band, and each app has a single production site,
 #      so `netlify deploy --prod` would roll production back to older code and
-#      claim the newer "latest" release for it. When this fires, main is behind
-#      its own released version — record the hotfix on main (see the app's
-#      RELEASING.md) and the next push releases normally.
+#      claim the newer "latest" release for it.
+#   3. This tree does not contain the newest released commit. A higher version
+#      number is not the same as a superset of what is live: main can be
+#      numerically ahead of a hotfix while missing the fix itself, and
+#      deploying it would quietly take that fix off production. The hotfix lane
+#      applies the same rule in the opposite direction.
+#
+# Both skips mean the same thing — main has not caught up with a hotfix — and
+# have the same remedy: merge the hotfix branch into main (see the app's
+# RELEASING.md). Skipping rather than failing keeps the lane self-healing: the
+# push that lands the merge releases normally.
 #
 # Inputs (env): PKG_NAME, VERSION, GITHUB_OUTPUT.
 # Requires tags in the checkout (actions/checkout fetch-tags: true).
@@ -37,7 +45,16 @@ if [[ -n "$newest" ]]; then
   highest=$(printf '%s\n%s\n' "$VERSION" "$newest" | sort -V | tail -1)
   if [[ "$highest" == "$newest" ]]; then
     echo "skip=true" >> "$GITHUB_OUTPUT"
-    echo "::warning::$VERSION is older than the released $newest — refusing to deploy it over production. Record the newer release on main (see the app's RELEASING.md)."
+    echo "::warning::$VERSION is older than the released $newest — refusing to deploy it over production. Merge the hotfix branch into main (see the app's RELEASING.md)."
+    exit 0
+  fi
+
+  # Numerically ahead is not the same as containing what is live: main can be
+  # on 8.2.0 while a hotfixed 8.1.3 is missing from its history, and deploying
+  # it would take that fix off production behind a higher version number.
+  if ! git merge-base --is-ancestor "$PKG_NAME@$newest" HEAD 2>/dev/null; then
+    echo "skip=true" >> "$GITHUB_OUTPUT"
+    echo "::warning::This tree does not contain $PKG_NAME@$newest — refusing to deploy $VERSION over it. Merge the hotfix branch into main (see the app's RELEASING.md)."
     exit 0
   fi
 fi

--- a/.github/scripts/app-release-guard.sh
+++ b/.github/scripts/app-release-guard.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Decides whether an app release job should still deploy, checked once the job
+# is actually running (its concurrency lock held) rather than at detection time.
+# Writes `skip` to $GITHUB_OUTPUT.
+#
+# Skips when:
+#   1. The tag already exists — a parallel run released this version.
+#   2. The version is older than the newest released tag for the app. Releases
+#      no longer arrive from main alone: hotfix-release.yml can move an app's
+#      released version out of band, and each app has a single production site,
+#      so `netlify deploy --prod` would roll production back to older code and
+#      claim the newer "latest" release for it. When this fires, main is behind
+#      its own released version — record the hotfix on main (see the app's
+#      RELEASING.md) and the next push releases normally.
+#
+# Inputs (env): PKG_NAME, VERSION, GITHUB_OUTPUT.
+# Requires tags in the checkout (actions/checkout fetch-tags: true).
+set -euo pipefail
+
+tag="$PKG_NAME@$VERSION"
+
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  echo "$tag already released — nothing to do"
+  exit 0
+fi
+
+newest=$(
+  git tag --list "$PKG_NAME@*" |
+    sed "s|^$PKG_NAME@||" |
+    grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' |
+    sort -V |
+    tail -1
+) || true
+
+if [[ -n "$newest" ]]; then
+  highest=$(printf '%s\n%s\n' "$VERSION" "$newest" | sort -V | tail -1)
+  if [[ "$highest" == "$newest" ]]; then
+    echo "skip=true" >> "$GITHUB_OUTPUT"
+    echo "::warning::$VERSION is older than the released $newest — refusing to deploy it over production. Record the newer release on main (see the app's RELEASING.md)."
+    exit 0
+  fi
+fi
+
+echo "skip=false" >> "$GITHUB_OUTPUT"
+echo "$tag is clear to release (newest released: ${newest:-none})"

--- a/.github/scripts/app-release-guard.sh
+++ b/.github/scripts/app-release-guard.sh
@@ -42,5 +42,11 @@ if [[ -n "$newest" ]]; then
   fi
 fi
 
-echo "skip=false" >> "$GITHUB_OUTPUT"
+# `newest` feeds release-notes.mjs --since: a release queued behind others on
+# this app's concurrency group can be dropped while pending, so the body must
+# carry every CHANGELOG section released since the last tag, not just its own.
+{
+  echo "skip=false"
+  echo "newest=$newest"
+} >> "$GITHUB_OUTPUT"
 echo "$tag is clear to release (newest released: ${newest:-none})"

--- a/.github/scripts/resolve-hotfix-release.mjs
+++ b/.github/scripts/resolve-hotfix-release.mjs
@@ -15,10 +15,15 @@
 //      always replaces what is live: publishing an older maintenance line would
 //      roll production back to older code. GitHub release metadata cannot
 //      soften that, so the lane refuses instead.
+//   4. The commit must descend from the newest released tag. A higher version
+//      number is not the same as a superset of what is live: a branch cut from
+//      8.1.2 and versioned 8.1.4 passes rule 3 after 8.1.3 ships, yet its tree
+//      has never seen the 8.1.3 fix, so deploying it would take that fix off
+//      production while the version number moved forward.
 //
 // Inputs (env): APP (interviewer | architect), GITHUB_OUTPUT.
 // Requires tags in the checkout (actions/checkout fetch-tags: true).
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { appendFileSync, readFileSync } from 'node:fs';
 
 const LABELS = { interviewer: 'Interviewer', architect: 'Architect' };
@@ -69,6 +74,19 @@ if (newest && compare(version, newest) < 0) {
     `${version} is older than the released ${newest}. Deploying it would roll ${label} production back to older code; ` +
       `this lane only ships the newest line.`,
   );
+}
+
+if (newest) {
+  const newestTag = `@codaco/${app}@${newest}`;
+  const descends =
+    spawnSync('git', ['merge-base', '--is-ancestor', newestTag, 'HEAD'])
+      .status === 0;
+  if (!descends) {
+    fail(
+      `This tree does not contain ${newestTag}. Re-cut the hotfix from that tag and cherry-pick the fix: ` +
+        `releasing ${version} from here would take the changes in ${newest} off production.`,
+    );
+  }
 }
 
 appendFileSync(

--- a/.github/scripts/resolve-hotfix-release.mjs
+++ b/.github/scripts/resolve-hotfix-release.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Decides whether a hotfix dispatch may release the version on the checked-out
+// ref, and writes `version` + `label` to $GITHUB_OUTPUT.
+//
+// Unlike the normal lane (.github/scripts/detect-app-release.sh), which is
+// self-healing and silently skips anything it should not release, every
+// rejection here is a hard error: a dispatch is a deliberate request, so
+// quietly doing nothing would be the wrong answer.
+//
+// Rules:
+//   1. Stable semver only — a hotfix is a released version, never a prerelease.
+//   2. The tag must not exist yet.
+//   3. The version must be newer than every released version of this app.
+//      Each app has exactly one production site, so `netlify deploy --prod`
+//      always replaces what is live: publishing an older maintenance line would
+//      roll production back to older code. GitHub release metadata cannot
+//      soften that, so the lane refuses instead.
+//
+// Inputs (env): APP (interviewer | architect), GITHUB_OUTPUT.
+// Requires tags in the checkout (actions/checkout fetch-tags: true).
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const LABELS = { interviewer: 'Interviewer', architect: 'Architect' };
+
+const app = process.env.APP;
+const label = LABELS[app];
+if (!label) {
+  fail(
+    `Unsupported app '${app}'. Expected one of: ${Object.keys(LABELS).join(', ')}.`,
+  );
+}
+
+const pkgPath = `apps/${app}/package.json`;
+const { version } = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+const STABLE = /^(\d+)\.(\d+)\.(\d+)$/;
+if (!STABLE.test(version)) {
+  fail(
+    `${pkgPath} version '${version}' is not a stable semver. Bump it on the hotfix branch first.`,
+  );
+}
+
+const tags = execFileSync('git', ['tag', '--list', `@codaco/${app}@*`], {
+  encoding: 'utf8',
+})
+  .split('\n')
+  .map((tag) => tag.trim().slice(`@codaco/${app}@`.length))
+  .filter((candidate) => STABLE.test(candidate));
+
+if (tags.includes(version)) {
+  fail(
+    `@codaco/${app}@${version} is already released. Bump the version on the hotfix branch.`,
+  );
+}
+
+const parse = (semver) => semver.match(STABLE).slice(1, 4).map(Number);
+const compare = (a, b) => {
+  const [left, right] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] !== right[i]) return left[i] - right[i];
+  }
+  return 0;
+};
+
+const newest = tags.toSorted(compare).at(-1);
+if (newest && compare(version, newest) < 0) {
+  fail(
+    `${version} is older than the released ${newest}. Deploying it would roll ${label} production back to older code; ` +
+      `this lane only ships the newest line.`,
+  );
+}
+
+appendFileSync(
+  process.env.GITHUB_OUTPUT,
+  `version=${version}\nlabel=${label}\n`,
+);
+console.log(
+  `[hotfix] ${label} ${version} (newest released: ${newest ?? 'none'}) — clear to release`,
+);
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}

--- a/.github/scripts/resolve-hotfix-release.mjs
+++ b/.github/scripts/resolve-hotfix-release.mjs
@@ -73,7 +73,9 @@ if (newest && compare(version, newest) < 0) {
 
 appendFileSync(
   process.env.GITHUB_OUTPUT,
-  `version=${version}\nlabel=${label}\n`,
+  // `newest` feeds release-notes.mjs --since, so the release body also carries
+  // any CHANGELOG section whose own release run was dropped while pending.
+  `version=${version}\nlabel=${label}\nnewest=${newest ?? ''}\n`,
 );
 console.log(
   `[hotfix] ${label} ${version} (newest released: ${newest ?? 'none'}) — clear to release`,

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -2055,17 +2055,21 @@ jobs:
     if: needs.apps-release-detect.outputs.architect_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release per version. With per-commit push concurrency (see top of file)
-    # main pushes run in parallel, so two runs can both detect the same untagged
-    # version and race into a duplicate build/deploy/release. Serialise them on
-    # the tag so only one runs at a time; the guard step below turns the run that
+    # One release at a time for this app, whichever lane it comes from. With
+    # per-commit push concurrency (see top of file) main pushes run in parallel,
+    # so two runs can both detect the same untagged version and race into a
+    # duplicate build/deploy/release; the guard step below turns the run that
     # starts after the tag exists into a clean no-op (no redundant prod deploy).
-    # The version stays in the group on purpose: a versionless group would keep
-    # only one pending run, so a release queued behind another could be dropped
-    # and never tagged. Ordering against the hotfix lane is enforced by the guard
-    # step's newest-tag check instead of by a shared lock.
+    # The group omits the version so hotfix-release.yml shares it: both lanes
+    # deploy before they tag, so version checks alone leave a window where one
+    # lane reads a stale newest-tag and puts older code live. Only exclusion
+    # over the whole check → deploy → tag sequence closes it.
+    # A versionless group keeps just one pending run, so a release queued behind
+    # two others can be dropped before tagging. Its code ships in the next
+    # release, and its notes are not lost either: --since below carries every
+    # CHANGELOG section since the last released version.
     concurrency:
-      group: apps-release-@codaco/architect@${{ needs.apps-release-detect.outputs.architect_version }}
+      group: apps-release-@codaco/architect
       cancel-in-progress: false
     permissions:
       contents: write
@@ -2117,13 +2121,18 @@ jobs:
             --site="${{ secrets.NETLIFY_SITE_ID_ARCHITECT }}"
       - name: architect release notes
         if: steps.guard.outputs.skip != 'true'
+        # --since is the newest version released before this one, so the body
+        # also carries any CHANGELOG section whose own release run was dropped
+        # while pending on this app's concurrency group.
         env:
           VERSION: ${{ needs.apps-release-detect.outputs.architect_version }}
+          SINCE: ${{ steps.guard.outputs.newest }}
         run: >-
           node scripts/release-notes.mjs
           --app apps/architect
           --pkg @codaco/architect
           --version "$VERSION"
+          --since "$SINCE"
           --out "${RUNNER_TEMP}/architect-notes.md"
       - if: steps.guard.outputs.skip != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -2144,9 +2153,10 @@ jobs:
     if: needs.apps-release-detect.outputs.interviewer_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release per version — see apps-release-architect for the rationale.
+    # One release at a time for this app, shared with the hotfix lane — see
+    # apps-release-architect for the rationale.
     concurrency:
-      group: apps-release-@codaco/interviewer@${{ needs.apps-release-detect.outputs.interviewer_version }}
+      group: apps-release-@codaco/interviewer
       cancel-in-progress: false
     permissions:
       contents: write
@@ -2196,13 +2206,18 @@ jobs:
             --site="${{ secrets.NETLIFY_SITE_ID_INTERVIEWER }}"
       - name: interviewer release notes
         if: steps.guard.outputs.skip != 'true'
+        # --since is the newest version released before this one, so the body
+        # also carries any CHANGELOG section whose own release run was dropped
+        # while pending on this app's concurrency group.
         env:
           VERSION: ${{ needs.apps-release-detect.outputs.interviewer_version }}
+          SINCE: ${{ steps.guard.outputs.newest }}
         run: >-
           node scripts/release-notes.mjs
           --app apps/interviewer
           --pkg @codaco/interviewer
           --version "$VERSION"
+          --since "$SINCE"
           --out "${RUNNER_TEMP}/interviewer-notes.md"
       - if: steps.guard.outputs.skip != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -2055,18 +2055,17 @@ jobs:
     if: needs.apps-release-detect.outputs.architect_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release at a time per app. With per-commit push concurrency (see top of
-    # file) main pushes run in parallel, so two runs can both detect the same
-    # untagged version and race into a duplicate build/deploy/release. Serialise
-    # them so only one runs at a time; the guard step below turns the run that
+    # One release per version. With per-commit push concurrency (see top of file)
+    # main pushes run in parallel, so two runs can both detect the same untagged
+    # version and race into a duplicate build/deploy/release. Serialise them on
+    # the tag so only one runs at a time; the guard step below turns the run that
     # starts after the tag exists into a clean no-op (no redundant prod deploy).
-    # The group deliberately omits the version so hotfix-release.yml — which
-    # cannot know its version before checkout — shares the same lock and can
-    # never deploy this app's single production site concurrently with this job.
-    # A pending run superseded by a newer one is recoverable: detection is
-    # tag-driven and self-healing, so the next main push releases it.
+    # The version stays in the group on purpose: a versionless group would keep
+    # only one pending run, so a release queued behind another could be dropped
+    # and never tagged. Ordering against the hotfix lane is enforced by the guard
+    # step's newest-tag check instead of by a shared lock.
     concurrency:
-      group: apps-release-@codaco/architect
+      group: apps-release-@codaco/architect@${{ needs.apps-release-detect.outputs.architect_version }}
       cancel-in-progress: false
     permissions:
       contents: write
@@ -2079,17 +2078,15 @@ jobs:
         with:
           fetch-tags: true
           persist-credentials: false
-      - name: Skip if this version was already released
+      # Also refuses a version older than the newest released tag: the hotfix
+      # lane can move the released version out of band, and this app has one
+      # production site to roll back.
+      - name: Skip if this version should not be deployed
         id: guard
         env:
-          TAG: '@codaco/architect@${{ needs.apps-release-detect.outputs.architect_version }}'
-        run: |
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "$TAG already released — nothing to do"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          PKG_NAME: '@codaco/architect'
+          VERSION: ${{ needs.apps-release-detect.outputs.architect_version }}
+        run: bash .github/scripts/app-release-guard.sh
       - if: steps.guard.outputs.skip != 'true'
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
@@ -2147,10 +2144,9 @@ jobs:
     if: needs.apps-release-detect.outputs.interviewer_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release at a time per app, shared with the hotfix lane — see
-    # apps-release-architect for the rationale.
+    # One release per version — see apps-release-architect for the rationale.
     concurrency:
-      group: apps-release-@codaco/interviewer
+      group: apps-release-@codaco/interviewer@${{ needs.apps-release-detect.outputs.interviewer_version }}
       cancel-in-progress: false
     permissions:
       contents: write
@@ -2161,17 +2157,15 @@ jobs:
         with:
           fetch-tags: true
           persist-credentials: false
-      - name: Skip if this version was already released
+      # Also refuses a version older than the newest released tag: the hotfix
+      # lane can move the released version out of band, and this app has one
+      # production site to roll back.
+      - name: Skip if this version should not be deployed
         id: guard
         env:
-          TAG: '@codaco/interviewer@${{ needs.apps-release-detect.outputs.interviewer_version }}'
-        run: |
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "$TAG already released — nothing to do"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          PKG_NAME: '@codaco/interviewer'
+          VERSION: ${{ needs.apps-release-detect.outputs.interviewer_version }}
+        run: bash .github/scripts/app-release-guard.sh
       - if: steps.guard.outputs.skip != 'true'
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -2081,10 +2081,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-tags: true
+          # Full history: the guard checks that this tree contains the newest
+          # released commit, which a shallow clone cannot answer.
+          fetch-depth: 0
           persist-credentials: false
-      # Also refuses a version older than the newest released tag: the hotfix
-      # lane can move the released version out of band, and this app has one
-      # production site to roll back.
+      # Refuses anything the hotfix lane has overtaken — a version older than
+      # the newest tag, or a tree missing the newest released commit. This app
+      # has one production site, and either would roll a shipped fix off it.
       - name: Skip if this version should not be deployed
         id: guard
         env:
@@ -2166,10 +2169,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-tags: true
+          # Full history: the guard checks that this tree contains the newest
+          # released commit, which a shallow clone cannot answer.
+          fetch-depth: 0
           persist-credentials: false
-      # Also refuses a version older than the newest released tag: the hotfix
-      # lane can move the released version out of band, and this app has one
-      # production site to roll back.
+      # Refuses anything the hotfix lane has overtaken — a version older than
+      # the newest tag, or a tree missing the newest released commit. This app
+      # has one production site, and either would roll a shipped fix off it.
       - name: Skip if this version should not be deployed
         id: guard
         env:

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -2055,13 +2055,18 @@ jobs:
     if: needs.apps-release-detect.outputs.architect_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release per version. With per-commit push concurrency (see top of file)
-    # main pushes run in parallel, so two runs can both detect the same untagged
-    # version and race into a duplicate build/deploy/release. Serialise them on
-    # the tag so only one runs at a time; the guard step below turns the run that
+    # One release at a time per app. With per-commit push concurrency (see top of
+    # file) main pushes run in parallel, so two runs can both detect the same
+    # untagged version and race into a duplicate build/deploy/release. Serialise
+    # them so only one runs at a time; the guard step below turns the run that
     # starts after the tag exists into a clean no-op (no redundant prod deploy).
+    # The group deliberately omits the version so hotfix-release.yml — which
+    # cannot know its version before checkout — shares the same lock and can
+    # never deploy this app's single production site concurrently with this job.
+    # A pending run superseded by a newer one is recoverable: detection is
+    # tag-driven and self-healing, so the next main push releases it.
     concurrency:
-      group: apps-release-@codaco/architect@${{ needs.apps-release-detect.outputs.architect_version }}
+      group: apps-release-@codaco/architect
       cancel-in-progress: false
     permissions:
       contents: write
@@ -2142,9 +2147,10 @@ jobs:
     if: needs.apps-release-detect.outputs.interviewer_released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # One release per version — see apps-release-architect for the rationale.
+    # One release at a time per app, shared with the hotfix lane — see
+    # apps-release-architect for the rationale.
     concurrency:
-      group: apps-release-@codaco/interviewer@${{ needs.apps-release-detect.outputs.interviewer_version }}
+      group: apps-release-@codaco/interviewer
       cancel-in-progress: false
     permissions:
       contents: write

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -1,0 +1,141 @@
+name: Hotfix Release
+
+# Releases Architect or Interviewer from a branch that is NOT main.
+#
+# The normal lane (`apps-release-detect` + `apps-release-<app>` in
+# ci-and-release.yml) builds whatever is on main, so it can only ship a patch
+# together with everything else merged since the last release. When main
+# carries work that is not ready to go out, the only way to ship a fix alone is
+# a branch cut from the released tag — and nothing on such a branch can trigger
+# the normal lane, which fires exclusively on push-to-main. This workflow is
+# that missing trigger: the same build → deploy → tag → release steps, run
+# against the dispatched ref.
+#
+# Procedure (see each app's RELEASING.md):
+#   1. Cut `hotfix/<app>-<version>` from the released tag, cherry-pick the fix,
+#      bump package.json and CHANGELOG.md, push the branch.
+#   2. Run this workflow with that branch selected under "Use workflow from".
+#   3. Record the released version on main afterwards, or the normal lane's tag
+#      guard will silently swallow main's next release.
+#
+# The chosen ref supplies both the workflow file and the tree that is built, so
+# a hotfix branch cut from an old tag must carry this file too.
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: App to release
+        required: true
+        type: choice
+        options:
+          - interviewer
+          - architect
+      mark_latest:
+        description: Mark the GitHub release as "Latest" (turn off when patching an older line)
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+# One release per app+version, and never cancelled: a half-finished deploy is
+# worse than a queued one. Mirrors the normal lane's per-release group.
+concurrency:
+  group: hotfix-release-@codaco/${{ inputs.app }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  hotfix-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      APP: ${{ inputs.app }}
+    steps:
+      - name: Refuse to run on main
+        if: github.ref_name == 'main'
+        run: |
+          echo "::error::main releases through apps-release-<app> in ci-and-release.yml. This lane exists for hotfix branches cut from a release tag." >&2
+          exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-tags: true
+          persist-credentials: false
+
+      # Unlike the normal lane — which is self-healing and silently skips an
+      # already-tagged version on every main push — a dispatch is a deliberate
+      # request, so an already-released version is an error, not a no-op.
+      - name: Resolve and validate the version
+        id: version
+        run: |
+          version=$(node -p "require('./apps/$APP/package.json').version")
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::apps/$APP/package.json version '$version' is not a stable semver. Bump it on the hotfix branch first." >&2
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/@codaco/$APP@$version" >/dev/null; then
+            echo "::error::@codaco/$APP@$version is already released. Bump the version on the hotfix branch." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          case "$APP" in
+            interviewer) echo 'label=Interviewer' >> "$GITHUB_OUTPUT" ;;
+            architect) echo 'label=Architect' >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          install: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # A hotfix branch has no required `quality` gate behind it, so the app's
+      # own suites run here. Its workspace dependencies are whatever the release
+      # tag pinned, already verified by the release they shipped in; a hotfix
+      # that changes a dependency package belongs in a pull request, not here.
+      - name: Verify the app
+        run: pnpm exec turbo run typecheck test --filter=@codaco/${{ env.APP }}
+
+      - name: Build ${{ inputs.app }}
+        # Scoped to this step alone, exactly as in the normal lane: only the
+        # build needs the PostHog credentials that switch source-map upload on,
+        # and keeping them off the job means the deploy step's dynamically
+        # fetched netlify-cli never sees them.
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: pnpm exec turbo run build --filter=@codaco/${{ env.APP }}
+
+      - name: Deploy ${{ inputs.app }} to production
+        run: |
+          npx --yes netlify-cli@22 deploy --no-build --prod \
+            --filter="@codaco/$APP" \
+            --dir="apps/$APP/dist" \
+            --site="${{ inputs.app == 'interviewer' && secrets.NETLIFY_SITE_ID_INTERVIEWER || secrets.NETLIFY_SITE_ID_ARCHITECT }}"
+
+      - name: Release notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: >-
+          node scripts/release-notes.mjs
+          --app "apps/$APP"
+          --pkg "@codaco/$APP"
+          --version "$VERSION"
+          --out "${RUNNER_TEMP}/hotfix-notes.md"
+
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: '@codaco/${{ inputs.app }}@${{ steps.version.outputs.version }}'
+          target_commitish: ${{ github.sha }}
+          name: ${{ steps.version.outputs.label }} ${{ steps.version.outputs.version }}
+          body_path: ${{ runner.temp }}/hotfix-notes.md
+          prerelease: false
+          make_latest: ${{ inputs.mark_latest }}

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -44,15 +44,17 @@ on:
 permissions:
   contents: read
 
-# Deliberately the same group the normal lane's apps-release-<app> job uses, so
-# the two lanes cannot deploy the same production site at once: a hotfix that
-# validated before a concurrent main release tagged a newer version would
-# otherwise land last and roll production back. Per app rather than per version
-# because two branches carrying the same version would each pass the tag check
-# and race, and because the version is not knowable at job-start — it comes from
-# the checked-out ref.
+# Serialized per app rather than per ref: two branches carrying the same version
+# would each pass the tag check and race, leaving one SHA tagged while the other
+# build is what production actually serves. Ordering against the normal lane is
+# enforced by version, not by a shared lock — this job re-validates against the
+# newest tag immediately before deploying, and the normal lane's guard refuses
+# anything older than the newest tag — because a lock the two lanes could share
+# would have to drop the version from the normal lane's group, and a versionless
+# group keeps only one pending run: a release queued behind another could be
+# dropped and never tagged.
 concurrency:
-  group: apps-release-@codaco/${{ inputs.app }}
+  group: hotfix-release-@codaco/${{ inputs.app }}
   cancel-in-progress: false
 
 jobs:
@@ -68,8 +70,14 @@ jobs:
       SOURCE_REF: ${{ inputs.source_ref }}
     steps:
       - name: Validate the dispatch
+        # DISPATCH_REF comes through the environment, never interpolated into the
+        # script: `$(...)` is a legal git ref name, and an expression pasted
+        # straight into bash would execute it before this check could reject it —
+        # with the environment's deploy credentials already in scope.
+        env:
+          DISPATCH_REF: ${{ github.ref }}
         run: |
-          if [[ "${{ github.ref_name }}" != 'main' ]]; then
+          if [[ "$DISPATCH_REF" != 'refs/heads/main' ]]; then
             echo "::error::Dispatch this workflow from main and name the branch to release in source_ref. Running it from a branch would take the job definition from that branch too." >&2
             exit 1
           fi
@@ -120,7 +128,7 @@ jobs:
       # compiles straight into the app. The filter therefore covers the app's
       # whole dependency closure (`...`), not just the app.
       - name: Verify the app and its workspace dependencies
-        run: pnpm exec turbo run typecheck test --filter=@codaco/${{ env.APP }}...
+        run: pnpm exec turbo run typecheck test --filter="@codaco/$APP..."
 
       - name: Build ${{ inputs.app }}
         # Scoped to this step alone, exactly as in the normal lane: only the
@@ -130,7 +138,17 @@ jobs:
         env:
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
-        run: pnpm exec turbo run build --filter=@codaco/${{ env.APP }}
+        run: pnpm exec turbo run build --filter="@codaco/$APP"
+
+      # The build takes minutes, during which the normal lane can tag and deploy
+      # a newer version. Re-fetch tags and re-run the same validator, so a hotfix
+      # that has been overtaken aborts here instead of putting older code live.
+      - name: Re-check the version against the newest release
+        run: |
+          # Anonymous fetch over https (the checkout persists no credentials);
+          # a failure here fails the step rather than validating stale tags.
+          git fetch --tags --force origin
+          node .hotfix-lane/.github/scripts/resolve-hotfix-release.mjs
 
       - name: Deploy ${{ inputs.app }} to production
         # Both site ids come in as environment variables and the app picks one in

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -44,11 +44,15 @@ on:
 permissions:
   contents: read
 
-# Serialized per app rather than per ref: two branches carrying the same version
-# would each pass the tag check and race, leaving one SHA tagged while the other
-# build is what production actually serves.
+# Deliberately the same group the normal lane's apps-release-<app> job uses, so
+# the two lanes cannot deploy the same production site at once: a hotfix that
+# validated before a concurrent main release tagged a newer version would
+# otherwise land last and roll production back. Per app rather than per version
+# because two branches carrying the same version would each pass the tag check
+# and race, and because the version is not knowable at job-start — it comes from
+# the checked-out ref.
 concurrency:
-  group: hotfix-release-@codaco/${{ inputs.app }}
+  group: apps-release-@codaco/${{ inputs.app }}
   cancel-in-progress: false
 
 jobs:
@@ -80,13 +84,27 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      # The ref being released is a branch cut from a release tag, so it predates
+      # this lane and carries no copy of the validator. Take that one file from
+      # the dispatching main commit instead — it is also the only copy anyone has
+      # reviewed. It reads apps/<app>/package.json and `git tag` relative to the
+      # working directory, never to its own location, so it validates the ref's
+      # tree while living outside it.
+      - name: Check out the lane's validator from main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.sha }}
+          path: .hotfix-lane
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
       - name: Resolve the released commit
         id: commit
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve and validate the version
         id: version
-        run: node .github/scripts/resolve-hotfix-release.mjs
+        run: node .hotfix-lane/.github/scripts/resolve-hotfix-release.mjs
 
       - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
@@ -115,11 +133,28 @@ jobs:
         run: pnpm exec turbo run build --filter=@codaco/${{ env.APP }}
 
       - name: Deploy ${{ inputs.app }} to production
+        # Both site ids come in as environment variables and the app picks one in
+        # bash. A `inputs.app == 'x' && secrets.A || secrets.B` expression would
+        # silently fall through to the *other* app's site whenever the selected
+        # secret is unset — deploying, say, Interviewer over Architect's
+        # production site instead of failing for the missing setup.
+        env:
+          SITE_ID_INTERVIEWER: ${{ secrets.NETLIFY_SITE_ID_INTERVIEWER }}
+          SITE_ID_ARCHITECT: ${{ secrets.NETLIFY_SITE_ID_ARCHITECT }}
         run: |
+          case "$APP" in
+            interviewer) site="$SITE_ID_INTERVIEWER"; secret=NETLIFY_SITE_ID_INTERVIEWER ;;
+            architect) site="$SITE_ID_ARCHITECT"; secret=NETLIFY_SITE_ID_ARCHITECT ;;
+            *) echo "::error::No production site is configured for '$APP'." >&2; exit 1 ;;
+          esac
+          if [[ -z "$site" ]]; then
+            echo "::error::$secret is unset. See apps/$APP/RELEASING.md for the one-time setup." >&2
+            exit 1
+          fi
           npx --yes netlify-cli@22 deploy --no-build --prod \
             --filter="@codaco/$APP" \
             --dir="apps/$APP/dist" \
-            --site="${{ inputs.app == 'interviewer' && secrets.NETLIFY_SITE_ID_INTERVIEWER || secrets.NETLIFY_SITE_ID_ARCHITECT }}"
+            --site="$site"
 
       - name: Release notes
         env:

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -93,6 +93,9 @@ jobs:
         with:
           ref: ${{ inputs.source_ref }}
           fetch-tags: true
+          # Full history: the validator checks that this tree descends from the
+          # newest release tag, which a shallow clone cannot answer.
+          fetch-depth: 0
           persist-credentials: false
 
       # The ref being released is a branch cut from a release tag, so its copy of

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -13,11 +13,19 @@ name: Hotfix Release
 #
 # The workflow is dispatched FROM main and takes the branch to release as an
 # input, so the job definition — which steps run, which secrets they see, which
-# guards they pass — is always reviewed code from the protected branch. Only the
-# tree that gets built comes from the hotfix branch. That tree still executes
-# its own build scripts, so this lane is gated on the `<app>-hotfix-production`
-# environment; give it required reviewers (see each app's RELEASING.md) or a
-# dispatch is only as trustworthy as write access to the repository.
+# guards they pass — is reviewed code from the protected branch. Only the tree
+# that gets built comes from the hotfix branch.
+#
+# NOTE(human-setup-required): that separation is a convention this file cannot
+# enforce. GitHub runs whichever copy of a workflow lives on the ref a dispatch
+# selects, so a writer who selects their own branch runs their own definition —
+# including one with the guard below and the `environment:` line deleted. No
+# check written here survives that, because the attacker edits the check. The
+# same is already true of any workflow in this repository that a branch can
+# trigger, so this lane widens nothing; what closes it is configuration:
+# `<app>-hotfix-production` needs required reviewers AND its deployment branches
+# restricted to main, with the deploy credentials held as environment secrets
+# rather than repository secrets. See each app's RELEASING.md.
 #
 # Procedure (see each app's RELEASING.md):
 #   1. Cut `hotfix/<app>-<version>` from the released tag, cherry-pick the fix,
@@ -172,6 +180,25 @@ jobs:
           git fetch --tags --force origin
           node .hotfix-lane/.github/scripts/resolve-hotfix-release.mjs
 
+      # Claimed BEFORE the deploy, deliberately. Tagging afterwards fails
+      # unsafely: a deploy whose tag step then errors leaves production carrying
+      # a release that neither lane's guard can see, so the next normal release
+      # quietly overwrites it. This way the inconsistency points the other way —
+      # a tag with nothing live, which blocks later releases until someone
+      # reconciles it, and is visible on a run that has already gone red.
+      # Creating the ref through the API is atomic, so a duplicate run fails
+      # here rather than racing. If the deploy below fails, delete this tag
+      # before re-dispatching (see the app's RELEASING.md).
+      - name: Claim the release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: '@codaco/${{ inputs.app }}@${{ steps.version.outputs.version }}'
+          SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$SHA"
+
       - name: Deploy ${{ inputs.app }} to production
         # Both site ids come in as environment variables and the app picks one in
         # bash. A `inputs.app == 'x' && secrets.A || secrets.B` expression would
@@ -211,8 +238,9 @@ jobs:
           --since "$SINCE"
           --out "${RUNNER_TEMP}/hotfix-notes.md"
 
-      # Always the newest line — resolve-hotfix-release.mjs refuses anything
-      # older than the current release — so this is always the latest release.
+      # The tag already exists from the claim step; this only attaches the
+      # release notes to it. Always the newest line — resolve-hotfix-release.mjs
+      # refuses anything older than the current release.
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: '@codaco/${{ inputs.app }}@${{ steps.version.outputs.version }}'

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -44,17 +44,20 @@ on:
 permissions:
   contents: read
 
-# Serialized per app rather than per ref: two branches carrying the same version
-# would each pass the tag check and race, leaving one SHA tagged while the other
-# build is what production actually serves. Ordering against the normal lane is
-# enforced by version, not by a shared lock — this job re-validates against the
-# newest tag immediately before deploying, and the normal lane's guard refuses
-# anything older than the newest tag — because a lock the two lanes could share
-# would have to drop the version from the normal lane's group, and a versionless
-# group keeps only one pending run: a release queued behind another could be
-# dropped and never tagged.
+# The same group the normal lane's apps-release-<app> job uses. Version checks
+# alone cannot order the two lanes: each job deploys before it tags, so a
+# re-check can read a stale newest-tag and put older code live in the window
+# before the other lane's tag appears. Only mutual exclusion over the whole
+# check → deploy → tag sequence closes that, which means one group per app,
+# without the version.
+#
+# The cost is that a versionless group keeps only one pending run, so a release
+# queued behind two others can be dropped before it ever tags. Its code is not
+# lost — the next release contains it — and its notes are not either: both lanes
+# pass `--since <newest released version>` to release-notes.mjs, so a release
+# body carries every CHANGELOG section skipped that way.
 concurrency:
-  group: hotfix-release-@codaco/${{ inputs.app }}
+  group: apps-release-@codaco/${{ inputs.app }}
   cancel-in-progress: false
 
 jobs:
@@ -108,7 +111,17 @@ jobs:
 
       - name: Resolve the released commit
         id: commit
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        # Compares commits, not strings: `refs/heads/main` and a raw SHA both
+        # slip past a literal 'main' check and would start a second release path
+        # for the very tree the normal lane owns. `.hotfix-lane` is checked out
+        # at the dispatching main commit, so its HEAD is main's tip.
+        run: |
+          sha=$(git rev-parse HEAD)
+          if [[ "$sha" == "$(git -C .hotfix-lane rev-parse HEAD)" ]]; then
+            echo "::error::source_ref '$SOURCE_REF' resolves to main. main releases through apps-release-<app> in ci-and-release.yml." >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Resolve and validate the version
         id: version
@@ -175,13 +188,18 @@ jobs:
             --site="$site"
 
       - name: Release notes
+        # --since is the newest version released before this one, so the body
+        # also carries any CHANGELOG section whose own release run was dropped
+        # while pending on the shared lock above.
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          SINCE: ${{ steps.version.outputs.newest }}
         run: >-
           node scripts/release-notes.mjs
           --app "apps/$APP"
           --pkg "@codaco/$APP"
           --version "$VERSION"
+          --since "$SINCE"
           --out "${RUNNER_TEMP}/hotfix-notes.md"
 
       # Always the newest line — resolve-hotfix-release.mjs refuses anything

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -95,18 +95,24 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      # The ref being released is a branch cut from a release tag, so it predates
-      # this lane and carries no copy of the validator. Take that one file from
-      # the dispatching main commit instead — it is also the only copy anyone has
-      # reviewed. It reads apps/<app>/package.json and `git tag` relative to the
-      # working directory, never to its own location, so it validates the ref's
-      # tree while living outside it.
-      - name: Check out the lane's validator from main
+      # The ref being released is a branch cut from a release tag, so its copy of
+      # this lane's tooling is whatever existed then — the validator did not
+      # exist at all, and release-notes.mjs predates `--since` and would ignore
+      # it silently. Both come from the dispatching main commit instead, which
+      # is also the only copy anyone has reviewed. Each reads its inputs
+      # (package.json, git tags, the app's CHANGELOG) relative to the working
+      # directory rather than to its own location, so they operate on the ref's
+      # tree while living outside it. One consequence: release-notes.mjs looks
+      # for a dedicated `release-*` changeset under `.hotfix-lane`, which the
+      # sparse checkout omits, so it always takes its CHANGELOG path here.
+      - name: Check out the lane's tooling from main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           ref: ${{ github.sha }}
           path: .hotfix-lane
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            scripts
           persist-credentials: false
 
       - name: Resolve the released commit
@@ -195,7 +201,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           SINCE: ${{ steps.version.outputs.newest }}
         run: >-
-          node scripts/release-notes.mjs
+          node .hotfix-lane/scripts/release-notes.mjs
           --app "apps/$APP"
           --pkg "@codaco/$APP"
           --version "$VERSION"

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -9,17 +9,22 @@ name: Hotfix Release
 # a branch cut from the released tag — and nothing on such a branch can trigger
 # the normal lane, which fires exclusively on push-to-main. This workflow is
 # that missing trigger: the same build → deploy → tag → release steps, run
-# against the dispatched ref.
+# against a ref named at dispatch time.
+#
+# The workflow is dispatched FROM main and takes the branch to release as an
+# input, so the job definition — which steps run, which secrets they see, which
+# guards they pass — is always reviewed code from the protected branch. Only the
+# tree that gets built comes from the hotfix branch. That tree still executes
+# its own build scripts, so this lane is gated on the `<app>-hotfix-production`
+# environment; give it required reviewers (see each app's RELEASING.md) or a
+# dispatch is only as trustworthy as write access to the repository.
 #
 # Procedure (see each app's RELEASING.md):
 #   1. Cut `hotfix/<app>-<version>` from the released tag, cherry-pick the fix,
 #      bump package.json and CHANGELOG.md, push the branch.
-#   2. Run this workflow with that branch selected under "Use workflow from".
+#   2. Run this workflow from main with `source_ref` set to that branch.
 #   3. Record the released version on main afterwards, or the normal lane's tag
 #      guard will silently swallow main's next release.
-#
-# The chosen ref supplies both the workflow file and the tree that is built, so
-# a hotfix branch cut from an old tag must carry this file too.
 
 on:
   workflow_dispatch:
@@ -31,62 +36,57 @@ on:
         options:
           - interviewer
           - architect
-      mark_latest:
-        description: Mark the GitHub release as "Latest" (turn off when patching an older line)
+      source_ref:
+        description: Branch or tag to release (e.g. hotfix/interviewer-8.1.3)
         required: true
-        type: boolean
-        default: true
+        type: string
 
 permissions:
   contents: read
 
-# One release per app+version, and never cancelled: a half-finished deploy is
-# worse than a queued one. Mirrors the normal lane's per-release group.
+# Serialized per app rather than per ref: two branches carrying the same version
+# would each pass the tag check and race, leaving one SHA tagged while the other
+# build is what production actually serves.
 concurrency:
-  group: hotfix-release-@codaco/${{ inputs.app }}-${{ github.ref }}
+  group: hotfix-release-@codaco/${{ inputs.app }}
   cancel-in-progress: false
 
 jobs:
   hotfix-release:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
+    environment: ${{ inputs.app }}-hotfix-production
     permissions:
       contents: write
     env:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       APP: ${{ inputs.app }}
+      SOURCE_REF: ${{ inputs.source_ref }}
     steps:
-      - name: Refuse to run on main
-        if: github.ref_name == 'main'
+      - name: Validate the dispatch
         run: |
-          echo "::error::main releases through apps-release-<app> in ci-and-release.yml. This lane exists for hotfix branches cut from a release tag." >&2
-          exit 1
+          if [[ "${{ github.ref_name }}" != 'main' ]]; then
+            echo "::error::Dispatch this workflow from main and name the branch to release in source_ref. Running it from a branch would take the job definition from that branch too." >&2
+            exit 1
+          fi
+          if [[ "$SOURCE_REF" == 'main' ]]; then
+            echo "::error::main releases through apps-release-<app> in ci-and-release.yml. This lane exists for hotfix branches cut from a release tag." >&2
+            exit 1
+          fi
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
+          ref: ${{ inputs.source_ref }}
           fetch-tags: true
           persist-credentials: false
 
-      # Unlike the normal lane — which is self-healing and silently skips an
-      # already-tagged version on every main push — a dispatch is a deliberate
-      # request, so an already-released version is an error, not a no-op.
+      - name: Resolve the released commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Resolve and validate the version
         id: version
-        run: |
-          version=$(node -p "require('./apps/$APP/package.json').version")
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::apps/$APP/package.json version '$version' is not a stable semver. Bump it on the hotfix branch first." >&2
-            exit 1
-          fi
-          if git rev-parse -q --verify "refs/tags/@codaco/$APP@$version" >/dev/null; then
-            echo "::error::@codaco/$APP@$version is already released. Bump the version on the hotfix branch." >&2
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          case "$APP" in
-            interviewer) echo 'label=Interviewer' >> "$GITHUB_OUTPUT" ;;
-            architect) echo 'label=Architect' >> "$GITHUB_OUTPUT" ;;
-          esac
+        run: node .github/scripts/resolve-hotfix-release.mjs
 
       - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
@@ -97,12 +97,12 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
-      # A hotfix branch has no required `quality` gate behind it, so the app's
-      # own suites run here. Its workspace dependencies are whatever the release
-      # tag pinned, already verified by the release they shipped in; a hotfix
-      # that changes a dependency package belongs in a pull request, not here.
-      - name: Verify the app
-        run: pnpm exec turbo run typecheck test --filter=@codaco/${{ env.APP }}
+      # A hotfix branch has no required `quality` gate behind it, and workspace
+      # packages are consumed as source — a fix cherry-picked into a dependency
+      # compiles straight into the app. The filter therefore covers the app's
+      # whole dependency closure (`...`), not just the app.
+      - name: Verify the app and its workspace dependencies
+        run: pnpm exec turbo run typecheck test --filter=@codaco/${{ env.APP }}...
 
       - name: Build ${{ inputs.app }}
         # Scoped to this step alone, exactly as in the normal lane: only the
@@ -131,11 +131,13 @@ jobs:
           --version "$VERSION"
           --out "${RUNNER_TEMP}/hotfix-notes.md"
 
+      # Always the newest line — resolve-hotfix-release.mjs refuses anything
+      # older than the current release — so this is always the latest release.
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: '@codaco/${{ inputs.app }}@${{ steps.version.outputs.version }}'
-          target_commitish: ${{ github.sha }}
+          target_commitish: ${{ steps.commit.outputs.sha }}
           name: ${{ steps.version.outputs.label }} ${{ steps.version.outputs.version }}
           body_path: ${{ runner.temp }}/hotfix-notes.md
           prerelease: false
-          make_latest: ${{ inputs.mark_latest }}
+          make_latest: 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,14 @@ Both apps' production jobs build `main`, so the normal lane cannot ship a patch
 without everything else merged since the last release. When `main` holds work
 that must not go out yet, cut `hotfix/<app>-<version>` from the released tag,
 cherry-pick the fix, bump `package.json` + `CHANGELOG.md`, and run the
-**Hotfix Release** workflow (`.github/workflows/hotfix-release.yml`) against
-that branch. Afterwards, record the released version on `main` — the lane is
-tag-driven and self-healing, so a version whose tag already exists is skipped,
-and skipping it on `main` means `main` never deploys. Full procedure in each
-app's `RELEASING.md`.
+**Hotfix Release** workflow (`.github/workflows/hotfix-release.yml`) from
+`main`, naming that branch in `source_ref`. The lane only ships the newest
+line — one production site per app means a `--prod` deploy always replaces what
+is live. Afterwards, record the released version on `main` (and drop only that
+app's entry from the changeset the hotfix consumed): the lane is tag-driven and
+self-healing, so a version whose tag already exists is skipped, and skipping it
+on `main` means `main` never deploys. Full procedure in each app's
+`RELEASING.md`.
 
 #### Apps that release by mirroring
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,12 @@ cherry-pick the fix, bump `package.json` + `CHANGELOG.md`, and run the
 **Hotfix Release** workflow (`.github/workflows/hotfix-release.yml`) from
 `main`, naming that branch in `source_ref`. The lane only ships the newest
 line — one production site per app means a `--prod` deploy always replaces what
-is live. Afterwards, record the released version on `main` (and drop only that
-app's entry from the changeset the hotfix consumed): the lane is tag-driven and
-self-healing, so a version whose tag already exists is skipped, and skipping it
-on `main` means `main` never deploys. Full procedure in each app's
-`RELEASING.md`.
+is live. Afterwards, merge the hotfix branch into `main` (dropping only that
+app's entry from the changeset it consumed). Both release lanes refuse to
+deploy a tree that does not contain the newest released commit, and the
+tag-driven guard skips a version whose tag already exists — so until that merge
+lands, `main` cannot release the app at all. Cherry-picking does not count: the
+guard checks commit ancestry. Full procedure in each app's `RELEASING.md`.
 
 #### Apps that release by mirroring
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ pnpm publish-packages
 - See the `creating-a-changeset` skill and
   `docs/superpowers/specs/2026-08-03-stable-app-release-design.md`.
 
+#### Hotfix releases for Architect and Interviewer
+
+Both apps' production jobs build `main`, so the normal lane cannot ship a patch
+without everything else merged since the last release. When `main` holds work
+that must not go out yet, cut `hotfix/<app>-<version>` from the released tag,
+cherry-pick the fix, bump `package.json` + `CHANGELOG.md`, and run the
+**Hotfix Release** workflow (`.github/workflows/hotfix-release.yml`) against
+that branch. Afterwards, record the released version on `main` — the lane is
+tag-driven and self-healing, so a version whose tag already exists is skipped,
+and skipping it on `main` means `main` never deploys. Full procedure in each
+app's `RELEASING.md`.
+
 #### Apps that release by mirroring
 
 Fresco and the two classic apps are developed here but ship from their own

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -58,12 +58,11 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/architect@<version>`.
 
-   Ordering against the normal lane is enforced by version rather than by a
-   shared lock: the hotfix job re-checks the newest tag after building and
-   aborts if a normal release has overtaken it, and the normal lane's own guard
-   refuses to deploy anything older than the newest tag. A hotfix that loses
-   that race leaves production on the newer release and needs re-cutting from
-   the new tag.
+   A hotfix and a normal release for the same app hold one lock, so a dispatch
+   made while a Version Packages release is deploying waits for it rather than
+   racing it to the production site. On top of that the hotfix job re-checks
+   the newest tag after building: a hotfix overtaken while it waited aborts
+   instead of deploying, and needs re-cutting from the new tag.
 
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -58,6 +58,10 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/architect@<version>`.
 
+   A hotfix and a normal release for the same app share one concurrency lock, so
+   a dispatch made while a Version Packages release is deploying waits for it to
+   finish rather than racing it to the production site.
+
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one
    production site and `netlify deploy --prod` always replaces what is live.

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -52,19 +52,37 @@ is not ready to go out, release from the previous tag instead:
    reads that section for the GitHub release. Do **not** run
    `changeset version` on the branch — it would consume changesets that belong
    to main's next release.
-3. Make sure `.github/workflows/hotfix-release.yml` exists on the branch
-   (cherry-pick it if the branch predates it): a dispatch runs the workflow file
-   from the ref it targets.
-4. Push, then run the **Hotfix Release** workflow with _Use workflow from_ set
-   to the hotfix branch and `app: architect`. It runs the app's typecheck and
-   tests, builds with PostHog source maps, deploys to Netlify production, and
-   cuts `@codaco/architect@<version>`.
-5. **Record the released version on main** in a follow-up PR: bump
-   `package.json` and `CHANGELOG.md` to the hotfix version and delete the
-   changeset it consumed. This step is not optional. The lane is tag-driven and
+3. Push the branch, then run the **Hotfix Release** workflow **from main**,
+   with `app: architect` and `source_ref` set to the hotfix branch. It runs
+   typecheck and tests across the app's whole workspace dependency closure,
+   builds with PostHog source maps, deploys to Netlify production, and cuts
+   `@codaco/architect@<version>`.
+
+   The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
+   refuses a version older than the current release, because each app has one
+   production site and `netlify deploy --prod` always replaces what is live.
+   A branch that needs an older line published needs a separate channel, not
+   this lane.
+
+4. **Record the released version on main** in a follow-up PR, whenever the
+   hotfix version is higher than main's current one:
+   - bump `package.json` and `CHANGELOG.md` to the hotfix version;
+   - remove **only** `'@codaco/architect'` from the changeset the hotfix
+     consumed, deleting the file only if the app was its sole target. Normal-lane
+     changesets may also name libraries, the other app, and Fresco, and those
+     packages still need their bumps from main's next release.
+
+   Recording is what keeps main releasable: the lane is tag-driven and
    self-healing (`.github/scripts/detect-app-release.sh`), so if main later
-   versions itself to the same number the existing tag makes the guard skip
-   it — and main's release would never deploy.
+   versions itself to the number already tagged, the guard skips it and main's
+   release never deploys. If main is somehow already ahead of the hotfix
+   version, leave it alone — nothing needs recording, and downgrading main would
+   make its next changeset release calculate from the wrong baseline.
+
+**Setup:** the workflow is gated on the `architect-hotfix-production` GitHub
+environment. Give that environment required reviewers, or any dispatch deploys
+straight to production — the job definition comes from main, but the tree it
+builds (and the build scripts it runs) come from the branch being released.
 
 ## Developer site
 

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -97,10 +97,34 @@ is not ready to go out, release from the previous tag instead:
    the version number, and downgrading main's version would make its next
    changeset release calculate from the wrong baseline.
 
-**Setup:** the workflow is gated on the `architect-hotfix-production` GitHub
-environment. Give that environment required reviewers, or any dispatch deploys
-straight to production — the job definition comes from main, but the tree it
-builds (and the build scripts it runs) come from the branch being released.
+**Setup (one-time, and load-bearing).** The workflow declares the
+`architect-hotfix-production` environment, but a workflow file cannot enforce
+its own protection: GitHub runs whichever copy of the YAML lives on the ref a
+dispatch selects, so a branch copy with the guard and the `environment:` line
+deleted would run instead. Only repository configuration closes that, and it is
+what makes this lane safe to have:
+
+1. Create the `architect-hotfix-production` environment.
+2. Give it **required reviewers**, so a dispatch pauses for a human.
+3. Restrict its **deployment branches** to `main`, so a job reaching for it from
+   any other ref is refused.
+4. Hold the deploy credentials (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID_ARCHITECT`,
+   the PostHog pair) as **environment** secrets rather than repository secrets,
+   so a workflow copy that drops the `environment:` line gets nothing. Note the
+   normal release lane reads the same names at repository scope today, so this
+   step is a wider change than the hotfix lane alone — until it happens, steps
+   2 and 3 are the protection.
+
+**If a dispatch fails.** The tag is claimed before the production deploy, so a
+run that goes red after tagging has left `@codaco/architect@<version>` pointing at
+a version that may never have gone live. That state deliberately blocks later
+releases rather than letting one quietly overwrite an unrecorded deploy. Check
+what production is actually serving, then either re-run the deploy or delete the
+tag before re-dispatching:
+
+```bash
+git push --delete origin '@codaco/architect@<version>'
+```
 
 ## Developer site
 

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -76,20 +76,26 @@ is not ready to go out, release from the previous tag instead:
    A branch that needs an older line published needs a separate channel, not
    this lane.
 
-4. **Record the released version on main** in a follow-up PR, whenever the
-   hotfix version is higher than main's current one:
-   - bump `package.json` and `CHANGELOG.md` to the hotfix version;
-   - remove **only** `'@codaco/architect'` from the changeset the hotfix
-     consumed, deleting the file only if the app was its sole target. Normal-lane
-     changesets may also name libraries, the other app, and Fresco, and those
-     packages still need their bumps from main's next release.
+4. **Merge the hotfix branch into main.** Open a pull request from the hotfix
+   branch itself rather than re-applying its content: the normal lane refuses
+   to deploy a tree that does not contain the newest released commit, so a
+   cherry-pick — which makes a different commit — leaves main blocked. The
+   merge brings the version bump and CHANGELOG with it. While you are there,
+   remove **only** `'@codaco/architect'` from the changeset the hotfix consumed,
+   deleting the file only if the app was its sole target: normal-lane
+   changesets may also name libraries, the other app, and Fresco, and those
+   packages still need their bumps from main's next release.
 
-   Recording is what keeps main releasable: the lane is tag-driven and
-   self-healing (`.github/scripts/detect-app-release.sh`), so if main later
-   versions itself to the number already tagged, the guard skips it and main's
-   release never deploys. If main is somehow already ahead of the hotfix
-   version, leave it alone — nothing needs recording, and downgrading main would
-   make its next changeset release calculate from the wrong baseline.
+   Both halves matter. Until the merge lands, `.github/scripts/app-release-guard.sh`
+   skips main's release of this app — deploying a tree without the hotfix would
+   take the fix off production behind a higher version number — and the tag
+   guard would swallow a main release that later reaches the version already
+   tagged. Once merged, the next push to main releases normally.
+
+   If main is somehow already ahead of the hotfix version, still merge the
+   branch: what unblocks the lane is the commit being in main's history, not
+   the version number, and downgrading main's version would make its next
+   changeset release calculate from the wrong baseline.
 
 **Setup:** the workflow is gated on the `architect-hotfix-production` GitHub
 environment. Give that environment required reviewers, or any dispatch deploys

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -64,6 +64,12 @@ is not ready to go out, release from the previous tag instead:
    the newest tag after building: a hotfix overtaken while it waited aborts
    instead of deploying, and needs re-cutting from the new tag.
 
+   Watch the run to completion. GitHub keeps only one pending run per
+   concurrency group, so if two hotfix dispatches for the same app queue behind
+   a release that is already deploying, the earlier pending one is cancelled.
+   Nothing silently ships in its place — a cancelled run is visible in Actions —
+   but it does need re-dispatching.
+
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one
    production site and `netlify deploy --prod` always replaces what is live.

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -58,9 +58,12 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/architect@<version>`.
 
-   A hotfix and a normal release for the same app share one concurrency lock, so
-   a dispatch made while a Version Packages release is deploying waits for it to
-   finish rather than racing it to the production site.
+   Ordering against the normal lane is enforced by version rather than by a
+   shared lock: the hotfix job re-checks the newest tag after building and
+   aborts if a normal release has overtaken it, and the normal lane's own guard
+   refuses to deploy anything older than the newest tag. A hotfix that loses
+   that race leaves production on the newer release and needs re-cutting from
+   the new tag.
 
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one

--- a/apps/architect/RELEASING.md
+++ b/apps/architect/RELEASING.md
@@ -31,6 +31,41 @@ directly on the PR. Production is no longer deployed on every push to `main`—i
 is deployed only when the Version Packages PR containing an Architect version
 bump merges.
 
+## Hotfix releases (when main is ahead)
+
+The changeset lane always builds main, so it can only ship a patch together
+with everything else merged since the last release. When main carries work that
+is not ready to go out, release from the previous tag instead:
+
+1. Cut the branch from the released tag and cherry-pick the fix:
+
+   ```bash
+   git switch -c hotfix/architect-<version> '@codaco/architect@<previous>'
+   git cherry-pick <sha>
+   ```
+
+   Land the same fix on main through the usual pull request as well — the
+   hotfix branch is a delivery vehicle, not the source of truth.
+
+2. Bump `apps/architect/package.json` to the hotfix version and add the
+   matching `## <version>` section to `CHANGELOG.md`; `scripts/release-notes.mjs`
+   reads that section for the GitHub release. Do **not** run
+   `changeset version` on the branch — it would consume changesets that belong
+   to main's next release.
+3. Make sure `.github/workflows/hotfix-release.yml` exists on the branch
+   (cherry-pick it if the branch predates it): a dispatch runs the workflow file
+   from the ref it targets.
+4. Push, then run the **Hotfix Release** workflow with _Use workflow from_ set
+   to the hotfix branch and `app: architect`. It runs the app's typecheck and
+   tests, builds with PostHog source maps, deploys to Netlify production, and
+   cuts `@codaco/architect@<version>`.
+5. **Record the released version on main** in a follow-up PR: bump
+   `package.json` and `CHANGELOG.md` to the hotfix version and delete the
+   changeset it consumed. This step is not optional. The lane is tag-driven and
+   self-healing (`.github/scripts/detect-app-release.sh`), so if main later
+   versions itself to the same number the existing tag makes the guard skip
+   it — and main's release would never deploy.
+
 ## Developer site
 
 The separate `.dev` Netlify site is intentionally linked to this repository and

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -81,20 +81,26 @@ is not ready to go out, release from the previous tag instead:
    A branch that needs an older line published needs a separate channel, not
    this lane.
 
-4. **Record the released version on main** in a follow-up PR, whenever the
-   hotfix version is higher than main's current one:
-   - bump `package.json` and `CHANGELOG.md` to the hotfix version;
-   - remove **only** `'@codaco/interviewer'` from the changeset the hotfix
-     consumed, deleting the file only if the app was its sole target. Normal-lane
-     changesets may also name libraries, the other app, and Fresco, and those
-     packages still need their bumps from main's next release.
+4. **Merge the hotfix branch into main.** Open a pull request from the hotfix
+   branch itself rather than re-applying its content: the normal lane refuses
+   to deploy a tree that does not contain the newest released commit, so a
+   cherry-pick — which makes a different commit — leaves main blocked. The
+   merge brings the version bump and CHANGELOG with it. While you are there,
+   remove **only** `'@codaco/interviewer'` from the changeset the hotfix consumed,
+   deleting the file only if the app was its sole target: normal-lane
+   changesets may also name libraries, the other app, and Fresco, and those
+   packages still need their bumps from main's next release.
 
-   Recording is what keeps main releasable: the lane is tag-driven and
-   self-healing (`.github/scripts/detect-app-release.sh`), so if main later
-   versions itself to the number already tagged, the guard skips it and main's
-   release never deploys. If main is somehow already ahead of the hotfix
-   version, leave it alone — nothing needs recording, and downgrading main would
-   make its next changeset release calculate from the wrong baseline.
+   Both halves matter. Until the merge lands, `.github/scripts/app-release-guard.sh`
+   skips main's release of this app — deploying a tree without the hotfix would
+   take the fix off production behind a higher version number — and the tag
+   guard would swallow a main release that later reaches the version already
+   tagged. Once merged, the next push to main releases normally.
+
+   If main is somehow already ahead of the hotfix version, still merge the
+   branch: what unblocks the lane is the commit being in main's history, not
+   the version number, and downgrading main's version would make its next
+   changeset release calculate from the wrong baseline.
 
 **Setup:** the workflow is gated on the `interviewer-hotfix-production` GitHub
 environment. Give that environment required reviewers, or any dispatch deploys

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -63,12 +63,11 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/interviewer@<version>`.
 
-   Ordering against the normal lane is enforced by version rather than by a
-   shared lock: the hotfix job re-checks the newest tag after building and
-   aborts if a normal release has overtaken it, and the normal lane's own guard
-   refuses to deploy anything older than the newest tag. A hotfix that loses
-   that race leaves production on the newer release and needs re-cutting from
-   the new tag.
+   A hotfix and a normal release for the same app hold one lock, so a dispatch
+   made while a Version Packages release is deploying waits for it rather than
+   racing it to the production site. On top of that the hotfix job re-checks
+   the newest tag after building: a hotfix overtaken while it waited aborts
+   instead of deploying, and needs re-cutting from the new tag.
 
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -63,6 +63,10 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/interviewer@<version>`.
 
+   A hotfix and a normal release for the same app share one concurrency lock, so
+   a dispatch made while a Version Packages release is deploying waits for it to
+   finish rather than racing it to the production site.
+
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one
    production site and `netlify deploy --prod` always replaces what is live.

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -36,6 +36,41 @@ directly on the PR. Production is no longer deployed on every push to `main`—i
 is deployed only when the Version Packages PR containing an Interviewer version
 bump merges.
 
+## Hotfix releases (when main is ahead)
+
+The changeset lane always builds main, so it can only ship a patch together
+with everything else merged since the last release. When main carries work that
+is not ready to go out, release from the previous tag instead:
+
+1. Cut the branch from the released tag and cherry-pick the fix:
+
+   ```bash
+   git switch -c hotfix/interviewer-8.1.3 '@codaco/interviewer@8.1.2'
+   git cherry-pick <sha>
+   ```
+
+   Land the same fix on main through the usual pull request as well — the
+   hotfix branch is a delivery vehicle, not the source of truth.
+
+2. Bump `apps/interviewer/package.json` to the hotfix version and add the
+   matching `## <version>` section to `CHANGELOG.md`; `scripts/release-notes.mjs`
+   reads that section for the GitHub release. Do **not** run
+   `changeset version` on the branch — it would consume changesets that belong
+   to main's next release.
+3. Make sure `.github/workflows/hotfix-release.yml` exists on the branch
+   (cherry-pick it if the branch predates it): a dispatch runs the workflow file
+   from the ref it targets.
+4. Push, then run the **Hotfix Release** workflow with _Use workflow from_ set
+   to the hotfix branch and `app: interviewer`. It runs the app's typecheck and
+   tests, builds with PostHog source maps and the PWA assertion, deploys to
+   Netlify production, and cuts `@codaco/interviewer@<version>`.
+5. **Record the released version on main** in a follow-up PR: bump
+   `package.json` and `CHANGELOG.md` to the hotfix version and delete the
+   changeset it consumed. This step is not optional. The lane is tag-driven and
+   self-healing (`.github/scripts/detect-app-release.sh`), so if main later
+   versions itself to the same number the existing tag makes the guard skip
+   it — and main's release would never deploy.
+
 ## Developer site
 
 The separate `.dev` Netlify site is intentionally linked to this repository and

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -63,9 +63,12 @@ is not ready to go out, release from the previous tag instead:
    builds with PostHog source maps, deploys to Netlify production, and cuts
    `@codaco/interviewer@<version>`.
 
-   A hotfix and a normal release for the same app share one concurrency lock, so
-   a dispatch made while a Version Packages release is deploying waits for it to
-   finish rather than racing it to the production site.
+   Ordering against the normal lane is enforced by version rather than by a
+   shared lock: the hotfix job re-checks the newest tag after building and
+   aborts if a normal release has overtaken it, and the normal lane's own guard
+   refuses to deploy anything older than the newest tag. A hotfix that loses
+   that race leaves production on the newer release and needs re-cutting from
+   the new tag.
 
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -102,10 +102,34 @@ is not ready to go out, release from the previous tag instead:
    the version number, and downgrading main's version would make its next
    changeset release calculate from the wrong baseline.
 
-**Setup:** the workflow is gated on the `interviewer-hotfix-production` GitHub
-environment. Give that environment required reviewers, or any dispatch deploys
-straight to production — the job definition comes from main, but the tree it
-builds (and the build scripts it runs) come from the branch being released.
+**Setup (one-time, and load-bearing).** The workflow declares the
+`interviewer-hotfix-production` environment, but a workflow file cannot enforce
+its own protection: GitHub runs whichever copy of the YAML lives on the ref a
+dispatch selects, so a branch copy with the guard and the `environment:` line
+deleted would run instead. Only repository configuration closes that, and it is
+what makes this lane safe to have:
+
+1. Create the `interviewer-hotfix-production` environment.
+2. Give it **required reviewers**, so a dispatch pauses for a human.
+3. Restrict its **deployment branches** to `main`, so a job reaching for it from
+   any other ref is refused.
+4. Hold the deploy credentials (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID_INTERVIEWER`,
+   the PostHog pair) as **environment** secrets rather than repository secrets,
+   so a workflow copy that drops the `environment:` line gets nothing. Note the
+   normal release lane reads the same names at repository scope today, so this
+   step is a wider change than the hotfix lane alone — until it happens, steps
+   2 and 3 are the protection.
+
+**If a dispatch fails.** The tag is claimed before the production deploy, so a
+run that goes red after tagging has left `@codaco/interviewer@<version>` pointing at
+a version that may never have gone live. That state deliberately blocks later
+releases rather than letting one quietly overwrite an unrecorded deploy. Check
+what production is actually serving, then either re-run the deploy or delete the
+tag before re-dispatching:
+
+```bash
+git push --delete origin '@codaco/interviewer@<version>'
+```
 
 ## Developer site
 

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -69,6 +69,12 @@ is not ready to go out, release from the previous tag instead:
    the newest tag after building: a hotfix overtaken while it waited aborts
    instead of deploying, and needs re-cutting from the new tag.
 
+   Watch the run to completion. GitHub keeps only one pending run per
+   concurrency group, so if two hotfix dispatches for the same app queue behind
+   a release that is already deploying, the earlier pending one is cancelled.
+   Nothing silently ships in its place — a cancelled run is visible in Actions —
+   but it does need re-dispatching.
+
    The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
    refuses a version older than the current release, because each app has one
    production site and `netlify deploy --prod` always replaces what is live.

--- a/apps/interviewer/RELEASING.md
+++ b/apps/interviewer/RELEASING.md
@@ -57,19 +57,37 @@ is not ready to go out, release from the previous tag instead:
    reads that section for the GitHub release. Do **not** run
    `changeset version` on the branch — it would consume changesets that belong
    to main's next release.
-3. Make sure `.github/workflows/hotfix-release.yml` exists on the branch
-   (cherry-pick it if the branch predates it): a dispatch runs the workflow file
-   from the ref it targets.
-4. Push, then run the **Hotfix Release** workflow with _Use workflow from_ set
-   to the hotfix branch and `app: interviewer`. It runs the app's typecheck and
-   tests, builds with PostHog source maps and the PWA assertion, deploys to
-   Netlify production, and cuts `@codaco/interviewer@<version>`.
-5. **Record the released version on main** in a follow-up PR: bump
-   `package.json` and `CHANGELOG.md` to the hotfix version and delete the
-   changeset it consumed. This step is not optional. The lane is tag-driven and
+3. Push the branch, then run the **Hotfix Release** workflow **from main**,
+   with `app: interviewer` and `source_ref` set to the hotfix branch. It runs
+   typecheck and tests across the app's whole workspace dependency closure,
+   builds with PostHog source maps, deploys to Netlify production, and cuts
+   `@codaco/interviewer@<version>`.
+
+   The lane only ships the newest line: `.github/scripts/resolve-hotfix-release.mjs`
+   refuses a version older than the current release, because each app has one
+   production site and `netlify deploy --prod` always replaces what is live.
+   A branch that needs an older line published needs a separate channel, not
+   this lane.
+
+4. **Record the released version on main** in a follow-up PR, whenever the
+   hotfix version is higher than main's current one:
+   - bump `package.json` and `CHANGELOG.md` to the hotfix version;
+   - remove **only** `'@codaco/interviewer'` from the changeset the hotfix
+     consumed, deleting the file only if the app was its sole target. Normal-lane
+     changesets may also name libraries, the other app, and Fresco, and those
+     packages still need their bumps from main's next release.
+
+   Recording is what keeps main releasable: the lane is tag-driven and
    self-healing (`.github/scripts/detect-app-release.sh`), so if main later
-   versions itself to the same number the existing tag makes the guard skip
-   it — and main's release would never deploy.
+   versions itself to the number already tagged, the guard skips it and main's
+   release never deploys. If main is somehow already ahead of the hotfix
+   version, leave it alone — nothing needs recording, and downgrading main would
+   make its next changeset release calculate from the wrong baseline.
+
+**Setup:** the workflow is gated on the `interviewer-hotfix-production` GitHub
+environment. Give that environment required reviewers, or any dispatch deploys
+straight to production — the job definition comes from main, but the tree it
+builds (and the build scripts it runs) come from the branch being released.
 
 ## Developer site
 

--- a/scripts/app-release-guard.test.mjs
+++ b/scripts/app-release-guard.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '.github',
+  'scripts',
+  'app-release-guard.sh',
+);
+
+const PKG_NAME = '@codaco/interviewer';
+
+function git(cwd, ...args) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+// A throwaway repo carrying `tags`, so the guard's tag lookups see them.
+// Returns the parsed $GITHUB_OUTPUT the script wrote.
+function guard({ version, tags = [] }) {
+  const cwd = mkdtempSync(join(tmpdir(), 'arg-'));
+  git(cwd, 'init', '-q');
+  git(cwd, 'config', 'user.email', 'ci@example.com');
+  git(cwd, 'config', 'user.name', 'ci');
+  writeFileSync(join(cwd, 'README.md'), 'x\n');
+  git(cwd, 'add', '.');
+  git(cwd, 'commit', '-qm', 'first');
+  for (const tag of tags) git(cwd, 'tag', tag);
+
+  const outputPath = join(cwd, 'github-output');
+  writeFileSync(outputPath, '');
+  execFileSync('bash', [SCRIPT], {
+    cwd,
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      PKG_NAME,
+      VERSION: version,
+      GITHUB_OUTPUT: outputPath,
+    },
+  });
+  return Object.fromEntries(
+    readFileSync(outputPath, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.split('=')),
+  );
+}
+
+test('releases a version newer than every tag', () => {
+  const out = guard({
+    version: '8.1.3',
+    tags: [`${PKG_NAME}@8.1.1`, `${PKG_NAME}@8.1.2`],
+  });
+  assert.equal(out.skip, 'false');
+  assert.equal(out.newest, '8.1.2');
+});
+
+test('releases the first version, with no tags at all', () => {
+  const out = guard({ version: '1.0.0' });
+  assert.equal(out.skip, 'false');
+  // Written but empty, which release-notes.mjs reads as "nothing to roll up".
+  assert.equal(out.newest, '');
+});
+
+test('skips a version that is already tagged', () => {
+  const out = guard({ version: '8.1.2', tags: [`${PKG_NAME}@8.1.2`] });
+  assert.equal(out.skip, 'true');
+});
+
+// The reason this guard exists: hotfix-release.yml can move an app's released
+// version out of band, and the app has a single production site to roll back.
+test('skips a version older than the newest release', () => {
+  const out = guard({ version: '8.1.3', tags: [`${PKG_NAME}@8.1.4`] });
+  assert.equal(out.skip, 'true');
+});
+
+test('orders versions numerically, not lexically', () => {
+  // 8.1.10 beats 8.1.9 despite sorting before it as a string.
+  assert.equal(
+    guard({ version: '8.1.9', tags: [`${PKG_NAME}@8.1.10`] }).skip,
+    'true',
+  );
+  assert.equal(
+    guard({ version: '8.1.10', tags: [`${PKG_NAME}@8.1.9`] }).skip,
+    'false',
+  );
+});
+
+test('ignores prereleases and other packages when picking the newest', () => {
+  const out = guard({
+    version: '8.1.3',
+    tags: [
+      `${PKG_NAME}@8.1.2`,
+      `${PKG_NAME}@9.0.0-beta.1`,
+      '@codaco/architect@12.0.0',
+      'interviewer-v8@v8.0.0-alpha.10',
+    ],
+  });
+  assert.equal(out.skip, 'false');
+  assert.equal(out.newest, '8.1.2');
+});

--- a/scripts/app-release-guard.test.mjs
+++ b/scripts/app-release-guard.test.mjs
@@ -22,7 +22,7 @@ function git(cwd, ...args) {
 
 // A throwaway repo carrying `tags`, so the guard's tag lookups see them.
 // Returns the parsed $GITHUB_OUTPUT the script wrote.
-function guard({ version, tags = [] }) {
+function guard({ version, tags = [], strandedTags = [] }) {
   const cwd = mkdtempSync(join(tmpdir(), 'arg-'));
   git(cwd, 'init', '-q');
   git(cwd, 'config', 'user.email', 'ci@example.com');
@@ -31,6 +31,21 @@ function guard({ version, tags = [] }) {
   git(cwd, 'add', '.');
   git(cwd, 'commit', '-qm', 'first');
   for (const tag of tags) git(cwd, 'tag', tag);
+
+  // Tags on a commit this tree never saw — main's shape when a hotfix has
+  // shipped but its branch has not been merged back.
+  if (strandedTags.length) {
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+    }).trim();
+    git(cwd, 'checkout', '-q', '-b', 'hotfix');
+    writeFileSync(join(cwd, 'HOTFIX.md'), 'shipped out of band\n');
+    git(cwd, 'add', '.');
+    git(cwd, 'commit', '-qm', 'hotfix');
+    for (const tag of strandedTags) git(cwd, 'tag', tag);
+    git(cwd, 'checkout', '-q', head);
+  }
 
   const outputPath = join(cwd, 'github-output');
   writeFileSync(outputPath, '');
@@ -104,4 +119,25 @@ test('ignores prereleases and other packages when picking the newest', () => {
   });
   assert.equal(out.skip, 'false');
   assert.equal(out.newest, '8.1.2');
+});
+
+// The mirror of the hotfix lane's descendant rule. main can be numerically
+// ahead of a hotfix while missing the fix itself, and deploying it would take
+// that fix off production behind a higher version number.
+test('skips when the tree does not contain the newest released commit', () => {
+  const out = guard({
+    version: '8.2.0',
+    tags: [`${PKG_NAME}@8.1.2`],
+    strandedTags: [`${PKG_NAME}@8.1.3`],
+  });
+  assert.equal(out.skip, 'true');
+});
+
+test('releases once the hotfix commit is in this tree', () => {
+  const out = guard({
+    version: '8.2.0',
+    tags: [`${PKG_NAME}@8.1.2`, `${PKG_NAME}@8.1.3`],
+  });
+  assert.equal(out.skip, 'false');
+  assert.equal(out.newest, '8.1.3');
 });

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -51,6 +51,33 @@ export function notesFromDedicatedChangeset(pkgName, version, changesetDir) {
   return '';
 }
 
+// Every stable version in the changelog above `since` and up to `version`,
+// newest first. A release run can be dropped while pending on its app's
+// concurrency group (see apps-release-<app> in ci-and-release.yml), and the
+// next release is then the first to mention those changes — so its body has to
+// carry their sections too, or the skipped notes never reach anyone.
+export function versionsSince(appDir, version, since) {
+  const changelogPath = join(appDir, 'CHANGELOG.md');
+  if (!existsSync(changelogPath)) return [];
+  const stable = /^## +(\d+\.\d+\.\d+)\s*$/gm;
+  const found = [...readFileSync(changelogPath, 'utf8').matchAll(stable)].map(
+    (match) => match[1],
+  );
+  const rank = (semver) => semver.split('.').map(Number);
+  const newer = (a, b) => {
+    const [left, right] = [rank(a), rank(b)];
+    for (let i = 0; i < 3; i += 1) {
+      if (left[i] !== right[i]) return left[i] > right[i];
+    }
+    return false;
+  };
+  return found.filter(
+    (candidate) =>
+      !newer(candidate, version) &&
+      (candidate === version || !since || newer(candidate, since)),
+  );
+}
+
 export function notesFromChangelog(appDir, version) {
   const changelogPath = join(appDir, 'CHANGELOG.md');
   if (!existsSync(changelogPath)) return '';
@@ -65,13 +92,29 @@ export function notesFromChangelog(appDir, version) {
   return section.replace(/^## .*\n?/, '').trim();
 }
 
-export function releaseNotes({ appDir, pkgName, version }) {
+export function releaseNotes({ appDir, pkgName, version, since }) {
   const dedicated = notesFromDedicatedChangeset(
     pkgName,
     version,
     join(repoRoot, '.changeset'),
   );
   if (dedicated) return dedicated;
+
+  // Only ever more than one when a release was skipped: each extra section
+  // keeps its own heading so the reader can see which versions rolled up here.
+  // Without a previous release there is nothing to roll up — an app's whole
+  // changelog is not release notes for one version.
+  const versions = since ? versionsSince(appDir, version, since) : [];
+  if (versions.length > 1) {
+    const rolled = versions
+      .map((each) => {
+        const body = notesFromChangelog(appDir, each);
+        return body ? `## ${each}\n\n${body}` : '';
+      })
+      .filter(Boolean);
+    if (rolled.length) return rolled.join('\n\n');
+  }
+
   const fromChangelog = notesFromChangelog(appDir, version);
   if (fromChangelog) return fromChangelog;
   return `Release v${version}`;
@@ -86,14 +129,14 @@ function parseArgs(argv) {
 }
 
 function main() {
-  const { app, pkg, version, out } = parseArgs(process.argv.slice(2));
+  const { app, pkg, version, since, out } = parseArgs(process.argv.slice(2));
   if (!app || !pkg || !version) {
     console.error(
-      'Usage: node scripts/release-notes.mjs --app <appDir> --pkg <packageName> --version <version> [--out <path>]',
+      'Usage: node scripts/release-notes.mjs --app <appDir> --pkg <packageName> --version <version> [--since <version>] [--out <path>]',
     );
     process.exit(1);
   }
-  const notes = releaseNotes({ appDir: app, pkgName: pkg, version });
+  const notes = releaseNotes({ appDir: app, pkgName: pkg, version, since });
   if (out) {
     writeFileSync(out, `${notes}\n`);
     console.error(`[release-notes] wrote ${out}`);

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { releaseNotes, versionsSince } from './release-notes.mjs';
+
+const CHANGELOG = `# @codaco/interviewer
+
+## 8.1.3
+
+### Patch Changes
+
+- aaa1111: Safari downloads exports directly.
+
+## 8.1.2
+
+### Patch Changes
+
+- bbb2222: Dependency updates.
+
+## 8.1.1
+
+### Patch Changes
+
+- ccc3333: Pedigree fixes.
+`;
+
+function appDir(changelog = CHANGELOG) {
+  const dir = mkdtempSync(join(tmpdir(), 'rn-'));
+  writeFileSync(join(dir, 'CHANGELOG.md'), changelog);
+  return dir;
+}
+
+const notes = (dir, version, since) =>
+  releaseNotes({ appDir: dir, pkgName: '@codaco/interviewer', version, since });
+
+test('a release that follows the previous one carries only its own section', () => {
+  const body = notes(appDir(), '8.1.3', '8.1.2');
+  assert.match(body, /Safari downloads exports directly/);
+  assert.ok(!body.includes('Dependency updates'));
+  // One section keeps the bare body, with no version heading above it.
+  assert.ok(!body.startsWith('## '));
+});
+
+// A release run can be dropped while pending on its app's concurrency group,
+// so the next release is the first to mention those changes and has to carry
+// their sections too.
+test('a release that skipped a version carries both sections, each headed', () => {
+  const body = notes(appDir(), '8.1.3', '8.1.1');
+  assert.match(body, /^## 8\.1\.3/);
+  assert.match(body, /## 8\.1\.2/);
+  assert.match(body, /Safari downloads exports directly/);
+  assert.match(body, /Dependency updates/);
+  // Not the one that did get released.
+  assert.ok(!body.includes('Pedigree fixes'));
+});
+
+test('without a previous release, only the version at hand is described', () => {
+  const body = notes(appDir(), '8.1.3', '');
+  assert.match(body, /Safari downloads exports directly/);
+  assert.ok(!body.includes('Dependency updates'));
+});
+
+test('versionsSince spans the gap, newest first, and never reaches past the target', () => {
+  const dir = appDir();
+  assert.deepEqual(versionsSince(dir, '8.1.3', '8.1.1'), ['8.1.3', '8.1.2']);
+  assert.deepEqual(versionsSince(dir, '8.1.2', '8.1.1'), ['8.1.2']);
+  assert.deepEqual(versionsSince(dir, '8.1.1', '8.1.0'), ['8.1.1']);
+});
+
+test('falls back to a bare line when the changelog has no such version', () => {
+  assert.equal(notes(appDir(), '9.9.9', '8.1.3'), 'Release v9.9.9');
+});

--- a/scripts/resolve-hotfix-release.test.mjs
+++ b/scripts/resolve-hotfix-release.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '.github',
+  'scripts',
+  'resolve-hotfix-release.mjs',
+);
+
+function git(cwd, ...args) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+// A throwaway repo holding the app's package.json and `tags`. The script is
+// deliberately run from OUTSIDE that tree — in the workflow it comes from a
+// sparse checkout of main, because a hotfix branch cut from a release tag
+// predates it — so this also pins that it reads the working directory rather
+// than its own location. Returns { ok, output, stderr }.
+function resolve({ app = 'interviewer', version, tags = [] }) {
+  const cwd = mkdtempSync(join(tmpdir(), 'rhr-'));
+  mkdirSync(join(cwd, 'apps', app), { recursive: true });
+  git(cwd, 'init', '-q');
+  git(cwd, 'config', 'user.email', 'ci@example.com');
+  git(cwd, 'config', 'user.name', 'ci');
+  writeFileSync(
+    join(cwd, 'apps', app, 'package.json'),
+    `${JSON.stringify({ name: `@codaco/${app}`, version }, null, 2)}\n`,
+  );
+  git(cwd, 'add', '.');
+  git(cwd, 'commit', '-qm', 'first');
+  for (const tag of tags) git(cwd, 'tag', tag);
+
+  const outputPath = join(cwd, 'github-output');
+  writeFileSync(outputPath, '');
+  let ok = true;
+  let stderr = '';
+  try {
+    execFileSync('node', [SCRIPT], {
+      cwd,
+      stdio: 'pipe',
+      env: { ...process.env, APP: app, GITHUB_OUTPUT: outputPath },
+    });
+  } catch (error) {
+    ok = false;
+    stderr = String(error.stderr ?? '');
+  }
+  const output = Object.fromEntries(
+    readFileSync(outputPath, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.split('=')),
+  );
+  return { ok, output, stderr };
+}
+
+test('clears a hotfix newer than every released tag', () => {
+  const { ok, output } = resolve({
+    version: '8.1.3',
+    tags: ['@codaco/interviewer@8.1.1', '@codaco/interviewer@8.1.2'],
+  });
+  assert.ok(ok);
+  assert.equal(output.version, '8.1.3');
+  assert.equal(output.label, 'Interviewer');
+  assert.equal(output.newest, '8.1.2');
+});
+
+test('labels architect too', () => {
+  const { ok, output } = resolve({ app: 'architect', version: '7.0.1' });
+  assert.ok(ok);
+  assert.equal(output.label, 'Architect');
+  assert.equal(output.newest, '');
+});
+
+// A dispatch is a deliberate request, so unlike the normal lane's guard every
+// rejection here is a hard failure rather than a silent skip.
+test('fails on a version that is already released', () => {
+  const { ok, stderr } = resolve({
+    version: '8.1.2',
+    tags: ['@codaco/interviewer@8.1.2'],
+  });
+  assert.equal(ok, false);
+  assert.match(stderr, /already released/);
+});
+
+test('fails on a version older than the newest release', () => {
+  const { ok, stderr } = resolve({
+    version: '8.0.5',
+    tags: ['@codaco/interviewer@8.1.2'],
+  });
+  assert.equal(ok, false);
+  assert.match(stderr, /older than the released 8\.1\.2/);
+});
+
+test('fails on a prerelease version', () => {
+  const { ok, stderr } = resolve({ version: '8.1.3-beta.1' });
+  assert.equal(ok, false);
+  assert.match(stderr, /not a stable semver/);
+});
+
+test('fails on an app the lane does not release', () => {
+  const { ok, stderr } = resolve({ app: 'fresco', version: '1.0.0' });
+  assert.equal(ok, false);
+  assert.match(stderr, /Unsupported app/);
+});

--- a/scripts/resolve-hotfix-release.test.mjs
+++ b/scripts/resolve-hotfix-release.test.mjs
@@ -23,7 +23,12 @@ function git(cwd, ...args) {
 // sparse checkout of main, because a hotfix branch cut from a release tag
 // predates it — so this also pins that it reads the working directory rather
 // than its own location. Returns { ok, output, stderr }.
-function resolve({ app = 'interviewer', version, tags = [] }) {
+function resolve({
+  app = 'interviewer',
+  version,
+  tags = [],
+  strandedTags = [],
+}) {
   const cwd = mkdtempSync(join(tmpdir(), 'rhr-'));
   mkdirSync(join(cwd, 'apps', app), { recursive: true });
   git(cwd, 'init', '-q');
@@ -36,6 +41,21 @@ function resolve({ app = 'interviewer', version, tags = [] }) {
   git(cwd, 'add', '.');
   git(cwd, 'commit', '-qm', 'first');
   for (const tag of tags) git(cwd, 'tag', tag);
+
+  // Tags on a commit the released tree never saw — the shape a hotfix branch
+  // has when another hotfix shipped after it was cut.
+  if (strandedTags.length) {
+    const released = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd,
+      encoding: 'utf8',
+    }).trim();
+    git(cwd, 'checkout', '-q', '-b', 'elsewhere');
+    writeFileSync(join(cwd, 'apps', app, 'other.txt'), 'shipped elsewhere\n');
+    git(cwd, 'add', '.');
+    git(cwd, 'commit', '-qm', 'a release this branch never saw');
+    for (const tag of strandedTags) git(cwd, 'tag', tag);
+    git(cwd, 'checkout', '-q', released);
+  }
 
   const outputPath = join(cwd, 'github-output');
   writeFileSync(outputPath, '');
@@ -108,4 +128,26 @@ test('fails on an app the lane does not release', () => {
   const { ok, stderr } = resolve({ app: 'fresco', version: '1.0.0' });
   assert.equal(ok, false);
   assert.match(stderr, /Unsupported app/);
+});
+
+// A higher version number is not a superset of what is live: this branch was
+// cut from 8.1.2 and never saw the 8.1.3 that shipped in the meantime, so
+// deploying it would take the 8.1.3 fix off production.
+test('fails when the tree does not descend from the newest release', () => {
+  const { ok, stderr } = resolve({
+    version: '8.1.4',
+    tags: ['@codaco/interviewer@8.1.2'],
+    strandedTags: ['@codaco/interviewer@8.1.3'],
+  });
+  assert.equal(ok, false);
+  assert.match(stderr, /does not contain @codaco\/interviewer@8\.1\.3/);
+});
+
+test('clears a hotfix re-cut from the newest release', () => {
+  const { ok, output } = resolve({
+    version: '8.1.4',
+    tags: ['@codaco/interviewer@8.1.2', '@codaco/interviewer@8.1.3'],
+  });
+  assert.ok(ok);
+  assert.equal(output.newest, '8.1.3');
 });


### PR DESCRIPTION
## Summary

Both apps' production jobs (`apps-release-architect` / `apps-release-interviewer`) build `main` and fire only on push-to-main. That works until `main` holds work that must not ship yet — then there is no way to deliver a patch at all, which is exactly the situation the desktop-Safari export fix ([#1368](https://github.com/complexdatacollective/network-canvas-monorepo/pull/1368)) is in: `main` is 198 commits ahead of `@codaco/interviewer@8.1.2`, including a `major` for the interview/shared-consts/exporters group.

Adds `.github/workflows/hotfix-release.yml`, a `workflow_dispatch` lane that runs the same steps as the normal lane — verify → build (with PostHog source maps) → Netlify production deploy → tag → GitHub release — against the dispatched ref, so a branch cut from the released tag can ship on its own.

Differences from the normal lane, each deliberate:

- **An already-released version fails the run.** The normal lane is tag-driven and self-healing, so it silently skips a version whose tag exists; a manual dispatch is a deliberate request, and silently doing nothing would be the wrong answer.
- **Dispatching from `main` is refused.** That is the normal lane's job, and a duplicate path to it invites divergence.
- **The app's typecheck and tests run first.** A hotfix branch has no required `quality` gate behind it. Its workspace dependencies are whatever the release tag pinned, already verified by the release they shipped in — a hotfix that changes a dependency package belongs in a pull request instead.
- **`mark_latest` is an input**, so patching an older line doesn't mislabel the newest release.

Both `RELEASING.md` files document the procedure, including the step that records the released version back on `main`. That step is load-bearing: `detect-app-release.sh` skips any version whose tag already exists, so a hotfix released out-of-band would otherwise make `main`'s own next release at that number a silent no-op.

## Test plan

- [x] `pnpm lint:fix` clean; workflow YAML parses.
- [x] Steps, action pins, secret names, and the `netlify-cli` invocation mirror `apps-release-interviewer` / `apps-release-architect` exactly.
- [ ] End-to-end proof comes from the first real dispatch: Interviewer 8.1.3 off `hotfix/interviewer-8.1.3`, immediately after this merges. A `workflow_dispatch` trigger only becomes available once the file is on the default branch, so it cannot be exercised from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)