### PR TITLE
Release Documentation

### DIFF
--- a/.changeset/quiet-zones-narrate.md
+++ b/.changeset/quiet-zones-narrate.md
@@ -1,5 +1,0 @@
----
-"@codaco/documentation": minor
----
-
-Document the Background Creator — draw responsive canvas backgrounds, define zones, and export ready-to-run Python or R scripts that classify nodes by zone — as the recommended way to build responsive SVG backgrounds, alongside the existing manual template and graphics-editor workflows. Links to the hosted tool at bg-creator.networkcanvas.com and shows it in use with annotated screenshots.

--- a/apps/documentation/CHANGELOG.md
+++ b/apps/documentation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @codaco/documentation
 
+## 0.4.0
+
+### Minor Changes
+
+- Document the Background Creator — draw responsive canvas backgrounds, define zones, and export ready-to-run Python or R scripts that classify nodes by zone — as the recommended way to build responsive SVG backgrounds, alongside the existing manual template and graphics-editor workflows. Links to the hosted tool at bg-creator.networkcanvas.com and shows it in use with annotated screenshots.
+
 ## 0.3.3
 
 ### Patch Changes

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/documentation",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Merging this PR releases `@codaco/documentation` to Netlify **production**.

| Product | From | To |
| --- | --- | --- |
| `@codaco/documentation` | 0.3.3 | 0.4.0 |

### @codaco/documentation@0.4.0

### Minor Changes

- Document the Background Creator — draw responsive canvas backgrounds, define zones, and export ready-to-run Python or R scripts that classify nodes by zone — as the recommended way to build responsive SVG backgrounds, alongside the existing manual template and graphics-editor workflows. Links to the hosted tool at bg-creator.networkcanvas.com and shows it in use with annotated screenshots.
