### PR TITLE
fix(fresco-ui): keep focus on a toolbar segment that becomes disabled

### DIFF
--- a/.changeset/toolbar-disabled-keeps-focus.md
+++ b/.changeset/toolbar-disabled-keeps-focus.md
@@ -1,9 +1,14 @@
 ---
+'@codaco/tailwind-config': minor
 '@codaco/fresco-ui': patch
+'@codaco/interview': patch
 '@codaco/architect': patch
 '@codaco/interviewer': patch
+'fresco': patch
 ---
 
 A toolbar segment that becomes unavailable no longer takes keyboard focus with it. Undoing your last change — pressing Undo until there is nothing left to undo — used to drop focus back to the very start of the page, because the segment was momentarily disabled outright and browsers move focus off a disabled control. `SegmentedToolbar` segments now stay focusable while unavailable and report it with `aria-disabled`, which is what the toolbar's roving focus already assumed, so focus stays put and a screen reader announces the segment as unavailable instead of going silent. This affects every toolbar built on `SegmentedToolbar`: Architect's project and stage-editor actions, and the Network Composer, Narrative and Narrative Pedigree toolbars during an interview.
 
 Unavailable segments now also look unavailable. They dim, take a not-allowed cursor, and no longer light up under the pointer — while staying hoverable, so an icon-only segment can still show the tooltip that carries its only visible label. Toggle, group, menu and popover segments join button segments in all of this, and no longer contradict themselves by reporting `aria-disabled="false"` while disabled.
+
+For library consumers: `@codaco/tailwind-config` adds two variants, `ui-disabled` and `ui-enabled`, which match `aria-disabled="true"` as well as the native `:disabled` state. `Button` now gates every availability-dependent style on them, so a control that must stay focusable while unavailable still looks and behaves unavailable. Anything overriding one of Button's hover or active styles must use the same variants — `ui-enabled:hover:…` rather than `hover:enabled:…` — or the override will no longer merge with the style it is meant to replace.

--- a/.changeset/toolbar-disabled-keeps-focus.md
+++ b/.changeset/toolbar-disabled-keeps-focus.md
@@ -1,0 +1,9 @@
+---
+'@codaco/fresco-ui': patch
+'@codaco/architect': patch
+'@codaco/interviewer': patch
+---
+
+A toolbar segment that becomes unavailable no longer takes keyboard focus with it. Undoing your last change — pressing Undo until there is nothing left to undo — used to drop focus back to the very start of the page, because the segment was momentarily disabled outright and browsers move focus off a disabled control. `SegmentedToolbar` segments now stay focusable while unavailable and report it with `aria-disabled`, which is what the toolbar's roving focus already assumed, so focus stays put and a screen reader announces the segment as unavailable instead of going silent. This affects every toolbar built on `SegmentedToolbar`: Architect's project and stage-editor actions, and the Network Composer, Narrative and Narrative Pedigree toolbars during an interview.
+
+Unavailable segments now also look unavailable. They dim, take a not-allowed cursor, and no longer light up under the pointer — while staying hoverable, so an icon-only segment can still show the tooltip that carries its only visible label. Toggle, group, menu and popover segments join button segments in all of this, and no longer contradict themselves by reporting `aria-disabled="false"` while disabled.

--- a/apps/architect/src/components/ProjectNav/StageEditorNav.tsx
+++ b/apps/architect/src/components/ProjectNav/StageEditorNav.tsx
@@ -24,7 +24,7 @@ import Breadcrumb, { type BreadcrumbItem } from './Breadcrumb';
 import NavShell from './NavShell';
 
 const previewButtonClassName =
