### PR TITLE
fix(architect): reject null stage field values

### DIFF
--- a/.changeset/stale-ghosts-join.md
+++ b/.changeset/stale-ghosts-join.md
@@ -1,0 +1,6 @@
+---
+"@codaco/architect": patch
+"@codaco/fresco-ui": patch
+---
+
+Prevent null form field values from crashing Architect when changing the node type of configured ordinal or categorical bin stages.

--- a/apps/architect/src/components/StageEditor/__tests__/buildProtocolWithStage.test.ts
+++ b/apps/architect/src/components/StageEditor/__tests__/buildProtocolWithStage.test.ts
@@ -51,9 +51,9 @@ function makeProtocol(stageOverrides: Partial<Stage> = {}): CurrentProtocol {
 }
 
 describe('buildProtocolWithStage', () => {
-  it('prunes a freshly-created panel’s null filter so the wip protocol validates (regression)', async () => {
-    // This is the shape `createNewPanel` pushes once the user gives the panel a
-    // title and selects a roster: `filter` is still the placeholder `null`.
+  it('prunes a direct draft’s invalid null filter before preview', async () => {
+    // Callers outside the form can construct a draft that has not crossed the
+    // typed field writer. Preview must still match the pruned commit boundary.
     const wipStage = {
       ...makeProtocol().stages[0],
       panels: [

--- a/apps/architect/src/components/StageEditor/__tests__/requireStageFieldValue.test.ts
+++ b/apps/architect/src/components/StageEditor/__tests__/requireStageFieldValue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { requireStageFieldValue } from '../requireStageFieldValue';
+
+describe('requireStageFieldValue', () => {
+  it('rejects null instead of silently normalizing it', () => {
+    expect(() => requireStageFieldValue(null)).toThrow(TypeError);
+  });
+
+  it('preserves valid structured field values', () => {
+    const value = { join: 'AND', rules: [{ type: 'node' }] };
+
+    expect(requireStageFieldValue(value)).toBe(value);
+    expect(requireStageFieldValue([value])).toEqual([value]);
+  });
+
+  it('rejects an array containing a null field item', () => {
+    expect(() => requireStageFieldValue([null])).toThrow(TypeError);
+  });
+});

--- a/apps/architect/src/components/StageEditor/__tests__/stageFormHooks.test.tsx
+++ b/apps/architect/src/components/StageEditor/__tests__/stageFormHooks.test.tsx
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import Field from '@codaco/fresco-ui/form/Field/Field';
 import InputField from '@codaco/fresco-ui/form/fields/InputField';
@@ -16,7 +16,7 @@ type Probe = {
   value: unknown;
   initialValue: unknown;
   subject: ReturnType<typeof useSubject>;
-  setValue: (path: string, value: unknown) => void;
+  setValue: ReturnType<typeof useSetStageValue>;
 };
 
 /** Captures the hooks' output for the path under test. */
@@ -43,6 +43,12 @@ const makeProbe = (path: string) => {
 };
 
 describe('stageFormHooks', () => {
+  it('rejects null writes at the stage-field boundary', () => {
+    expectTypeOf<null>().not.toMatchTypeOf<
+      Parameters<ReturnType<typeof useSetStageValue>>[1]
+    >();
+  });
+
   describe('useStageFormValue', () => {
     it('falls back to the committed stage while no field is registered', () => {
       const { ProbeComponent, latest } = makeProbe('interviewScript');

--- a/apps/architect/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.panels.test.tsx
+++ b/apps/architect/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.panels.test.tsx
@@ -76,7 +76,7 @@ function renderNameGeneratorWithPanels() {
     subject: { entity: 'node', type: 'person' },
   } as unknown as Stage;
 
-  let setStageValue: ((path: string, value: unknown) => void) | null = null;
+  let setStageValue: ReturnType<typeof useSetStageValue> | null = null;
   const Probe = () => {
     setStageValue = useSetStageValue();
     return null;

--- a/apps/architect/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
+++ b/apps/architect/src/components/StageEditor/autoStageName/__tests__/useAutoStageName.test.tsx
@@ -3,7 +3,11 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Stage, StageType } from '@codaco/protocol-validation';
+import type {
+  Stage,
+  StageSubject,
+  StageType,
+} from '@codaco/protocol-validation';
 import stageEditorDraft from '~/ducks/modules/stageEditorDraft';
 
 import StageForm from '../../StageForm';
@@ -49,7 +53,7 @@ function renderHeading(
       }),
   });
 
-  let setStageValue: ((path: string, value: unknown) => void) | null = null;
+  let setStageValue: ReturnType<typeof useSetStageValue> | null = null;
   let history: ReturnType<typeof useStageDraftHistory> | null = null;
   const Probe = () => {
     setStageValue = useSetStageValue();
@@ -80,7 +84,7 @@ function renderHeading(
   return {
     store,
     input,
-    setSubject: (subject: unknown) =>
+    setSubject: (subject: StageSubject) =>
       act(() => {
         setStageValue?.('subject', subject);
       }),

--- a/apps/architect/src/components/StageEditor/buildProtocolWithStage.ts
+++ b/apps/architect/src/components/StageEditor/buildProtocolWithStage.ts
@@ -9,15 +9,13 @@ import prune from '~/utils/prune';
  * If inserting a new stage (i.e., stageId is null), generates a temporary ID for the stage for validation/preview purposes.
  *
  * The stage is pruned (null/empty values stripped) so that preview validates the
- * exact shape a save would commit. Without this, in-progress drafts can carry
- * placeholder nulls that the strict protocol schema rejects — e.g. a freshly
- * created side panel seeds `filter: null`, which fails `FilterSchema.optional()`
- * (optional accepts `undefined`, not `null`). `updateStage`/`createStage` prune on
- * commit, so previewing the unpruned draft would otherwise report "invalid" for a
- * stage that saves and reopens perfectly fine. Pruning here also means a panel
- * with no title resolves to a genuinely-invalid protocol (missing required
- * `title`) rather than a `null` the user could mistake for a transient state —
- * which is what keeps preview correctly disabled while a title is empty.
+ * exact shape a save would commit. The form contract excludes null, but this
+ * function can also receive drafts assembled outside the form; pruning here
+ * matches the `updateStage`/`createStage` commit boundary and avoids previewing
+ * a shape that would never be saved. It also means a panel with no title resolves
+ * to a genuinely-invalid protocol (missing required `title`) rather than a
+ * transient empty value, which keeps preview correctly disabled until a title
+ * is entered.
  */
 export function buildProtocolWithStage(
   protocol: CurrentProtocol,

--- a/apps/architect/src/components/StageEditor/interfaceTemplates.ts
+++ b/apps/architect/src/components/StageEditor/interfaceTemplates.ts
@@ -1,50 +1,52 @@
+import type { FieldValue } from '@codaco/fresco-ui/form/Field/types';
 import type { StageType } from '@codaco/protocol-validation';
 
-const INTERFACE_TEMPLATES: Partial<Record<StageType, Record<string, unknown>>> =
-  {
-    AlterEdgeForm: {},
-    AlterForm: {},
-    EgoForm: {},
-    OneToManyDyadCensus: {
-      behaviours: {
-        removeAfterConsideration: true,
-      },
+const INTERFACE_TEMPLATES: Partial<
+  Record<StageType, Record<string, FieldValue>>
+> = {
+  AlterEdgeForm: {},
+  AlterForm: {},
+  EgoForm: {},
+  OneToManyDyadCensus: {
+    behaviours: {
+      removeAfterConsideration: true,
     },
-    Narrative: {
-      behaviours: {
-        allowRepositioning: true,
-        automaticLayout: true,
-      },
+  },
+  Narrative: {
+    behaviours: {
+      allowRepositioning: true,
+      automaticLayout: true,
     },
-    NetworkComposer: {
-      behaviours: {
-        automaticLayout: true,
-      },
+  },
+  NetworkComposer: {
+    behaviours: {
+      automaticLayout: true,
     },
-    FamilyPedigree: {
-      framing: { mode: 'fixed', value: 'gamete' },
-      boundaries: {
-        requireGrandparents: 'off',
-        requireChildrenContributors: 'off',
-      },
-      introScreen: {
-        items: [
-          {
-            id: 'intro-text',
-            type: 'text',
-            content:
-              "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
-          },
-        ],
-      },
+  },
+  FamilyPedigree: {
+    framing: { mode: 'fixed', value: 'gamete' },
+    boundaries: {
+      requireGrandparents: 'off',
+      requireChildrenContributors: 'off',
     },
-    NarrativePedigree: {
-      sourceStageId: '',
-      diseases: [],
-      showAtRiskStatuses: false,
+    introScreen: {
+      items: [
+        {
+          id: 'intro-text',
+          type: 'text',
+          content:
+            "Building a pedigree means asking about the people you're biologically related to — the people whose egg and sperm you came from — not necessarily the people who raised you. A pedigree maps genetic relationships, so we focus on biological parents. Don't worry — you'll be able to include non-biological parents later.",
+        },
+      ],
     },
-  };
+  },
+  NarrativePedigree: {
+    sourceStageId: '',
+    diseases: [],
+    showAtRiskStatuses: false,
+  },
+};
 
 export const getInterfaceTemplate = (
   interfaceType: StageType,
-): Record<string, unknown> => INTERFACE_TEMPLATES[interfaceType] ?? {};
+): Record<string, FieldValue> => INTERFACE_TEMPLATES[interfaceType] ?? {};

--- a/apps/architect/src/components/StageEditor/requireStageFieldValue.ts
+++ b/apps/architect/src/components/StageEditor/requireStageFieldValue.ts
@@ -1,0 +1,30 @@
+import type { FieldValue } from '@codaco/fresco-ui/form/Field/types';
+
+const isFieldValueArrayItem = (
+  value: unknown,
+): value is string | number | boolean | Record<string, unknown> =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean' ||
+  (typeof value === 'object' && value !== null && !Array.isArray(value));
+
+const isFieldValue = (value: unknown): value is FieldValue =>
+  value === undefined ||
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean' ||
+  (Array.isArray(value) && value.every(isFieldValueArrayItem)) ||
+  (typeof value === 'object' && value !== null && !Array.isArray(value));
+
+/**
+ * Narrows a dynamically addressed stage value without weakening the form
+ * store's non-null contract. An invalid protocol or timeline value is an
+ * invariant violation and must remain visible rather than being cleared.
+ */
+export const requireStageFieldValue = (value: unknown): FieldValue => {
+  if (!isFieldValue(value)) {
+    throw new TypeError('Stage field values must satisfy the form contract.');
+  }
+
+  return value;
+};

--- a/apps/architect/src/components/StageEditor/stageFormHooks.ts
+++ b/apps/architect/src/components/StageEditor/stageFormHooks.ts
@@ -100,12 +100,12 @@ export function useStageFormValue<T = unknown>(path: string): T | undefined {
  * names are parked as a dormant pending write and re-attach when the field
  * next mounts, so this works for a collapsed or toggled-off section.
  */
-export function useSetStageValue(): (path: string, value: unknown) => void {
+export function useSetStageValue(): (path: string, value: FieldValue) => void {
   const { storeApi } = useStageFormContext();
 
   return useCallback(
-    (path: string, value: unknown) => {
-      storeApi.getState().setFieldValue(path, value as FieldValue);
+    (path: string, value: FieldValue) => {
+      storeApi.getState().setFieldValue(path, value);
     },
     [storeApi],
   );

--- a/apps/architect/src/components/StageEditor/useStageDraftHistory.ts
+++ b/apps/architect/src/components/StageEditor/useStageDraftHistory.ts
@@ -2,7 +2,6 @@ import { get, isEqual } from 'es-toolkit/compat';
 import { useCallback, useMemo } from 'react';
 import { useStore } from 'react-redux';
 
-import type { FieldValue } from '@codaco/fresco-ui/form/Field/types';
 import type { Stage } from '@codaco/protocol-validation';
 import { useAppDispatch, useAppSelector } from '~/ducks/hooks';
 import {
@@ -12,6 +11,7 @@ import {
 import type { RootState } from '~/ducks/store';
 import { getCanRedoDraft, getCanUndoDraft } from '~/selectors/stageEditorDraft';
 
+import { requireStageFieldValue } from './requireStageFieldValue';
 import {
   type StageFormStoreApi,
   useStageFormContext,
@@ -52,7 +52,7 @@ const applyDiff = (
   const knownNames = [...fields.keys(), ...dormantValues.keys()];
 
   for (const name of knownNames) {
-    const targetValue = get(target, name) as FieldValue;
+    const targetValue = requireStageFieldValue(get(target, name));
     if (isEqual(getFieldState(name)?.value, targetValue)) continue;
     setFieldValue(name, targetValue);
   }
@@ -65,7 +65,7 @@ const applyDiff = (
   for (const key of topLevelKeys) {
     if (knownNames.some((name) => coversTopLevelKey(name, key))) continue;
     if (isEqual(current[key], target[key])) continue;
-    setFieldValue(key, target[key] as FieldValue);
+    setFieldValue(key, requireStageFieldValue(target[key]));
   }
 };
 

--- a/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
+++ b/apps/architect/src/components/sections/NodePanels/NodePanel.tsx
@@ -11,6 +11,7 @@ import ArchitectField from '~/components/Form/ArchitectField';
 import DataSource from '~/components/Form/Fields/DataSource';
 import IssueAnchor from '~/components/IssueAnchor';
 import NetworkFilter from '~/components/sections/fields/NetworkFilter';
+import type { RuleSetValue } from '~/components/sections/fields/RuleSetFields';
 import { useStageRestoreVersion } from '~/components/StageEditor/StageFormBridge';
 import {
   useSetStageValue,
@@ -22,24 +23,26 @@ import { usePanelSlot } from './usePanelSlot';
 
 const EXISTING_DATA_SOURCE = 'existing';
 
-type PanelFilter = { join?: string; rules?: { type?: string }[] } | null;
+type PanelFilterInput = RuleSetValue | undefined;
 
-export const hasEdgeRules = (filter: PanelFilter): boolean =>
+export const hasEdgeRules = (filter: PanelFilterInput): boolean =>
   (filter?.rules ?? []).some((rule) => rule.type === 'edge');
 
-export const stripEdgeRules = (filter: PanelFilter): PanelFilter => {
+export const stripEdgeRules = (
+  filter: PanelFilterInput,
+): RuleSetValue | undefined => {
   const remaining = (filter?.rules ?? []).filter(
     (rule) => rule.type !== 'edge',
   );
-  if (remaining.length === 0) return null;
+  if (remaining.length === 0) return undefined;
   return { ...filter, rules: remaining };
 };
 
 export type NodePanelValue = Record<string, unknown> & {
   id: string;
-  title: string | null;
+  title: string | undefined;
   dataSource: string;
-  filter: unknown;
+  filter: RuleSetValue | undefined;
 };
 
 type NodePanelProps = ArrayFieldItemProps<NodePanelValue>;
@@ -80,10 +83,8 @@ const NodePanel = ({
   const dataSource = useStageFormValue<string | undefined>(
     `${fieldName}.dataSource`,
   );
-  const filter = useStageFormValue<PanelFilter>(`${fieldName}.filter`);
-  const initialTitle = useStageInitialValue<string | null>(
-    `${fieldName}.title`,
-  );
+  const filter = useStageFormValue<PanelFilterInput>(`${fieldName}.filter`);
+  const initialTitle = useStageInitialValue<string>(`${fieldName}.title`);
   const initialDataSource = useStageInitialValue<string | undefined>(
     `${fieldName}.dataSource`,
   );
@@ -105,7 +106,7 @@ const NodePanel = ({
       previousValue === undefined ||
       dataSource === previousValue ||
       dataSource === EXISTING_DATA_SOURCE ||
-      !hasEdgeRules(filter ?? null) ||
+      !hasEdgeRules(filter) ||
       // A superseded row reads the slot values of the panel that replaced it,
       // so its `dataSource` appears to change when the list is re-indexed.
       // Prompting there would ask about a panel that no longer exists.
@@ -133,7 +134,7 @@ const NodePanel = ({
       });
 
       if (confirmed) {
-        setStageValue(`${fieldName}.filter`, stripEdgeRules(filter ?? null));
+        setStageValue(`${fieldName}.filter`, stripEdgeRules(filter));
       } else {
         setStageValue(`${fieldName}.dataSource`, previousValue);
       }

--- a/apps/architect/src/components/sections/NodePanels/NodePanels.tsx
+++ b/apps/architect/src/components/sections/NodePanels/NodePanels.tsx
@@ -6,6 +6,7 @@ import UnconnectedField from '@codaco/fresco-ui/form/Field/UnconnectedField';
 import ArrayField from '@codaco/fresco-ui/form/fields/ArrayField/ArrayField';
 import Paragraph from '@codaco/fresco-ui/typography/Paragraph';
 import { Section } from '~/components/EditorLayout';
+import type { RuleSetValue } from '~/components/sections/fields/RuleSetFields';
 import { HiddenFieldValue } from '~/components/sections/Form/withFieldsHandlers';
 import type { StageEditorSectionProps } from '~/components/StageEditor/Interfaces';
 import { useStageRestoreVersion } from '~/components/StageEditor/StageFormBridge';
@@ -42,9 +43,9 @@ const EMPTY_PANELS: NodePanelValue[] = [];
 
 const createNodePanel = (): NodePanelValue => ({
   id: uuid(),
-  title: null,
+  title: undefined,
   dataSource: 'existing',
-  filter: null,
+  filter: undefined,
 });
 
 /**
@@ -68,9 +69,9 @@ const createNodePanel = (): NodePanelValue => ({
  */
 const usePanelAt = (index: number): NodePanelValue | undefined => {
   const id = useStageFormValue<string>(`panels[${index}].id`);
-  const title = useStageFormValue<string | null>(`panels[${index}].title`);
+  const title = useStageFormValue<string>(`panels[${index}].title`);
   const dataSource = useStageFormValue<string>(`panels[${index}].dataSource`);
-  const filter = useStageFormValue(`panels[${index}].filter`);
+  const filter = useStageFormValue<RuleSetValue>(`panels[${index}].filter`);
 
   return useMemo(() => {
     if (typeof id !== 'string') return undefined;
@@ -80,9 +81,9 @@ const usePanelAt = (index: number): NodePanelValue | undefined => {
     // shut — into a hole in the panel it writes back.
     return {
       id,
-      title: title ?? null,
+      title,
       dataSource: dataSource ?? 'existing',
-      filter: filter ?? null,
+      filter,
     };
   }, [dataSource, filter, id, title]);
 };
@@ -196,12 +197,12 @@ export const NodePanels = (_props: StageEditorSectionProps) => {
   const writePanelAt = useCallback(
     (index: number, panel: NodePanelValue | undefined) => {
       setStageValue(`panels[${index}].id`, panel?.id);
-      setStageValue(`panels[${index}].title`, panel?.title ?? null);
+      setStageValue(`panels[${index}].title`, panel?.title);
       setStageValue(
         `panels[${index}].dataSource`,
         panel?.dataSource ?? 'existing',
       );
-      setStageValue(`panels[${index}].filter`, panel?.filter ?? null);
+      setStageValue(`panels[${index}].filter`, panel?.filter);
     },
     [setStageValue],
   );

--- a/apps/architect/src/components/sections/NodePanels/__tests__/NodePanel.test.tsx
+++ b/apps/architect/src/components/sections/NodePanels/__tests__/NodePanel.test.tsx
@@ -41,7 +41,7 @@ const edgeRule = { type: 'edge', id: 'e1' };
 
 describe('hasEdgeRules', () => {
   it.each([
-    ['a null filter', null, false],
+    ['an unset filter', undefined, false],
     ['a filter with no rules', { rules: [] }, false],
     ['a filter with only alter rules', { rules: [alterRule] }, false],
     ['a filter with an edge rule', { rules: [alterRule, edgeRule] }, true],
@@ -58,7 +58,7 @@ describe('stripEdgeRules', () => {
   });
 
   it('clears the filter entirely when every rule was an edge rule', () => {
-    expect(stripEdgeRules({ join: 'AND', rules: [edgeRule] })).toBeNull();
+    expect(stripEdgeRules({ join: 'AND', rules: [edgeRule] })).toBeUndefined();
   });
 
   it('leaves a filter with no edge rules unchanged', () => {
@@ -66,10 +66,6 @@ describe('stripEdgeRules', () => {
       join: 'AND',
       rules: [alterRule],
     });
-  });
-
-  it('handles a null filter', () => {
-    expect(stripEdgeRules(null)).toBeNull();
   });
 });
 

--- a/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.identity.test.tsx
+++ b/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.identity.test.tsx
@@ -22,12 +22,12 @@ const toggle = () =>
   screen.getByRole('switch', { name: 'Turn this feature on or off' });
 
 const ONE_PANEL = [
-  { id: 'panel-1', title: 'A', dataSource: 'existing', filter: null },
+  { id: 'panel-1', title: 'A', dataSource: 'existing', filter: undefined },
 ];
 
 const TWO_PANELS = [
   ...ONE_PANEL,
-  { id: 'panel-2', title: 'B', dataSource: 'existing', filter: null },
+  { id: 'panel-2', title: 'B', dataSource: 'existing', filter: undefined },
 ];
 
 const renderPanels = (panels: Record<string, unknown>[] = ONE_PANEL) =>

--- a/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.test.tsx
+++ b/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.test.tsx
@@ -21,13 +21,13 @@ import { handlePanelToggleChange, NodePanels } from '../NodePanels';
 
 const panel = (id: string): NodePanelValue => ({
   id,
-  title: null,
+  title: undefined,
   dataSource: 'existing',
-  filter: null,
+  filter: undefined,
 });
 
 describe('NodePanels', () => {
-  it('keeps null storage until add and creates at most two UUID-backed panels', async () => {
+  it('keeps fields unset until add and creates at most two UUID-backed panels', async () => {
     const { getFieldState } = renderStageForm({
       committedStage: asStage({ subject: { entity: 'node', type: 'person' } }),
       children: (
@@ -70,12 +70,12 @@ describe('NodePanels', () => {
     expect(typeof panel0Id).toBe('string');
     expect(typeof panel1Id).toBe('string');
     expect(panel0Id).not.toBe(panel1Id);
-    expect(getFieldState('panels[0].title')?.value).toBeNull();
+    expect(getFieldState('panels[0].title')?.value).toBeUndefined();
     expect(getFieldState('panels[0].dataSource')?.value).toBe('existing');
-    expect(getFieldState('panels[0].filter')?.value).toBeNull();
-    expect(getFieldState('panels[1].title')?.value).toBeNull();
+    expect(getFieldState('panels[0].filter')?.value).toBeUndefined();
+    expect(getFieldState('panels[1].title')?.value).toBeUndefined();
     expect(getFieldState('panels[1].dataSource')?.value).toBe('existing');
-    expect(getFieldState('panels[1].filter')?.value).toBeNull();
+    expect(getFieldState('panels[1].filter')?.value).toBeUndefined();
 
     expect(
       screen.queryByRole('button', { name: 'Add new panel' }),

--- a/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.timeline.test.tsx
+++ b/apps/architect/src/components/sections/NodePanels/__tests__/NodePanels.timeline.test.tsx
@@ -126,7 +126,7 @@ describe('NodePanels undo timeline', () => {
 
   it('does not record an entry for a stage that opens with panels already configured', async () => {
     const { getHistory, snapshots } = renderPanels([
-      { id: 'panel-1', title: 'A', dataSource: 'existing', filter: null },
+      { id: 'panel-1', title: 'A', dataSource: 'existing', filter: undefined },
     ]);
 
     await waitFor(() =>

--- a/apps/architect/src/components/sections/__tests__/useResetStageOnSubjectChange.test.tsx
+++ b/apps/architect/src/components/sections/__tests__/useResetStageOnSubjectChange.test.tsx
@@ -1,8 +1,11 @@
-import { act } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { type ComponentType, useEffect, useRef } from 'react';
 import { describe, expect, it } from 'vitest';
 
+import DialogProvider from '@codaco/fresco-ui/dialogs/DialogProvider';
 import Field from '@codaco/fresco-ui/form/Field/Field';
+import ArrayField from '@codaco/fresco-ui/form/fields/ArrayField/ArrayField';
+import type { ArrayFieldItemProps } from '@codaco/fresco-ui/form/fields/ArrayField/ArrayField';
 import type { StageType } from '@codaco/protocol-validation';
 import {
   asStage,
@@ -52,6 +55,24 @@ const SubjectField = () => (
   />
 );
 
+type BinPrompt = { id: string; text: string };
+
+const BinPromptItem = ({ item }: ArrayFieldItemProps<BinPrompt>) => (
+  <span>{item.text}</span>
+);
+
+const BinPromptField = ({ prompts }: { prompts: BinPrompt[] }) => (
+  <Field
+    name="prompts"
+    label="Prompts"
+    component={ArrayField<BinPrompt>}
+    initialValue={prompts}
+    itemComponent={BinPromptItem}
+    itemTemplate={() => ({ id: 'draft', text: '' })}
+    confirmDelete={false}
+  />
+);
+
 const ResetOnSubjectChange = ({
   interfaceType,
 }: {
@@ -62,6 +83,43 @@ const ResetOnSubjectChange = ({
 };
 
 describe('useResetStageOnSubjectChange', () => {
+  it.each(['OrdinalBin', 'CategoricalBin'] as const)(
+    'clears a rendered %s prompt array without passing null to ArrayField',
+    async (interfaceType) => {
+      const prompts = [{ id: 'p1', text: 'Old subject prompt' }];
+      const { getFieldState, getStoreApi } = renderStageForm({
+        committedStage: asStage({
+          id: 'stage-1',
+          type: interfaceType,
+          label: 'Sort people',
+          subject: PERSON,
+          prompts,
+        }),
+        children: (
+          <DialogProvider>
+            <ResetOnSubjectChange interfaceType={interfaceType} />
+            <SubjectField />
+            <BinPromptField prompts={prompts} />
+          </DialogProvider>
+        ),
+      });
+
+      expect(screen.getByText('Old subject prompt')).toBeInTheDocument();
+
+      act(() => {
+        getStoreApi().getState().setFieldValue('subject', FRIEND);
+      });
+
+      expect(getFieldState('prompts')?.value).toBeUndefined();
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Old subject prompt'),
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByText(/no items added yet/i)).toBeInTheDocument();
+    },
+  );
+
   it('resets the descendants a section registers, not just their container', () => {
     const { getFieldState, getFormValues, getStoreApi } = renderStageForm({
       committedStage: asStage({
@@ -246,9 +304,9 @@ describe('useResetStageOnSubjectChange', () => {
       expect(getPresent()).toEqual({
         subject: FRIEND,
         form: {},
-        // The template has no prompts for an AlterForm, so the reset parks an
-        // explicit empty value rather than leaving the old subject's.
-        prompts: null,
+        // The template has no prompts for an AlterForm, so the reset uses the
+        // form contract's unset value rather than leaving the old subject's.
+        prompts: undefined,
       });
     });
 
@@ -277,7 +335,7 @@ describe('useResetStageOnSubjectChange', () => {
 
       expect(getFieldState('subject')?.value).toEqual(FRIEND);
       expect(getFieldState('form.fields')?.value).toBeUndefined();
-      expect(getFieldState('prompts')?.value).toBeNull();
+      expect(getFieldState('prompts')?.value).toBeUndefined();
       expect(snapshots).toHaveLength(1);
       expect(store.getState().stageEditorDraft.history.future).toHaveLength(0);
       expect(getHistory().canUndo).toBe(true);

--- a/apps/architect/src/components/sections/useResetStageOnSubjectChange.ts
+++ b/apps/architect/src/components/sections/useResetStageOnSubjectChange.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import type { StageSubject, StageType } from '@codaco/protocol-validation';
 import { clearFieldValue } from '~/components/Form/clearFieldValue';
 import { getInterfaceTemplate } from '~/components/StageEditor/interfaceTemplates';
+import { requireStageFieldValue } from '~/components/StageEditor/requireStageFieldValue';
 import { useStageRestoreVersion } from '~/components/StageEditor/StageFormBridge';
 import { useStageFormContext } from '~/components/StageEditor/stageFormContext';
 import {
@@ -83,7 +84,7 @@ const useResetStageOnSubjectChange = (interfaceType: StageType): void => {
         // saved still carrying the previous subject's variable references.
         clearFieldValue(storeApi, field);
 
-        setStageValue(field, template[field] ?? null);
+        setStageValue(field, template[field]);
 
         const { fields, dormantValues } = storeApi.getState();
         const names = new Set([...fields.keys(), ...dormantValues.keys()]);
@@ -93,7 +94,8 @@ const useResetStageOnSubjectChange = (interfaceType: StageType): void => {
           }
           // A nested template default has to be addressed by the same name the
           // section registered, or it lands on the container instead.
-          setStageValue(name, get(template, name));
+          const templateValue = get(template, name);
+          setStageValue(name, requireStageFieldValue(templateValue));
         }
       });
     });

--- a/packages/fresco-ui/src/form/Field/types.ts
+++ b/packages/fresco-ui/src/form/Field/types.ts
@@ -24,6 +24,7 @@ export type FieldValue =
   | (string | number | boolean | Record<string, unknown>)[]
   | number
   | boolean
+  | Record<string, unknown>
   | JSONContent //
   | undefined;
 


### PR DESCRIPTION
## Summary

- tighten Architect's stage-field writer to accept only `FieldValue`, so null writes fail typechecking instead of being cast through
- reset absent stage fields and side-panel values with `undefined`, while failing loudly if undo/redo encounters an invalid dynamic value
- add mounted `ArrayField` regressions for Ordinal Bin and Categorical Bin node-type changes

## Cause

PR #1350 made entity attribute values sparse, but this crash came from a separate stage-form boundary. `useSetStageValue` accepted `unknown` and cast it to `FieldValue`; changing a configured bin's node type consequently reset `prompts` to `null`, and `ArrayField` attempted to iterate it.

## Test plan

- [x] `pnpm lint:fix`
- [x] `pnpm check:changesets`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm --filter @codaco/architect test` (1,689 passed; 4 todo)
- [x] `pnpm --filter @codaco/fresco-ui test` (1,256 passed)
- [x] `pnpm turbo run build --filter=@codaco/architect`
- [x] `pnpm --filter @codaco/architect exec playwright test --config e2e/playwright.config.ts` (63 passed)
- [x] live dev-server verification: changed `person` to `family member` and confirmed reset on both Ordinal Bin and Categorical Bin; each remained mounted with an empty prompt list
- [x] visual-impact classifier reviewed; no baseline changes required because Fresco UI changed only a type and valid rendered states are unchanged
