### PR TITLE
ci: give seed-turbo-cache the Postgres the test task needs

### DIFF
--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -428,6 +428,23 @@ jobs:
     # carries the release jobs.
     continue-on-error: true
     runs-on: ubuntu-latest
+    # The `test` task includes the studio-sync and studio-server conformance
+    # suites, which refuse to skip under CI. Without this they abort the whole
+    # `turbo run`, and the job seeds no cache at all — see the `test` job, whose
+    # service this mirrors.
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: spike
+          POSTGRES_DB: studio_dev
+        ports:
+          - 54318:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:


### PR DESCRIPTION
## What

Adds the `postgres:18` service container to the `seed-turbo-cache` job, mirroring the one the `test` job already declares.

## Why

`seed-turbo-cache` warms the Turbo cache on main by running `turbo run build test typecheck`. Since #1401, the `test` task includes the studio-sync and studio-server conformance suites, which probe Postgres on `127.0.0.1:54318` and deliberately **throw rather than skip** when `CI` is set.

That guard is correct and should stay. Skipping silently in CI would report coverage that never ran, and — because the `test` task's hash covers `src/**`, `package.json`, and three declared env vars, but not database availability — the seed job would write a green cache entry for a `test` task that never touched a database, which PR runs would then restore as a hit.

The problem is that only the `test` job got the service container when those suites landed (d1b1a392d). `seed-turbo-cache` runs the same task and did not. On a push to `main` the `test` job is gated off (`github.event_name != 'push'`), so the seed job is the only thing running tests there — and it ran them with no database.

Observed on the merge of #1401 ([run 32274104879](https://github.com/complexdatacollective/network-canvas-monorepo/actions/runs/32274104879)):

```
Error: the sync conformance suites cannot run: 127.0.0.1:54318 is unreachable
       (Error: connect ECONNREFUSED 127.0.0.1:54318)
FAIL src/__tests__/commit.test.ts  [ + 4 more suites ]
```

studio-sync's five suites failed, which aborted the `turbo run` before `@codaco/studio-server:test` executed at all — its group opens in the log and produces no output. So the job seeded no cache for anything at or after that point in the graph, which is the one thing it exists to do.

`continue-on-error: true` (it is cache warming only) kept the push run green, so this surfaced as a red job on a **successful** run rather than a broken `main`. Nothing was blocked; the cache seeding was just silently not happening.

## Why this shape of fix

Considered dropping `test` from the seed job instead. Rejected: the `test` job falls back to a full, unscoped `turbo run test` whenever a PR touches a root config, workflow, script, or the lockfile, and main's seeded cache is what keeps that fallback cheap.

## Verification

The credentials already line up, so no new configuration was needed — `apps/studio/server/.env.development` (loaded by its `vitest.config.ts`) points at `postgres://postgres:spike@127.0.0.1:54318/studio_dev`, and studio-sync defaults to the same port.

Both suites run clean against a matching Postgres with the CI guard armed:

```
CI=true pnpm exec turbo run test --filter=@codaco/studio-sync --filter=@codaco/studio-server --force
  @codaco/studio-sync:test:    Test Files  5 passed (5)
  @codaco/studio-server:test:  Test Files  16 passed (16)
  Tasks: 2 successful, 2 total
```

The parsed service block is identical to the `test` job's. `oxfmt --check` clean, `lint.mjs --changed-from=main` exits 0.

No changeset: workflow-only, no publishable package or app artifact changes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)