### PR TITLE
feat(studio): workspaces as better-auth organizations

### DIFF
--- a/apps/studio/server/src/__tests__/assets.test.ts
+++ b/apps/studio/server/src/__tests__/assets.test.ts
@@ -60,6 +60,7 @@ function signedInApp(override?: StudioEnv) {
   const auth: AuthService = {
     handler: () => Promise.resolve(Response.json({})),
     getSession: () => Promise.resolve(PRINCIPAL),
+    getMembership: () => Promise.resolve(null),
   };
   return createApp(override ?? readEnv(), { auth });
 }
@@ -83,6 +84,7 @@ describe('asset upload authorisation', () => {
     const auth: AuthService = {
       handler: () => Promise.resolve(Response.json({})),
       getSession: () => Promise.resolve(null),
+      getMembership: () => Promise.resolve(null),
     };
     const app = createApp(readEnv(), { auth });
     const res = await app.request('/storage', spaUpload('bytes', 'text/plain'));
@@ -100,6 +102,7 @@ describe('asset upload authorisation', () => {
         lookups += 1;
         return Promise.resolve(PRINCIPAL);
       },
+      getMembership: () => Promise.resolve(null),
     };
     const app = createApp(readEnv(), { auth });
     const res = await app.request('/storage', {
@@ -119,6 +122,7 @@ describe.skipIf(!reachable)('asset retrieval authorisation', () => {
     let lookups = 0;
     const auth: AuthService = {
       handler: () => Promise.resolve(Response.json({})),
+      getMembership: () => Promise.resolve(null),
       getSession: () => {
         lookups += 1;
         return Promise.resolve(null);

--- a/apps/studio/server/src/__tests__/assets.test.ts
+++ b/apps/studio/server/src/__tests__/assets.test.ts
@@ -10,8 +10,9 @@ import {
   createAssetStore,
   deliveryFor,
 } from '../assets.ts';
-import type { AuthService, SessionPrincipal } from '../auth/service.ts';
+import type { SessionPrincipal } from '../auth/service.ts';
 import { readEnv, type StudioEnv } from '../env.ts';
+import { stubAuthService } from './support/auth.ts';
 
 // Integration suite against a real S3-compatible endpoint — the dev MinIO
 // from scripts/dev-s3.ts (or whatever S3_* points at). Skips when no object
@@ -57,11 +58,9 @@ const PRINCIPAL: SessionPrincipal = {
 };
 
 function signedInApp(override?: StudioEnv) {
-  const auth: AuthService = {
-    handler: () => Promise.resolve(Response.json({})),
+  const auth = stubAuthService({
     getSession: () => Promise.resolve(PRINCIPAL),
-    getMembership: () => Promise.resolve(null),
-  };
+  });
   return createApp(override ?? readEnv(), { auth });
 }
 
@@ -81,12 +80,7 @@ const spaUpload = (
 // Both cases refuse before the store is consulted, so they need no MinIO.
 describe('asset upload authorisation', () => {
   it('refuses an unauthenticated upload', async () => {
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
-      getSession: () => Promise.resolve(null),
-      getMembership: () => Promise.resolve(null),
-    };
-    const app = createApp(readEnv(), { auth });
+    const app = createApp(readEnv(), { auth: stubAuthService() });
     const res = await app.request('/storage', spaUpload('bytes', 'text/plain'));
     expect(res.status).toBe(401);
     expect(res.headers.get('Content-Type')).toContain(
@@ -96,14 +90,12 @@ describe('asset upload authorisation', () => {
 
   it('refuses a cross-origin upload before any session lookup', async () => {
     let lookups = 0;
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
+    const auth = stubAuthService({
       getSession: () => {
         lookups += 1;
         return Promise.resolve(PRINCIPAL);
       },
-      getMembership: () => Promise.resolve(null),
-    };
+    });
     const app = createApp(readEnv(), { auth });
     const res = await app.request('/storage', {
       method: 'POST',
@@ -120,14 +112,12 @@ describe.skipIf(!reachable)('asset retrieval authorisation', () => {
     // Assets are fetched from contexts that carry no cookie, and the content
     // address is the capability. A GET must not consult the session at all.
     let lookups = 0;
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
-      getMembership: () => Promise.resolve(null),
+    const auth = stubAuthService({
       getSession: () => {
         lookups += 1;
         return Promise.resolve(null);
       },
-    };
+    });
     const app = createApp(readEnv(), { auth });
     const res = await app.request(`/storage/${'a'.repeat(64)}`);
     expect(res.status).toBe(404);

--- a/apps/studio/server/src/__tests__/auth.test.ts
+++ b/apps/studio/server/src/__tests__/auth.test.ts
@@ -42,6 +42,7 @@ describe('principal resolution', () => {
     const auth: AuthService = {
       handler: () => Promise.resolve(Response.json({})),
       getSession: () => Promise.resolve(PRINCIPAL),
+      getMembership: () => Promise.resolve(null),
     };
     const client = createRpcClient(createApp(readEnv(), { auth }));
     const me = await client.me();
@@ -57,6 +58,7 @@ describe('principal resolution', () => {
     const auth: AuthService = {
       handler: () => Promise.resolve(Response.json({})),
       getSession: () => Promise.resolve(null),
+      getMembership: () => Promise.resolve(null),
     };
     const client = createRpcClient(createApp(readEnv(), { auth }));
     const { error } = await safe(client.me());
@@ -71,6 +73,7 @@ describe('principal resolution', () => {
         getSessionCalls += 1;
         return Promise.resolve(PRINCIPAL);
       },
+      getMembership: () => Promise.resolve(null),
     };
     const app = createApp(readEnv(), { auth });
 
@@ -210,6 +213,64 @@ describe.skipIf(!db)('magic-link sign-in', () => {
 
       const { error } = await safe(createRpcClient(app).me());
       expect(error).toMatchObject({ code: 'UNAUTHORIZED' });
+    } finally {
+      await scratch.dispose();
+    }
+  });
+});
+
+describe.skipIf(!db)('workspaces (organization plugin)', () => {
+  it('creates a workspace and resolves the creator membership', async () => {
+    if (!db || !env.auth) throw new Error('dev env must configure auth');
+    const scratch = await createScratchSchema(db);
+    const pool = scratch.pool;
+    try {
+      await provisionScratchSchema(pool);
+
+      const sent: { email: string; url: string }[] = [];
+      const auth = createBetterAuthService(env.auth, pool, {
+        sendMagicLink: (input) => {
+          sent.push(input);
+          return Promise.resolve();
+        },
+      });
+      const app = createApp(env, { auth });
+      const email = `owner-${Date.now()}@example.com`;
+
+      const send = await app.request('/api/auth/sign-in/magic-link', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'origin': 'http://localhost:5173',
+        },
+        body: JSON.stringify({ email, callbackURL: '/' }),
+      });
+      expect(send.status).toBe(200);
+      const verify = await app.request(sent[0]!.url);
+      const cookie = (verify.headers.get('set-cookie') ?? '').split(';')[0]!;
+      const me = await createRpcClient(app, { cookie }).me();
+
+      // Through the plugin's own endpoint: exercises the drizzle adapter
+      // against the folded workspace tables end to end.
+      const create = await app.request('/api/auth/organization/create', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'origin': 'http://localhost:5173',
+          cookie,
+        },
+        body: JSON.stringify({ name: 'My Study Group', slug: 'my-studies' }),
+      });
+      expect(create.status).toBe(200);
+      const workspace = (await create.json()) as { id: string; slug: string };
+      expect(workspace.slug).toBe('my-studies');
+
+      expect(await auth.getMembership(me.userId, workspace.id)).toEqual({
+        workspaceId: workspace.id,
+        role: 'owner',
+      });
+      expect(await auth.getMembership(me.userId, 'not-a-workspace')).toBeNull();
+      expect(await auth.getMembership('someone-else', workspace.id)).toBeNull();
     } finally {
       await scratch.dispose();
     }

--- a/apps/studio/server/src/__tests__/auth.test.ts
+++ b/apps/studio/server/src/__tests__/auth.test.ts
@@ -255,6 +255,17 @@ describe.skipIf(!db)('workspaces (organization plugin)', () => {
       });
       expect(await auth.getMembership(me.userId, 'not-a-workspace')).toBeNull();
       expect(await auth.getMembership('someone-else', workspace.id)).toBeNull();
+
+      // The plugin only check-then-inserts memberships, so the composite
+      // unique index is what keeps that single-row read unambiguous. Omitting
+      // created_at also exercises its default.
+      await expect(
+        scratch.pool.query(
+          `insert into workspace_members (id, workspace_id, user_id, role)
+           values ($1, $2, $3, 'member')`,
+          ['second-membership', workspace.id, me.userId],
+        ),
+      ).rejects.toThrow(/duplicate key/);
     } finally {
       await scratch.dispose();
     }

--- a/apps/studio/server/src/__tests__/auth.test.ts
+++ b/apps/studio/server/src/__tests__/auth.test.ts
@@ -1,14 +1,16 @@
 import { createORPCClient, safe } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import type { RouterContractClient } from '@orpc/contract';
+import type pg from 'pg';
 import { describe, expect, it } from 'vitest';
 
 import type { contract } from '@codaco/studio-rpc';
 
 import { createApp } from '../app.ts';
 import { createBetterAuthService } from '../auth/better-auth.ts';
-import type { AuthService, SessionPrincipal } from '../auth/service.ts';
+import type { SessionPrincipal } from '../auth/service.ts';
 import { readEnv, type StudioEnv } from '../env.ts';
+import { stubAuthService } from './support/auth.ts';
 import {
   createScratchSchema,
   provisionScratchSchema,
@@ -39,11 +41,9 @@ function createRpcClient(
 
 describe('principal resolution', () => {
   it('resolves the cookie session into the RPC context', async () => {
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
+    const auth = stubAuthService({
       getSession: () => Promise.resolve(PRINCIPAL),
-      getMembership: () => Promise.resolve(null),
-    };
+    });
     const client = createRpcClient(createApp(readEnv(), { auth }));
     const me = await client.me();
     expect(me).toEqual({
@@ -55,11 +55,7 @@ describe('principal resolution', () => {
   });
 
   it('refuses protected procedures without a session', async () => {
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
-      getSession: () => Promise.resolve(null),
-      getMembership: () => Promise.resolve(null),
-    };
+    const auth = stubAuthService();
     const client = createRpcClient(createApp(readEnv(), { auth }));
     const { error } = await safe(client.me());
     expect(error).toMatchObject({ code: 'UNAUTHORIZED' });
@@ -67,14 +63,12 @@ describe('principal resolution', () => {
 
   it('never falls back to the cookie when an Authorization header is present', async () => {
     let getSessionCalls = 0;
-    const auth: AuthService = {
-      handler: () => Promise.resolve(Response.json({})),
+    const auth = stubAuthService({
       getSession: () => {
         getSessionCalls += 1;
         return Promise.resolve(PRINCIPAL);
       },
-      getMembership: () => Promise.resolve(null),
-    };
+    });
     const app = createApp(readEnv(), { auth });
 
     const me = await createRpcClient(app).me();
@@ -166,46 +160,56 @@ const env = readEnv();
 
 const db = await reachableDb();
 
+/**
+ * Signs a fresh user in end to end against a provisioned scratch schema,
+ * asserting each step of the flow. The schema must be freshly provisioned:
+ * the magic-link limit (5/60s per IP) is durable in Postgres and vitest
+ * always resolves to the same localhost key, so counters left by an earlier
+ * run in a shared table would 429 the send.
+ */
+async function signInWithMagicLink(pool: pg.Pool, prefix: string) {
+  if (!env.auth) throw new Error('dev env must configure auth');
+  const sent: { email: string; url: string }[] = [];
+  const auth = createBetterAuthService(env.auth, pool, {
+    sendMagicLink: (input) => {
+      sent.push(input);
+      return Promise.resolve();
+    },
+  });
+  const app = createApp(env, { auth });
+  const email = `${prefix}-${Date.now()}@example.com`;
+
+  const send = await app.request('/api/auth/sign-in/magic-link', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'origin': 'http://localhost:5173',
+    },
+    body: JSON.stringify({ email, callbackURL: '/' }),
+  });
+  expect(send.status).toBe(200);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]?.email).toBe(email);
+
+  const verify = await app.request(sent[0]!.url);
+  expect([302, 200]).toContain(verify.status);
+  const setCookie = verify.headers.get('set-cookie');
+  expect(setCookie).toBeTruthy();
+  const cookie = (setCookie ?? '').split(';')[0]!;
+
+  return { app, auth, email, cookie };
+}
+
 describe.skipIf(!db)('magic-link sign-in', () => {
   it('signs in end to end: send, verify, session, me', async () => {
-    if (!db || !env.auth) throw new Error('dev env must configure auth');
+    if (!db) throw new Error('unreachable');
     const scratch = await createScratchSchema(db);
-    const pool = scratch.pool;
     try {
-      // A fresh schema, so this both builds the tables and guarantees the
-      // empty rate-limit window the send below needs: the magic-link limit
-      // (5/60s per IP) is durable in Postgres and vitest always resolves to
-      // the same localhost key, so counters left by an earlier run in a
-      // shared table would 429 this one.
-      await provisionScratchSchema(pool);
-
-      const sent: { email: string; url: string }[] = [];
-      const auth = createBetterAuthService(env.auth, pool, {
-        sendMagicLink: (input) => {
-          sent.push(input);
-          return Promise.resolve();
-        },
-      });
-      const app = createApp(env, { auth });
-      const email = `researcher-${Date.now()}@example.com`;
-
-      const send = await app.request('/api/auth/sign-in/magic-link', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'origin': 'http://localhost:5173',
-        },
-        body: JSON.stringify({ email, callbackURL: '/' }),
-      });
-      expect(send.status).toBe(200);
-      expect(sent).toHaveLength(1);
-      expect(sent[0]?.email).toBe(email);
-
-      const verify = await app.request(sent[0]!.url);
-      expect([302, 200]).toContain(verify.status);
-      const setCookie = verify.headers.get('set-cookie');
-      expect(setCookie).toBeTruthy();
-      const cookie = (setCookie ?? '').split(';')[0]!;
+      await provisionScratchSchema(scratch.pool);
+      const { app, email, cookie } = await signInWithMagicLink(
+        scratch.pool,
+        'researcher',
+      );
 
       const me = await createRpcClient(app, { cookie }).me();
       expect(me.email).toBe(email);
@@ -221,33 +225,14 @@ describe.skipIf(!db)('magic-link sign-in', () => {
 
 describe.skipIf(!db)('workspaces (organization plugin)', () => {
   it('creates a workspace and resolves the creator membership', async () => {
-    if (!db || !env.auth) throw new Error('dev env must configure auth');
+    if (!db) throw new Error('unreachable');
     const scratch = await createScratchSchema(db);
-    const pool = scratch.pool;
     try {
-      await provisionScratchSchema(pool);
-
-      const sent: { email: string; url: string }[] = [];
-      const auth = createBetterAuthService(env.auth, pool, {
-        sendMagicLink: (input) => {
-          sent.push(input);
-          return Promise.resolve();
-        },
-      });
-      const app = createApp(env, { auth });
-      const email = `owner-${Date.now()}@example.com`;
-
-      const send = await app.request('/api/auth/sign-in/magic-link', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'origin': 'http://localhost:5173',
-        },
-        body: JSON.stringify({ email, callbackURL: '/' }),
-      });
-      expect(send.status).toBe(200);
-      const verify = await app.request(sent[0]!.url);
-      const cookie = (verify.headers.get('set-cookie') ?? '').split(';')[0]!;
+      await provisionScratchSchema(scratch.pool);
+      const { app, auth, cookie } = await signInWithMagicLink(
+        scratch.pool,
+        'owner',
+      );
       const me = await createRpcClient(app, { cookie }).me();
 
       // Through the plugin's own endpoint: exercises the drizzle adapter
@@ -266,7 +251,6 @@ describe.skipIf(!db)('workspaces (organization plugin)', () => {
       expect(workspace.slug).toBe('my-studies');
 
       expect(await auth.getMembership(me.userId, workspace.id)).toEqual({
-        workspaceId: workspace.id,
         role: 'owner',
       });
       expect(await auth.getMembership(me.userId, 'not-a-workspace')).toBeNull();

--- a/apps/studio/server/src/__tests__/csrf.test.ts
+++ b/apps/studio/server/src/__tests__/csrf.test.ts
@@ -1,19 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { createApp } from '../app.ts';
-import type { AuthService } from '../auth/service.ts';
 import { readEnv } from '../env.ts';
-
-function fakeAuthService(): AuthService {
-  return {
-    handler: () => Promise.resolve(Response.json({})),
-    getSession: () => Promise.resolve(null),
-    getMembership: () => Promise.resolve(null),
-  };
-}
+import { stubAuthService } from './support/auth.ts';
 
 function appWithFakeAuth() {
-  return createApp(readEnv(), { auth: fakeAuthService() });
+  return createApp(readEnv(), { auth: stubAuthService() });
 }
 
 describe('cookie-plane CSRF', () => {

--- a/apps/studio/server/src/__tests__/csrf.test.ts
+++ b/apps/studio/server/src/__tests__/csrf.test.ts
@@ -8,6 +8,7 @@ function fakeAuthService(): AuthService {
   return {
     handler: () => Promise.resolve(Response.json({})),
     getSession: () => Promise.resolve(null),
+    getMembership: () => Promise.resolve(null),
   };
 }
 

--- a/apps/studio/server/src/__tests__/schema.test.ts
+++ b/apps/studio/server/src/__tests__/schema.test.ts
@@ -83,6 +83,9 @@ describe.skipIf(!db)('schema verification', () => {
         'user',
         'verification',
         'version_sections',
+        'workspace_invitations',
+        'workspace_members',
+        'workspaces',
       ]);
       expect([...SCHEMA_TABLES].toSorted()).toEqual(
         tables.rows

--- a/apps/studio/server/src/__tests__/support/auth.ts
+++ b/apps/studio/server/src/__tests__/support/auth.ts
@@ -1,0 +1,15 @@
+import type { AuthService } from '../../auth/service.ts';
+
+/**
+ * An AuthService double that answers every method with its null case; tests
+ * state only what they override. Growing the AuthService interface then
+ * touches this file, not every test that stubs it.
+ */
+export function stubAuthService(overrides?: Partial<AuthService>): AuthService {
+  return {
+    handler: () => Promise.resolve(Response.json({})),
+    getSession: () => Promise.resolve(null),
+    getMembership: () => Promise.resolve(null),
+    ...overrides,
+  };
+}

--- a/apps/studio/server/src/auth/better-auth.ts
+++ b/apps/studio/server/src/auth/better-auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { magicLink, organization } from 'better-auth/plugins';
+import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import type pg from 'pg';
 
@@ -115,6 +116,7 @@ export function createBetterAuthService(
   mailer: MagicLinkMailer,
 ): AuthService {
   const auth = createBetterAuthInstance(env, pool, mailer);
+  const db = drizzle({ client: pool });
   return {
     handler: (request) => auth.handler(request),
     getSession: async (headers) => {
@@ -130,14 +132,23 @@ export function createBetterAuthService(
       };
     },
     getMembership: async (userId, workspaceId) => {
-      // Raw pg like every other runtime query: the plugin's api surface is
-      // session-header-driven, and this check is (userId, workspaceId)-keyed.
-      const result = await pool.query<{ role: string }>(
-        'select role from workspace_members where user_id = $1 and workspace_id = $2',
-        [userId, workspaceId],
-      );
-      const row = result.rows[0];
-      return row ? { workspaceId, role: row.role } : null;
+      // Through the drizzle definitions rather than a raw SQL string: the
+      // adapter already queries these tables via drizzle, and this keeps the
+      // physical names single-sourced in auth-schema.ts. The plugin's own api
+      // surface is session-header-driven; this check is (userId, workspaceId)-
+      // keyed, so it queries directly.
+      const members = AUTH_TABLES.workspace_members;
+      const rows = await db
+        .select({ role: members.role })
+        .from(members)
+        .where(
+          and(
+            eq(members.user_id, userId),
+            eq(members.workspace_id, workspaceId),
+          ),
+        )
+        .limit(1);
+      return rows[0] ?? null;
     },
   };
 }

--- a/apps/studio/server/src/auth/better-auth.ts
+++ b/apps/studio/server/src/auth/better-auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { magicLink } from 'better-auth/plugins';
+import { magicLink, organization } from 'better-auth/plugins';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import type pg from 'pg';
 
@@ -75,6 +75,36 @@ export function createBetterAuthInstance(
         storeToken: 'hashed',
         sendMagicLink: ({ email, url }) => mailer.sendMagicLink({ email, url }),
       }),
+      // Workspaces are better-auth organizations (#1249). The tenant boundary
+      // tables keep domain names and snake_case: they are domain tables that
+      // better-auth happens to manage. session stays camelCase like the rest
+      // of the auth core. Invitation email delivery lands with #1256.
+      organization({
+        schema: {
+          session: { fields: { activeOrganizationId: 'activeWorkspaceId' } },
+          organization: {
+            modelName: 'workspaces',
+            fields: { createdAt: 'created_at' },
+          },
+          member: {
+            modelName: 'workspace_members',
+            fields: {
+              organizationId: 'workspace_id',
+              userId: 'user_id',
+              createdAt: 'created_at',
+            },
+          },
+          invitation: {
+            modelName: 'workspace_invitations',
+            fields: {
+              organizationId: 'workspace_id',
+              inviterId: 'inviter_id',
+              expiresAt: 'expires_at',
+              createdAt: 'created_at',
+            },
+          },
+        },
+      }),
     ],
   });
 }
@@ -98,6 +128,16 @@ export function createBetterAuthService(
         name: result.user.name,
         sessionId: result.session.id,
       };
+    },
+    getMembership: async (userId, workspaceId) => {
+      // Raw pg like every other runtime query: the plugin's api surface is
+      // session-header-driven, and this check is (userId, workspaceId)-keyed.
+      const result = await pool.query<{ role: string }>(
+        'select role from workspace_members where user_id = $1 and workspace_id = $2',
+        [userId, workspaceId],
+      );
+      const row = result.rows[0];
+      return row ? { workspaceId, role: row.role } : null;
     },
   };
 }

--- a/apps/studio/server/src/auth/service.ts
+++ b/apps/studio/server/src/auth/service.ts
@@ -13,10 +13,26 @@ export type SessionPrincipal = {
 
 export type Principal = SessionPrincipal;
 
+/**
+ * A user's standing in one workspace. Roles are the organization plugin's
+ * ('owner' | 'admin' | 'member' by default); #1257's RBAC taxonomy maps onto
+ * them later. Kept behind AuthService so better-auth stays replaceable
+ * (#1245) — no other module may read the membership tables.
+ */
+export type WorkspaceMembership = {
+  workspaceId: string;
+  role: string;
+};
+
 export type AuthService = {
   handler(request: Request): Promise<Response>;
   /** Cookie-session lookup; null when absent, expired, or auth is disabled. */
   getSession(headers: Headers): Promise<SessionPrincipal | null>;
+  /** Null when the user is not a member of the workspace (or auth is disabled). */
+  getMembership(
+    userId: string,
+    workspaceId: string,
+  ): Promise<WorkspaceMembership | null>;
 };
 
 export function createDisabledAuthService(): AuthService {
@@ -32,5 +48,6 @@ export function createDisabledAuthService(): AuthService {
         ),
       ),
     getSession: () => Promise.resolve(null),
+    getMembership: () => Promise.resolve(null),
   };
 }

--- a/apps/studio/server/src/auth/service.ts
+++ b/apps/studio/server/src/auth/service.ts
@@ -14,13 +14,13 @@ export type SessionPrincipal = {
 export type Principal = SessionPrincipal;
 
 /**
- * A user's standing in one workspace. Roles are the organization plugin's
- * ('owner' | 'admin' | 'member' by default); #1257's RBAC taxonomy maps onto
- * them later. Kept behind AuthService so better-auth stays replaceable
- * (#1245) — no other module may read the membership tables.
+ * A user's standing in the workspace they were resolved against. Roles are
+ * the organization plugin's ('owner' | 'admin' | 'member' by default);
+ * #1257's RBAC taxonomy maps onto them later. Kept behind AuthService so
+ * better-auth stays replaceable (#1245) — no other module may read the
+ * membership tables.
  */
 export type WorkspaceMembership = {
-  workspaceId: string;
   role: string;
 };
 

--- a/apps/studio/server/src/db/auth-schema.ts
+++ b/apps/studio/server/src/db/auth-schema.ts
@@ -9,6 +9,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 
 const user = pgTable('user', {
@@ -106,7 +107,9 @@ const workspaces = pgTable('workspaces', {
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
   logo: text('logo'),
-  created_at: timestamp('created_at', { withTimezone: true }).notNull(),
+  created_at: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
   metadata: text('metadata'),
 });
 
@@ -121,13 +124,20 @@ const workspace_members = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
     role: text('role').default('member').notNull(),
-    created_at: timestamp('created_at', { withTimezone: true }).notNull(),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
-  // Composite rather than the generated single-column user_id index: the
-  // membership check filters on both columns, and the user_id prefix still
-  // serves "workspaces for this user".
+  // A user holds at most one membership per workspace, enforced here because
+  // the plugin only check-then-inserts: it keeps getMembership's single-row
+  // read unambiguous. The unique index subsumes the generated single-column
+  // workspace_id index; the reversed composite serves "workspaces for this
+  // user".
   (table) => [
-    index('workspace_members_workspace_id_idx').on(table.workspace_id),
+    uniqueIndex('workspace_members_workspace_id_user_id_idx').on(
+      table.workspace_id,
+      table.user_id,
+    ),
     index('workspace_members_user_id_workspace_id_idx').on(
       table.user_id,
       table.workspace_id,

--- a/apps/studio/server/src/db/auth-schema.ts
+++ b/apps/studio/server/src/db/auth-schema.ts
@@ -123,9 +123,15 @@ const workspace_members = pgTable(
     role: text('role').default('member').notNull(),
     created_at: timestamp('created_at', { withTimezone: true }).notNull(),
   },
+  // Composite rather than the generated single-column user_id index: the
+  // membership check filters on both columns, and the user_id prefix still
+  // serves "workspaces for this user".
   (table) => [
     index('workspace_members_workspace_id_idx').on(table.workspace_id),
-    index('workspace_members_user_id_idx').on(table.user_id),
+    index('workspace_members_user_id_workspace_id_idx').on(
+      table.user_id,
+      table.workspace_id,
+    ),
   ],
 );
 

--- a/apps/studio/server/src/db/auth-schema.ts
+++ b/apps/studio/server/src/db/auth-schema.ts
@@ -40,6 +40,7 @@ const session = pgTable(
     userId: text('userId')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
+    activeWorkspaceId: text('activeWorkspaceId'),
   },
   (table) => [index('session_userId_idx').on(table.userId)],
 );
@@ -96,10 +97,69 @@ const rateLimit = pgTable('rateLimit', {
   lastRequest: bigint('lastRequest', { mode: 'number' }).notNull(),
 });
 
+// The organization plugin's tables, renamed to domain vocabulary via the
+// plugin's schema overrides in src/auth/better-auth.ts (#1249). Property keys
+// are snake_case because the drizzle adapter resolves overridden field names
+// against them.
+const workspaces = pgTable('workspaces', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull().unique(),
+  logo: text('logo'),
+  created_at: timestamp('created_at', { withTimezone: true }).notNull(),
+  metadata: text('metadata'),
+});
+
+const workspace_members = pgTable(
+  'workspace_members',
+  {
+    id: text('id').primaryKey(),
+    workspace_id: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    user_id: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role').default('member').notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull(),
+  },
+  (table) => [
+    index('workspace_members_workspace_id_idx').on(table.workspace_id),
+    index('workspace_members_user_id_idx').on(table.user_id),
+  ],
+);
+
+const workspace_invitations = pgTable(
+  'workspace_invitations',
+  {
+    id: text('id').primaryKey(),
+    workspace_id: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    email: text('email').notNull(),
+    role: text('role'),
+    status: text('status').default('pending').notNull(),
+    expires_at: timestamp('expires_at', { withTimezone: true }).notNull(),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    inviter_id: text('inviter_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    index('workspace_invitations_workspace_id_idx').on(table.workspace_id),
+    index('workspace_invitations_email_idx').on(table.email),
+  ],
+);
+
 export const AUTH_TABLES = {
   user,
   session,
   account,
   verification,
   rateLimit,
+  workspaces,
+  workspace_members,
+  workspace_invitations,
 };

--- a/apps/studio/server/src/db/fingerprint.generated.ts
+++ b/apps/studio/server/src/db/fingerprint.generated.ts
@@ -2,4 +2,4 @@
 // Resync after any schema or sidecar change:
 //   pnpm --filter @codaco/studio-server sync-fingerprint
 export const SCHEMA_FINGERPRINT =
-  '396c4e9ee06b0d9e7f11932b264a1e066617fd845b40a19e22cdff481309480c';
+  '02ba7f502ada3bb46a9ff72144b8d0bc57a20ac9815da5ff65473c8c79e276a8';

--- a/apps/studio/server/src/db/fingerprint.generated.ts
+++ b/apps/studio/server/src/db/fingerprint.generated.ts
@@ -2,4 +2,4 @@
 // Resync after any schema or sidecar change:
 //   pnpm --filter @codaco/studio-server sync-fingerprint
 export const SCHEMA_FINGERPRINT =
-  '02ba7f502ada3bb46a9ff72144b8d0bc57a20ac9815da5ff65473c8c79e276a8';
+  'eb09dee806921a5a8bf8ab373ac26c9f66e845d6c3ad8cf8730715b6d056c59a';

--- a/apps/studio/server/src/db/fingerprint.generated.ts
+++ b/apps/studio/server/src/db/fingerprint.generated.ts
@@ -2,4 +2,4 @@
 // Resync after any schema or sidecar change:
 //   pnpm --filter @codaco/studio-server sync-fingerprint
 export const SCHEMA_FINGERPRINT =
-  'eb09dee806921a5a8bf8ab373ac26c9f66e845d6c3ad8cf8730715b6d056c59a';
+  'c20a6e47b727620bab359ea88aaf67d88ca3e3aa308ff998d9fdb5d1c16cf829';


### PR DESCRIPTION
This PR adds the workspace model that the studio tenancy implementation (#1249) will build on.

Studio workspaces are represented as better-auth organizations (via the better-auth organizations plugin) instead of creating our own workspace tables. This lets us use better-auth for workspace membership, invitations, and SSO, but will let us handle tenancy checks ourselves (will be implemented in follow up PRs)

**Database schema:**
Implemented overrides for the better-auth organizations plugin table and field names to match Studio's workspace terminology. This will allow better clarity/consistency. The table names follow the Studio workspace terminology from #1249.
- better-auth `organization` -> `workspaces`
- better-auth `member` -> `workspace_members`
- better-auth `invitations` -> `workspace_invitations`
- better-auth `organization_id` -> `workspace_id`

These tables are added to `auth-schema.ts` along with the existing auth tables.

`session` also gets an `activeWorkspaceId`, so that a user can belong to multiple workspaces and we can keep track of which one is actively selected.

**Auth**
`AuthService` now has `getMembership(userId, workspaceId) → { workspaceId, role } | null`. This gives the app a single place to check if a user belongs to a given workspace, and what their role is within that workspace. 

**Testing**
The e2e auth test signs in with a magic link, creates a workspace using better-auth's organization endpoint, and checks the following:
- the creator is returned as the `owner`
- a user who is not a member returns `null`
- trying to look up a different workspace returns `null`

The schema fingerprint was updated since the db schema changed. 

_______

Second PR under #1249, and the smallest of the three planned: it settles the workspace *model* before the tenancy spine is built on it. Studio workspaces are better-auth organizations — decided over hand-rolled domain tables because per-workspace SSO IdP registration (`@better-auth/sso` scopes provider registration by `organizationId`, per the ADR #1245 SAML spike) and #1256's invitation flows both ride on the plugin, while everything that *enforces* tenancy (`workspace_id` columns, RLS, roles) stays in our own data layer and lands in the next two PRs.

## The tables keep domain names

The plugin's schema overrides (in `src/auth/better-auth.ts`) rename its models to domain vocabulary: `workspaces`, `workspace_members`, `workspace_invitations`, with `organization_id → workspace_id`, so the tenant boundary reads as ours even though better-auth manages the rows. The three tables are folded into `auth-schema.ts` from `@better-auth/cli generate` output per that file's convention — snake_case like the domain tables (they are domain tables that better-auth happens to manage), while the auth core (`user`, `session`, …) keeps its existing camelCase physical names untouched. Property keys on the new tables are snake_case deliberately: the drizzle adapter resolves overridden field names against the TS keys. Timestamps take `withTimezone` per file convention, and the generated `workspaces_slug_uidx` is dropped — the `.unique()` on `slug` already creates one.

`session` gains `activeWorkspaceId` (the plugin's `activeOrganizationId`, camelCase like its siblings). It is UX convenience only — the authz input will be an explicit per-request `workspaceId`, resolved in middleware, per ADR #1248's "every route is workspace-scoped by construction".

Teams stay off (plugin default), sign-up stays open (#1255), and `seed` still writes nothing — the first workspace owner and default workspace remain #1256's.

## The membership seam

`AuthService` gains `getMembership(userId, workspaceId) → { workspaceId, role } | null`. This is the only surface through which membership is ever read: ADR #1245 keeps better-auth replaceable behind the auth seam, and the tenancy middleware in the next PR consumes this method rather than the plugin's session-header-driven API (the check is `(userId, workspaceId)`-keyed). The implementation is a raw parameterized query like every other runtime query — drizzle remains schema-definition plus adapter only.

## Verification

The fingerprint is resynced (one flag day, as with any schema change under the wipe-and-seed posture: existing dev databases report `stale (mismatch)` until `db:reset`). The new end-to-end test signs in via magic link, creates a workspace through the plugin's own `/api/auth/organization/create` endpoint — exercising the adapter against the folded tables and every override — and asserts `getMembership` resolves the creator as `owner` and returns null in both non-member directions. `schema.test.ts`'s table inventory grows to the three new tables; existing `AuthService` test doubles gain the new method.

Types, lint, knip, and both studio test suites (`@codaco/studio-server` 155 passed, `@codaco/studio-sync` 33 passed) are green against the dev Postgres. No changeset: Studio packages are private and pre-release, in no release lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
