### PR TITLE
fix(protocols): stop rewriting the compat packages on every install

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -509,6 +509,10 @@ jobs:
         id: changesets
         continue-on-error: true
         run: pnpm check:changesets
+      - name: Check compat protocol packages match their canonical source
+        id: compat-protocols
+        continue-on-error: true
+        run: pnpm check:compat-protocols
       - name: Test repository scripts
         id: scripts
         continue-on-error: true
@@ -526,6 +530,7 @@ jobs:
         env:
           KNIP_OUTCOME: ${{ steps.knip.outcome }}
           CHANGESETS_OUTCOME: ${{ steps.changesets.outcome }}
+          COMPAT_PROTOCOLS_OUTCOME: ${{ steps.compat-protocols.outcome }}
           SCRIPTS_OUTCOME: ${{ steps.scripts.outcome }}
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
@@ -534,6 +539,7 @@ jobs:
           for result in \
             "knip=$KNIP_OUTCOME" \
             "changesets=$CHANGESETS_OUTCOME" \
+            "compat-protocols=$COMPAT_PROTOCOLS_OUTCOME" \
             "scripts=$SCRIPTS_OUTCOME" \
             "build=$BUILD_OUTCOME" \
             "typecheck=$TYPECHECK_OUTCOME"; do

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "version-packages": "pnpm exec changeset version && pnpm install --no-frozen-lockfile && pnpm lint:fix",
     "changeset": "changeset add",
     "check:changesets": "node scripts/check-changeset-app-isolation.mjs",
+    "check:compat-protocols": "node packages/protocols/scripts/check-compat-packages.mjs",
     "verify:publish-exports": "node scripts/verify-publish-exports.mjs",
     "lint": "node scripts/lint.mjs",
     "lint:changed": "node scripts/lint.mjs --changed-from",

--- a/packages/development-protocol/.gitignore
+++ b/packages/development-protocol/.gitignore
@@ -1,3 +1,9 @@
-protocol.json
-assets/
+# protocol.json and assets/ are copied from packages/protocols/development, but
+# they are also tracked here: this package is published from its committed copy,
+# and `prepack` only refreshes it at publish time. Do not ignore them.
+
+# Staging area used by the prepack sync while it swaps the copies into place.
+.sync-tmp/
+
+# Zipped protocol bundle — built by CI for releases, never committed.
 Development.netcanvas

--- a/packages/development-protocol/package.json
+++ b/packages/development-protocol/package.json
@@ -25,7 +25,6 @@
     "./assets/*": "./assets/*"
   },
   "scripts": {
-    "prepare": "node ../protocols/scripts/sync-compat-package.mjs development .",
     "prepack": "node ../protocols/scripts/sync-compat-package.mjs development ."
   },
   "engines": {

--- a/packages/protocols/scripts/check-compat-packages.mjs
+++ b/packages/protocols/scripts/check-compat-packages.mjs
@@ -1,0 +1,63 @@
+// Fails when a published compatibility package has drifted from the canonical
+// protocol it mirrors.
+//
+// The compat copies are tracked in Git and only regenerated at publish time
+// (each package's `prepack`), so nothing regenerates them for a contributor who
+// edits the canonical protocol. This check turns that divergence into a red
+// build instead of a surprise at release. It only reads: it never writes to the
+// working tree, so a failure here cannot leave the repository dirty.
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { diffCompatPackage } from './sync-compat-package.mjs';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+);
+
+const compatPackages = [
+  {
+    name: '@codaco/sample-protocol',
+    sourceDir: path.join(repoRoot, 'packages', 'protocols', 'sample'),
+    targetDir: path.join(repoRoot, 'packages', 'sample-protocol'),
+    syncCommand:
+      'node ../protocols/scripts/sync-compat-package.mjs sample . (from packages/sample-protocol)',
+  },
+  {
+    name: '@codaco/development-protocol',
+    sourceDir: path.join(repoRoot, 'packages', 'protocols', 'development'),
+    targetDir: path.join(repoRoot, 'packages', 'development-protocol'),
+    syncCommand:
+      'node ../protocols/scripts/sync-compat-package.mjs development . (from packages/development-protocol)',
+  },
+];
+
+let drifted = false;
+
+for (const { name, sourceDir, targetDir, syncCommand } of compatPackages) {
+  const differences = await diffCompatPackage(sourceDir, targetDir);
+
+  if (differences.length === 0) {
+    console.log(`${name} matches ${path.relative(repoRoot, sourceDir)}`);
+    continue;
+  }
+
+  drifted = true;
+  console.error(
+    `\n${name} has drifted from ${path.relative(repoRoot, sourceDir)}:`,
+  );
+  for (const difference of differences) {
+    console.error(`  - ${difference}`);
+  }
+  console.error(`  Fix by running: ${syncCommand}`);
+}
+
+if (drifted) {
+  console.error(
+    '\nThe compatibility packages are published from their committed copies. Re-run the sync above and commit the result.',
+  );
+  process.exit(1);
+}

