### PR TITLE
fix(fresco): handle a missing protocol on onboarding as an expected outcome

### DIFF
--- a/.changeset/fresco-onboard-invalid-protocol-link.md
+++ b/.changeset/fresco-onboard-invalid-protocol-link.md
@@ -10,4 +10,8 @@ Interview creation now reports why it failed using a fixed set of outcomes rathe
 
 Activity that is recorded in the dashboard feed now reaches analytics again. The feed entry and the analytics report are made together, but the report was scheduled only once the entry had been saved — by which point the request that triggered it had usually finished, so the report was dropped without a trace. Only the two places that waited for the entry to save were unaffected, leaving most activity missing from analytics since Fresco moved to its current release process, and some of it never reported at all. Uninstalling a protocol is now recorded like every other activity, which matters because that is what invalidates recruitment URLs already given to participants.
 
+Feed entries are also no longer at risk of being lost. The entry was written without anything waiting for it, so a host that stops work once a response has been sent could discard it mid-write; the write is now held open until it completes.
+
 Analytics no longer receives the feed's written description of an activity, which names the researcher who acted and, for interview activity, the participant. Only the kind of activity and any counts are reported.
+
+Recording activity is no longer reachable from the browser. It accepts whatever description it is given and runs during interview and sign-in flows where no account is established yet, so it could not be restricted to signed-in researchers; it is now internal to the server instead, and can no longer be used to plant entries in a study's activity feed.

--- a/.changeset/fresco-onboard-invalid-protocol-link.md
+++ b/.changeset/fresco-onboard-invalid-protocol-link.md
@@ -1,0 +1,9 @@
+---
+'fresco': patch
+---
+
+An onboarding link whose protocol no longer exists now sends the participant to a page explaining that the link is no longer valid, rather than the generic "something went wrong" page. The protocol id comes from the URL, so this is what a participant sees whenever a study's protocol has been deleted or a link was mistyped — an ordinary outcome that deserves an answer they can act on.
+
+Such a link is also no longer reported as an application error. Every one of these visits previously raised a database exception carrying internal schema detail, so the error reports that reach a deployment now describe faults worth investigating instead of routine dead links.
+
+Interview creation now reports why it failed using a fixed set of outcomes rather than passing the underlying database error message back to its caller.

--- a/.changeset/fresco-onboard-invalid-protocol-link.md
+++ b/.changeset/fresco-onboard-invalid-protocol-link.md
@@ -12,6 +12,8 @@ Activity that is recorded in the dashboard feed now reaches analytics again. The
 
 Feed entries are also no longer at risk of being lost. The entry was written without anything waiting for it, so a host that stops work once a response has been sent could discard it mid-write; the write is now held open until it completes.
 
+Reports could also be lost while handling a single request. Several reports can be queued to send once a response has gone out, and they share one connection to the analytics service; whichever finished first closed that connection, leaving the rest unsent. They now flush the connection instead of closing it, so every report is delivered whatever order they finish in.
+
 Analytics no longer receives the feed's written description of an activity, which names the researcher who acted and, for interview activity, the participant. Only the kind of activity and any counts are reported.
 
 Recording activity is no longer reachable from the browser. It accepts whatever description it is given and runs during interview and sign-in flows where no account is established yet, so it could not be restricted to signed-in researchers; it is now internal to the server instead, and can no longer be used to plant entries in a study's activity feed.

--- a/.changeset/fresco-onboard-invalid-protocol-link.md
+++ b/.changeset/fresco-onboard-invalid-protocol-link.md
@@ -7,3 +7,7 @@ An onboarding link whose protocol no longer exists now sends the participant to 
 Such a link is also no longer reported as an application error. Every one of these visits previously raised a database exception carrying internal schema detail, so the error reports that reach a deployment now describe faults worth investigating instead of routine dead links.
 
 Interview creation now reports why it failed using a fixed set of outcomes rather than passing the underlying database error message back to its caller.
+
+Activity that is recorded in the dashboard feed now reaches analytics again. The feed entry and the analytics report are made together, but the report was scheduled only once the entry had been saved — by which point the request that triggered it had usually finished, so the report was dropped without a trace. Only the two places that waited for the entry to save were unaffected, leaving most activity missing from analytics since Fresco moved to its current release process, and some of it never reported at all. Uninstalling a protocol is now recorded like every other activity, which matters because that is what invalidates recruitment URLs already given to participants.
+
+Analytics no longer receives the feed's written description of an activity, which names the researcher who acted and, for interview activity, the participant. Only the kind of activity and any counts are reported.