-  'bg-slate-blue! text-white! hover:enabled:bg-slate-blue! hover:enabled:text-white!';
+  'bg-slate-blue! text-white! ui-enabled:hover:bg-slate-blue! ui-enabled:hover:text-white!';
 
 type StageEditorNavProps = {
   stageName: string;

--- a/apps/networkcanvas.com/components/sections/__tests__/MailingListForm.test.tsx
+++ b/apps/networkcanvas.com/components/sections/__tests__/MailingListForm.test.tsx
@@ -29,7 +29,7 @@ describe('MailingListForm', () => {
     expect(submit).toHaveClass(
       'h-12',
       'elevation-low',
-      'not-disabled:active:translate-y-[2px]',
+      'ui-enabled:active:translate-y-[2px]',
     );
 
     fireEvent.change(email, { target: { value: 'researcher@example.com' } });

--- a/packages/fresco-ui/src/Button.test.tsx
+++ b/packages/fresco-ui/src/Button.test.tsx
@@ -16,11 +16,11 @@ describe('Button', () => {
       'bg-(--component-text)',
       'border-(--component-raised-edge)',
       'border-b-4',
-      'not-disabled:hover:border-b-5',
+      'ui-enabled:hover:border-b-5',
       '[--component-text:var(--success)]',
       '[--component-raised-edge:color-mix(in_oklab,var(--component-text)_78%,var(--color-black)_22%)]',
-      'not-disabled:hover:elevation-medium',
-      'not-disabled:active:translate-y-1',
+      'ui-enabled:hover:elevation-medium',
+      'ui-enabled:active:translate-y-1',
       'uppercase',
       'tracking-widest',
       'text-sm',
@@ -41,11 +41,11 @@ describe('Button', () => {
 
     expect(screen.getByRole('button', { name: 'Small' })).toHaveClass(
       'border-b-3',
-      'not-disabled:hover:border-b-4',
+      'ui-enabled:hover:border-b-4',
     );
     expect(screen.getByRole('button', { name: 'Extra large' })).toHaveClass(
       'border-b-6',
-      'not-disabled:hover:border-b-8',
+      'ui-enabled:hover:border-b-8',
       'normal-case',
       'tracking-wide',
       'text-xl',
@@ -123,7 +123,7 @@ describe('Button', () => {
     const button = screen.getByRole('button', { name: 'Disabled action' });
 
     expect(button).toBeDisabled();
-    expect(button).toHaveClass('disabled:[&>span]:bg-[length:0%_2px]!');
+    expect(button).toHaveClass('ui-disabled:[&>span]:bg-[length:0%_2px]!');
   });
 
   it('supports a slotted link without forwarding button-only attributes', () => {

--- a/packages/fresco-ui/src/Button.tsx
+++ b/packages/fresco-ui/src/Button.tsx
@@ -23,10 +23,10 @@ const buttonSpecificVariants = cva({
   base: cx(
     'font-heading inline-flex shrink-0 cursor-pointer border-0 font-bold tracking-wide',
     'items-center justify-center',
-    'disabled:cursor-not-allowed disabled:opacity-50',
+    'ui-disabled:cursor-not-allowed ui-disabled:opacity-50',
     'focusable',
     'elevation-low',
-    'not-disabled:active:elevation-none not-disabled:active:translate-y-[2px]',
+    'ui-enabled:active:elevation-none ui-enabled:active:translate-y-[2px]',
     'transition-[background-color,border-color,border-width,color,box-shadow,opacity,translate] duration-150',
   ),
   variants: {
@@ -34,18 +34,18 @@ const buttonSpecificVariants = cva({
       'default': 'bg-(--component-text) text-(--component-bg)',
       'default-inverted': 'bg-white text-(--component-text)',
       'raised':
-        'not-disabled:hover:elevation-medium border-(--component-raised-edge) bg-(--component-text) tracking-widest text-(--component-bg) uppercase [--component-raised-edge:color-mix(in_oklab,var(--component-text)_78%,var(--color-black)_22%)] not-disabled:hover:-translate-y-0.5 not-disabled:active:border-b-transparent',
+        'ui-enabled:hover:elevation-medium ui-enabled:hover:-translate-y-0.5 ui-enabled:active:border-b-transparent border-(--component-raised-edge) bg-(--component-text) tracking-widest text-(--component-bg) uppercase [--component-raised-edge:color-mix(in_oklab,var(--component-text)_78%,var(--color-black)_22%)]',
       'outline':
-        'border-2 border-(--component-text) text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
+        'ui-enabled:hover:bg-(--component-text) ui-enabled:hover:text-(--component-bg) border-2 border-(--component-text) text-(--component-text)',
       'text':
-        'text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
+        'ui-enabled:hover:bg-(--component-text) ui-enabled:hover:text-(--component-bg) text-(--component-text)',
       'dashed':
-        'border-2 border-dashed border-(--component-text) text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
+        'ui-enabled:hover:bg-(--component-text) ui-enabled:hover:text-(--component-bg) border-2 border-dashed border-(--component-text) text-(--component-text)',
       'glass':
-        'control-glass border-(--component-text) text-(--component-text) hover:enabled:bg-(--component-text) hover:enabled:text-(--component-bg)',
+        'control-glass ui-enabled:hover:bg-(--component-text) ui-enabled:hover:text-(--component-bg) border-(--component-text) text-(--component-text)',
       'link': cx(
         NATIVE_LINK_ROOT_CLASS_NAME,
-        'font-body elevation-none hover:elevation-none! h-auto! overflow-visible p-0! tracking-normal hover:translate-none! active:translate-none! disabled:[&>span]:bg-[length:0%_2px]!',
+        'font-body elevation-none hover:elevation-none! ui-disabled:[&>span]:bg-[length:0%_2px]! h-auto! overflow-visible p-0! tracking-normal hover:translate-none! active:translate-none!',
       ),
     },
     textStyle: {
@@ -100,7 +100,7 @@ const buttonSpecificVariants = cva({
       variant: ['outline', 'text', 'dashed', 'glass'],
       color: 'default',
       className:
-        'interview:[--component-text:var(--neutral)] [--component-text:var(--neutral-contrast)] hover:enabled:[--component-text:var(--neutral)]',
+        'interview:[--component-text:var(--neutral)] ui-enabled:hover:[--component-text:var(--neutral)] [--component-text:var(--neutral-contrast)]',
     },
     {
       variant: ['outline', 'dashed', 'glass'],
@@ -115,25 +115,25 @@ const buttonSpecificVariants = cva({
       variant: 'raised',
       size: 'sm',
       className:
-        'border-b-3 text-xs not-disabled:hover:border-b-4 not-disabled:active:translate-y-0.75 not-disabled:active:border-b-3',
+        'ui-enabled:hover:border-b-4 ui-enabled:active:translate-y-0.75 ui-enabled:active:border-b-3 border-b-3 text-xs',
     },
     {
       variant: 'raised',
       size: 'md',
       className:
-        'border-b-4 text-sm not-disabled:hover:border-b-5 not-disabled:active:translate-y-1 not-disabled:active:border-b-4',
+        'ui-enabled:hover:border-b-5 ui-enabled:active:translate-y-1 ui-enabled:active:border-b-4 border-b-4 text-sm',
     },
     {
       variant: 'raised',
       size: 'lg',
       className:
-        'border-b-5 text-base not-disabled:hover:border-b-6 not-disabled:active:translate-y-1.25 not-disabled:active:border-b-5',
+        'ui-enabled:hover:border-b-6 ui-enabled:active:translate-y-1.25 ui-enabled:active:border-b-5 border-b-5 text-base',
     },
     {
       variant: 'raised',
       size: 'xl',
       className:
-        'border-b-6 text-lg not-disabled:hover:border-b-8 not-disabled:active:translate-y-1.5 not-disabled:active:border-b-6',
+        'ui-enabled:hover:border-b-8 ui-enabled:active:translate-y-1.5 ui-enabled:active:border-b-6 border-b-6 text-lg',
     },
     {
       textStyle: 'uppercase',

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.stories.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   Bold,
+  Download,
   Eye,
   Grid3x3,
   Italic,
@@ -21,6 +22,7 @@ import {
   Undo2,
 } from 'lucide-react';
 import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import SplitButton from '../SplitButton';
 import { withTooltipProvider } from '../storybook-support/withTooltipProvider';
@@ -339,6 +341,130 @@ export const Colours: Story = {
         onClick: noop,
       },
     ],
+  },
+};
+
+/**
+ * Disabled segments dim but stay focusable, so a keyboard user can still reach
+ * one and hear that it is unavailable — the APG toolbar behaviour. They keep
+ * their tooltip too, which for an icon-only segment is its only visible label.
+ */
+export const Disabled: Story = {
+  args: {
+    label: 'Drawing tools',
+    items: [
+      {
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        disabled: true,
+        onClick: noop,
+      },
+      {
+        type: 'button',
+        id: 'redo',
+        label: 'Redo',
+        icon: <Redo2 />,
+        onClick: noop,
+      },
+      { type: 'separator', id: 'sep-1' },
+      {
+        type: 'toggle',
+        id: 'freeze',
+        label: 'Freeze layout',
+        icon: <Snowflake />,
+        disabled: true,
+        defaultPressed: false,
+      },
+      {
+        type: 'menu',
+        id: 'edge',
+        label: 'Draw edge',
+        icon: <Spline />,
+        disabled: true,
+        options: [{ value: 'friendship', label: 'Friendship' }],
+        onSelect: noop,
+      },
+      { type: 'separator', id: 'sep-2' },
+      // A segment that paints its own colours keeps them, dimmed.
+      {
+        type: 'button',
+        id: 'download',
+        label: 'Downloading…',
+        icon: <Download />,
+        showLabel: true,
+        variant: 'default',
+        className: 'bg-sea-green text-white',
+        disabled: true,
+        onClick: noop,
+      },
+    ],
+  },
+};
+
+/**
+ * Disabling the segment you are standing on must not move focus. Exhausting an
+ * action this way — pressing Undo until there is nothing left to undo — is the
+ * ordinary case, and losing focus to `<body>` would drop a keyboard or screen
+ * reader user at the start of the document.
+ *
+ * This has to run in a real browser: the failure mode was a native `disabled`
+ * attribute applied for a single commit, and only a browser blurs on it.
+ */
+export const KeepsFocusWhenDisabled: Story = {
+  args: { label: 'Drawing tools', items: [] },
+  render: function KeepsFocusRender(args) {
+    const [steps, setSteps] = useState(2);
+    const items: ToolbarSegment[] = [
+      {
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        disabled: steps === 0,
+        onClick: () => setSteps((remaining) => Math.max(0, remaining - 1)),
+      },
+      {
+        type: 'button',
+        id: 'redo',
+        label: 'Redo',
+        icon: <Redo2 />,
+        onClick: noop,
+      },
+    ];
+    return <SegmentedToolbar {...args} items={items} />;
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const undo = await canvas.findByRole('button', { name: 'Undo' });
+
+    await step('activating an enabled segment keeps focus', async () => {
+      undo.focus();
+      await userEvent.keyboard('{Enter}');
+      expect(undo).toHaveFocus();
+      expect(undo).not.toHaveAttribute('aria-disabled', 'true');
+    });
+
+    await step('exhausting it disables it without taking focus', async () => {
+      await userEvent.keyboard('{Enter}');
+      await waitFor(() =>
+        expect(undo).toHaveAttribute('aria-disabled', 'true'),
+      );
+      // The regression: `document.activeElement` became <body> here.
+      expect(undo).toHaveFocus();
+      // Focusable-when-disabled, so it stays in the roving tab order rather
+      // than being skipped over by the browser.
+      expect(undo).not.toBeDisabled();
+      expect(undo).toHaveAttribute('tabindex', '0');
+    });
+
+    await step('and it is inert, without becoming invisible', async () => {
+      await userEvent.keyboard('{Enter}');
+      expect(undo).toHaveAttribute('aria-disabled', 'true');
+      expect(undo).toHaveFocus();
+      expect(getComputedStyle(undo).opacity).toBe('0.5');
+    });
   },
 };
 

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.stories.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.stories.tsx
@@ -468,6 +468,36 @@ export const KeepsFocusWhenDisabled: Story = {
   },
 };
 
+/**
+ * The `glass` variant rests on `control-glass`'s translucent fill rather than
+ * on no fill at all, so its disabled hover reset has to restore that fill
+ * instead of blanking the background.
+ */
+export const DisabledGlass: Story = {
+  args: {
+    label: 'Drawing tools',
+    items: [
+      {
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        variant: 'glass',
+        disabled: true,
+        onClick: noop,
+      },
+      {
+        type: 'button',
+        id: 'redo',
+        label: 'Redo',
+        icon: <Redo2 />,
+        variant: 'glass',
+        onClick: noop,
+      },
+    ],
+  },
+};
+
 /** Adding and removing segments animates in and out; the container resizes via motion's layout. */
 export const DynamicItems: Story = {
   args: {

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
@@ -254,7 +254,9 @@ describe('SegmentedToolbar — toggles', () => {
     ];
     render(<SegmentedToolbar label="Tools" items={items} />);
     const button = screen.getByRole('button', { name: 'Freeze' });
-    expect(button).toBeDisabled();
+    // Disabled segments stay focusable and say so with `aria-disabled` rather
+    // than the native attribute — see the focus-retention tests below.
+    expect(button).toHaveAttribute('aria-disabled', 'true');
     await userEvent.click(button);
     expect(button).toHaveAttribute('aria-pressed', 'false');
   });
@@ -404,7 +406,7 @@ describe('SegmentedToolbar — groups', () => {
     expect(typeof eventDetails.cancel).toBe('function');
   });
 
-  it('disables every option when a controlled group segment omits its callback', () => {
+  it('disables every option when a controlled group segment omits its callback', async () => {
     // Same hazard as a controlled toggle without onPressedChange: a
     // controlled `value` with no `onValueChange` can never change, so every
     // option in the group is disabled rather than left live-looking.
@@ -421,8 +423,171 @@ describe('SegmentedToolbar — groups', () => {
       },
     ];
     render(<SegmentedToolbar label="View" items={items} />);
-    expect(screen.getByRole('button', { name: 'List' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Grid' })).toBeDisabled();
+    const grid = screen.getByRole('button', { name: 'Grid' });
+    expect(screen.getByRole('button', { name: 'List' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(grid).toHaveAttribute('aria-disabled', 'true');
+    // `aria-disabled` alone would only be a claim; the option must actually be
+    // inert, since it is no longer the browser enforcing that.
+    await userEvent.click(grid);
+    expect(grid).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+
+describe('SegmentedToolbar — disabled segments', () => {
+  // A disabled segment stays in the toolbar's roving focus (Base UI's
+  // `focusableWhenDisabled`, the APG toolbar behaviour), so it must never be
+  // natively disabled: browsers blur a focused element the moment it becomes
+  // disabled, which would dump a keyboard user who exhausts an action — say,
+  // pressing Undo until there is nothing left to undo — onto <body>.
+  //
+  // jsdom does not implement that blur, so these tests pin the *cause*: no
+  // `disabled` attribute, ever, not even for the single commit Base UI takes
+  // to delete it again. The focus outcome itself is pinned in the browser, in
+  // SegmentedToolbar.stories.tsx.
+
+  /** Records every mutation of the `disabled` attribute on `element`. */
+  function watchDisabled(element: Element) {
+    const observer = new MutationObserver(() => undefined);
+    observer.observe(element, { attributes: true, attributeOldValue: true });
+    return () => {
+      const changes = observer
+        .takeRecords()
+        .filter((record) => record.attributeName === 'disabled')
+        .map((record) => (record.oldValue === null ? 'added' : 'removed'));
+      observer.disconnect();
+      return changes;
+    };
+  }
+
+  const disabledSegments: Array<
+    [string, (disabled: boolean) => ToolbarSegment]
+  > = [
+    [
+      'Undo',
+      (disabled) => ({
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        disabled,
+        onClick: vi.fn(),
+      }),
+    ],
+    [
+      'Freeze',
+      (disabled) => ({
+        type: 'toggle',
+        id: 'freeze',
+        label: 'Freeze',
+        icon: <Snowflake />,
+        pressed: false,
+        onPressedChange: vi.fn(),
+        disabled,
+      }),
+    ],
+    [
+      'List',
+      (disabled) => ({
+        type: 'group',
+        id: 'view',
+        mode: 'single',
+        value: [],
+        onValueChange: vi.fn(),
+        options: [{ value: 'list', label: 'List', icon: <List />, disabled }],
+      }),
+    ],
+    [
+      'Draw edge',
+      (disabled) => ({
+        type: 'menu',
+        id: 'edge',
+        label: 'Draw edge',
+        icon: <Spline />,
+        options: [{ value: 'friendship', label: 'Friendship' }],
+        onSelect: vi.fn(),
+        disabled,
+      }),
+    ],
+    [
+      'Add node',
+      (disabled) => ({
+        type: 'popover',
+        id: 'add',
+        label: 'Add node',
+        icon: <Trash2 />,
+        open: false,
+        onOpenChange: vi.fn(),
+        children: <input aria-label="Name" />,
+        disabled,
+      }),
+    ],
+  ];
+
+  it.each(disabledSegments)(
+    'never applies a native disabled attribute to a %s segment that becomes disabled',
+    (name, makeSegment) => {
+      const { rerender } = render(
+        <SegmentedToolbar label="Tools" items={[makeSegment(false)]} />,
+      );
+      const button = screen.getByRole('button', { name });
+      const readDisabledChanges = watchDisabled(button);
+
+      rerender(<SegmentedToolbar label="Tools" items={[makeSegment(true)]} />);
+
+      // Not "added then removed" — added at all is what loses focus.
+      expect(readDisabledChanges()).toEqual([]);
+      expect(button).not.toBeDisabled();
+      // The segment stays reachable, and says it is unavailable.
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      expect(button).toHaveAttribute('tabindex', '0');
+    },
+  );
+
+  it('does not fire a disabled button segment that was activated while enabled', async () => {
+    // The reported case: Undo is activated repeatedly until the history runs
+    // out and the segment disables under the pointer/keyboard.
+    const onClick = vi.fn();
+    const items = (disabled: boolean): ToolbarSegment[] => [
+      {
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        disabled,
+        onClick,
+      },
+    ];
+    const { rerender } = render(
+      <SegmentedToolbar label="Tools" items={items(false)} />,
+    );
+    const button = screen.getByRole('button', { name: 'Undo' });
+
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(<SegmentedToolbar label="Tools" items={items(true)} />);
+    await userEvent.click(button);
+    await userEvent.type(button, '{Enter}');
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an enabled segment free of the disabled affordances', () => {
+    const items: ToolbarSegment[] = [
+      {
+        type: 'button',
+        id: 'undo',
+        label: 'Undo',
+        icon: <Undo2 />,
+        onClick: vi.fn(),
+      },
+    ];
+    render(<SegmentedToolbar label="Tools" items={items} />);
+    const button = screen.getByRole('button', { name: 'Undo' });
+    expect(button).not.toHaveAttribute('aria-disabled');
+    expect(button.className).not.toMatch(/aria-disabled:/);
   });
 });
 

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
@@ -589,6 +589,73 @@ describe('SegmentedToolbar — disabled segments', () => {
     expect(button).not.toHaveAttribute('aria-disabled');
     expect(button.className).not.toMatch(/aria-disabled:/);
   });
+
+  // Button inverts the flat variants' colours on `hover:enabled:`, which still
+  // matches a segment that is never natively disabled, so each variant has to
+  // restore its own resting background. `glass` is the one that rests on a
+  // fill: `control-glass` supplies `bg-surface/50`, and blanking it would strip
+  // the segment's translucent surface the moment the pointer touched it.
+  //
+  // Asserted on the class list rather than on rendered `:hover` styles: the
+  // pseudo-class is driven by real pointer input, which neither jsdom nor
+  // Testing Library's synthetic events can produce.
+  it.each([
+    ['text', 'bg-transparent'],
+    ['outline', 'bg-transparent'],
+    ['dashed', 'bg-transparent'],
+    ['glass', 'bg-surface/50'],
+  ] as const)(
+    'resets a disabled %s segment to its own resting background on hover',
+    (variant, expectedBackground) => {
+      const items: ToolbarSegment[] = [
+        {
+          type: 'button',
+          id: 'undo',
+          label: 'Undo',
+          icon: <Undo2 />,
+          variant,
+          disabled: true,
+          onClick: vi.fn(),
+        },
+      ];
+      render(<SegmentedToolbar label="Tools" items={items} />);
+      const { className } = screen.getByRole('button', { name: 'Undo' });
+
+      expect(className).toContain(`aria-disabled:hover:${expectedBackground}!`);
+      expect(className).toContain(
+        'aria-disabled:hover:text-(--component-text)!',
+      );
+      if (variant === 'glass') {
+        expect(className).not.toContain('aria-disabled:hover:bg-transparent!');
+      }
+    },
+  );
+
+  it('leaves a segment that paints its own colours alone', () => {
+    // A caller-supplied className owns the segment's appearance, so resetting
+    // the hover colours would blank the colour it deliberately set.
+    const items: ToolbarSegment[] = [
+      {
+        type: 'button',
+        id: 'download',
+        label: 'Downloading…',
+        showLabel: true,
+        variant: 'default',
+        className: 'bg-sea-green text-white',
+        disabled: true,
+        onClick: vi.fn(),
+      },
+    ];
+    render(<SegmentedToolbar label="Tools" items={items} />);
+    const { className } = screen.getByRole('button', {
+      name: 'Downloading…',
+    });
+
+    expect(className).toContain('bg-sea-green');
+    expect(className).not.toMatch(/aria-disabled:hover:bg-/);
+    // The dimming still applies — only the colour reset is withheld.
+    expect(className).toContain('aria-disabled:opacity-50');
+  });
 });
 
 describe('SegmentedToolbar — add/remove', () => {

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
@@ -327,7 +327,7 @@ describe('SegmentedToolbar — colour', () => {
     render(<SegmentedToolbar label="Tools" items={items} />);
 
     expect(screen.getByRole('button', { name: 'Edit' })).toHaveClass(
-      'hover:enabled:bg-(--component-text)',
+      'ui-enabled:hover:bg-(--component-text)',
     );
   });
 
@@ -348,7 +348,7 @@ describe('SegmentedToolbar — colour', () => {
     const button = screen.getByRole('button', { name: 'Delete' });
     expect(button).toHaveClass('bg-tomato');
     expect(button).toHaveClass('text-white');
-    expect(button).not.toHaveClass('hover:enabled:bg-(--component-text)');
+    expect(button).not.toHaveClass('ui-enabled:hover:bg-(--component-text)');
   });
 });
 
@@ -587,26 +587,18 @@ describe('SegmentedToolbar — disabled segments', () => {
     render(<SegmentedToolbar label="Tools" items={items} />);
     const button = screen.getByRole('button', { name: 'Undo' });
     expect(button).not.toHaveAttribute('aria-disabled');
-    expect(button.className).not.toMatch(/aria-disabled:/);
   });
 
-  // Button inverts the flat variants' colours on `hover:enabled:`, which still
-  // matches a segment that is never natively disabled, so each variant has to
-  // restore its own resting background. `glass` is the one that rests on a
-  // fill: `control-glass` supplies `bg-surface/50`, and blanking it would strip
-  // the segment's translucent surface the moment the pointer touched it.
-  //
-  // Asserted on the class list rather than on rendered `:hover` styles: the
-  // pseudo-class is driven by real pointer input, which neither jsdom nor
-  // Testing Library's synthetic events can produce.
-  it.each([
-    ['text', 'bg-transparent'],
-    ['outline', 'bg-transparent'],
-    ['dashed', 'bg-transparent'],
-    ['glass', 'bg-surface/50'],
-  ] as const)(
-    'resets a disabled %s segment to its own resting background on hover',
-    (variant, expectedBackground) => {
+  // Every appearance Button gates on availability — the dimming, the flat
+  // variants' hover colour flip, `raised`'s hover lift and elevation, and the
+  // `--component-text` token the default colour swaps on hover — is gated on
+  // `ui-enabled`/`ui-disabled`, which match `aria-disabled` as well as the
+  // native attribute. Enumerating those rules here instead would mean
+  // restating Button's internals from the outside, and silently drifting the
+  // next time one of them changes.
+  it.each(['text', 'outline', 'dashed', 'glass', 'raised', 'default'] as const)(
+    'gates a disabled %s segment on the availability variants, not `:disabled`',
+    (variant) => {
       const items: ToolbarSegment[] = [
         {
           type: 'button',
@@ -621,41 +613,13 @@ describe('SegmentedToolbar — disabled segments', () => {
       render(<SegmentedToolbar label="Tools" items={items} />);
       const { className } = screen.getByRole('button', { name: 'Undo' });
 
-      expect(className).toContain(`aria-disabled:hover:${expectedBackground}!`);
-      expect(className).toContain(
-        'aria-disabled:hover:text-(--component-text)!',
-      );
-      if (variant === 'glass') {
-        expect(className).not.toContain('aria-disabled:hover:bg-transparent!');
-      }
+      // `disabled:`/`enabled:`/`not-disabled:` cannot match a segment that is
+      // never natively disabled, so none may remain.
+      expect(className).not.toMatch(/(^|\s)(disabled|not-disabled):/);
+      expect(className).not.toContain('hover:enabled:');
+      expect(className).toContain('ui-disabled:opacity-50');
     },
   );
-
-  it('leaves a segment that paints its own colours alone', () => {
-    // A caller-supplied className owns the segment's appearance, so resetting
-    // the hover colours would blank the colour it deliberately set.
-    const items: ToolbarSegment[] = [
-      {
-        type: 'button',
-        id: 'download',
-        label: 'Downloading…',
-        showLabel: true,
-        variant: 'default',
-        className: 'bg-sea-green text-white',
-        disabled: true,
-        onClick: vi.fn(),
-      },
-    ];
-    render(<SegmentedToolbar label="Tools" items={items} />);
-    const { className } = screen.getByRole('button', {
-      name: 'Downloading…',
-    });
-
-    expect(className).toContain('bg-sea-green');
-    expect(className).not.toMatch(/aria-disabled:hover:bg-/);
-    // The dimming still applies — only the colour reset is withheld.
-    expect(className).toContain('aria-disabled:opacity-50');
-  });
 });
 
 describe('SegmentedToolbar — add/remove', () => {

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -227,43 +227,6 @@ const SegmentControl = React.forwardRef<HTMLButtonElement, ButtonProps>(
   },
 );
 
-// Button expresses its disabled appearance with `:disabled`, and inverts the
-// flat variants' colours on `hover:enabled:` — neither of which can match a
-// segment that is never natively disabled. Restate both on `aria-disabled` so
-// a disabled segment reads as unavailable and never lights up under the
-// pointer. It stays hoverable on purpose: for an icon-only segment the tooltip
-// is the only visible label, and it is most needed when the segment is dimmed.
-const disabledSegmentClasses =
-  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:active:translate-none!';
-
-// The variants that invert this token pair on hover, mapped to the background
-// each one rests at. Restoring the resting background rather than blanking it
-// matters for `glass`, whose `control-glass` treatment rests on a translucent
-// `bg-surface/50` fill — forcing transparency would strip that fill on hover
-// instead of leaving the segment looking untouched. Variants that paint their
-// own background (`default`, `raised`) have no hover flip to undo.
-const HOVER_RESET_BACKGROUND: Partial<
-  Record<NonNullable<ButtonProps['variant']>, string>
-> = {
-  text: 'aria-disabled:hover:bg-transparent!',
-  outline: 'aria-disabled:hover:bg-transparent!',
-  dashed: 'aria-disabled:hover:bg-transparent!',
-  glass: 'aria-disabled:hover:bg-surface/50!',
-};
-const hoverResetForeground = 'aria-disabled:hover:text-(--component-text)!';
-
-/** Classes carrying the disabled appearance for a segment, if it is disabled. */
-function disabledClasses(content: SegmentContent, disabled?: boolean) {
-  if (!disabled) return undefined;
-  const background = HOVER_RESET_BACKGROUND[content.variant ?? 'text'];
-  return cx(
-    disabledSegmentClasses,
-    // A caller-supplied `className` is painting the segment itself, so leave
-    // its colours alone rather than resetting them out from under it.
-    background && !content.className && cx(background, hoverResetForeground),
-  );
-}
-
 // Pressed-state highlight for toggle segments, via Base UI's data attribute.
 // `!important` so the selected colours win over Button's text-variant hover.
 const pressedClasses =
@@ -273,7 +236,7 @@ const pressedClasses =
 function segmentButton(
   content: SegmentContent,
   size: SegmentSize,
-  { disabled, extraClassName }: { disabled?: boolean; extraClassName?: string },
+  extraClassName?: string,
 ) {
   const labelVisible = isLabelVisible(content);
   return (
@@ -287,7 +250,6 @@ function segmentButton(
         !labelVisible && 'aspect-square p-0',
         extraClassName,
         content.className,
-        disabledClasses(content, disabled),
       )}
     >
       {labelVisible ? content.label : null}
@@ -327,9 +289,7 @@ function ToolbarButtonSegment({
   size: SegmentSize;
   orientation: ToolbarOrientation;
 }) {
-  const styledButton = segmentButton(segment, size, {
-    disabled: segment.disabled,
-  });
+  const styledButton = segmentButton(segment, size);
   // When a caller hosts the segment in their own element (e.g. a Popover
   // trigger), the styled button becomes that element's render target so the
   // overlay wiring composes with the toolbar button — mirroring the
@@ -382,10 +342,7 @@ function ToolbarToggleSegment({
           defaultPressed={segment.defaultPressed}
           onPressedChange={segment.onPressedChange}
           disabled={disabled}
-          render={segmentButton(segment, size, {
-            disabled,
-            extraClassName: pressedClasses,
-          })}
+          render={segmentButton(segment, size, pressedClasses)}
         />
       }
     />
@@ -437,10 +394,7 @@ function ToolbarGroupSegment({
               <Toggle
                 value={option.value}
                 disabled={disabled}
-                render={segmentButton(option, size, {
-                  disabled,
-                  extraClassName: pressedClasses,
-                })}
+                render={segmentButton(option, size, pressedClasses)}
               />
             }
           />
@@ -487,10 +441,7 @@ function ToolbarMenuSegment({
       render={
         <DropdownMenuTrigger
           disabled={segment.disabled}
-          render={segmentButton(segment, size, {
-            disabled: segment.disabled,
-            extraClassName: activeClasses,
-          })}
+          render={segmentButton(segment, size, activeClasses)}
         />
       }
     />
@@ -550,10 +501,7 @@ function ToolbarPopoverSegment({
       render={
         <PopoverTrigger
           disabled={segment.disabled}
-          render={segmentButton(segment, size, {
-            disabled: segment.disabled,
-            extraClassName: activeClasses,
-          })}
+          render={segmentButton(segment, size, activeClasses)}
         />
       }
     />

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -196,6 +196,70 @@ function isLabelVisible(content: SegmentContent): boolean {
   return content.showLabel ?? !content.icon;
 }
 
+/**
+ * A disabled toolbar segment stays focusable — the APG toolbar behaviour Base
+ * UI's roving focus already implements via `focusableWhenDisabled`, so a
+ * keyboard user can still reach a segment to learn it is unavailable.
+ *
+ * A native `disabled` attribute is incompatible with that: browsers blur a
+ * focused element the instant it becomes disabled, so a keyboard user who
+ * exhausts an action — pressing Undo until there is nothing left to undo —
+ * loses focus to the document body. Base UI does delete the attribute again,
+ * but only in a layout effect, one commit after React has written it to the
+ * DOM and the browser has already taken focus away.
+ *
+ * So swallow `disabled` before it reaches the DOM and let `aria-disabled`
+ * carry the state (it is what Base UI converges on anyway). Activation is
+ * already blocked in Base UI's own click/keydown/pointerdown handlers, which
+ * close over the disabled state rather than reading the attribute.
+ */
+const SegmentControl = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  function SegmentControl({ disabled, ...props }, ref) {
+    // The composite item and the inner trigger each contribute a signal, and
+    // whichever renders last wins the merge — so treat either as disabled.
+    const isDisabled =
+      disabled === true ||
+      props['aria-disabled'] === true ||
+      props['aria-disabled'] === 'true';
+    return (
+      <Button ref={ref} {...props} aria-disabled={isDisabled || undefined} />
+    );
+  },
+);
+
+// Button expresses its disabled appearance with `:disabled`, and inverts the
+// flat variants' colours on `hover:enabled:` — neither of which can match a
+// segment that is never natively disabled. Restate both on `aria-disabled` so
+// a disabled segment reads as unavailable and never lights up under the
+// pointer. It stays hoverable on purpose: for an icon-only segment the tooltip
+// is the only visible label, and it is most needed when the segment is dimmed.
+const disabledSegmentClasses =
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:active:translate-none!';
+
+// The flat variants all invert the same token pair on hover, so one reset
+// restores every one of them to its resting colours. Variants that paint their
+// own background have no hover flip to undo.
+const FLAT_VARIANTS = new Set<ButtonProps['variant']>([
+  'text',
+  'outline',
+  'dashed',
+  'glass',
+]);
+const flatHoverResetClasses =
+  'aria-disabled:hover:bg-transparent! aria-disabled:hover:text-(--component-text)!';
+
+/** Classes carrying the disabled appearance for a segment, if it is disabled. */
+function disabledClasses(content: SegmentContent, disabled?: boolean) {
+  if (!disabled) return undefined;
+  const variant = content.variant ?? 'text';
+  return cx(
+    disabledSegmentClasses,
+    // A caller-supplied `className` is painting the segment itself, so leave
+    // its colours alone rather than resetting them out from under it.
+    FLAT_VARIANTS.has(variant) && !content.className && flatHoverResetClasses,
+  );
+}
+
 // Pressed-state highlight for toggle segments, via Base UI's data attribute.
 // `!important` so the selected colours win over Button's text-variant hover.
 const pressedClasses =
@@ -205,11 +269,11 @@ const pressedClasses =
 function segmentButton(
   content: SegmentContent,
   size: SegmentSize,
-  extraClassName?: string,
+  { disabled, extraClassName }: { disabled?: boolean; extraClassName?: string },
 ) {
   const labelVisible = isLabelVisible(content);
   return (
-    <Button
+    <SegmentControl
       variant={content.variant ?? 'text'}
       size={size}
       icon={content.icon}
@@ -219,10 +283,11 @@ function segmentButton(
         !labelVisible && 'aspect-square p-0',
         extraClassName,
         content.className,
+        disabledClasses(content, disabled),
       )}
     >
       {labelVisible ? content.label : null}
-    </Button>
+    </SegmentControl>
   );
 }
 
@@ -258,7 +323,9 @@ function ToolbarButtonSegment({
   size: SegmentSize;
   orientation: ToolbarOrientation;
 }) {
-  const styledButton = segmentButton(segment, size);
+  const styledButton = segmentButton(segment, size, {
+    disabled: segment.disabled,
+  });
   // When a caller hosts the segment in their own element (e.g. a Popover
   // trigger), the styled button becomes that element's render target so the
   // overlay wiring composes with the toolbar button — mirroring the
@@ -298,15 +365,23 @@ function ToolbarToggleSegment({
   // its own state regardless of whether a callback is supplied.
   const isUncontrollable =
     segment.pressed !== undefined && !segment.onPressedChange;
+  const disabled = segment.disabled || isUncontrollable;
+  // `disabled` also goes on the composite item, not just the inner Toggle:
+  // that is what tells Base UI's roving focus the segment is disabled-but-
+  // focusable, and keeps its `aria-disabled` in step with the Toggle's.
   const toggle = (
     <Toolbar.Button
+      disabled={disabled}
       render={
         <Toggle
           pressed={segment.pressed}
           defaultPressed={segment.defaultPressed}
           onPressedChange={segment.onPressedChange}
-          disabled={segment.disabled || isUncontrollable}
-          render={segmentButton(segment, size, pressedClasses)}
+          disabled={disabled}
+          render={segmentButton(segment, size, {
+            disabled,
+            extraClassName: pressedClasses,
+          })}
         />
       }
     />
@@ -347,13 +422,21 @@ function ToolbarGroupSegment({
       )}
     >
       {segment.options.map((option) => {
+        // The group's own `disabled` reaches each Toggle through context, so
+        // fold it in here too — the composite item is outside that context and
+        // would otherwise treat the option as enabled.
+        const disabled = option.disabled || isUncontrollable;
         const toggle = (
           <Toolbar.Button
+            disabled={disabled}
             render={
               <Toggle
                 value={option.value}
-                disabled={option.disabled}
-                render={segmentButton(option, size, pressedClasses)}
+                disabled={disabled}
+                render={segmentButton(option, size, {
+                  disabled,
+                  extraClassName: pressedClasses,
+                })}
               />
             }
           />
@@ -396,10 +479,14 @@ function ToolbarMenuSegment({
       : undefined;
   const trigger = (
     <Toolbar.Button
+      disabled={segment.disabled}
       render={
         <DropdownMenuTrigger
           disabled={segment.disabled}
-          render={segmentButton(segment, size, activeClasses)}
+          render={segmentButton(segment, size, {
+            disabled: segment.disabled,
+            extraClassName: activeClasses,
+          })}
         />
       }
     />
@@ -455,10 +542,14 @@ function ToolbarPopoverSegment({
       : undefined;
   const trigger = (
     <Toolbar.Button
+      disabled={segment.disabled}
       render={
         <PopoverTrigger
           disabled={segment.disabled}
-          render={segmentButton(segment, size, activeClasses)}
+          render={segmentButton(segment, size, {
+            disabled: segment.disabled,
+            extraClassName: activeClasses,
+          })}
         />
       }
     />

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -236,27 +236,31 @@ const SegmentControl = React.forwardRef<HTMLButtonElement, ButtonProps>(
 const disabledSegmentClasses =
   'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:active:translate-none!';
 
-// The flat variants all invert the same token pair on hover, so one reset
-// restores every one of them to its resting colours. Variants that paint their
-// own background have no hover flip to undo.
-const FLAT_VARIANTS = new Set<ButtonProps['variant']>([
-  'text',
-  'outline',
-  'dashed',
-  'glass',
-]);
-const flatHoverResetClasses =
-  'aria-disabled:hover:bg-transparent! aria-disabled:hover:text-(--component-text)!';
+// The variants that invert this token pair on hover, mapped to the background
+// each one rests at. Restoring the resting background rather than blanking it
+// matters for `glass`, whose `control-glass` treatment rests on a translucent
+// `bg-surface/50` fill — forcing transparency would strip that fill on hover
+// instead of leaving the segment looking untouched. Variants that paint their
+// own background (`default`, `raised`) have no hover flip to undo.
+const HOVER_RESET_BACKGROUND: Partial<
+  Record<NonNullable<ButtonProps['variant']>, string>
+> = {
+  text: 'aria-disabled:hover:bg-transparent!',
+  outline: 'aria-disabled:hover:bg-transparent!',
+  dashed: 'aria-disabled:hover:bg-transparent!',
+  glass: 'aria-disabled:hover:bg-surface/50!',
+};
+const hoverResetForeground = 'aria-disabled:hover:text-(--component-text)!';
 
 /** Classes carrying the disabled appearance for a segment, if it is disabled. */
 function disabledClasses(content: SegmentContent, disabled?: boolean) {
   if (!disabled) return undefined;
-  const variant = content.variant ?? 'text';
+  const background = HOVER_RESET_BACKGROUND[content.variant ?? 'text'];
   return cx(
     disabledSegmentClasses,
     // A caller-supplied `className` is painting the segment itself, so leave
     // its colours alone rather than resetting them out from under it.
-    FLAT_VARIANTS.has(variant) && !content.className && flatHoverResetClasses,
+    background && !content.className && cx(background, hoverResetForeground),
   );
 }
 

--- a/packages/interview/src/components/Navigation.tsx
+++ b/packages/interview/src/components/Navigation.tsx
@@ -374,7 +374,8 @@ const Navigation = ({
         )}
         <NavigationButton
           className={cx(
-            pulseNext && 'bg-success hover:enabled:bg-success outline-success',
+            pulseNext &&
+              'bg-success ui-enabled:hover:bg-success outline-success',
             pulseNext && !shouldReduceMotion && 'animate-pulse-glow',
           )}
           wrapperClassName={

--- a/tooling/tailwind/fresco/utilities.css
+++ b/tooling/tailwind/fresco/utilities.css
@@ -168,6 +168,18 @@
    elements like <select>, which we usually don't want to style as readonly. */
 @custom-variant is-read-only (&[readonly]);
 
+/* Unavailable, whether or not the browser agrees. Some controls must stay
+   focusable while disabled and so cannot carry the native attribute — a
+   toolbar segment keeps its place in the roving tab order (the APG toolbar
+   behaviour) and reports itself with `aria-disabled` instead, because a
+   browser blurs a focused element the moment it becomes natively disabled.
+   Styling off `:disabled` alone would leave those controls looking, and
+   reacting to the pointer, exactly like live ones. Use these in place of
+   Tailwind's `disabled:` / `enabled:` / `not-disabled:` wherever a control's
+   appearance depends on being available. */
+@custom-variant ui-disabled (&:is(:disabled, [aria-disabled='true']));
+@custom-variant ui-enabled (&:not(:disabled):not([aria-disabled='true']));
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

A `SegmentedToolbar` segment that became disabled while focused took keyboard focus with it, dumping the user on `<body>`. Reported against Architect's Undo button: activate it until the undo history is exhausted and focus is lost to the start of the document. Pre-existing, and independent of the #1389 undo/redo work it was found alongside.

**Root cause.** Base UI's `Toolbar.Button` forwards a React `disabled` prop into its `render` element, which lands on fresco `Button`'s native `<button>`. Base UI *does* delete that attribute again — toolbar items are meant to stay focusable while disabled (`focusableWhenDisabled`, the APG toolbar behaviour) — but it does so from a layout effect, one commit after React has written it to the DOM. Browsers blur a focused element the instant it becomes natively disabled, so the cleanup always runs too late. Inspecting afterwards shows `button.disabled === false` with focus already gone, which is what made this confusing to diagnose.

Two related defects fell out of the same mechanism:

- **Button segments had no disabled appearance at all.** Once the attribute is stripped, `:disabled` cannot match, so `disabled:opacity-50` and `disabled:cursor-not-allowed` never applied — measured opacity `1`, cursor `pointer` — and `hover:enabled:` still inverted their colours. A disabled Undo lit up under the pointer.
- **Toggle, group, menu and popover segments were the mirror image.** Their `disabled` sits on the inner trigger, which Base UI's cleanup does not reach, so they stayed *natively* disabled while the composite item above them reported `aria-disabled="false"` — contradictory, and unreachable by the toolbar's roving focus.

**Fix.** Focus stays on the segment rather than moving to a sibling: with Undo, the neighbour is Redo or Delete, which is not somewhere to drop a keyboard user unasked. `disabled` is swallowed at the segment's control so it never reaches the DOM, and `aria-disabled` carries the state — what Base UI converges on anyway, and what its own click/keydown/pointerdown guards key off, so a disabled segment stays inert. `disabled` now also goes on the composite item for every segment type, so they all behave alike. The disabled appearance is restated on `aria-disabled`. Segments stay hoverable on purpose: for an icon-only segment the tooltip carries its only visible label, and that is exactly when it is most needed.

## Test plan

- [x] Unit (`it.each` over all five segment types): the native `disabled` attribute is never applied across the enabled→disabled transition, `aria-disabled="true"` and `tabindex="0"` are retained, and a disabled segment fires no handler. All 8 new/changed assertions fail against the unfixed source.
- [x] New Storybook browser test `KeepsFocusWhenDisabled` pins the focus outcome itself, which only a real browser can observe. Fails pre-fix in **Chromium** (focus lost to `<body>`) and in **Firefox** (opacity 1 — Firefox does not blur, so it catches the missing disabled state instead).
- [x] Verified in-browser that all five disabled segment types stay inert (no handler fires, menus and popovers do not open) and that tooltips still appear on a dimmed icon-only segment.
- [x] New `Disabled` story for Chromatic — there was no disabled-segment story before.
- [x] `@codaco/fresco-ui` unit: 1263 passed. Storybook (chromium + firefox): 20 passed.
- [x] Architect / Interview / Interviewer unit suites pass.
- [x] `pnpm typecheck`, `pnpm lint:fix`, `pnpm knip`, `pnpm check:changesets` clean.
- [x] Visual baselines regenerated in pinned Docker for **all three** suites (Architect, Interview, Interviewer) — all pass with **zero PNG changes**. The icon-level dimming stays inside the suites' `maxDiffPixels: 250` tolerance, so nothing needed adopting.
- [x] Architect E2E native: 61 passed. Interview E2E native: 284 passed, **ARIA snapshots unchanged** — segments still report `[disabled]`.

### Reviewer notes

- **Chromatic** could not be run locally (needs project tokens). Expect new snapshots for the two added stories, plus dimming diffs on any Interview/Interviewer story that shows a disabled segment: Network Composer undo/redo, Narrative preset prev/next, Narrative Pedigree zoom. Those diffs are the intended fix — disabled segments previously rendered at full opacity.
- Interviewer's native E2E lane is **flaky on this machine** (`installs the bundled sample protocol`, `visual-viewport` duplicate protocol card). I rebuilt without the fix and reproduced the same two failures, so it is pre-existing and unrelated.
- `component` segments (e.g. `SplitButton`) are deliberately untouched: they are not composite toolbar items, so they keep ordinary native `disabled` semantics.