--- a/packages/protocols/scripts/sync-compat-package.mjs
+++ b/packages/protocols/scripts/sync-compat-package.mjs
@@ -1,4 +1,27 @@
-import { cp, mkdir, rm } from 'node:fs/promises';
+// Copies a canonical protocol (protocol.json + assets/) from this package into
+// one of the published compatibility packages.
+//
+// The compat packages' copies are tracked in Git, so this script must never
+// leave the working tree in a half-written state:
+//
+//   - Nothing is touched when the target already matches the source, which is
+//     the normal case for a clean checkout. No mtime churn, no cache busting.
+//   - When a write is needed, everything is staged under a sibling temp
+//     directory first, so the only mutation of the real paths is a rename.
+//     A `cp -r` directly over `assets/` would leave the tracked files missing
+//     for the whole copy, and permanently missing if the process died there.
+//
+// Invoked from each compat package's `prepack` (publish time) and, in
+// comparison-only form, by check-compat-packages.mjs (pnpm check:compat-protocols).
+import {
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+} from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -12,27 +35,187 @@ const protocolSources = {
   sample: path.join(packageRoot, 'sample'),
 };
 
-const [protocolId, targetDirArg = '.'] = process.argv.slice(2);
-const sourceDir = protocolSources[protocolId];
+// Staging area for the copies. A single directory keeps the swap on the same
+// filesystem as the target (so `rename` is atomic) and needs only one
+// .gitignore entry in each compat package.
+const STAGING_DIR = '.sync-tmp';
 
