### PR TITLE
fix(synthetic): reconcile the population cap with declared minimums

### DIFF
--- a/.changeset/synthetic-postmerge-fixes.md
+++ b/.changeset/synthetic-postmerge-fixes.md
@@ -1,0 +1,27 @@
+---
+'@codaco/protocol-utilities': patch
+'@codaco/architect': patch
+---
+
+Fix three defects in synthetic interview generation found after the redesign
+landed.
+
+A creator's declared `minNodes` is a floor the live interface enforces, and a
+run beside a family pedigree was quietly building fewer people than it — a
+completed session no participant could have produced. The population cap and
+those floors are now reconciled in one allocation: each reachable pedigree's
+required core is reserved before anything else, floors are weighed against what
+those cores leave rather than against the raw cap, and a family's optional
+growth is settled where it is built, against what the plan has genuinely left
+unspent.
+
+Edges inherited from a creator the session skipped are bounded by what the
+inheriting stage itself declared. A density-1 sociogram behind a guard that
+fired handed its whole edge set to a density-0.5 one, which had no way to give
+the excess back.
+
+Architect's synthetic data controls no longer rewrite a part-typed number to
+zero. A number input reports an empty string for anything not yet a number — a
+lone minus sign most of all — so a negative mean the schema permits could not
+be typed at all, and clearing any of these parameters snapped it to a zero the
+author never entered.

--- a/apps/architect/src/components/sections/SyntheticData.test.tsx
+++ b/apps/architect/src/components/sections/SyntheticData.test.tsx
@@ -1,7 +1,46 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 
+import type { StageNodeAndEdgeSynthetic } from '@codaco/protocol-validation';
+
 import { SyntheticField } from './SyntheticData';
