### PR TITLE
Release Documentation

### DIFF
--- a/.changeset/gentle-taxis-document.md
+++ b/.changeset/gentle-taxis-document.md
@@ -1,6 +1,0 @@
----
-'@codaco/documentation': patch
----
-
-Populate PostHog's built-in app name and version metadata for Documentation
-events.

--- a/apps/documentation/CHANGELOG.md
+++ b/apps/documentation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @codaco/documentation
 
+## 0.3.3
+
+### Patch Changes
+
+- Populate PostHog's built-in app name and version metadata for Documentation
+  events.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/documentation",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `@codaco/documentation` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `@codaco/documentation` | 0.3.2 | 0.3.3 |

### @codaco/documentation@0.3.3

### Patch Changes

- Populate PostHog's built-in app name and version metadata for Documentation
  events.