-if (!sourceDir) {
-  console.error(
-    `Unknown protocol "${protocolId}". Expected one of: ${Object.keys(protocolSources).join(', ')}`,
-  );
-  process.exit(1);
+// Code-unit ordering, matching the default `Array#sort` comparison for strings.
+const byPath = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+
+/** Relative paths of every file under `dir`, sorted. */
+async function listFiles(dir, prefix = '') {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(
+        ...((await listFiles(path.join(dir, entry.name), relativePath)) ?? []),
+      );
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files.toSorted(byPath);
 }
 
-const targetDir = path.resolve(process.cwd(), targetDirArg);
+async function filesAreEqual(a, b) {
+  try {
+    const [statA, statB] = await Promise.all([stat(a), stat(b)]);
+    if (statA.size !== statB.size) {
+      return false;
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  const [bytesA, bytesB] = await Promise.all([readFile(a), readFile(b)]);
+  return bytesA.equals(bytesB);
+}
 
-await mkdir(targetDir, { recursive: true });
+/**
+ * Compares a canonical protocol directory against a compat package directory.
+ * Returns the human-readable differences; an empty array means they match.
+ */
+export async function diffCompatPackage(sourceDir, targetDir) {
+  const differences = [];
 
-await cp(
-  path.join(sourceDir, 'protocol.json'),
-  path.join(targetDir, 'protocol.json'),
-);
+  if (
+    !(await filesAreEqual(
+      path.join(sourceDir, 'protocol.json'),
+      path.join(targetDir, 'protocol.json'),
+    ))
+  ) {
+    differences.push('protocol.json differs');
+  }
 
-await rm(path.join(targetDir, 'assets'), { recursive: true, force: true });
+  const sourceAssets = (await listFiles(path.join(sourceDir, 'assets'))) ?? [];
+  const targetAssets = await listFiles(path.join(targetDir, 'assets'));
 
-await cp(path.join(sourceDir, 'assets'), path.join(targetDir, 'assets'), {
-  recursive: true,
-});
+  if (targetAssets === null) {
+    differences.push('assets/ is missing');
+    return differences;
+  }
+
+  const targetSet = new Set(targetAssets);
+  const sourceSet = new Set(sourceAssets);
+
+  for (const file of sourceAssets) {
+    if (!targetSet.has(file)) {
+      differences.push(`assets/${file} is missing`);
+    } else if (
+      !(await filesAreEqual(
+        path.join(sourceDir, 'assets', file),
+        path.join(targetDir, 'assets', file),
+      ))
+    ) {
+      differences.push(`assets/${file} differs`);
+    }
+  }
+
+  for (const file of targetAssets) {
+    if (!sourceSet.has(file)) {
+      differences.push(`assets/${file} is not in the canonical protocol`);
+    }
+  }
+
+  return differences.toSorted(byPath);
+}
+
+/**
+ * Makes `targetDir` match the canonical protocol, writing nothing when it
+ * already does. Returns true when files were written.
+ */
+export async function syncCompatPackage(protocolId, targetDir) {
+  const sourceDir = protocolSources[protocolId];
+  if (!sourceDir) {
+    throw new Error(
+      `Unknown protocol "${protocolId}". Expected one of: ${Object.keys(protocolSources).join(', ')}`,
+    );
+  }
+
+  await mkdir(targetDir, { recursive: true });
+
+  if ((await diffCompatPackage(sourceDir, targetDir)).length === 0) {
+    return false;
+  }
+
+  const staging = path.join(targetDir, STAGING_DIR);
+  await rm(staging, { recursive: true, force: true });
+
+  try {
+    await mkdir(staging, { recursive: true });
+    await cp(
+      path.join(sourceDir, 'protocol.json'),
+      path.join(staging, 'protocol.json'),
+    );
+    await cp(path.join(sourceDir, 'assets'), path.join(staging, 'assets'), {
+      recursive: true,
+    });
+
+    // Same-directory rename: replaces the file atomically.
+    await rename(
+      path.join(staging, 'protocol.json'),
+      path.join(targetDir, 'protocol.json'),
+    );
+
+    // `rename` refuses to replace a non-empty directory, so displace the old
+    // one first. The gap where assets/ does not exist spans two renames rather
+    // than a multi-megabyte recursive copy, and the previous contents survive
+    // under the staging directory until the new ones are in place.
+    const assets = path.join(targetDir, 'assets');
+    const displaced = path.join(staging, 'assets.previous');
+    let hasExistingAssets = true;
+    try {
+      await rename(assets, displaced);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+      hasExistingAssets = false;
+    }
+
+    try {
+      await rename(path.join(staging, 'assets'), assets);
+    } catch (error) {
+      if (hasExistingAssets) {
+        await rename(displaced, assets);
+      }
+      throw error;
+    }
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+
+  return true;
+}
+
+// CLI entry point: `node sync-compat-package.mjs <protocol> [targetDir]`
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [protocolId, targetDirArg = '.'] = process.argv.slice(2);
+  const targetDir = path.resolve(process.cwd(), targetDirArg);
+
+  try {
+    const written = await syncCompatPackage(protocolId, targetDir);
+    console.log(
+      written
+        ? `Synced ${protocolId} protocol into ${targetDir}`
+        : `${protocolId} protocol already up to date in ${targetDir}`,
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/packages/sample-protocol/.gitignore
+++ b/packages/sample-protocol/.gitignore
@@ -1,2 +1,6 @@
-protocol.json
-assets/
+# protocol.json and assets/ are copied from packages/protocols/sample, but they
+# are also tracked here: this package is published from its committed copy, and
+# `prepack` only refreshes it at publish time. Do not ignore them.
+
+# Staging area used by the prepack sync while it swaps the copies into place.
+.sync-tmp/

--- a/packages/sample-protocol/package.json
+++ b/packages/sample-protocol/package.json
@@ -25,7 +25,6 @@
     "./assets/*": "./assets/*"
   },
   "scripts": {
-    "prepare": "node ../protocols/scripts/sync-compat-package.mjs sample .",
     "prepack": "node ../protocols/scripts/sync-compat-package.mjs sample ."
   },
   "engines": {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -326,6 +326,7 @@ test('short quality checks share one setup without joining the critical path', (
   assert.match(support, /uses: \.\/\.github\/actions\/turbo-ci-setup/);
   assert.match(support, /pnpm exec turbo run \/\/#knip/);
   assert.match(support, /pnpm check:changesets/);
+  assert.match(support, /pnpm check:compat-protocols/);
   assert.match(support, /pnpm test:scripts/);
   assert.match(support, /turbo run build --filter='\.\/packages\/\*'/);
   assert.match(support, /turbo run typecheck/);

--- a/scripts/compat-protocol-sync.test.mjs
+++ b/scripts/compat-protocol-sync.test.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  diffCompatPackage,
+  syncCompatPackage,
+} from '../packages/protocols/scripts/sync-compat-package.mjs';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const sampleSource = path.join(repoRoot, 'packages', 'protocols', 'sample');
+
+async function withTempDir(run) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'compat-protocol-'));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function makeFixture(root) {
+  const source = path.join(root, 'source');
+  const target = path.join(root, 'target');
+  for (const dir of [source, target]) {
+    await mkdir(path.join(dir, 'assets'), { recursive: true });
+    await writeFile(path.join(dir, 'protocol.json'), '{"schemaVersion":8}');
+    await writeFile(path.join(dir, 'assets', 'image.png'), 'pixels');
+  }
+  return { source, target };
+}
+
+test('diffCompatPackage reports nothing for identical directories', async () => {
+  await withTempDir(async (root) => {
+    const { source, target } = await makeFixture(root);
+    assert.deepEqual(await diffCompatPackage(source, target), []);
+  });
+});
+
+test('diffCompatPackage reports every kind of drift', async () => {
+  await withTempDir(async (root) => {
+    const { source, target } = await makeFixture(root);
+    await writeFile(path.join(target, 'protocol.json'), '{"schemaVersion":7}');
+    await writeFile(path.join(target, 'assets', 'image.png'), 'other pixels');
+    await writeFile(path.join(source, 'assets', 'added.csv'), 'a,b');
+    await writeFile(path.join(target, 'assets', 'stale.csv'), 'c,d');
+
+    assert.deepEqual(await diffCompatPackage(source, target), [
+      'assets/added.csv is missing',
+      'assets/image.png differs',
+      'assets/stale.csv is not in the canonical protocol',
+      'protocol.json differs',
+    ]);
+  });
+});
+
+test('diffCompatPackage compares assets in nested directories', async () => {
+  await withTempDir(async (root) => {
+    const { source, target } = await makeFixture(root);
+    await mkdir(path.join(source, 'assets', 'nested'), { recursive: true });
+    await writeFile(path.join(source, 'assets', 'nested', 'deep.txt'), 'one');
+    await mkdir(path.join(target, 'assets', 'nested'), { recursive: true });
+    await writeFile(path.join(target, 'assets', 'nested', 'deep.txt'), 'two');
+
+    assert.deepEqual(await diffCompatPackage(source, target), [
+      'assets/nested/deep.txt differs',
+    ]);
+  });
+});
+
+test('diffCompatPackage reports a missing assets directory', async () => {
+  await withTempDir(async (root) => {
+    const { source, target } = await makeFixture(root);
+    await rm(path.join(target, 'assets'), { recursive: true });
+    assert.deepEqual(await diffCompatPackage(source, target), [
+      'assets/ is missing',
+    ]);
+  });
+});
+
+test('syncCompatPackage populates an empty target and leaves no staging directory', async () => {
+  await withTempDir(async (root) => {
+    const target = path.join(root, 'compat');
+    assert.equal(await syncCompatPackage('sample', target), true);
+    assert.deepEqual(await diffCompatPackage(sampleSource, target), []);
+    assert.ok(!(await readdir(target)).includes('.sync-tmp'));
+  });
+});
+
+test('syncCompatPackage writes nothing when the target already matches', async () => {
+  await withTempDir(async (root) => {
+    const target = path.join(root, 'compat');
+    await syncCompatPackage('sample', target);
+
+    const before = await stat(path.join(target, 'protocol.json'));
+    assert.equal(await syncCompatPackage('sample', target), false);
+    const after = await stat(path.join(target, 'protocol.json'));
+
+    // An unconditional copy would churn mtimes on byte-identical files and
+    // bust every mtime-keyed cache downstream.
+    assert.equal(after.mtimeMs, before.mtimeMs);
+  });
+});
+
+test('syncCompatPackage repairs a stale target without stranding files', async () => {
+  await withTempDir(async (root) => {
+    const target = path.join(root, 'compat');
+    await syncCompatPackage('sample', target);
+    await writeFile(path.join(target, 'protocol.json'), 'corrupted');
+    await writeFile(path.join(target, 'assets', 'stowaway.txt'), 'delete me');
+
+    assert.equal(await syncCompatPackage('sample', target), true);
+    assert.deepEqual(await diffCompatPackage(sampleSource, target), []);
+    assert.ok(!(await readdir(target)).includes('.sync-tmp'));
+  });
+});
+
+test('syncCompatPackage rejects an unknown protocol id', async () => {
+  await withTempDir(async (root) => {
+    await assert.rejects(
+      () => syncCompatPackage('nonexistent', path.join(root, 'compat')),
+      /Unknown protocol "nonexistent"/,
+    );
+  });
+});
+
+test('the compat packages regenerate only at publish time, never on install', async () => {
+  for (const pkg of ['sample-protocol', 'development-protocol']) {
+    const manifest = JSON.parse(
+      await readFile(
+        path.join(repoRoot, 'packages', pkg, 'package.json'),
+        'utf8',
+      ),
+    );
+    // `prepare` runs on every `pnpm install`, which would rewrite these
+    // packages' tracked files in every contributor's working tree.
+    assert.equal(
+      manifest.scripts.prepare,
+      undefined,
+      `${pkg} must not sync from a prepare script`,
+    );
+    assert.match(manifest.scripts.prepack, /sync-compat-package\.mjs/);
+  }
+});
+
+test('the compat packages do not ignore their tracked generated files', async () => {
+  for (const pkg of ['sample-protocol', 'development-protocol']) {
+    const ignored = await readFile(
+      path.join(repoRoot, 'packages', pkg, '.gitignore'),
+      'utf8',
+    );
+    const patterns = ignored
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+
+    for (const tracked of ['protocol.json', 'assets/', 'assets']) {
+      assert.ok(
+        !patterns.includes(tracked),
+        `${pkg}/.gitignore must not ignore ${tracked}, which is tracked in Git`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
`packages/sample-protocol` and `packages/development-protocol` track their `protocol.json` and `assets/` in Git, but both also regenerated them from a **`prepare`** script — which pnpm runs on every `pnpm install`.

The sync it ran was `rm -rf assets` followed by a recursive copy, so **every install opened a window in which ten tracked files were genuinely absent from the working tree**. Anything reading the tree during that window — a parallel turbo task, a file watcher, a dev server, CI, a concurrent agent — saw a broken package, and an install interrupted there (Ctrl-C, OOM) left the files deleted until someone thought to `git checkout` them. It also churned mtimes on byte-identical files, busting mtime-keyed caches.

Separately, both `.gitignore` files listed `protocol.json` and `assets/` **while Git tracked them**. `.gitignore` has no effect on already-tracked files, so all this did was leave contributors with regenerated bytes in unrelated diffs and no signal about whether to stage them. History shows it was accidental: the ignore file landed in `8b9440bb8`, and the assets were modified and committed eight days later in `53880ad95`.

## What changed

- **Dropped `prepare` from both packages.** `prepack` still syncs, so `changeset publish` → `pnpm publish` refreshes the copies at the only moment they need refreshing. Installing stops mutating the working tree.
- **Stopped ignoring the tracked files.** `development-protocol` keeps its `Development.netcanvas` entry, which is genuinely build-only.
- **Made the sync atomic and idempotent** as defence in depth, so a `prepack` or a manual run cannot leave a half-state:
  - it writes **nothing** when the target already matches the source (the normal case), so no mtime churn either;
  - when a write is needed, copies are staged under `.sync-tmp/` and swapped in with `rename`. The window where `assets/` does not exist is now two renames rather than a multi-megabyte recursive copy, and the previous contents survive under the staging directory until the new ones are in place.
- **Added `pnpm check:compat-protocols`**, wired into the `quality-support` job, so divergence between a canonical protocol and its compat copy is a red build instead of a silent tree mutation. The check only reads — it cannot leave the tree dirty on failure.

## Verification

- **Precondition re-verified** before changing anything: all four `diff`s between `packages/protocols/{sample,development}` and the compat packages were identical. No drift to reconcile.
- **The bug was reproduced, not assumed.** With a marker `prepare` in place, a cold `pnpm install` printed `packages/sample-protocol prepare$ …`. After the change, a cold install prints no compat-package `prepare` at all.
- **Acceptance test passes**: after `rm -rf node_modules && pnpm install`, `git status --short -- packages/sample-protocol packages/development-protocol` prints nothing, and all 20 asset mtimes are unchanged.
- **Publishing still works**: `pnpm pack` on both packages produces tarballs containing `protocol.json` and all 10 assets, with no `.sync-tmp` leakage. Deliberately corrupting the compat copy (bad `protocol.json`, a deleted asset, a stowaway file) and then packing produced a **correct** tarball and left the tree restored — `prepack` repairs drift exactly as before.
- **`verify-publish-exports.mjs` does not apply here**: it only covers packages carrying a `publishConfig` swap, and neither compat package has one. Direct tarball inspection covers the same ground.
- `pnpm typecheck` ✅ (21/21) · `pnpm lint:fix` ✅ (exit 0, no changes) · `pnpm knip` ✅ (exit 0) · `pnpm test:scripts` ✅ (214 pass, 0 fail)

## No changeset

npm strips lifecycle scripts from the packed manifest, so **the published output does not change**. Packing `@codaco/sample-protocol` from `main` and from this branch produces the same file list and a byte-identical published `package.json` (`"scripts": {}` in both). Per `creating-a-changeset`, this is a tooling change with no consumer-visible effect.

## New tests

`scripts/compat-protocol-sync.test.mjs` (10 tests, in the existing `pnpm test:scripts` lane) covers the diffing, the no-op fast path (asserting mtimes are preserved), the repair path, staging-directory cleanup, and two regression guards: that neither package regains a `prepare` script, and that neither `.gitignore` re-ignores its tracked files. `scripts/ci-workflow.test.mjs` asserts the new CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)