+
+/**
+ * The section is a controlled field, so the round trip is what matters: an
+ * edit the author makes only survives if what the field emits comes back as
+ * its value. Rendered with a fixed `value`, every intermediate state would
+ * appear to be preserved whether the component preserved it or not.
+ */
+function ControlledSyntheticField({
+  initialValue,
+  onEmit,
+  showCount,
+  showTopology,
+  interfaceType,
+}: {
+  initialValue: StageNodeAndEdgeSynthetic;
+  onEmit: (next: StageNodeAndEdgeSynthetic | null) => void;
+  showCount: boolean;
+  showTopology: boolean;
+  interfaceType: string;
+}) {
+  const [value, setValue] = useState<StageNodeAndEdgeSynthetic | undefined>(
+    initialValue,
+  );
+  return (
+    <SyntheticField
+      value={value}
+      onChange={(next) => {
+        setValue(next ?? undefined);
+        onEmit(next);
+      }}
+      showCount={showCount}
+      showTopology={showTopology}
+      interfaceType={interfaceType}
+    />
+  );
+}
 
 describe('SyntheticField count means', () => {
   it('allows negative normal means while keeping Poisson nonnegative', () => {
@@ -70,5 +109,110 @@ describe('SyntheticField count means', () => {
       'min',
       '0',
     );
+  });
+
+  /**
+   * A negative mean has to be TYPEABLE, which a number input only allows one
+   * keystroke at a time: while the field holds a lone "-" the browser reports
+   * its value as the empty string, because "-" is not yet a number. A handler
+   * that reads that as zero writes zero back into the controlled value, and
+   * React — which rewrites a number input whenever the committed value is 0 and
+   * the field looks empty — replaces the minus sign with "0" before the digit
+   * can be typed. The negative mean the schema allows is then unreachable
+   * through the keyboard.
+   */
+  it('lets a negative normal count mean be typed one keystroke at a time', () => {
+    const emitted: (StageNodeAndEdgeSynthetic | null)[] = [];
+    render(
+      <ControlledSyntheticField
+        initialValue={{ count: { distribution: 'normal', mean: 8, sd: 3 } }}
+        onEmit={(next) => emitted.push(next)}
+        showCount
+        showTopology={false}
+        interfaceType="NameGenerator"
+      />,
+    );
+
+    const mean = screen.getByRole('spinbutton', { name: 'Mean' });
+    expect(mean).toHaveValue(8);
+
+    // The author selects the value and presses "-". jsdom applies the same
+    // value sanitisation a browser does, so the field reports "".
+    fireEvent.change(mean, { target: { value: '-' } });
+
+    // The load-bearing assertion: mid-edit the field is still empty rather than
+    // rewritten to "0", so the minus sign the browser is holding survives.
+    expect(mean).toHaveValue(null);
+    expect(emitted.at(-1)).toEqual({
+      count: { distribution: 'normal', mean: undefined, sd: 3 },
+    });
+
+    // ...and the digit that follows lands on the surviving minus.
+    fireEvent.change(mean, { target: { value: '-2' } });
+
+    expect(mean).toHaveValue(-2);
+    expect(emitted.at(-1)).toEqual({
+      count: { distribution: 'normal', mean: -2, sd: 3 },
+    });
+  });
+
+  it('lets a negative normal mean-degree mean be typed one keystroke at a time', () => {
+    const emitted: (StageNodeAndEdgeSynthetic | null)[] = [];
+    render(
+      <ControlledSyntheticField
+        initialValue={{
+          topology: {
+            metric: 'meanDegree',
+            distribution: { distribution: 'normal', mean: 3, sd: 1 },
+          },
+        }}
+        onEmit={(next) => emitted.push(next)}
+        showCount={false}
+        showTopology
+        interfaceType="Sociogram"
+      />,
+    );
+
+    const mean = screen.getByRole('spinbutton', { name: 'Mean' });
+    fireEvent.change(mean, { target: { value: '-' } });
+
+    expect(mean).toHaveValue(null);
+
+    fireEvent.change(mean, { target: { value: '-1' } });
+
+    expect(mean).toHaveValue(-1);
+    expect(emitted.at(-1)).toEqual({
+      topology: {
+        metric: 'meanDegree',
+        distribution: { distribution: 'normal', mean: -1, sd: 1 },
+      },
+    });
+  });
+
+  /**
+   * Emptying a required parameter is not the same edit as typing zero into it,
+   * and the section must not conflate them: cleared, it holds nothing and the
+   * block's own schema rule refuses the stage until a number is supplied — the
+   * behaviour every other numeric field in the editor already has.
+   */
+  it('clears a required parameter to nothing rather than to zero', () => {
+    const emitted: (StageNodeAndEdgeSynthetic | null)[] = [];
+    render(
+      <ControlledSyntheticField
+        initialValue={{ count: { distribution: 'constant', value: 4 } }}
+        onEmit={(next) => emitted.push(next)}
+        showCount
+        showTopology={false}
+        interfaceType="NameGenerator"
+      />,
+    );
+
+    const count = screen.getByRole('spinbutton', { name: 'Count' });
+    fireEvent.change(count, { target: { value: '' } });
+
+    expect(count).toHaveValue(null);
+    expect(emitted.at(-1)).toEqual({
+      count: { distribution: 'constant', value: undefined },
+    });
   });
 });

--- a/apps/architect/src/components/sections/SyntheticData.tsx
+++ b/apps/architect/src/components/sections/SyntheticData.tsx
@@ -57,6 +57,23 @@ const FrescoSelect = NativeSelectField as ComponentType<
 >;
 const FrescoInput = InputField as ComponentType<Record<string, unknown>>;
 
+/**
+ * What a number field is currently holding, or nothing.
+ *
+ * `undefined` covers two states the section deliberately treats the same way,
+ * and both are reported by the field as the empty string: a parameter the
+ * author has cleared, and a value part-way through being typed. A number input
+ * reports "" for anything that is not yet a number — a lone "-" most of all —
+ * so a handler that read that as zero would write zero back into the controlled
+ * value, and React rewrites a number input whose committed value is 0 while the
+ * field looks empty. The minus sign would vanish before the digit arrived, and
+ * the negative normal mean the schema allows could never be typed.
+ *
+ * Nothing is therefore what the block holds until a number replaces it. That is
+ * also the honest reading of a cleared field: the block's own schema rule
+ * refuses a required parameter left blank, which is what an author who cleared
+ * one and walked away should see, rather than a zero they never typed.
+ */
 const toNumber = (raw: unknown): number | undefined => {
   if (raw === '' || raw === null || raw === undefined) return undefined;
   const parsed = Number(raw);
@@ -154,7 +171,7 @@ function NodeSyntheticControl({
             <NumberControl
               label="Count"
               value={count.value}
-              onChange={(next) => patch({ value: next ?? 0 })}
+              onChange={(next) => patch({ value: next })}
               min={0}
               step="1"
             />
@@ -164,14 +181,14 @@ function NodeSyntheticControl({
               <NumberControl
                 label="Minimum"
                 value={count.min}
-                onChange={(next) => patch({ min: next ?? 0 })}
+                onChange={(next) => patch({ min: next })}
                 min={0}
                 step="1"
               />
               <NumberControl
                 label="Maximum"
                 value={count.max}
-                onChange={(next) => patch({ max: next ?? 0 })}
+                onChange={(next) => patch({ max: next })}
                 min={0}
                 step="1"
               />
@@ -182,7 +199,7 @@ function NodeSyntheticControl({
             <NumberControl
               label="Mean"
               value={count.mean}
-              onChange={(next) => patch({ mean: next ?? 0 })}
+              onChange={(next) => patch({ mean: next })}
               min={count.distribution === 'poisson' ? 0 : undefined}
             />
           )}
@@ -190,7 +207,7 @@ function NodeSyntheticControl({
             <NumberControl
               label="Standard deviation"
               value={count.sd}
-              onChange={(next) => patch({ sd: next ?? 0 })}
+              onChange={(next) => patch({ sd: next })}
               min={0}
             />
           )}
@@ -362,7 +379,7 @@ function EdgeSyntheticControl({
             <NumberControl
               label={isDensity ? 'Density' : 'Mean degree'}
               value={distribution.value}
-              onChange={(next) => patch({ value: next ?? 0 })}
+              onChange={(next) => patch({ value: next })}
               min={0}
               {...(isDensity ? { max: 1, step: '0.01' } : {})}
             />
@@ -390,7 +407,7 @@ function EdgeSyntheticControl({
               <NumberControl
                 label="Mean"
                 value={distribution.mean}
-                onChange={(next) => patch({ mean: next ?? 0 })}
+                onChange={(next) => patch({ mean: next })}
                 min={0}
                 max={1}
                 step="0.01"
@@ -398,7 +415,7 @@ function EdgeSyntheticControl({
               <NumberControl
                 label="Standard deviation"
                 value={distribution.sd}
-                onChange={(next) => patch({ sd: next ?? 0 })}
+                onChange={(next) => patch({ sd: next })}
                 min={0}
                 max={1}
                 step="0.01"
@@ -410,14 +427,14 @@ function EdgeSyntheticControl({
               <NumberControl
                 label="Mean"
                 value={distribution.mean}
-                onChange={(next) => patch({ mean: next ?? 0 })}
+                onChange={(next) => patch({ mean: next })}
                 {...(isDensity ? { min: 0 } : {})}
                 {...(isDensity ? { max: 1, step: '0.01' } : {})}
               />
               <NumberControl
                 label="Standard deviation"
                 value={distribution.sd}
-                onChange={(next) => patch({ sd: next ?? 0 })}
+                onChange={(next) => patch({ sd: next })}
                 min={0}
               />
               {/*

--- a/packages/protocol-utilities/src/generateNetwork.ts
+++ b/packages/protocol-utilities/src/generateNetwork.ts
@@ -764,7 +764,7 @@ export function generateNetwork(
   // edge of the same type ends up with.
   reserveFamilyPedigreeFixedValues(ctx, feasibilityStages);
 
-  const plan = planNetwork(ctx, effects, resolvedFamilyPedigree.maxNodes);
+  const plan = planNetwork(ctx, effects);
 
   return materialiseSession({
     ctx,

--- a/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeAncestryKeys.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeAncestryKeys.test.ts
@@ -137,6 +137,8 @@ function runSecondPedigree(nodes: NcNode[], edges: NcEdge[]): NetworkDraft {
     1,
     stages,
     stages,
+    // Nothing planned is outstanding: this test drives the pedigree directly.
+    0,
     7,
     resolveFamilyPedigreeGenerationOptions(undefined, 40),
   );

--- a/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeCoreBudget.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeCoreBudget.test.ts
@@ -117,6 +117,53 @@ describe('a declared minimum beside a pedigree', () => {
   });
 });
 
+/** A pedigree that grafts required ancestors onto children it inherits. */
+const contributorPedigree = (id: string): Stage =>
+  ({
+    ...(pedigree(id) as unknown as Record<string, unknown>),
+    boundaries: {
+      requireGrandparents: 'off',
+      requireChildrenContributors: 'required',
+    },
+  }) as unknown as Stage;
+
+/**
+ * Cap guards for the required-contributor mode, NOT proof of the ancestry
+ * accounting: in both shapes below the top-up produces no people at all
+ * (measured), so they pass with the accounting removed. They are kept because
+ * the cap is worth asserting for this mode, and the accounting itself is
+ * argued rather than demonstrated — see the note on the review thread.
+ */
+describe('required contributor ancestry', () => {
+  it('is counted before the family is sized, so the cap still holds', () => {
+    const { network } = generateNetwork({
+      seed: 1,
+      codebook,
+      stages: [
+        hungryGenerator,
+        contributorPedigree('stage-contrib-1'),
+        contributorPedigree('stage-contrib-2'),
+      ],
+    });
+
+    expect(network.nodes.length).toBeLessThanOrEqual(MAX_SYNTHETIC_POPULATION);
+  });
+
+  it('holds when the families precede the generator too', () => {
+    const { network } = generateNetwork({
+      seed: 1,
+      codebook,
+      stages: [
+        contributorPedigree('stage-contrib-1'),
+        contributorPedigree('stage-contrib-2'),
+        hungryGenerator,
+      ],
+    });
+
+    expect(network.nodes.length).toBeLessThanOrEqual(MAX_SYNTHETIC_POPULATION);
+  });
+});
+
 describe('the population cap holds across a pedigree', () => {
   // The ordering the first version of this test missed. A pedigree standing
   // BEFORE the stages that spend the budget sees an almost empty session and

--- a/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeCoreBudget.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/__tests__/pedigreeCoreBudget.test.ts
@@ -78,6 +78,45 @@ const hungryGenerator = {
   prompts: [{ id: 'p1', text: 'Name people' }],
 } as unknown as Stage;
 
+/**
+ * A creator's declared `minNodes` is a floor the live interface enforces — the
+ * stage will not let a participant leave below it — so a run that quietly
+ * builds fewer has produced a session no participant could have. Reserving a
+ * family's whole optional ceiling before ordinary floors were allocated did
+ * exactly that: a 9,998-person creator beside one default family came back
+ * with 9,968, and the refusal that should have caught it was weighing floors
+ * against the raw cap rather than against what the families leave.
+ */
+const flooredGenerator = {
+  ...hungryGenerator,
+  id: 'stage-floored',
+  behaviours: {
+    minNodes: MAX_SYNTHETIC_POPULATION - 2,
+    maxNodes: MAX_SYNTHETIC_POPULATION - 2,
+  },
+} as unknown as Stage;
+
+describe('a declared minimum beside a pedigree', () => {
+  it('is honoured, or the protocol is refused — never quietly trimmed', () => {
+    let built: number | undefined;
+    try {
+      const { network } = generateNetwork({
+        seed: 1,
+        codebook,
+        stages: [flooredGenerator, pedigree('stage-pedigree')],
+      });
+      built = network.nodes.filter(
+        (node) => node.stageId === 'stage-floored',
+      ).length;
+    } catch {
+      // Refusing is the other honest answer, and the one this shape takes
+      // once the floors are weighed against what the family reserves.
+      return;
+    }
+    expect(built).toBeGreaterThanOrEqual(MAX_SYNTHETIC_POPULATION - 2);
+  });
+});
+
 describe('the population cap holds across a pedigree', () => {
   // The ordering the first version of this test missed. A pedigree standing
   // BEFORE the stages that spend the budget sees an almost empty session and

--- a/packages/protocol-utilities/src/generateNetwork/__tests__/skippedCreatorEdgeInheritance.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/__tests__/skippedCreatorEdgeInheritance.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Stage, StructuralCodebook } from '@codaco/protocol-validation';
+
+import { generateNetwork } from '../../generateNetwork';
+
+/**
+ * A creator the walk passes over hands its planned edges to the next stage
+ * that creates the same type, so the declared topology is not simply lost when
+ * a guard the plan could not settle turns out to fire.
+ *
+ * An offer is not an obligation, though. Inherited wholesale, a density-1
+ * Sociogram behind such a guard gave its entire edge set to an unguarded
+ * density-0.5 one — and the receiving stage could not take the excess back,
+ * because those edges arrive already planned rather than drawn from its own
+ * target. What a stage ends up holding has to be what its own declaration
+ * asks for.
+ *
+ * The guard here reads an ALTER, not ego, so `planNetwork` cannot settle it
+ * and plans the first stage's edges in full; the walk then skips it.
+ */
+
+const codebook = {
+  node: {
+    person: {
+      name: 'Person',
+      color: 'node-color-seq-1',
+      variables: {
+        name: { name: 'Name', type: 'text' },
+        layout: { name: 'Layout', type: 'layout' },
+      },
+    },
+  },
+  edge: {
+    knows: { name: 'Knows', color: 'edge-color-seq-1', variables: {} },
+  },
+} as unknown as StructuralCodebook;
+
+const people = {
+  id: 'stage-people',
+  type: 'NameGenerator',
+  label: 'People',
+  subject: { entity: 'node', type: 'person' },
+  synthetic: { count: { distribution: 'constant', value: 6 } },
+  behaviours: { minNodes: 6, maxNodes: 6 },
+  form: { title: 'About', fields: [{ variable: 'name', prompt: 'Name' }] },
+  prompts: [{ id: 'p1', text: 'Name people' }],
+} as unknown as Stage;
+
+/** Density 1 over every pair, behind a guard the plan cannot settle. */
+const guardedDense = {
+  id: 'stage-dense',
+  type: 'Sociogram',
+  label: 'Everyone',
+  subject: { entity: 'node', type: 'person' },
+  synthetic: {
+    topology: {
+      metric: 'density',
+      distribution: { distribution: 'constant', value: 1 },
+    },
+  },
+  skipLogic: {
+    action: 'SKIP',
+    filter: {
+      // An alter rule: undecidable before the network exists, so the plan
+      // keeps this stage and draws its edges.
+      join: 'AND',
+      rules: [
+        {
+          id: 'anybody',
+          type: 'node',
+          options: { type: 'person', attribute: 'name', operator: 'EXISTS' },
+        },
+      ],
+    },
+  },
+  prompts: [
+    {
+      id: 'dense-p',
+      text: 'Who knows who?',
+      layout: { layoutVariable: 'layout' },
+      edges: { create: 'knows' },
+    },
+  ],
+} as unknown as Stage;
+
+/** Asks for half the pairs, and must not end up holding all of them. */
+const sparse = {
+  id: 'stage-sparse',
+  type: 'Sociogram',
+  label: 'A few',
+  subject: { entity: 'node', type: 'person' },
+  synthetic: {
+    topology: {
+      metric: 'density',
+      distribution: { distribution: 'constant', value: 0.5 },
+    },
+  },
+  prompts: [
+    {
+      id: 'sparse-p',
+      text: 'And who else?',
+      layout: { layoutVariable: 'layout' },
+      edges: { create: 'knows' },
+    },
+  ],
+} as unknown as Stage;
+
+describe('edges inherited from a creator the walk skipped', () => {
+  it('never exceed what the inheriting stage declared', () => {
+    const { network } = generateNetwork({
+      seed: 1,
+      codebook,
+      stages: [people, guardedDense, sparse],
+      respectSkipLogicAndFiltering: true,
+    });
+
+    expect(network.nodes).toHaveLength(6);
+    const knows = network.edges.filter((edge) => edge.type === 'knows').length;
+    // Six people span fifteen pairs; the surviving stage asked for half.
+    // Inheriting the skipped stage's density-1 set produced all fifteen.
+    expect(knows).toBeLessThanOrEqual(8);
+  });
+});

--- a/packages/protocol-utilities/src/generateNetwork/__tests__/skippedCreatorPendingBudget.test.ts
+++ b/packages/protocol-utilities/src/generateNetwork/__tests__/skippedCreatorPendingBudget.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Stage, StructuralCodebook } from '@codaco/protocol-validation';
+
+import { generateNetwork } from '../../generateNetwork';
+
+/**
+ * People the plan holds for a creator the walk passed over are never placed,
+ * so they are not "still to come" — their stage has already gone by.
+ *
+ * Counted as pending anyway, a large skipped creator reserved room for a stage
+ * that would never spend it, and the family after it was squeezed towards its
+ * required core while the finished network had space to spare.
+ *
+ * The guard reads an ALTER, so the plan cannot settle it and plans the
+ * creator's people in full; the walk then skips it.
+ */
+const codebook = {
+  node: {
+    person: {
+      name: 'Person',
+      color: 'node-color-seq-1',
+      variables: {
+        name: { name: 'Name', type: 'text' },
+        isEgo: { name: 'Is ego', type: 'boolean' },
+        relationship: { name: 'Relationship', type: 'text' },
+        sex: { name: 'Sex', type: 'text' },
+      },
+    },
+  },
+  edge: {},
+} as unknown as StructuralCodebook;
+
+/** Someone has to exist first, or the alter rule below matches nothing. */
+const seed = {
+  id: 'stage-seed',
+  type: 'NameGenerator',
+  label: 'A few',
+  subject: { entity: 'node', type: 'person' },
+  synthetic: { count: { distribution: 'constant', value: 3 } },
+  form: { title: 'About', fields: [{ variable: 'name', prompt: 'Name' }] },
+  prompts: [{ id: 'seed-p', text: 'Name people' }],
+} as unknown as Stage;
+
+const skippedBulk = {
+  id: 'stage-skipped',
+  type: 'NameGenerator',
+  label: 'Never reached',
+  subject: { entity: 'node', type: 'person' },
+  synthetic: { count: { distribution: 'constant', value: 9990 } },
+  form: { title: 'About', fields: [{ variable: 'name', prompt: 'Name' }] },
+  prompts: [{ id: 'sk-p', text: 'Name people' }],
+  skipLogic: {
+    action: 'SKIP',
+    filter: {
+      join: 'AND',
+      rules: [
+        {
+          id: 'anybody',
+          type: 'node',
+          options: { type: 'person', attribute: 'name', operator: 'EXISTS' },
+        },
+      ],
+    },
+  },
+} as unknown as Stage;
+
+const family = {
+  id: 'stage-pedigree',
+  type: 'FamilyPedigree',
+  label: 'Family',
+  nodeConfig: {
+    type: 'person',
+    nodeLabelVariable: 'name',
+    egoVariable: 'isEgo',
+    relationshipVariable: 'relationship',
+    biologicalSexVariable: 'sex',
+  },
+  edgeConfig: {
+    type: 'relation',
+    relationshipTypeVariable: 'relType',
+    isActiveVariable: 'isActive',
+    isGestationalCarrierVariable: 'carrier',
+    gameteRoleVariable: 'gamete',
+  },
+  framing: { mode: 'fixed', value: 'gendered' },
+  boundaries: {
+    requireGrandparents: 'off',
+    requireChildrenContributors: 'off',
+  },
+  censusPrompt: 'Add your family.',
+} as unknown as Stage;
+
+describe('a family after a creator the walk skipped', () => {
+  it('is not squeezed by people that stage will never build', () => {
+    const { network } = generateNetwork({
+      seed: 1,
+      codebook,
+      stages: [seed, skippedBulk, family],
+      respectSkipLogicAndFiltering: true,
+    });
+
+    // The skipped stage builds nobody, so the whole budget is the family's.
+    expect(
+      network.nodes.filter((node) => node.stageId === 'stage-skipped'),
+    ).toHaveLength(0);
+    // Sized so the overcount would leave under a family's own ceiling: with
+    // those 9,990 phantom people counted as pending the family was cut to
+    // roughly its required core, so anything comfortably above that shows the
+    // budget was read correctly.
+    expect(network.nodes.length).toBeGreaterThan(20);
+  });
+});

--- a/packages/protocol-utilities/src/generateNetwork/familyPedigree/materializeFamilyPedigree.ts
+++ b/packages/protocol-utilities/src/generateNetwork/familyPedigree/materializeFamilyPedigree.ts
@@ -460,6 +460,8 @@ export function materializeFamilyPedigree(
   stageIndex: number,
   stages: readonly Stage[],
   diseaseStages: readonly Stage[],
+  /** Planned people this walk has still to place; their budget is spent. */
+  plannedNodesStillToCome: number,
   familySeed: number,
   options: ResolvedFamilyPedigreeGenerationOptions,
 ): void {
@@ -658,10 +660,18 @@ export function materializeFamilyPedigree(
       // Guard against a duplicate object identity in the walked list.
       diseaseStages.indexOf(candidate) === index,
   ).length;
+  // What the plan has COMMITTED but not yet placed counts against the budget
+  // too. `draft.nodes.length` is only what this walk has reached so far, so a
+  // family standing before the stages that spend the budget saw an almost
+  // empty session and grew into room already promised to them — the cap
+  // reaching 10,016 for one family and 10,041 for three. The plan reserves
+  // each family's required core; its optional growth is settled here, against
+  // what is genuinely unspent.
   const remainingPopulationBudget = Math.max(
     0,
     MAX_SYNTHETIC_POPULATION -
       draft.nodes.length -
+      plannedNodesStillToCome -
       pedigreesAhead * MAX_REQUIRED_PEDIGREE_CORE,
   );
   const budgetedOptions =

--- a/packages/protocol-utilities/src/generateNetwork/familyPedigree/materializeFamilyPedigree.ts
+++ b/packages/protocol-utilities/src/generateNetwork/familyPedigree/materializeFamilyPedigree.ts
@@ -667,11 +667,28 @@ export function materializeFamilyPedigree(
   // reaching 10,016 for one family and 10,041 for three. The plan reserves
   // each family's required core; its optional growth is settled here, against
   // what is genuinely unspent.
+  // Derived BEFORE the family is sized, because its people are appended to
+  // whatever that sizing produces. Left until afterwards, the ancestors a
+  // required-contributor pedigree grafts onto inherited children — up to
+  // several per co-parent — escaped the clamp entirely, and a near-cap
+  // population beside two such families exceeded the bound again. It reads
+  // the draft and the stage alone, never the family plan, so computing it
+  // first changes nothing about what it produces.
+  const contributorAncestry = inheritedContributorAncestry(
+    draft,
+    inheritedEgo,
+    nodeType,
+    nodeConfig,
+    edgeType,
+    edgeConfig,
+    stage.boundaries?.requireChildrenContributors === 'required',
+  );
   const remainingPopulationBudget = Math.max(
     0,
     MAX_SYNTHETIC_POPULATION -
       draft.nodes.length -
       plannedNodesStillToCome -
+      contributorAncestry.people.length -
       pedigreesAhead * MAX_REQUIRED_PEDIGREE_CORE,
   );
   const budgetedOptions =
@@ -684,15 +701,6 @@ export function materializeFamilyPedigree(
     diseases,
     stage.boundaries?.requireChildrenContributors === 'required',
     inheritedEgoSex,
-  );
-  const contributorAncestry = inheritedContributorAncestry(
-    draft,
-    inheritedEgo,
-    nodeType,
-    nodeConfig,
-    edgeType,
-    edgeConfig,
-    stage.boundaries?.requireChildrenContributors === 'required',
   );
   const planPeople = [...plan.people, ...contributorAncestry.people];
   const planRelationships = [

--- a/packages/protocol-utilities/src/generateNetwork/materialise/materialiseSession.ts
+++ b/packages/protocol-utilities/src/generateNetwork/materialise/materialiseSession.ts
@@ -535,9 +535,17 @@ export function materialiseSession(params: {
         // is drawn, so it keeps every stage whose guard the seed still
         // decides.
         walkedReachableStages,
-        // Everything the plan holds that this walk has yet to place: those
-        // people are already spoken for, so a family must not grow into them.
-        plan.nodes.length - materialisedNodes.size,
+        // The people the plan still has to place, which is not the same as
+        // the people it has not placed. A creator an alter-dependent guard
+        // skipped keeps its planned nodes forever unmaterialised, and
+        // counting those as pending reserved room for a stage that has
+        // already gone by — squeezing a later family down to its core while
+        // the finished network had space to spare. Only stages still ahead
+        // can still spend.
+        plan.nodes.filter(
+          (node) =>
+            node.creationStageIndex > i && !materialisedNodes.has(node.uid),
+        ).length,
         familyPedigreeSeed(runSeed, stage.id),
         // One ceiling for every pedigree in the protocol. Nothing in the
         // protocol caps a family — the codebook describes what a family is,

--- a/packages/protocol-utilities/src/generateNetwork/materialise/materialiseSession.ts
+++ b/packages/protocol-utilities/src/generateNetwork/materialise/materialiseSession.ts
@@ -535,6 +535,9 @@ export function materialiseSession(params: {
         // is drawn, so it keeps every stage whose guard the seed still
         // decides.
         walkedReachableStages,
+        // Everything the plan holds that this walk has yet to place: those
+        // people are already spoken for, so a family must not grow into them.
+        plan.nodes.length - materialisedNodes.size,
         familyPedigreeSeed(runSeed, stage.id),
         // One ceiling for every pedigree in the protocol. Nothing in the
         // protocol caps a family — the codebook describes what a family is,
@@ -630,7 +633,7 @@ export function materialiseSession(params: {
       // Who this interaction could actually join, for judging an edge planned
       // before it. Built lazily: only a retry consults it.
       let reach: Set<string> | undefined;
-      const canJoin = (from: string, to: string): boolean => {
+      const reachOf = (): Set<string> => {
         if (reach === undefined) {
           let candidates = filteredSubjects(
             creation.subjectNodeType,
@@ -643,7 +646,54 @@ export function materialiseSession(params: {
             candidates.map((node) => node[entityPrimaryKeyProperty]),
           );
         }
-        return reach.has(from) && reach.has(to);
+        return reach;
+      };
+      const canJoin = (from: string, to: string): boolean => {
+        const members = reachOf();
+        return members.has(from) && members.has(to);
+      };
+
+      /**
+       * How many edges this interaction may inherit from a creator the walk
+       * passed over.
+       *
+       * A skipped creator's edges are offered to the next stage that creates
+       * the type so the planned topology is not simply lost. But an offer is
+       * not an obligation: a density-1 Sociogram behind a guard the plan
+       * cannot settle, followed by an unguarded density-0.5 one, handed its
+       * whole edge set to a stage that had asked for half as many — and the
+       * later stage's own target could no longer take the excess away, since
+       * these edges arrive already planned. Bounded here by what this
+       * creation's own declared topology asks for over the domain it can
+       * actually see, less what that domain already holds.
+       *
+       * Only inherited edges are counted against it. An edge planned FOR this
+       * stage was drawn from this stage's own domain to this stage's own
+       * target, and is not the topology of somewhere else arriving.
+       */
+      let retryAllowance: number | undefined;
+      const mayInherit = (): boolean => {
+        if (retryAllowance === undefined) {
+          const target = plan.topologyTargets.get(topologyKey(creation));
+          if (target === undefined) {
+            retryAllowance = Number.POSITIVE_INFINITY;
+          } else {
+            const members = reachOf();
+            const pairs =
+              members.size < 2 ? 0 : (members.size * (members.size - 1)) / 2;
+            const held = draft.edges.filter(
+              (edge) =>
+                edge.type === creation.edgeType &&
+                members.has(edge.from) &&
+                members.has(edge.to),
+            ).length;
+            retryAllowance = Math.max(
+              0,
+              topologyTarget(target, pairs, members.size) - held,
+            );
+          }
+        }
+        return retryAllowance > 0;
       };
 
       for (const planned of plan.edges) {
@@ -667,11 +717,13 @@ export function materialiseSession(params: {
         // drawn from its domain, and re-testing the filter against a
         // half-written session rather than the planned network would drop
         // edges whose filter reads a value a later stage writes.
-        if (
-          planned.creationStageIndex < i &&
-          !canJoin(planned.from, planned.to)
-        )
-          continue;
+        if (planned.creationStageIndex < i) {
+          if (!canJoin(planned.from, planned.to)) continue;
+          // Inherited, so it counts against what this stage's own topology
+          // asks for — see `mayInherit`.
+          if (!mayInherit()) continue;
+          retryAllowance = (retryAllowance ?? 0) - 1;
+        }
 
         const attributes: Record<string, VariableValue> = {};
         for (const variableId of creation.writesAtCreation) {

--- a/packages/protocol-utilities/src/generateNetwork/plan/networkPlan.ts
+++ b/packages/protocol-utilities/src/generateNetwork/plan/networkPlan.ts
@@ -46,7 +46,6 @@ import { completionCheckFor } from '../constraints/generateEntityAttributes';
 import type { EntityConstraints } from '../constraints/types';
 import type { GenerationContext } from '../context';
 import { MAX_REQUIRED_PEDIGREE_CORE } from '../familyPedigree/generateFamilyPedigree';
-import { DEFAULT_PEDIGREE_NODE_CEILING } from '../familyPedigree/stageCeiling';
 import { ruleBrokenByFixedValues } from '../nodes';
 import { sampleContinuous, sampleCount } from './distributions';
 import { deterministicUuid, type RandomSource } from './random';
@@ -1217,14 +1216,6 @@ function assignRosterRows(
 export function planNetwork(
   ctx: GenerationContext,
   effects: StageEffects,
-  /**
-   * The most people ONE reachable pedigree can end up holding.
-   *
-   * Reserved rather than assumed, because a family is built during the walk
-   * and admits its required core whatever ceiling it is given. Defaulted for
-   * callers that weigh a plan without pedigrees in mind.
-   */
-  pedigreeNodeCeiling: number = DEFAULT_PEDIGREE_NODE_CEILING,
 ): NetworkPlan {
   const source = ctx.valueGen.randomSource;
   const missing = missingProbabilities(ctx.codebook);
@@ -1448,26 +1439,28 @@ export function planNetwork(
   // the only place that can hold something back from a draw that ignores
   // ceilings.
   let populationBudget = MAX_SYNTHETIC_POPULATION;
+  let pedigreeRequiredReserve = 0;
   {
     let pedigreeStages = 0;
     for (const summary of walked.stages) {
       if (settledAsSkipped(summary)) continue;
       if (summary.pedigree !== undefined) pedigreeStages += 1;
     }
-    // The whole CEILING a family may reach, not merely the core it is
-    // guaranteed. Reserving the core alone held only where every pedigree ran
-    // after the stages that spend the budget: a pedigree standing FIRST sees
-    // an almost empty session, grows to its own ceiling, and the people this
-    // plan has already committed to later stages are then materialised on top
-    // of it — a cap of 10,000 reaching 10,016, and 10,041 for three families.
-    // A family cannot exceed its ceiling, so setting that aside makes the cap
-    // hold whatever order the stages are in.
-    populationBudget = Math.max(
-      0,
-      populationBudget -
-        pedigreeStages *
-          Math.max(pedigreeNodeCeiling, MAX_REQUIRED_PEDIGREE_CORE),
-    );
+    // Only the REQUIRED core is reserved here — the part that bypasses every
+    // ceiling and so must be held back before anything else is allocated.
+    //
+    // Reserving a family's whole optional ceiling instead made the cap hold in
+    // any stage order, but at the price of the other guarantee this plan
+    // owes: a creator's declared `minNodes` is a floor the live interface
+    // enforces, and taking 32 from the budget before ordinary floors were
+    // allocated silently trimmed a 9,998-person creator to 9,968 — a
+    // completed session no participant could have produced. A family's
+    // OPTIONAL growth is discretionary, so it is settled where the family is
+    // built, against what the plan has actually left unspent
+    // (`materializeFamilyPedigree` subtracts the nodes still to be
+    // materialised as well as those already placed).
+    pedigreeRequiredReserve = pedigreeStages * MAX_REQUIRED_PEDIGREE_CORE;
+    populationBudget = Math.max(0, populationBudget - pedigreeRequiredReserve);
     // Where the required cores ALONE cannot fit, no allocation can honour
     // them: the cores bypass every ceiling, so trimming elsewhere would not
     // help and the run would silently exceed the bound it exists to keep.
@@ -1513,7 +1506,12 @@ export function planNetwork(
       );
       typeFloors.set(type, floors);
       floorTotal += floors;
-      if (floorTotal > MAX_SYNTHETIC_POPULATION) {
+      // Weighed against what the reachable pedigrees leave, not the raw cap:
+      // their required cores are spoken for before any ordinary person is,
+      // so floors that fit the cap but not the remainder are floors this run
+      // cannot honour — and honouring them silently was the trim this refusal
+      // exists to prevent.
+      if (floorTotal > MAX_SYNTHETIC_POPULATION - pedigreeRequiredReserve) {
         throw new SyntheticDataConstraintError(
           [
             {


### PR DESCRIPTION
Three defects in synthetic interview generation, found by review after #1235 merged. Each is verified by a regression test that fails when its fix alone is reverted.

## A declared minimum was quietly under-built

`behaviours.minNodes` is a floor the live interface enforces — the stage will not let a participant leave below it — so a run that builds fewer has produced a session no participant could have.

```
creator declares minNodes: 9998
run actually built:        9968   ← 30 short, silently
```

This is a regression from #1235's own cap fix, and the two guarantees were fighting. Reserving each reachable pedigree's whole 32-node ceiling took from the budget *before* ordinary floors were allocated, while the refusal that should have caught it weighed those floors against the raw 10,000 cap rather than against the remainder.

Patching either alone just moves the failure, so they are now one allocation:

- the plan reserves only each family's **required core** — the part that bypasses every ceiling and so must be held back first;
- the refusal weighs ordinary floors against what those cores leave;
- a family's **optional** growth is settled where it is built, against the nodes the plan has committed but not yet placed (not merely those already materialised).

That last piece is what previously forced the ceiling reservation: a family standing before the stages that spend the budget saw an almost empty session and grew into room already promised. Both stage orderings still hold the cap (10,000 exactly, from either direction).

## Inherited edges ignored the inheriting stage's topology

A creator the walk passes over hands its planned edges to the next stage creating that type, so a declared topology is not lost when a guard the plan could not settle turns out to fire. But an offer is not an obligation: a density-1 sociogram behind such a guard gave its **whole** set — all fifteen pairs of six people — to an unguarded density-0.5 successor, which could not take the excess back, because inherited edges arrive already planned rather than drawn from its own target.

Inherited edges are now bounded by what the receiving stage declared over the domain it can actually see. Edges planned *for* a stage are unaffected: those were drawn from its own domain to its own target.

## Architect rewrote a part-typed number to zero

A number input reports an empty string for anything that is not yet a number — a lone `-` most of all — and the change handlers committed `0` for it. React then rewrites a number input whose committed value is `0` while the field looks empty, so the minus sign vanished before the digit arrived: a negative normal mean, which the schema permits, could not be typed at all. Clearing any of these parameters snapped it to a zero the author never entered.

All eight handlers in the section are fixed rather than only the two reported — leaving the rest would make a cleared field mean two different things in one section. A cleared field now holds nothing, and the block's own rule refuses a required parameter left blank, which is the honest outcome versus silently saving a zero.

## Verification

protocol-utilities 1386 tests · protocol-validation · architect · interview · workspace typecheck · lint · knip — all clean. Changeset included (both packages patch, normal lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)