### PR TITLE
Release Website

### DIFF
--- a/.changeset/fresh-scholar-publication.md
+++ b/.changeset/fresh-scholar-publication.md
@@ -1,5 +1,0 @@
----
-"networkcanvas.com": patch
----
-
-Add a newly published Network Canvas study to the website publications list.

--- a/.changeset/website-publications-page.md
+++ b/.changeset/website-publications-page.md
@@ -1,8 +1,0 @@
----
-"networkcanvas.com": minor
----
-
-Add a publications page listing every publication that uses Network Canvas,
-newest first, and link to it from the homepage. The page restores the full list
-that the previous site offered, including the publications that were not
-carried over when the site was rebuilt, and each entry now shows its year.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,18 @@
 # networkcanvas.com
 
+## 0.4.0
+
+### Minor Changes
+
+- Add a publications page listing every publication that uses Network Canvas,
+  newest first, and link to it from the homepage. The page restores the full list
+  that the previous site offered, including the publications that were not
+  carried over when the site was rebuilt, and each entry now shows its year.
+
+### Patch Changes
+
+- Add a newly published Network Canvas study to the website publications list.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.3.0 | 0.4.0 |

### networkcanvas.com@0.4.0

### Minor Changes

- Add a publications page listing every publication that uses Network Canvas,
  newest first, and link to it from the homepage. The page restores the full list
  that the previous site offered, including the publications that were not
  carried over when the site was rebuilt, and each entry now shows its year.

### Patch Changes

- Add a newly published Network Canvas study to the website publications list.
