### PR TITLE
Release Website

### DIFF
--- a/.changeset/quiet-sites-report.md
+++ b/.changeset/quiet-sites-report.md
@@ -1,5 +1,0 @@
----
-'networkcanvas.com': patch
----
-
-Populate PostHog's built-in app name and version metadata for Website events.

--- a/apps/networkcanvas.com/CHANGELOG.md
+++ b/apps/networkcanvas.com/CHANGELOG.md
@@ -1,5 +1,11 @@
 # networkcanvas.com
 
+## 0.4.1
+
+### Patch Changes
+
+- Populate PostHog's built-in app name and version metadata for Website events.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/apps/networkcanvas.com/package.json
+++ b/apps/networkcanvas.com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "networkcanvas.com",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `networkcanvas.com` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `networkcanvas.com` | 0.4.0 | 0.4.1 |

### networkcanvas.com@0.4.1

### Patch Changes

- Populate PostHog's built-in app name and version metadata for Website events.