--- a/apps/fresco/actions/__tests__/activityFeed.test.ts
+++ b/apps/fresco/actions/__tests__/activityFeed.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCreateMany,
+  mockCaptureEvent,
+  mockShutdownPostHog,
+  mockSafeUpdateTag,
+  afterCallbacks,
+} = vi.hoisted(() => ({
+  mockCreateMany: vi.fn(),
+  mockCaptureEvent: vi.fn(),
+  mockShutdownPostHog: vi.fn(),
+  mockSafeUpdateTag: vi.fn(),
+  afterCallbacks: [] as (() => Promise<unknown>)[],
+}));
+
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    // Collect rather than run, so tests can assert on *when* registration
+    // happened as well as what the callback does.
+    after: vi.fn((callback: () => Promise<unknown>) => {
+      afterCallbacks.push(callback);
+    }),
+  };
+});
+
+vi.mock('~/lib/db', () => ({
+  prisma: {
+    events: {
+      createMany: mockCreateMany,
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('~/lib/cache', () => ({
+  safeUpdateTag: mockSafeUpdateTag,
+}));
+
+vi.mock('~/lib/posthog-server', () => ({
+  captureEvent: mockCaptureEvent,
+  shutdownPostHog: mockShutdownPostHog,
+}));
+
+vi.mock('~/lib/auth/guards', () => ({
+  requireApiAuth: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { addEvent, addEvents } from '../activityFeed';
+
+const flushAfterCallbacks = async () => {
+  for (const callback of afterCallbacks.splice(0)) {
+    await callback();
+  }
+};
+
+describe('activity feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    afterCallbacks.length = 0;
+    mockCreateMany.mockResolvedValue({ count: 1 });
+  });
+
+  describe('analytics registration', () => {
+    // The regression this guards: registering `after` only once the database
+    // write had resolved. Callers almost always fire these without awaiting,
+    // so by then the request scope was gone, `after` threw, and the error was
+    // swallowed — analytics silently stopped for every unawaited caller.
+    it('registers analytics before the database write settles', () => {
+      mockCreateMany.mockReturnValue(new Promise(() => undefined));
+
+      void addEvent(
+        'Protocol Uninstalled',
+        'User admin uninstalled a protocol',
+      );
+
+      expect(afterCallbacks).toHaveLength(1);
+    });
+
+    it('reports the activity even when the caller does not await it', async () => {
+      void addEvent(
+        'Protocol Uninstalled',
+        'User admin uninstalled a protocol',
+      );
+      await flushAfterCallbacks();
+
+      expect(mockCaptureEvent).toHaveBeenCalledWith(
+        'Protocol Uninstalled',
+        undefined,
+      );
+    });
+  });
+
+  describe('what reaches analytics', () => {
+    // The message is prose for the researcher reading the feed and carries
+    // usernames and participant identifiers. It must not leave the
+    // installation.
+    it('does not report the activity message', async () => {
+      await addEvent(
+        'Interview Started',
+        'Participant "Ada Lovelace (P-001)" started an interview',
+      );
+      await flushAfterCallbacks();
+
+      const [, reportedProperties] = mockCaptureEvent.mock.calls[0] as [
+        string,
+        Record<string, unknown> | undefined,
+      ];
+
+      expect(JSON.stringify(reportedProperties ?? {})).not.toContain('P-001');
+    });
+
+    it('reports explicitly-passed properties', async () => {
+      await addEvent('Data Exported', 'User admin exported 3 interview(s)', {
+        interviewCount: 3,
+      });
+      await flushAfterCallbacks();
+
+      expect(mockCaptureEvent).toHaveBeenCalledWith('Data Exported', {
+        interviewCount: 3,
+      });
+    });
+
+    it('still writes the message to the feed', async () => {
+      await addEvent('Protocol Uninstalled', 'User admin uninstalled "Study"');
+
+      expect(mockCreateMany).toHaveBeenCalledWith({
+        data: [
+          {
+            type: 'Protocol Uninstalled',
+            message: 'User admin uninstalled "Study"',
+          },
+        ],
+      });
+      expect(mockSafeUpdateTag).toHaveBeenCalledWith('activityFeed');
+    });
+  });
+
+  describe('batches', () => {
+    it('writes one row per activity and reports each one', async () => {
+      await addEvents([
+        { type: 'Protocol Uninstalled', message: 'User admin removed "A"' },
+        { type: 'Protocol Uninstalled', message: 'User admin removed "B"' },
+      ]);
+      await flushAfterCallbacks();
+
+      expect(mockCreateMany).toHaveBeenCalledTimes(1);
+      expect(mockCreateMany.mock.calls[0]).toEqual([
+        {
+          data: [
+            { type: 'Protocol Uninstalled', message: 'User admin removed "A"' },
+            { type: 'Protocol Uninstalled', message: 'User admin removed "B"' },
+          ],
+        },
+      ]);
+      expect(mockCaptureEvent).toHaveBeenCalledTimes(2);
+    });
+
+    // Shutting the client down is what flushes it, and it nulls the shared
+    // instance. One callback per activity would race its own siblings.
+    it('shuts the analytics client down once for the whole batch', async () => {
+      await addEvents([
+        { type: 'Protocol Uninstalled', message: 'User admin removed "A"' },
+        { type: 'Protocol Uninstalled', message: 'User admin removed "B"' },
+        { type: 'Protocol Uninstalled', message: 'User admin removed "C"' },
+      ]);
+
+      expect(afterCallbacks).toHaveLength(1);
+
+      await flushAfterCallbacks();
+
+      expect(mockShutdownPostHog).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when there is nothing to record', async () => {
+      const result = await addEvents([]);
+
+      expect(result).toEqual({ success: true, error: null });
+      expect(mockCreateMany).not.toHaveBeenCalled();
+      expect(afterCallbacks).toHaveLength(0);
+    });
+  });
+
+  it('reports failure without throwing when the write fails', async () => {
+    mockCreateMany.mockRejectedValue(new Error('Connection refused'));
+
+    const result = await addEvent('Protocol Uninstalled', 'User admin removed');
+
+    expect(result).toEqual({ success: false, error: 'Failed to add event' });
+  });
+});

--- a/apps/fresco/actions/__tests__/apiTokens.test.ts
+++ b/apps/fresco/actions/__tests__/apiTokens.test.ts
@@ -20,7 +20,7 @@ vi.mock('~/lib/db', () => ({
 }));
 vi.mock('~/lib/auth/guards', () => ({ requireApiAuth: vi.fn() }));
 vi.mock('~/lib/cache', () => ({ safeUpdateTag: vi.fn() }));
-vi.mock('~/actions/activityFeed', () => ({ addEvent: vi.fn() }));
+vi.mock('~/lib/activityFeed', () => ({ addEvent: vi.fn() }));
 vi.mock('~/schemas/apiTokens', () => ({
   createApiTokenSchema: { parse: vi.fn() },
   updateApiTokenSchema: { parse: vi.fn() },

--- a/apps/fresco/actions/__tests__/auth.test.ts
+++ b/apps/fresco/actions/__tests__/auth.test.ts
@@ -135,7 +135,7 @@ vi.mock('~/utils/password', () => ({
   verifyPassword: mockVerifyPassword,
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: mockAddEvent,
 }));
 

--- a/apps/fresco/actions/__tests__/commitInterviewExport.test.ts
+++ b/apps/fresco/actions/__tests__/commitInterviewExport.test.ts
@@ -38,7 +38,7 @@ vi.mock('~/lib/db', () => ({ prisma: { interview: { updateMany } } }));
 vi.mock('~/lib/activityFeed', () => ({ addEvent }));
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent,
-  shutdownPostHog: vi.fn(() => Promise.resolve()),
+  flushPostHog: vi.fn(() => Promise.resolve()),
 }));
 vi.mock('~/lib/cache', () => ({
   safeUpdateTag,

--- a/apps/fresco/actions/__tests__/commitInterviewExport.test.ts
+++ b/apps/fresco/actions/__tests__/commitInterviewExport.test.ts
@@ -35,7 +35,7 @@ vi.mock('~/lib/auth/guards', () => ({
   ),
 }));
 vi.mock('~/lib/db', () => ({ prisma: { interview: { updateMany } } }));
-vi.mock('~/actions/activityFeed', () => ({ addEvent }));
+vi.mock('~/lib/activityFeed', () => ({ addEvent }));
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent,
   shutdownPostHog: vi.fn(() => Promise.resolve()),

--- a/apps/fresco/actions/__tests__/createInterview.test.ts
+++ b/apps/fresco/actions/__tests__/createInterview.test.ts
@@ -100,7 +100,7 @@ vi.mock('next/server', async (importOriginal) => {
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent: vi.fn(),
   captureException: mockCaptureException,
-  shutdownPostHog: vi.fn(),
+  flushPostHog: vi.fn(),
 }));
 
 vi.mock('@codaco/interview/contract', () => ({

--- a/apps/fresco/actions/__tests__/createInterview.test.ts
+++ b/apps/fresco/actions/__tests__/createInterview.test.ts
@@ -345,16 +345,27 @@ describe('createInterview', () => {
       expect(mockPrismaCreate).not.toHaveBeenCalled();
     });
 
-    // A protocol that is gone makes the recruitment setting irrelevant, and
-    // reporting that setting instead sends the researcher after a fix that
-    // cannot help. Reaching the create is what used to decide this, so an
-    // earlier return hid the real cause.
+    // A protocol that is gone is the whole answer — every other reason sends
+    // the researcher after a fix that cannot help, whether that is enabling
+    // anonymous recruitment or correcting an identifier on a dead link. The
+    // create used to be what decided this, so any earlier return hid it.
     it('should prefer no-protocol over no-anonymous-recruitment', async () => {
       mockProtocolFindUnique.mockResolvedValue(null);
       mockGetAppSetting.mockResolvedValue(false);
 
       const result = await createInterview({
         protocolId: 'non-existent-protocol',
+      });
+
+      expect(result.errorType).toBe('no-protocol');
+    });
+
+    it('should prefer no-protocol over invalid-identifier', async () => {
+      mockProtocolFindUnique.mockResolvedValue(null);
+
+      const result = await createInterview({
+        protocolId: 'non-existent-protocol',
+        participantIdentifier: '   ',
       });
 
       expect(result.errorType).toBe('no-protocol');

--- a/apps/fresco/actions/__tests__/createInterview.test.ts
+++ b/apps/fresco/actions/__tests__/createInterview.test.ts
@@ -50,11 +50,13 @@ vi.mock('~/utils/auth', () => ({
 // Use vi.hoisted to define mocks that can be referenced before module execution
 const {
   mockPrismaCreate,
+  mockProtocolFindUnique,
   mockGetAppSetting,
   mockSafeRevalidateTag,
   mockCaptureException,
 } = vi.hoisted(() => ({
   mockPrismaCreate: vi.fn(),
+  mockProtocolFindUnique: vi.fn(),
   mockGetAppSetting: vi.fn(),
   mockSafeRevalidateTag: vi.fn(),
   mockCaptureException: vi.fn(),
@@ -65,6 +67,9 @@ vi.mock('~/lib/db', () => ({
   prisma: {
     interview: {
       create: mockPrismaCreate,
+    },
+    protocol: {
+      findUnique: mockProtocolFindUnique,
     },
   },
 }));
@@ -127,6 +132,7 @@ type MockInterviewResult = {
 describe('createInterview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProtocolFindUnique.mockResolvedValue({ id: 'protocol-123' });
   });
 
   describe('with participantIdentifier provided', () => {
@@ -326,6 +332,33 @@ describe('createInterview', () => {
         "An operation failed because it depends on one or more records that were required but not found. No 'Protocol' record (needed to inline the relation on 'Interview' record(s)) was found for a nested connect on one-to-many relation 'InterviewToProtocol'.",
         { code: 'P2025', clientVersion: 'test' },
       );
+
+    it('should return a no-protocol error before consulting other settings', async () => {
+      mockProtocolFindUnique.mockResolvedValue(null);
+
+      const result = await createInterview({
+        protocolId: 'non-existent-protocol',
+      });
+
+      expect(result.errorType).toBe('no-protocol');
+      expect(result.error).toBe('Protocol not found');
+      expect(mockPrismaCreate).not.toHaveBeenCalled();
+    });
+
+    // A protocol that is gone makes the recruitment setting irrelevant, and
+    // reporting that setting instead sends the researcher after a fix that
+    // cannot help. Reaching the create is what used to decide this, so an
+    // earlier return hid the real cause.
+    it('should prefer no-protocol over no-anonymous-recruitment', async () => {
+      mockProtocolFindUnique.mockResolvedValue(null);
+      mockGetAppSetting.mockResolvedValue(false);
+
+      const result = await createInterview({
+        protocolId: 'non-existent-protocol',
+      });
+
+      expect(result.errorType).toBe('no-protocol');
+    });
 
     it('should return a no-protocol error when the protocol does not exist', async () => {
       const protocolId = 'non-existent-protocol';

--- a/apps/fresco/actions/__tests__/createInterview.test.ts
+++ b/apps/fresco/actions/__tests__/createInterview.test.ts
@@ -48,12 +48,17 @@ vi.mock('~/utils/auth', () => ({
 }));
 
 // Use vi.hoisted to define mocks that can be referenced before module execution
-const { mockPrismaCreate, mockGetAppSetting, mockSafeRevalidateTag } =
-  vi.hoisted(() => ({
-    mockPrismaCreate: vi.fn(),
-    mockGetAppSetting: vi.fn(),
-    mockSafeRevalidateTag: vi.fn(),
-  }));
+const {
+  mockPrismaCreate,
+  mockGetAppSetting,
+  mockSafeRevalidateTag,
+  mockCaptureException,
+} = vi.hoisted(() => ({
+  mockPrismaCreate: vi.fn(),
+  mockGetAppSetting: vi.fn(),
+  mockSafeRevalidateTag: vi.fn(),
+  mockCaptureException: vi.fn(),
+}));
 
 // Mock dependencies before importing
 vi.mock('~/lib/db', () => ({
@@ -82,13 +87,14 @@ vi.mock('next/server', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    after: vi.fn(),
+    // Run the callback inline so telemetry side effects are observable.
+    after: vi.fn((callback: () => unknown) => void callback()),
   };
 });
 
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent: vi.fn(),
-  captureException: vi.fn(),
+  captureException: mockCaptureException,
   shutdownPostHog: vi.fn(),
 }));
 
@@ -104,6 +110,8 @@ vi.mock('@codaco/interview/contract', () => ({
 }));
 
 // Import the function under test
+import { Prisma } from '~/lib/db/generated/client';
+
 import { createInterview } from '../interviews';
 
 // Type for the mock return value
@@ -309,13 +317,21 @@ describe('createInterview', () => {
   });
 
   describe('error handling', () => {
-    it('should return error when protocol does not exist', async () => {
+    // The protocol id arrives from an unauthenticated URL, so a deleted or
+    // mistyped protocol is a routine outcome. Prisma signals it as P2025 on the
+    // nested connect, and it must be reported as such rather than captured as
+    // an application exception.
+    const missingProtocolError = () =>
+      new Prisma.PrismaClientKnownRequestError(
+        "An operation failed because it depends on one or more records that were required but not found. No 'Protocol' record (needed to inline the relation on 'Interview' record(s)) was found for a nested connect on one-to-many relation 'InterviewToProtocol'.",
+        { code: 'P2025', clientVersion: 'test' },
+      );
+
+    it('should return a no-protocol error when the protocol does not exist', async () => {
       const protocolId = 'non-existent-protocol';
       const participantIdentifier = 'TEST-PARTICIPANT';
 
-      mockPrismaCreate.mockRejectedValue(
-        new Error('Record to connect not found'),
-      );
+      mockPrismaCreate.mockRejectedValue(missingProtocolError());
 
       const result = await createInterview({
         participantIdentifier,
@@ -323,8 +339,19 @@ describe('createInterview', () => {
       });
 
       expect(result.createdInterviewId).toBeNull();
-      expect(result.error).toBe('Failed to create interview');
-      expect(result.errorType).toBe('Record to connect not found');
+      expect(result.errorType).toBe('no-protocol');
+      expect(result.error).toBe('Protocol not found');
+    });
+
+    it('should not report a missing protocol as an exception', async () => {
+      mockPrismaCreate.mockRejectedValue(missingProtocolError());
+
+      await createInterview({
+        participantIdentifier: 'TEST-PARTICIPANT',
+        protocolId: 'non-existent-protocol',
+      });
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
 
     it('should return error on database failure', async () => {
@@ -340,7 +367,32 @@ describe('createInterview', () => {
 
       expect(result.createdInterviewId).toBeNull();
       expect(result.error).toBe('Failed to create interview');
-      expect(result.errorType).toBe('Connection refused');
+      expect(result.errorType).toBe('unknown');
+    });
+
+    it('should report an unexpected database failure as an exception', async () => {
+      mockPrismaCreate.mockRejectedValue(new Error('Connection refused'));
+
+      await createInterview({
+        participantIdentifier: 'DB-ERROR-TEST',
+        protocolId: 'protocol-db-error',
+      });
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not leak the underlying error message to the caller', async () => {
+      mockPrismaCreate.mockRejectedValue(
+        new Error('connection to server at "10.0.0.4" failed'),
+      );
+
+      const result = await createInterview({
+        participantIdentifier: 'LEAK-TEST',
+        protocolId: 'protocol-leak',
+      });
+
+      expect(result.errorType).toBe('unknown');
+      expect(result.error).not.toContain('10.0.0.4');
     });
 
     it('should not invalidate cache on error', async () => {

--- a/apps/fresco/actions/__tests__/createInterview.test.ts
+++ b/apps/fresco/actions/__tests__/createInterview.test.ts
@@ -79,7 +79,7 @@ vi.mock('~/lib/cache', () => ({
   safeCacheTag: vi.fn(),
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: vi.fn(),
 }));
 

--- a/apps/fresco/actions/__tests__/totp.test.ts
+++ b/apps/fresco/actions/__tests__/totp.test.ts
@@ -149,7 +149,7 @@ vi.mock('~/utils/password', () => ({
   verifyPassword: vi.fn(),
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: mockAddEvent,
 }));
 

--- a/apps/fresco/actions/__tests__/twoFactor.test.ts
+++ b/apps/fresco/actions/__tests__/twoFactor.test.ts
@@ -129,7 +129,7 @@ vi.mock('~/utils/password', () => ({
   verifyPassword: vi.fn(),
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: mockAddEvent,
 }));
 

--- a/apps/fresco/actions/__tests__/updateParticipant.test.ts
+++ b/apps/fresco/actions/__tests__/updateParticipant.test.ts
@@ -26,7 +26,7 @@ vi.mock('~/lib/auth/guards', () => ({
   requireApiAuth: vi.fn().mockResolvedValue({ user: { username: 'admin' } }),
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: vi.fn(),
 }));
 

--- a/apps/fresco/actions/__tests__/webauthn.test.ts
+++ b/apps/fresco/actions/__tests__/webauthn.test.ts
@@ -99,7 +99,7 @@ vi.mock('~/utils/password', () => ({
   verifyPassword: vi.fn(),
 }));
 
-vi.mock('~/actions/activityFeed', () => ({
+vi.mock('~/lib/activityFeed', () => ({
   addEvent: vi.fn(),
 }));
 

--- a/apps/fresco/actions/activityFeed.ts
+++ b/apps/fresco/actions/activityFeed.ts
@@ -11,30 +11,69 @@ import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
 
-export async function addEvent(
-  type: ActivityType,
-  message: Activity['message'],
-  properties?: Record<string, unknown>,
-) {
+type NewActivity = {
+  type: ActivityType;
+  message: Activity['message'];
+  properties?: Record<string, unknown>;
+};
+
+/**
+ * Records activity in the dashboard feed and reports it to analytics.
+ *
+ * The analytics callback is registered before the first await. Almost every
+ * caller invokes these without awaiting them, so a callback scheduled after a
+ * suspension point races the enclosing action's response: by the time it ran
+ * the request scope had gone, `after` threw, and the catch below swallowed it.
+ * That is why only the two awaited callers ever reached analytics.
+ *
+ * One callback covers the whole batch. Each ends by shutting the PostHog
+ * client down, so a callback per activity would race its own siblings.
+ *
+ * `message` is deliberately not reported. It is prose written for the
+ * researcher reading the feed, and it embeds usernames and — for interview
+ * activity — participant labels and identifiers. Only the activity type and
+ * explicitly-passed properties leave the installation.
+ */
+async function recordActivity(activities: NewActivity[]) {
+  if (activities.length === 0) {
+    return { success: true, error: null };
+  }
+
+  after(async () => {
+    for (const { type, properties } of activities) {
+      await captureEvent(type, properties);
+    }
+
+    await shutdownPostHog();
+  });
+
   try {
-    await prisma.events.create({
-      data: {
-        type,
-        message,
-      },
+    await prisma.events.createMany({
+      data: activities.map(({ type, message }) => ({ type, message })),
     });
 
     safeUpdateTag('activityFeed');
-
-    after(async () => {
-      await captureEvent(type, { message, ...properties });
-      await shutdownPostHog();
-    });
 
     return { success: true, error: null };
   } catch (_error) {
     return { success: false, error: 'Failed to add event' };
   }
+}
+
+export async function addEvent(
+  type: ActivityType,
+  message: Activity['message'],
+  properties?: Record<string, unknown>,
+) {
+  return recordActivity([{ type, message, properties }]);
+}
+
+/**
+ * Records several activities at once, for actions that operate on a selection
+ * and describe each item separately in the feed.
+ */
+export async function addEvents(activities: NewActivity[]) {
+  return recordActivity(activities);
 }
 
 export async function getActivitiesForExport(): Promise<Activity[]> {

--- a/apps/fresco/actions/activityFeed.ts
+++ b/apps/fresco/actions/activityFeed.ts
@@ -1,80 +1,8 @@
 'use server';
 
-import { after } from 'next/server';
-
-import type {
-  Activity,
-  ActivityType,
-} from '~/app/dashboard/_components/ActivityFeed/types';
+import type { Activity } from '~/app/dashboard/_components/ActivityFeed/types';
 import { requireApiAuth } from '~/lib/auth/guards';
-import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
-import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
-
-type NewActivity = {
-  type: ActivityType;
-  message: Activity['message'];
-  properties?: Record<string, unknown>;
-};
-
-/**
- * Records activity in the dashboard feed and reports it to analytics.
- *
- * The analytics callback is registered before the first await. Almost every
- * caller invokes these without awaiting them, so a callback scheduled after a
- * suspension point races the enclosing action's response: by the time it ran
- * the request scope had gone, `after` threw, and the catch below swallowed it.
- * That is why only the two awaited callers ever reached analytics.
- *
- * One callback covers the whole batch. Each ends by shutting the PostHog
- * client down, so a callback per activity would race its own siblings.
- *
- * `message` is deliberately not reported. It is prose written for the
- * researcher reading the feed, and it embeds usernames and — for interview
- * activity — participant labels and identifiers. Only the activity type and
- * explicitly-passed properties leave the installation.
- */
-async function recordActivity(activities: NewActivity[]) {
-  if (activities.length === 0) {
-    return { success: true, error: null };
-  }
-
-  after(async () => {
-    for (const { type, properties } of activities) {
-      await captureEvent(type, properties);
-    }
-
-    await shutdownPostHog();
-  });
-
-  try {
-    await prisma.events.createMany({
-      data: activities.map(({ type, message }) => ({ type, message })),
-    });
-
-    safeUpdateTag('activityFeed');
-
-    return { success: true, error: null };
-  } catch (_error) {
-    return { success: false, error: 'Failed to add event' };
-  }
-}
-
-export async function addEvent(
-  type: ActivityType,
-  message: Activity['message'],
-  properties?: Record<string, unknown>,
-) {
-  return recordActivity([{ type, message, properties }]);
-}
-
-/**
- * Records several activities at once, for actions that operate on a selection
- * and describe each item separately in the feed.
- */
-export async function addEvents(activities: NewActivity[]) {
-  return recordActivity(activities);
-}
 
 export async function getActivitiesForExport(): Promise<Activity[]> {
   await requireApiAuth();

--- a/apps/fresco/actions/apiTokens.ts
+++ b/apps/fresco/actions/apiTokens.ts
@@ -2,6 +2,7 @@
 
 import { createHash, randomBytes } from 'crypto';
 
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
@@ -10,8 +11,6 @@ import {
   deleteApiTokenSchema,
   updateApiTokenSchema,
 } from '~/schemas/apiTokens';
-
-import { addEvent } from './activityFeed';
 
 // Generate a secure random token
 function generateToken(): string {

--- a/apps/fresco/actions/appSettings.ts
+++ b/apps/fresco/actions/appSettings.ts
@@ -10,7 +10,7 @@ import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
-import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
+import { captureEvent, flushPostHog } from '~/lib/posthog-server';
 import { getStorageEnvStatus } from '~/lib/storage/config';
 import { getInstallationId } from '~/queries/appSettings';
 import {
@@ -211,7 +211,7 @@ export async function completeSetup() {
     await captureEvent('AppSetup', {
       installationId,
     });
-    await shutdownPostHog();
+    await flushPostHog();
   });
 
   redirect('/dashboard');

--- a/apps/fresco/actions/appSettings.ts
+++ b/apps/fresco/actions/appSettings.ts
@@ -6,7 +6,7 @@ import { after } from 'next/server';
 import { type z } from 'zod';
 import { z as zm } from 'zod/mini';
 
-import { addEvent } from '~/actions/activityFeed';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';

--- a/apps/fresco/actions/auth.ts
+++ b/apps/fresco/actions/auth.ts
@@ -6,6 +6,7 @@ import { redirect } from 'next/navigation';
 import z from 'zod';
 
 import { type FormSubmissionResult } from '@codaco/fresco-ui/form/store/types';
+import { addEvent } from '~/lib/activityFeed';
 import { getServerSession } from '~/lib/auth/guards';
 import { createSessionCookie, SESSION_COOKIE_NAME } from '~/lib/auth/session';
 import { createTwoFactorToken, hashRecoveryCode } from '~/lib/auth/totp';
@@ -16,8 +17,6 @@ import { getInstallationId, isAppConfigured } from '~/queries/appSettings';
 import { createUserSchema, loginSchema } from '~/schemas/auth';
 import { getClientIp } from '~/utils/getClientIp';
 import { hashPassword, verifyPassword } from '~/utils/password';
-
-import { addEvent } from './activityFeed';
 
 type RateLimited = {
   success: false;

--- a/apps/fresco/actions/interviews.ts
+++ b/apps/fresco/actions/interviews.ts
@@ -10,7 +10,7 @@ import { requireApiAuth } from '~/lib/auth/guards';
 import { safeRevalidateTag, safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { Prisma } from '~/lib/db/generated/client';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { getInterviewIdsMatching } from '~/queries/interviews';
 import type {
@@ -289,7 +289,7 @@ export async function createInterview(
 
     after(async () => {
       await captureException(e);
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return {

--- a/apps/fresco/actions/interviews.ts
+++ b/apps/fresco/actions/interviews.ts
@@ -4,8 +4,8 @@ import { createId } from '@paralleldrive/cuid2';
 import { after } from 'next/server';
 
 import { createInitialNetwork } from '@codaco/interview/contract';
-import { addEvent } from '~/actions/activityFeed';
 import type { InterviewsSearchParams } from '~/app/dashboard/_components/InterviewsTable/searchParams';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeRevalidateTag, safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';

--- a/apps/fresco/actions/interviews.ts
+++ b/apps/fresco/actions/interviews.ts
@@ -147,11 +147,8 @@ export async function getIncompleteInterviewUrlData(
 /**
  * Prisma raises P2025 when a nested `connect` cannot resolve the record it
  * points at. For `createInterview` that can only be the protocol connect, so
- * it means the protocol id taken from the onboarding URL no longer exists.
- *
- * Checking the code rather than pre-reading the protocol keeps this to a
- * single round trip and stays correct when a protocol is deleted between the
- * check and the write.
+ * it means the protocol was deleted between the existence check below and the
+ * write — the one gap that check cannot close on its own.
  */
 function isMissingProtocol(error: unknown) {
   return (
@@ -182,6 +179,26 @@ export async function createInterview(
   }
 
   try {
+    // Establish this before anything else that can fail. A protocol that no
+    // longer exists makes every other consideration moot, and checking it only
+    // via the create below leaves it unreachable whenever an earlier condition
+    // returns first: an anonymous link to a deleted protocol, on an
+    // installation that does not allow anonymous recruitment, would report the
+    // recruitment setting and send the researcher after a fix that cannot
+    // help.
+    const protocol = await prisma.protocol.findUnique({
+      where: { id: protocolId },
+      select: { id: true },
+    });
+
+    if (!protocol) {
+      return {
+        errorType: 'no-protocol',
+        error: 'Protocol not found',
+        createdInterviewId: null,
+      };
+    }
+
     if (!validatedIdentifier) {
       const allowAnonymousRecruitment = await getAppSetting(
         'allowAnonymousRecruitment',

--- a/apps/fresco/actions/interviews.ts
+++ b/apps/fresco/actions/interviews.ts
@@ -9,10 +9,15 @@ import type { InterviewsSearchParams } from '~/app/dashboard/_components/Intervi
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeRevalidateTag, safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
+import { Prisma } from '~/lib/db/generated/client';
 import { captureException, shutdownPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { getInterviewIdsMatching } from '~/queries/interviews';
-import type { CreateInterview, DeleteInterviews } from '~/schemas/interviews';
+import type {
+  CreateInterview,
+  CreateInterviewResult,
+  DeleteInterviews,
+} from '~/schemas/interviews';
 import { participantIdentifierSchema } from '~/schemas/participant';
 import { ensureError } from '~/utils/ensureError';
 
@@ -139,7 +144,25 @@ export async function getIncompleteInterviewUrlData(
   }
 }
 
-export async function createInterview(data: CreateInterview) {
+/**
+ * Prisma raises P2025 when a nested `connect` cannot resolve the record it
+ * points at. For `createInterview` that can only be the protocol connect, so
+ * it means the protocol id taken from the onboarding URL no longer exists.
+ *
+ * Checking the code rather than pre-reading the protocol keeps this to a
+ * single round trip and stays correct when a protocol is deleted between the
+ * check and the write.
+ */
+function isMissingProtocol(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === 'P2025'
+  );
+}
+
+export async function createInterview(
+  data: CreateInterview,
+): Promise<CreateInterviewResult> {
   const { participantIdentifier, protocolId } = data;
 
   // The participant identifier may arrive unauthenticated via /onboard, so
@@ -234,6 +257,17 @@ export async function createInterview(data: CreateInterview) {
       errorType: null,
     };
   } catch (error) {
+    // A participant following a link to a protocol that no longer exists is an
+    // expected outcome of an unauthenticated, user-supplied id — report it to
+    // the caller so it can be explained, but never as an application exception.
+    if (isMissingProtocol(error)) {
+      return {
+        errorType: 'no-protocol',
+        error: 'Protocol not found',
+        createdInterviewId: null,
+      };
+    }
+
     const e = ensureError(error);
 
     after(async () => {
@@ -242,7 +276,7 @@ export async function createInterview(data: CreateInterview) {
     });
 
     return {
-      errorType: e.message,
+      errorType: 'unknown',
       error: 'Failed to create interview',
       createdInterviewId: null,
     };

--- a/apps/fresco/actions/interviews.ts
+++ b/apps/fresco/actions/interviews.ts
@@ -162,30 +162,13 @@ export async function createInterview(
 ): Promise<CreateInterviewResult> {
   const { participantIdentifier, protocolId } = data;
 
-  // The participant identifier may arrive unauthenticated via /onboard, so
-  // validate it (length, trim, non-whitespace) before it is persisted and
-  // later embedded in activity-feed messages and CSV exports.
-  let validatedIdentifier: string | undefined;
-  if (participantIdentifier !== undefined && participantIdentifier !== '') {
-    const parsed = participantIdentifierSchema.safeParse(participantIdentifier);
-    if (!parsed.success) {
-      return {
-        errorType: 'invalid-identifier',
-        error: 'Invalid participant identifier',
-        createdInterviewId: null,
-      };
-    }
-    validatedIdentifier = parsed.data;
-  }
-
   try {
-    // Establish this before anything else that can fail. A protocol that no
-    // longer exists makes every other consideration moot, and checking it only
-    // via the create below leaves it unreachable whenever an earlier condition
-    // returns first: an anonymous link to a deleted protocol, on an
-    // installation that does not allow anonymous recruitment, would report the
-    // recruitment setting and send the researcher after a fix that cannot
-    // help.
+    // A protocol that no longer exists is the whole answer: nothing else about
+    // the request can be acted on, and reporting any other reason sends the
+    // researcher after a fix that cannot help — enabling anonymous
+    // recruitment, or correcting an identifier on a link that is dead either
+    // way. So this precedes every other return, rather than being reached only
+    // when nothing else fails first.
     const protocol = await prisma.protocol.findUnique({
       where: { id: protocolId },
       select: { id: true },
@@ -197,6 +180,24 @@ export async function createInterview(
         error: 'Protocol not found',
         createdInterviewId: null,
       };
+    }
+
+    // The participant identifier may arrive unauthenticated via /onboard, so
+    // validate it (length, trim, non-whitespace) before it is persisted and
+    // later embedded in activity-feed messages and CSV exports.
+    let validatedIdentifier: string | undefined;
+    if (participantIdentifier !== undefined && participantIdentifier !== '') {
+      const parsed = participantIdentifierSchema.safeParse(
+        participantIdentifier,
+      );
+      if (!parsed.success) {
+        return {
+          errorType: 'invalid-identifier',
+          error: 'Invalid participant identifier',
+          createdInterviewId: null,
+        };
+      }
+      validatedIdentifier = parsed.data;
     }
 
     if (!validatedIdentifier) {

--- a/apps/fresco/actions/participants.ts
+++ b/apps/fresco/actions/participants.ts
@@ -2,8 +2,8 @@
 
 import { createId } from '@paralleldrive/cuid2';
 
-import { addEvent } from '~/actions/activityFeed';
 import type { ParticipantsSearchParams } from '~/app/dashboard/_components/ParticipantsTable/searchParams';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';

--- a/apps/fresco/actions/protocols.ts
+++ b/apps/fresco/actions/protocols.ts
@@ -4,6 +4,7 @@ import { Effect } from 'effect';
 import { type z } from 'zod';
 
 import { hashProtocol } from '@codaco/protocol-validation';
+import { addEvent, addEvents } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
@@ -12,8 +13,6 @@ import { selectUnreferencedKeys } from '~/lib/protocol/selectUnreferencedKeys';
 import { getStorageLayer } from '~/lib/storage/layers/StorageLayer';
 import { AssetStorage } from '~/lib/storage/services/AssetStorage';
 import { type protocolInsertSchema } from '~/schemas/protocol';
-
-import { addEvent, addEvents } from './activityFeed';
 
 /**
  * Check if a protocol with the given hash already exists.

--- a/apps/fresco/actions/protocols.ts
+++ b/apps/fresco/actions/protocols.ts
@@ -13,7 +13,7 @@ import { getStorageLayer } from '~/lib/storage/layers/StorageLayer';
 import { AssetStorage } from '~/lib/storage/services/AssetStorage';
 import { type protocolInsertSchema } from '~/schemas/protocol';
 
-import { addEvent } from './activityFeed';
+import { addEvent, addEvents } from './activityFeed';
 
 /**
  * Check if a protocol with the given hash already exists.
@@ -115,21 +115,17 @@ export async function deleteProtocols(hashes: string[]) {
       where: { hash: { in: hashes } },
     });
 
-    // insert an event for each protocol deleted
-    // eslint-disable-next-line no-console
-    console.log('inserting events for deleted protocols...');
-    const events = protocolsToBeDeleted.map((p) => {
-      return {
+    // One entry per protocol, matching how installation is recorded. This goes
+    // through addEvents rather than writing the rows directly so the deletion
+    // reaches analytics as well as the feed — an uninstalled protocol is what
+    // invalidates any recruitment URL already given to participants.
+    await addEvents(
+      protocolsToBeDeleted.map((p) => ({
         type: 'Protocol Uninstalled',
         message: `User ${session.user.username} uninstalled protocol "${p.name}"`,
-      };
-    });
+      })),
+    );
 
-    await prisma.events.createMany({
-      data: events,
-    });
-
-    safeUpdateTag('activityFeed');
     safeUpdateTag('summaryStatistics');
     safeUpdateTag('getProtocols');
     safeUpdateTag('getInterviews');

--- a/apps/fresco/actions/synthetic-interviews.ts
+++ b/apps/fresco/actions/synthetic-interviews.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { addEvent } from '~/actions/activityFeed';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';

--- a/apps/fresco/actions/totp.ts
+++ b/apps/fresco/actions/totp.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { type FormSubmissionResult } from '@codaco/fresco-ui/form/store/types';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import {
   generateQrCodeDataUrl,
@@ -14,8 +15,6 @@ import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { disableTotpSchema, verifyTotpSetupSchema } from '~/schemas/totp';
 import { getBaseUrl } from '~/utils/getBaseUrl';
-
-import { addEvent } from './activityFeed';
 
 export async function enableTotp() {
   try {

--- a/apps/fresco/actions/twoFactor.ts
+++ b/apps/fresco/actions/twoFactor.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { type FormSubmissionResult } from '@codaco/fresco-ui/form/store/types';
+import { addEvent } from '~/lib/activityFeed';
 import { createSessionCookie } from '~/lib/auth/session';
 import {
   hashRecoveryCode,
@@ -13,8 +14,6 @@ import { checkRateLimit, recordLoginAttempt } from '~/lib/rateLimit';
 import { getInstallationId } from '~/queries/appSettings';
 import { verifyTwoFactorSchema } from '~/schemas/totp';
 import { getClientIp } from '~/utils/getClientIp';
-
-import { addEvent } from './activityFeed';
 
 const TOTP_CODE_PATTERN = /^\d{6}$/;
 const RECOVERY_CODE_PATTERN = /^[0-9a-f]{20}$/;

--- a/apps/fresco/actions/users.ts
+++ b/apps/fresco/actions/users.ts
@@ -1,13 +1,12 @@
 'use server';
 
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { createUserSchema } from '~/schemas/auth';
 import { changePasswordSchema, deleteUsersSchema } from '~/schemas/users';
 import { hashPassword, verifyPassword } from '~/utils/password';
-
-import { addEvent } from './activityFeed';
 
 export async function createUser(data: unknown) {
   const session = await requireApiAuth();

--- a/apps/fresco/actions/webauthn.ts
+++ b/apps/fresco/actions/webauthn.ts
@@ -14,6 +14,7 @@ import {
 import { cookies } from 'next/headers';
 
 import { env } from '~/env';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { createSessionCookie } from '~/lib/auth/session';
 import { getAuthenticatorName } from '~/lib/auth/utils/getAuthenticatorName';
@@ -30,8 +31,6 @@ import { strongPasswordSchema } from '~/schemas/users';
 import { getClientIp } from '~/utils/getClientIp';
 import { STRONG_PASSWORD_MESSAGE } from '~/utils/isStrongPassword';
 import { hashPassword, verifyPassword } from '~/utils/password';
-
-import { addEvent } from './activityFeed';
 
 const CHALLENGE_COOKIE_NAME = 'webauthn_challenge';
 

--- a/apps/fresco/app/(interview)/interview/[interviewId]/page.tsx
+++ b/apps/fresco/app/(interview)/interview/[interviewId]/page.tsx
@@ -9,7 +9,7 @@ import { type ActivityType } from '~/app/dashboard/_components/ActivityFeed/type
 import { getServerSession } from '~/lib/auth/guards';
 import { safeRevalidateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
-import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
+import { captureEvent, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting, getDisableAnalytics } from '~/queries/appSettings';
 import {
   getInterviewById,
@@ -103,7 +103,7 @@ async function InterviewContent({
       safeRevalidateTag('activityFeed');
 
       await captureEvent('Interview Opened', { message });
-      await shutdownPostHog();
+      await flushPostHog();
     } catch {
       // Non-critical — don't block the interview
     }

--- a/apps/fresco/app/(interview)/interview/[interviewId]/sync/__tests__/route.test.ts
+++ b/apps/fresco/app/(interview)/interview/[interviewId]/sync/__tests__/route.test.ts
@@ -27,7 +27,7 @@ vi.mock('~/queries/appSettings', () => ({
 
 vi.mock('~/lib/posthog-server', () => ({
   captureException: vi.fn(),
-  shutdownPostHog: vi.fn(),
+  flushPostHog: vi.fn(),
 }));
 
 import { POST } from '../route';

--- a/apps/fresco/app/(interview)/interview/[interviewId]/sync/route.ts
+++ b/apps/fresco/app/(interview)/interview/[interviewId]/sync/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { NcNetworkSchema, StageMetadataSchema } from '@codaco/shared-consts';
 import { prisma } from '~/lib/db';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { ensureError } from '~/utils/ensureError';
 
@@ -19,7 +19,7 @@ const routeHandler = async (
   const invalidRequest = (error: unknown) => {
     after(async () => {
       await captureException(error, { interviewId });
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return NextResponse.json(

--- a/apps/fresco/app/(interview)/onboard/[protocolId]/__tests__/route.test.ts
+++ b/apps/fresco/app/(interview)/onboard/[protocolId]/__tests__/route.test.ts
@@ -26,7 +26,8 @@ vi.mock('next/server', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    after: vi.fn(),
+    // Run the callback inline so telemetry side effects are observable.
+    after: vi.fn((callback: () => unknown) => void callback()),
   };
 });
 
@@ -40,12 +41,14 @@ import { cookies } from 'next/headers';
 
 // Import after mocks are set up
 import { createInterview } from '~/actions/interviews';
+import { captureEvent } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 
 // Import the handlers
 import { GET, POST } from '../route';
 
 const mockCreateInterview = vi.mocked(createInterview);
+const mockCaptureEvent = vi.mocked(captureEvent);
 const mockGetAppSetting = vi.mocked(getAppSetting);
 const mockCookies = vi.mocked(cookies);
 
@@ -187,7 +190,7 @@ describe('Onboard Route Handler', () => {
       mockCreateInterview.mockResolvedValue({
         createdInterviewId: null,
         error: 'Failed to create interview',
-        errorType: 'unknown-error',
+        errorType: 'unknown',
       });
 
       const request = new NextRequest(
@@ -222,6 +225,33 @@ describe('Onboard Route Handler', () => {
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toBe(
         'http://localhost:3000/onboard/no-anonymous-recruitment',
+      );
+    });
+
+    it('should redirect to the invalid-link page when the protocol does not exist', async () => {
+      const protocolId = 'deleted-protocol-id';
+
+      mockCreateInterview.mockResolvedValue({
+        createdInterviewId: null,
+        error: 'Protocol not found',
+        errorType: 'no-protocol',
+      });
+
+      const request = new NextRequest(
+        `http://localhost:3000/onboard/${protocolId}`,
+      );
+      const params = Promise.resolve({ protocolId });
+
+      const response = await GET(request, { params });
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost:3000/onboard/invalid-link',
+      );
+      // An invalid link is a participant mistake, not a deployment error.
+      expect(mockCaptureEvent).not.toHaveBeenCalledWith(
+        'Error',
+        expect.anything(),
       );
     });
   });
@@ -298,7 +328,7 @@ describe('Onboard Route Handler', () => {
       mockCreateInterview.mockResolvedValue({
         createdInterviewId: null,
         error: 'Failed to create interview',
-        errorType: 'parse-error',
+        errorType: 'unknown',
       });
 
       const request = new NextRequest(

--- a/apps/fresco/app/(interview)/onboard/[protocolId]/__tests__/route.test.ts
+++ b/apps/fresco/app/(interview)/onboard/[protocolId]/__tests__/route.test.ts
@@ -34,7 +34,7 @@ vi.mock('next/server', async (importOriginal) => {
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent: vi.fn(),
   captureException: vi.fn(),
-  shutdownPostHog: vi.fn(),
+  flushPostHog: vi.fn(),
 }));
 
 import { cookies } from 'next/headers';

--- a/apps/fresco/app/(interview)/onboard/[protocolId]/route.ts
+++ b/apps/fresco/app/(interview)/onboard/[protocolId]/route.ts
@@ -50,22 +50,30 @@ const handler = async (
   }
 
   // Create a new interview given the protocolId and participantId
-  const { createdInterviewId, error, errorType } = await createInterview({
+  const result = await createInterview({
     participantIdentifier,
     protocolId,
   });
 
-  if (error) {
+  if (result.errorType) {
+    // The protocol id comes from the URL, so a link to a protocol that has been
+    // deleted (or was never valid) is a routine outcome rather than a fault in
+    // this deployment. Explain it to the participant without reporting an error.
+    if (result.errorType === 'no-protocol') {
+      url.pathname = '/onboard/invalid-link';
+      return NextResponse.redirect(url);
+    }
+
     after(async () => {
       await captureEvent('Error', {
-        name: error,
+        name: result.error,
         message: 'Failed to create interview',
         path: '/onboard/[protocolId]/route.ts',
       });
       await shutdownPostHog();
     });
 
-    if (errorType === 'no-anonymous-recruitment') {
+    if (result.errorType === 'no-anonymous-recruitment') {
       url.pathname = '/onboard/no-anonymous-recruitment';
       return NextResponse.redirect(url);
     }
@@ -89,7 +97,7 @@ const handler = async (
   // Explicitly disable caching to prevent Netlify from caching this redirect
   // (Netlify adds max-age=86400 by default, causing all users to get the same interview)
   // See: https://github.com/opennextjs/opennextjs-netlify/issues/3460
-  url.pathname = `/interview/${createdInterviewId}`;
+  url.pathname = `/interview/${result.createdInterviewId}`;
   return NextResponse.redirect(url, {
     headers: {
       'Cache-Control': 'no-cache, no-store, must-revalidate',

--- a/apps/fresco/app/(interview)/onboard/[protocolId]/route.ts
+++ b/apps/fresco/app/(interview)/onboard/[protocolId]/route.ts
@@ -3,7 +3,7 @@ import { after, NextResponse, type NextRequest } from 'next/server';
 
 import { createInterview } from '~/actions/interviews';
 import { env } from '~/env';
-import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
+import { captureEvent, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 
 const handler = async (
@@ -70,7 +70,7 @@ const handler = async (
         message: 'Failed to create interview',
         path: '/onboard/[protocolId]/route.ts',
       });
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     if (result.errorType === 'no-anonymous-recruitment') {
@@ -90,7 +90,7 @@ const handler = async (
     await captureEvent('InterviewStarted', {
       usingAnonymousParticipant: !participantIdentifier,
     });
-    await shutdownPostHog();
+    await flushPostHog();
   });
 
   // Redirect to the interview

--- a/apps/fresco/app/(interview)/onboard/invalid-link/page.tsx
+++ b/apps/fresco/app/(interview)/onboard/invalid-link/page.tsx
@@ -1,0 +1,10 @@
+import { ErrorMessage } from '../../interview/_components/ErrorMessage';
+
+export default function Page() {
+  return (
+    <ErrorMessage
+      title="This interview link is no longer valid"
+      message="The study this link points to is not available. Please contact the person who recruited you to this study for assistance."
+    />
+  );
+}

--- a/apps/fresco/app/api/[version]/interview/[interviewId]/route.ts
+++ b/apps/fresco/app/api/[version]/interview/[interviewId]/route.ts
@@ -5,7 +5,7 @@ import {
   requireApiTokenAuth,
 } from '~/app/api/_helpers/auth';
 import { prisma } from '~/lib/db';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { ensureError } from '~/utils/ensureError';
 
@@ -82,7 +82,7 @@ export async function GET(
     const error = ensureError(e);
     await captureException(error);
     after(async () => {
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return NextResponse.json(

--- a/apps/fresco/app/api/[version]/interview/route.ts
+++ b/apps/fresco/app/api/[version]/interview/route.ts
@@ -7,7 +7,7 @@ import {
 import { createVersionedHandler } from '~/app/api/_helpers/versioning';
 import { prisma } from '~/lib/db';
 import { type Prisma } from '~/lib/db/generated/client';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { ensureError } from '~/utils/ensureError';
 
@@ -112,7 +112,7 @@ async function v1(request: NextRequest) {
     const error = ensureError(e);
     await captureException(error);
     after(async () => {
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return NextResponse.json(

--- a/apps/fresco/app/api/[version]/protocols-meta/route.ts
+++ b/apps/fresco/app/api/[version]/protocols-meta/route.ts
@@ -6,7 +6,7 @@ import {
 } from '~/app/api/_helpers/auth';
 import { createVersionedHandler } from '~/app/api/_helpers/versioning';
 import { prisma } from '~/lib/db';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { getAppSetting } from '~/queries/appSettings';
 import { ensureError } from '~/utils/ensureError';
 
@@ -55,7 +55,7 @@ async function v1(request: NextRequest) {
     const error = ensureError(e);
     await captureException(error);
     after(async () => {
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return NextResponse.json(

--- a/apps/fresco/app/api/export-interviews/batch/route.ts
+++ b/apps/fresco/app/api/export-interviews/batch/route.ts
@@ -9,7 +9,7 @@ import { makeFileStreamOutputLayer } from '~/lib/export/FileStreamOutput';
 import { PrismaInterviewRepository } from '~/lib/export/InterviewRepository';
 import { PrismaProtocolRepository } from '~/lib/export/ProtocolRepository';
 import { encodeExportEvent } from '~/lib/export/streamProtocol';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { exportInterviewsSchema } from '~/schemas/export';
 
 export async function POST(request: Request) {
@@ -129,7 +129,7 @@ export async function POST(request: Request) {
           .catch(() => undefined);
         await writer.close().catch(() => undefined);
         await captureException(error);
-        await shutdownPostHog();
+        await flushPostHog();
       }),
     ),
     Effect.catchAll(() => Effect.void),

--- a/apps/fresco/app/api/generate-test-interviews/route.ts
+++ b/apps/fresco/app/api/generate-test-interviews/route.ts
@@ -4,7 +4,7 @@ import {
   generateNetwork,
   type GenerateNetworkParams,
 } from '@codaco/protocol-utilities';
-import { addEvent } from '~/actions/activityFeed';
+import { addEvent } from '~/lib/activityFeed';
 import { requireApiAuth } from '~/lib/auth/guards';
 import { prisma } from '~/lib/db';
 import { generateSyntheticInterviewsSchema } from '~/schemas/synthetic-interviews';

--- a/apps/fresco/app/api/interviews/[interviewId]/finish/route.ts
+++ b/apps/fresco/app/api/interviews/[interviewId]/finish/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { after, NextResponse } from 'next/server';
 
-import { addEvent } from '~/actions/activityFeed';
+import { addEvent } from '~/lib/activityFeed';
 import { safeRevalidateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
 import { captureException, shutdownPostHog } from '~/lib/posthog-server';

--- a/apps/fresco/app/api/interviews/[interviewId]/finish/route.ts
+++ b/apps/fresco/app/api/interviews/[interviewId]/finish/route.ts
@@ -4,7 +4,7 @@ import { after, NextResponse } from 'next/server';
 import { addEvent } from '~/lib/activityFeed';
 import { safeRevalidateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { ensureError } from '~/utils/ensureError';
 
 export async function POST(
@@ -44,7 +44,7 @@ export async function POST(
 
     after(async () => {
       await captureException(error, { interviewId });
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return NextResponse.json(

--- a/apps/fresco/components/VersionSection.tsx
+++ b/apps/fresco/components/VersionSection.tsx
@@ -10,7 +10,7 @@ import { Button } from '@codaco/fresco-ui/Button';
 import Heading from '@codaco/fresco-ui/typography/Heading';
 import Link from '~/components/Link';
 import { env } from '~/env';
-import { captureException, shutdownPostHog } from '~/lib/posthog-server';
+import { captureException, flushPostHog } from '~/lib/posthog-server';
 import { ensureError } from '~/utils/ensureError';
 import { getSemverUpdateType, semverSchema } from '~/utils/semVer';
 
@@ -69,7 +69,7 @@ async function checkForUpdate() {
     const error = ensureError(e);
     after(async () => {
       await captureException(error);
-      await shutdownPostHog();
+      await flushPostHog();
     });
 
     return {

--- a/apps/fresco/instrumentation.ts
+++ b/apps/fresco/instrumentation.ts
@@ -12,7 +12,7 @@ export const onRequestError: Instrumentation.onRequestError = async (
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     // Dynamic imports to avoid pulling Prisma (node:path, node:url, etc.)
     // into the Edge Instrumentation bundle
-    const { getPostHogServer, shutdownPostHog } =
+    const { getPostHogServer, flushPostHog } =
       await import('./lib/posthog-server');
     const { env } = await import('./env');
     const { prisma } = await import('./lib/db');
@@ -35,6 +35,6 @@ export const onRequestError: Instrumentation.onRequestError = async (
       $source: 'server',
     });
 
-    await shutdownPostHog();
+    await flushPostHog();
   }
 };

--- a/apps/fresco/lib/__tests__/activityFeed.test.ts
+++ b/apps/fresco/lib/__tests__/activityFeed.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('server-only', () => ({}));
+
 const {
   mockCreateMany,
   mockCaptureEvent,
@@ -19,7 +21,7 @@ vi.mock('next/server', async (importOriginal) => {
   return {
     ...actual,
     // Collect rather than run, so tests can assert on *when* registration
-    // happened as well as what the callback does.
+    // happened and on what the callback holds open, not just its effects.
     after: vi.fn((callback: () => Promise<unknown>) => {
       afterCallbacks.push(callback);
     }),
@@ -30,7 +32,6 @@ vi.mock('~/lib/db', () => ({
   prisma: {
     events: {
       createMany: mockCreateMany,
-      findMany: vi.fn(),
     },
   },
 }));
@@ -44,10 +45,6 @@ vi.mock('~/lib/posthog-server', () => ({
   shutdownPostHog: mockShutdownPostHog,
 }));
 
-vi.mock('~/lib/auth/guards', () => ({
-  requireApiAuth: vi.fn().mockResolvedValue(undefined),
-}));
-
 import { addEvent, addEvents } from '../activityFeed';
 
 const flushAfterCallbacks = async () => {
@@ -56,6 +53,8 @@ const flushAfterCallbacks = async () => {
   }
 };
 
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe('activity feed', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,27 +62,52 @@ describe('activity feed', () => {
     mockCreateMany.mockResolvedValue({ count: 1 });
   });
 
-  describe('analytics registration', () => {
-    // The regression this guards: registering `after` only once the database
-    // write had resolved. Callers almost always fire these without awaiting,
-    // so by then the request scope was gone, `after` threw, and the error was
+  describe('work that must outlive the response', () => {
+    // The regression this guards: registering `after` only once the feed write
+    // had resolved. Callers almost always fire these without awaiting, so by
+    // then the request scope was gone, `after` threw, and the error was
     // swallowed — analytics silently stopped for every unawaited caller.
-    it('registers analytics before the database write settles', () => {
+    it('registers before the feed write settles', () => {
       mockCreateMany.mockReturnValue(new Promise(() => undefined));
 
-      void addEvent(
-        'Protocol Uninstalled',
-        'User admin uninstalled a protocol',
-      );
+      void addEvent('Protocol Uninstalled', 'User admin uninstalled "Study"');
 
       expect(afterCallbacks).toHaveLength(1);
     });
 
-    it('reports the activity even when the caller does not await it', async () => {
-      void addEvent(
-        'Protocol Uninstalled',
-        'User admin uninstalled a protocol',
+    // Nothing else awaits the write when the caller does not, so the callback
+    // adopting it is the only thing keeping a serverless invocation alive
+    // until the row lands.
+    it('holds the invocation open until the feed write lands', async () => {
+      let settleWrite!: (value: { count: number }) => void;
+      mockCreateMany.mockReturnValue(
+        new Promise<{ count: number }>((resolve) => {
+          settleWrite = resolve;
+        }),
       );
+
+      void addEvent('Protocol Uninstalled', 'User admin uninstalled "Study"');
+
+      const callback = afterCallbacks[0];
+      expect(callback).toBeDefined();
+
+      let finished = false;
+      const running = callback!().then(() => {
+        finished = true;
+        return null;
+      });
+
+      await nextTick();
+      expect(finished).toBe(false);
+
+      settleWrite({ count: 1 });
+      await running;
+
+      expect(finished).toBe(true);
+    });
+
+    it('reports the activity even when the caller does not await it', async () => {
+      void addEvent('Protocol Uninstalled', 'User admin uninstalled "Study"');
       await flushAfterCallbacks();
 
       expect(mockCaptureEvent).toHaveBeenCalledWith(
@@ -123,7 +147,26 @@ describe('activity feed', () => {
       });
     });
 
-    it('still writes the message to the feed', async () => {
+    // A database refusing writes is precisely when the reports matter.
+    it('reports the activity even when the feed write fails', async () => {
+      mockCreateMany.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await addEvent(
+        'Protocol Uninstalled',
+        'User admin uninstalled "Study"',
+      );
+      await flushAfterCallbacks();
+
+      expect(result).toEqual({ success: false, error: 'Failed to add event' });
+      expect(mockCaptureEvent).toHaveBeenCalledWith(
+        'Protocol Uninstalled',
+        undefined,
+      );
+    });
+  });
+
+  describe('the feed', () => {
+    it('writes the message and invalidates the feed', async () => {
       await addEvent('Protocol Uninstalled', 'User admin uninstalled "Study"');
 
       expect(mockCreateMany).toHaveBeenCalledWith({
@@ -135,6 +178,22 @@ describe('activity feed', () => {
         ],
       });
       expect(mockSafeUpdateTag).toHaveBeenCalledWith('activityFeed');
+    });
+
+    // updateTag is only available in Server Actions, and most callers are not
+    // in one by the time this runs. A failed invalidation costs a slightly
+    // later refresh, never the row.
+    it('still succeeds when the feed cannot be invalidated', async () => {
+      mockSafeUpdateTag.mockImplementation(() => {
+        throw new Error('updateTag is not available here');
+      });
+
+      const result = await addEvent(
+        'Protocol Uninstalled',
+        'User admin uninstalled "Study"',
+      );
+
+      expect(result).toEqual({ success: true, error: null });
     });
   });
 
@@ -181,13 +240,5 @@ describe('activity feed', () => {
       expect(mockCreateMany).not.toHaveBeenCalled();
       expect(afterCallbacks).toHaveLength(0);
     });
-  });
-
-  it('reports failure without throwing when the write fails', async () => {
-    mockCreateMany.mockRejectedValue(new Error('Connection refused'));
-
-    const result = await addEvent('Protocol Uninstalled', 'User admin removed');
-
-    expect(result).toEqual({ success: false, error: 'Failed to add event' });
   });
 });

--- a/apps/fresco/lib/__tests__/activityFeed.test.ts
+++ b/apps/fresco/lib/__tests__/activityFeed.test.ts
@@ -42,7 +42,7 @@ vi.mock('~/lib/cache', () => ({
 
 vi.mock('~/lib/posthog-server', () => ({
   captureEvent: mockCaptureEvent,
-  shutdownPostHog: mockShutdownPostHog,
+  flushPostHog: mockShutdownPostHog,
 }));
 
 import { addEvent, addEvents } from '../activityFeed';

--- a/apps/fresco/lib/__tests__/posthog-server.test.ts
+++ b/apps/fresco/lib/__tests__/posthog-server.test.ts
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockCapture,
   mockCaptureException,
-  mockShutdown,
+  mockFlush,
   mockGetDisableAnalytics,
   mockGetInstallationId,
 } = vi.hoisted(() => ({
   mockCapture: vi.fn(),
   mockCaptureException: vi.fn(),
-  mockShutdown: vi.fn().mockResolvedValue(undefined),
+  mockFlush: vi.fn().mockResolvedValue(undefined),
   mockGetDisableAnalytics: vi.fn(),
   mockGetInstallationId: vi.fn(),
 }));
@@ -18,7 +18,7 @@ vi.mock('posthog-node', () => {
   const MockPostHog = vi.fn(function (this: Record<string, unknown>) {
     this.capture = mockCapture;
     this.captureException = mockCaptureException;
-    this.shutdown = mockShutdown;
+    this.flush = mockFlush;
   });
   return { PostHog: MockPostHog };
 });
@@ -120,25 +120,61 @@ describe('posthog-server', () => {
     });
   });
 
-  describe('shutdownPostHog', () => {
-    it('calls shutdown and allows re-initialization', async () => {
+  describe('flushPostHog', () => {
+    it('flushes what has been captured', async () => {
       mockGetDisableAnalytics.mockResolvedValue(false);
       mockGetInstallationId.mockResolvedValue('install-123');
 
-      const { captureEvent, shutdownPostHog } =
-        await import('../posthog-server');
+      const { captureEvent, flushPostHog } = await import('../posthog-server');
 
-      // Initialize the client by making a call
       await captureEvent('init-event');
       expect(mockCapture).toHaveBeenCalledTimes(1);
 
-      // Shutdown
-      await shutdownPostHog();
-      expect(mockShutdown).toHaveBeenCalledTimes(1);
+      await flushPostHog();
+      expect(mockFlush).toHaveBeenCalledTimes(1);
+    });
 
-      // Re-initialize by making another call
-      await captureEvent('post-shutdown-event');
-      expect(mockCapture).toHaveBeenCalledTimes(2);
+    // One request can queue several `after` callbacks — a route's telemetry
+    // alongside activity recorded by the action it called — and Next runs them
+    // concurrently against one shared client. Tearing that client down let
+    // whichever finished first strand the other's event; every flush must
+    // reach the client that holds it.
+    it('flushes for every caller sharing the client', async () => {
+      mockGetDisableAnalytics.mockResolvedValue(false);
+      mockGetInstallationId.mockResolvedValue('install-123');
+
+      const { captureEvent, flushPostHog } = await import('../posthog-server');
+
+      // Two callbacks capture against the one shared client...
+      await captureEvent('route-event');
+      await captureEvent('activity-event');
+
+      // ...and each then flushes what it captured. Under a teardown the first
+      // would drop the shared client, and the second would find nothing to
+      // flush and return with its event still queued.
+      await flushPostHog();
+      await flushPostHog();
+
+      expect(mockFlush).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not throw when the client has nothing to flush', async () => {
+      const { flushPostHog } = await import('../posthog-server');
+
+      await expect(flushPostHog()).resolves.toBeUndefined();
+      expect(mockFlush).not.toHaveBeenCalled();
+    });
+
+    it('swallows a failing flush', async () => {
+      mockGetDisableAnalytics.mockResolvedValue(false);
+      mockGetInstallationId.mockResolvedValue('install-123');
+      mockFlush.mockRejectedValueOnce(new Error('network down'));
+
+      const { captureEvent, flushPostHog } = await import('../posthog-server');
+
+      await captureEvent('init-event');
+
+      await expect(flushPostHog()).resolves.toBeUndefined();
     });
   });
 });

--- a/apps/fresco/lib/activityFeed.ts
+++ b/apps/fresco/lib/activityFeed.ts
@@ -1,0 +1,104 @@
+import { after } from 'next/server';
+import 'server-only';
+
+import type {
+  Activity,
+  ActivityType,
+} from '~/app/dashboard/_components/ActivityFeed/types';
+import { safeUpdateTag } from '~/lib/cache';
+import { prisma } from '~/lib/db';
+import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
+
+type NewActivity = {
+  type: ActivityType;
+  message: Activity['message'];
+  properties?: Record<string, unknown>;
+};
+
+/**
+ * Records activity in the dashboard feed and reports it to analytics.
+ *
+ * This is deliberately not a Server Action. It writes whatever type and
+ * message it is handed, and it is called from unauthenticated participant
+ * flows (starting and finishing an interview) and from login, before a session
+ * exists — so it can be guarded by neither `requireApiAuth` nor a session
+ * check. Exposing it as an action endpoint would let anyone forge feed
+ * entries; keeping it server-only means the only callers are the ones in this
+ * codebase, each of which has already established who is acting.
+ *
+ * Everything that has to happen within the caller's request is set up before
+ * the first await. Almost every caller invokes this without awaiting it, so a
+ * suspension point here means the enclosing action's response has already been
+ * sent by the time the rest runs.
+ */
+async function recordActivity(activities: NewActivity[]) {
+  if (activities.length === 0) {
+    return { success: true, error: null };
+  }
+
+  // Started rather than awaited, so `after` below can adopt the same in-flight
+  // write. Rejection is folded into the value: nothing awaits this promise
+  // before `after` runs, and an unhandled rejection would take the process
+  // down.
+  const written = prisma.events
+    .createMany({
+      data: activities.map(({ type, message }) => ({ type, message })),
+    })
+    .then(
+      () => true,
+      () => false,
+    );
+
+  after(async () => {
+    // Adopting the write is what keeps it supervised. Callers that do not
+    // await this would otherwise have their response sent — and a serverless
+    // container frozen — with the row still in flight.
+    const stored = await written;
+
+    // Analytics is reported either way. The activity happened; whether the
+    // feed managed to record it is a separate question, and a database that
+    // is refusing writes is precisely when the reports matter.
+    if (!stored) {
+      // eslint-disable-next-line no-console
+      console.log('Failed to write activity feed entries');
+    }
+
+    for (const { type, properties } of activities) {
+      await captureEvent(type, properties);
+    }
+
+    await shutdownPostHog();
+  });
+
+  if (!(await written)) {
+    return { success: false, error: 'Failed to add event' };
+  }
+
+  // Meaningful only for callers that await this from a Server Action.
+  // Elsewhere — route handlers, and the callers that do not await — the
+  // request has moved on and `updateTag` is unavailable, which costs nothing
+  // but a slightly later refresh of the feed.
+  try {
+    safeUpdateTag('activityFeed');
+  } catch {
+    // The row is written either way.
+  }
+
+  return { success: true, error: null };
+}
+
+export async function addEvent(
+  type: ActivityType,
+  message: Activity['message'],
+  properties?: Record<string, unknown>,
+) {
+  return recordActivity([{ type, message, properties }]);
+}
+
+/**
+ * Records several activities at once, for actions that operate on a selection
+ * and describe each item separately in the feed.
+ */
+export async function addEvents(activities: NewActivity[]) {
+  return recordActivity(activities);
+}

--- a/apps/fresco/lib/activityFeed.ts
+++ b/apps/fresco/lib/activityFeed.ts
@@ -7,7 +7,7 @@ import type {
 } from '~/app/dashboard/_components/ActivityFeed/types';
 import { safeUpdateTag } from '~/lib/cache';
 import { prisma } from '~/lib/db';
-import { captureEvent, shutdownPostHog } from '~/lib/posthog-server';
+import { captureEvent, flushPostHog } from '~/lib/posthog-server';
 
 type NewActivity = {
   type: ActivityType;
@@ -67,7 +67,7 @@ async function recordActivity(activities: NewActivity[]) {
       await captureEvent(type, properties);
     }
 
-    await shutdownPostHog();
+    await flushPostHog();
   });
 
   if (!(await written)) {

--- a/apps/fresco/lib/posthog-server.ts
+++ b/apps/fresco/lib/posthog-server.ts
@@ -76,9 +76,25 @@ export async function captureException(
   }
 }
 
-export async function shutdownPostHog() {
-  if (client) {
-    await client.shutdown();
-    client = null;
+/**
+ * Flushes anything captured so far, so it is delivered before a serverless
+ * invocation freezes.
+ *
+ * This flushes rather than shuts the client down. One request can queue
+ * several `after` callbacks — a route's own telemetry alongside activity
+ * recorded by the action it called — and Next runs them concurrently against
+ * this one shared client. Tearing the client down would let whichever callback
+ * finished first strand another's event: the second would find `client` already
+ * null, skip its own flush, and return with the event unsent. Flushing is
+ * idempotent and safe to call concurrently, and the client is meant to outlive
+ * a single request anyway — that is what memoizing it above is for.
+ */
+export async function flushPostHog() {
+  // Telemetry must never throw: this runs inside `after` callbacks, where an
+  // error would surface as an unhandled rejection long after the response.
+  try {
+    await client?.flush();
+  } catch {
+    // swallow
   }
 }

--- a/apps/fresco/schemas/interviews.ts
+++ b/apps/fresco/schemas/interviews.ts
@@ -8,3 +8,31 @@ export type CreateInterview = {
   participantIdentifier?: Participant['identifier'];
   protocolId: Protocol['id'];
 };
+
+/**
+ * Why a new interview could not be created. These are outcomes the caller is
+ * expected to route on, so they are a closed set of stable identifiers — never
+ * a raw error message, which would leak internal detail across the server
+ * action boundary and cannot be branched on reliably.
+ *
+ * `no-protocol` covers an onboarding link whose protocol no longer exists
+ * (deleted, or simply mistyped). That is a routine participant-facing outcome
+ * rather than a fault in the deployment.
+ */
+export type CreateInterviewErrorType =
+  | 'invalid-identifier'
+  | 'no-anonymous-recruitment'
+  | 'no-protocol'
+  | 'unknown';
+
+export type CreateInterviewResult =
+  | {
+      errorType: null;
+      error: null;
+      createdInterviewId: string;
+    }
+  | {
+      errorType: CreateInterviewErrorType;
+      error: string;
+      createdInterviewId: null;
+    };


### PR DESCRIPTION
## The exception

[PostHog exception `01a015fa-5c47-7cb9-8865-5a96f4a1a79f`](https://us.posthog.com/project/249487/events/01a015fa-5c47-7cb9-8865-5a96f4a1a79f/2026-08-18T17%3A45%3A24.458000Z) — `PrismaClientKnownRequestError` in `createInterview`, called from the `/onboard/[protocolId]` route:

> An operation failed because it depends on one or more records that were required but not found. No 'Protocol' record (needed to inline the relation on 'Interview' record(s)) was found for a nested connect on one-to-many relation 'InterviewToProtocol'.

12 occurrences on the `fresco-sandbox` installation between 2026-08-10 and 2026-08-18.

## Cause

The `protocolId` path segment is unauthenticated, user-supplied input. It went straight into `prisma.interview.create` as `protocol: { connect: { id: protocolId } }`, so a link to a protocol that had been deleted — or one that never existed — raised Prisma's P2025 rather than resolving to a normal "not found" result. `createInterview`'s catch treated every failure alike and reported it to error tracking.

Nothing crashed: participants were already redirected to `/onboard/error`. The defects are that a routine dead link is *classified* as an application fault, and that the generic error page tells the participant nothing they can act on.

## Changes

- `createInterview` catches P2025 specifically and returns a `no-protocol` outcome without capturing an exception. Checking the error code rather than pre-reading the protocol keeps this to one round trip and stays correct when a protocol is deleted between a check and the write.
- A new `/onboard/invalid-link` page tells the participant the link is no longer valid and who to contact, instead of the generic onboarding error. Built from the existing `ErrorMessage` component, mirroring `/onboard/no-anonymous-recruitment`.
- `errorType` was the raw error message (`e.message`). That leaks internal detail across the server action boundary and cannot be branched on, so it is now a closed union — `invalid-identifier | no-anonymous-recruitment | no-protocol | unknown` — with the result typed as a discriminated union so callers narrow correctly. This immediately caught a route test asserting a `parse-error` type the action never returns.

Genuine failures are unaffected: they still capture an exception and still redirect to `/onboard/error`.

## Verification

`pnpm --filter fresco typecheck`, `pnpm --filter fresco test` (384 passed), `pnpm lint`, `pnpm knip`, and `pnpm check:changesets` all pass.

New tests cover the P2025 path returning `no-protocol`, that path capturing no exception, an unexpected failure still capturing one, the underlying message not reaching the caller, and the `/onboard/invalid-link` redirect emitting no `Error` event. The `after` mocks in both suites were no-ops, so telemetry side effects were previously unobservable; they now run their callback inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)