### PR TITLE
ci(studio): give Studio its own gated changeset release lane

### DIFF
--- a/.agents/skills/creating-a-changeset/SKILL.md
+++ b/.agents/skills/creating-a-changeset/SKILL.md
@@ -14,7 +14,9 @@ released package or app:
   `@codaco/protocol-validation`) — any behaviour/API/type change consumers see.
 - A released app or product: `@codaco/architect`,
   `@codaco/background-creator`, `fresco`, `@codaco/interviewer`,
-  `@codaco/documentation`, or `networkcanvas.com`.
+  `@codaco/documentation`, `networkcanvas.com`, or a Studio package
+  (`@codaco/studio-client`, `@codaco/studio-server`, `@codaco/studio-rpc`,
+  `@codaco/studio-sync`).
 
 Skip it for repository-docs-only, test-only, CI/tooling-only, or internal
 refactors with no consumer-visible effect. Content changes to the released
@@ -27,23 +29,30 @@ Architect, Background Creator, Fresco, and Interviewer use the normal Changesets
 lane alongside libraries. A single changeset may target any combination of
 those normal-lane packages.
 
-Documentation and Website keep independent gated release PRs. CI (`pnpm
-check:changesets`) rejects either product mixed with the normal lane or with the
-other gated product because `changeset version` hard-errors on ignored and
-non-ignored packages in one file. If one feature affects multiple lanes, run
-`pnpm changeset` once per lane.
+Documentation, Website, and Studio keep independent gated release PRs. CI
+(`pnpm check:changesets`) rejects any gated product mixed with the normal lane
+or with another gated lane because `changeset version` hard-errors on ignored
+and non-ignored packages in one file. If one feature affects multiple lanes,
+run `pnpm changeset` once per lane.
 
-| Lane                                                          | Bump type          | Ships via                                      |
-| ------------------------------------------------------------- | ------------------ | ---------------------------------------------- |
-| Libraries, Architect, Background Creator, Fresco, Interviewer | Real semver impact | "Version Packages" PR → npm and/or app release |
-| Documentation                                                 | Real semver impact | "Release Documentation" PR → Netlify + tag     |
-| Website                                                       | Real semver impact | "Release Website" PR → Netlify + tag           |
+The Studio lane spans all four Studio workspace packages —
+`@codaco/studio-client`, `@codaco/studio-server`, `@codaco/studio-rpc`, and
+`@codaco/studio-sync` — so one Studio changeset may name any combination of
+them.
+
+| Lane                                                          | Bump type          | Ships via                                        |
+| ------------------------------------------------------------- | ------------------ | ------------------------------------------------ |
+| Libraries, Architect, Background Creator, Fresco, Interviewer | Real semver impact | "Version Packages" PR → npm and/or app release   |
+| Documentation                                                 | Real semver impact | "Release Documentation" PR → Netlify + tag       |
+| Website                                                       | Real semver impact | "Release Website" PR → Netlify + tag             |
+| Studio                                                        | Real semver impact | "Release Studio" PR → versions + changelogs only |
 
 ## How to author
 
 1. Run `pnpm changeset`.
 2. Select the package(s). Normal-lane libraries and apps may share a changeset;
-   do not combine Documentation or Website with another lane.
+   Studio packages may share a Studio changeset. Do not combine Documentation,
+   Website, or Studio with another lane.
 3. Choose the bump type. It drives the released semver for libraries and apps.
 4. Write the summary as **reader-facing release notes** — it becomes the
    changelog / GitHub release text. For app-facing entries use the

--- a/.agents/skills/regenerating-e2e-visual-snapshots/SKILL.md
+++ b/.agents/skills/regenerating-e2e-visual-snapshots/SKILL.md
@@ -33,8 +33,8 @@ intended baseline changes. Keep generation separate from normal verification.
 The complete Architect, Interview, and Interviewer E2E suites run in CI only for
 the normal Changesets branch `changeset-release/main` and merge groups whose
 library, Architect, or Interviewer versions trigger a release. The independent
-`changeset-release/documentation` and `changeset-release/website` branches ship
-none of the E2E subjects. The required `quality` check conditionally waits for
+`changeset-release/documentation`, `changeset-release/website`, and
+`changeset-release/studio` branches ship none of the E2E subjects. The required `quality` check conditionally waits for
 the selected E2E results. Ordinary PRs skip E2E and never inherit an older E2E
 result.
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,11 @@
     "@codaco/architect-classic",
     "@codaco/interviewer-classic",
     "@codaco/documentation",
-    "networkcanvas.com"
+    "networkcanvas.com",
+    "@codaco/studio-client",
+    "@codaco/studio-rpc",
+    "@codaco/studio-server",
+    "@codaco/studio-sync"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/.github/workflows/ci-and-release.yml
+++ b/.github/workflows/ci-and-release.yml
@@ -1943,9 +1943,9 @@ jobs:
         # changesets/action publish below.
         run: node scripts/verify-publish-exports.mjs
       - name: Hide separately gated product changesets from the normal release
-        # Documentation and Website changesets persist until their own release
-        # PR consumes them. Normal-lane apps intentionally remain for the
-        # Changesets CLI to version alongside library packages.
+        # Documentation, Website, and Studio changesets persist until their own
+        # release PR consumes them. Normal-lane apps intentionally remain for
+        # the Changesets CLI to version alongside library packages.
         # Working-tree-only deletion; see the script header.
         run: node scripts/prune-ignored-changesets.mjs
       - id: changesets
@@ -1973,7 +1973,10 @@ jobs:
 
   # Maintains generated PRs for the products that remain outside the normal
   # "Version Packages" PR. Normal-lane apps use that standard Changesets lane;
-  # Documentation and Website remain independently releasable.
+  # Documentation, Website, and Studio remain independently releasable. The
+  # Studio lane names all four Studio workspace packages so its release PR
+  # consumes changesets for either deployable half or the private boundary
+  # packages.
   product-release-pr:
     name: Release PR (${{ matrix.product }})
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -1987,6 +1990,13 @@ jobs:
           - product: Website
             slug: website
             package_args: "--package 'networkcanvas.com'"
+          - product: Studio
+            slug: studio
+            package_args: >-
+              --package '@codaco/studio-client'
+              --package '@codaco/studio-rpc'
+              --package '@codaco/studio-server'
+              --package '@codaco/studio-sync'
     runs-on: ubuntu-latest
     concurrency:
       group: product-release-pr-${{ matrix.slug }}

--- a/.github/workflows/open-e2e-snapshot-update-pr.yml
+++ b/.github/workflows/open-e2e-snapshot-update-pr.yml
@@ -46,6 +46,7 @@ jobs:
             const releaseRefs = new Set([
               'changeset-release/documentation',
               'changeset-release/main',
+              'changeset-release/studio',
               'changeset-release/website',
             ]);
             const snapshotBranch = 'e2e-snapshots/main';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,11 +145,16 @@ pnpm publish-packages
   npm; changed apps deploy and receive a GitHub release after that PR merges —
   Architect, Background Creator, and Interviewer to Netlify, Fresco via the
   mirror described below.
-- **Separately gated products** are Documentation and networkcanvas.com. They
-  keep independent stable-semver release PRs, production deploys, and Git tags.
+- **Separately gated products** are Documentation, networkcanvas.com, and
+  Studio. Documentation and Website keep independent stable-semver release PRs,
+  production deploys, and Git tags. The Studio lane covers all four Studio
+  workspace packages (`@codaco/studio-client`, `@codaco/studio-server`,
+  `@codaco/studio-rpc`, `@codaco/studio-sync`); its release PR records versions
+  and changelogs only — Studio has no automated production deploy lane yet.
 - **One release lane per changeset.** A normal-lane changeset may combine
-  libraries, Architect, Background Creator, Interviewer, and Fresco. Never mix
-  Documentation or Website with the normal lane or with each other; the
+  libraries, Architect, Background Creator, Interviewer, and Fresco. A Studio
+  changeset may combine the Studio packages. Never mix Documentation, Website,
+  or Studio with the normal lane or with another gated lane; the
   `pnpm check:changesets` guard rejects it.
 - See the `creating-a-changeset` skill and
   `docs/superpowers/specs/2026-08-03-stable-app-release-design.md`.
@@ -376,8 +381,8 @@ unrecognised paths, or unreadable history.
 Generated release branches (`changeset-release/*`) keep their release-aware
 selection: only suites whose subjects ship in that release lane run. The normal
 Changesets lane (`changeset-release/main`) runs all three because it versions
-libraries, Architect, and Interviewer; the Documentation and Website lanes run
-none. The mapping and feature-PR classifier live in
+libraries, Architect, and Interviewer; the Documentation, Website, and Studio
+lanes run none. The mapping and feature-PR classifier live in
 `scripts/release-e2e-policy.mjs`, with tests derived from the real package.json
 dependency graph. The required `quality` check requires exactly the suites the
 policy selects.

--- a/scripts/changeset-app-utils.mjs
+++ b/scripts/changeset-app-utils.mjs
@@ -7,19 +7,36 @@ import { join } from 'node:path';
 export const GATED_PRODUCT_PACKAGES = [
   '@codaco/documentation',
   'networkcanvas.com',
+  '@codaco/studio-client',
+  '@codaco/studio-rpc',
+  '@codaco/studio-server',
+  '@codaco/studio-sync',
 ];
 
 export const GATED_PRODUCT_DIRS = {
   '@codaco/documentation': 'apps/documentation',
   'networkcanvas.com': 'apps/networkcanvas.com',
+  '@codaco/studio-client': 'apps/studio/client',
+  '@codaco/studio-rpc': 'packages/studio-rpc',
+  '@codaco/studio-server': 'apps/studio/server',
+  '@codaco/studio-sync': 'packages/studio-sync',
 };
 
-// Documentation and Website keep separately generated release PRs because they
-// deploy independently from the normal Changesets lane. Architect and
-// Interviewer are private packages in that normal lane alongside libraries.
+// Documentation, Website, and Studio keep separately generated release PRs
+// because they release independently from the normal Changesets lane.
+// Architect and Interviewer are private packages in that normal lane alongside
+// libraries. The Studio lane spans all four Studio workspace packages — the
+// two deployable halves plus their private boundary packages — so a Studio
+// changeset can name any of them without touching the normal lane.
 export const GATED_PRODUCT_RELEASE_LANES = {
   documentation: ['@codaco/documentation'],
   website: ['networkcanvas.com'],
+  studio: [
+    '@codaco/studio-client',
+    '@codaco/studio-rpc',
+    '@codaco/studio-server',
+    '@codaco/studio-sync',
+  ],
 };
 
 export function releaseLaneForProduct(

--- a/scripts/changeset-app-utils.test.mjs
+++ b/scripts/changeset-app-utils.test.mjs
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 
 import {
   classifyChangeset,
+  GATED_PRODUCT_PACKAGES,
   isMixedChangeset,
   isMultiProductLaneChangeset,
   nextStableVersion,
@@ -22,6 +23,19 @@ test('normal Changesets versions private Architect and Interviewer packages', ()
   assert.deepEqual(config.privatePackages, { version: true, tag: false });
   assert.ok(!config.ignore.includes('@codaco/architect'));
   assert.ok(!config.ignore.includes('@codaco/interviewer'));
+});
+
+test('every separately gated product is in the changesets ignore list', () => {
+  // `changeset version` must never consume a gated product's changesets — a
+  // gated package missing from `ignore` rides the normal Version Packages PR
+  // (dependency bumps included), which is exactly the lane split this module
+  // exists to prevent.
+  const config = JSON.parse(
+    readFileSync(new URL('../.changeset/config.json', import.meta.url), 'utf8'),
+  );
+  for (const pkg of GATED_PRODUCT_PACKAGES) {
+    assert.ok(config.ignore.includes(pkg), `${pkg} must be ignored`);
+  }
 });
 
 test('parseChangeset extracts releases and summary', () => {
@@ -102,6 +116,10 @@ test('releaseLaneForProduct maps only separately gated products', () => {
   assert.equal(releaseLaneForProduct('@codaco/interviewer'), null);
   assert.equal(releaseLaneForProduct('@codaco/documentation'), 'documentation');
   assert.equal(releaseLaneForProduct('@codaco/interview'), null);
+  assert.equal(releaseLaneForProduct('@codaco/studio-client'), 'studio');
+  assert.equal(releaseLaneForProduct('@codaco/studio-rpc'), 'studio');
+  assert.equal(releaseLaneForProduct('@codaco/studio-server'), 'studio');
+  assert.equal(releaseLaneForProduct('@codaco/studio-sync'), 'studio');
 });
 
 test('isMultiProductLaneChangeset allows products in one release lane', () => {
@@ -113,9 +131,23 @@ test('isMultiProductLaneChangeset allows products in one release lane', () => {
       { name: 'networkcanvas.com', type: 'patch' },
     ],
   };
+  const studioLane = {
+    releases: [
+      { name: '@codaco/studio-server', type: 'minor' },
+      { name: '@codaco/studio-sync', type: 'patch' },
+    ],
+  };
+  const studioPlusDocs = {
+    releases: [
+      { name: '@codaco/studio-server', type: 'minor' },
+      { name: '@codaco/documentation', type: 'patch' },
+    ],
+  };
   assert.equal(isMultiProductLaneChangeset(app), false);
   assert.equal(isMultiProductLaneChangeset(lib), false);
   assert.equal(isMultiProductLaneChangeset(twoLanes), true);
+  assert.equal(isMultiProductLaneChangeset(studioLane), false);
+  assert.equal(isMultiProductLaneChangeset(studioPlusDocs), true);
 });
 
 test('nextStableVersion applies the highest requested semver bump', () => {

--- a/scripts/check-changeset-app-isolation.test.mjs
+++ b/scripts/check-changeset-app-isolation.test.mjs
@@ -46,6 +46,22 @@ test('allows normal-lane apps to share a changeset', () => {
   assert.equal(run(cwd).status, 0);
 });
 
+test('allows the studio packages to share a changeset within their lane', () => {
+  const cwd = fixture({
+    'studio.md': `---\n"@codaco/studio-server": minor\n"@codaco/studio-rpc": patch\n"@codaco/studio-sync": patch\n---\n\nstudio change`,
+  });
+  assert.equal(run(cwd).status, 0);
+});
+
+test('fails when a changeset mixes a studio package with the normal lane', () => {
+  const cwd = fixture({
+    'mixed-studio.md': `---\n"@codaco/studio-server": minor\n"@codaco/protocol-validation": patch\n---\n\nmixed`,
+  });
+  const res = run(cwd);
+  assert.equal(res.status, 1);
+  assert.match(res.stderr, /mixed-studio\.md/);
+});
+
 test('fails and names the file when a changeset mixes product lanes', () => {
   const cwd = fixture({
     'coupled.md': `---\n"@codaco/documentation": minor\n"networkcanvas.com": patch\n---\n\ncoupled`,

--- a/scripts/chromatic-affected.mjs
+++ b/scripts/chromatic-affected.mjs
@@ -28,6 +28,7 @@ const LOCKFILE_GRAPH_KEYS = new Set([
 const RELEASE_REFS = new Set([
   'changeset-release/documentation',
   'changeset-release/main',
+  'changeset-release/studio',
   'changeset-release/website',
 ]);
 const SPECIAL_PATHS = new Set(['pnpm-lock.yaml', 'pnpm-workspace.yaml']);
@@ -407,6 +408,7 @@ export function applyReleaseSeeds({
   }
   if (
     releaseRef === 'changeset-release/documentation' ||
+    releaseRef === 'changeset-release/studio' ||
     releaseRef === 'changeset-release/website'
   ) {
     return;

--- a/scripts/chromatic-affected.test.mjs
+++ b/scripts/chromatic-affected.test.mjs
@@ -409,9 +409,10 @@ test('adds dependency-aware library seeds in the normal Changesets lane', () => 
   );
 });
 
-test('does not seed documentation and website release lanes', () => {
+test('does not seed documentation, website, and studio release lanes', () => {
   for (const releaseRef of [
     'changeset-release/documentation',
+    'changeset-release/studio',
     'changeset-release/website',
   ]) {
     expectAffected(classify({ releaseRef }), NONE);

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { GATED_PRODUCT_RELEASE_LANES } from './changeset-app-utils.mjs';
 import { E2E_JOB_NAMES } from './release-e2e-policy.mjs';
 
 const workflow = readFileSync(
@@ -477,6 +478,27 @@ test('generated release PRs use the dedicated PAT and rely on native PR CI', () 
   );
   assert.doesNotMatch(productReleaseJob, /gh workflow run ci-and-release\.yml/);
   assert.doesNotMatch(productReleaseJob, /actions: write/);
+});
+
+test('product release PR matrix covers every gated release lane completely', () => {
+  // The matrix and GATED_PRODUCT_RELEASE_LANES must not drift: a lane missing
+  // here never gets a release PR, and a lane package missing from package_args
+  // makes version-gated-products.mjs reject the invocation as incomplete.
+  const productReleaseJob = job('product-release-pr');
+  assert.ok(productReleaseJob, 'product release PR job exists');
+  for (const [lane, packages] of Object.entries(GATED_PRODUCT_RELEASE_LANES)) {
+    assert.match(
+      productReleaseJob,
+      new RegExp(`slug: ${lane}\\b`),
+      `matrix has an entry for the ${lane} lane`,
+    );
+    for (const pkg of packages) {
+      assert.ok(
+        productReleaseJob.includes(`--package '${pkg}'`),
+        `${lane} lane passes --package '${pkg}'`,
+      );
+    }
+  }
 });
 
 test('normal-lane apps do not get separate generated release PRs', () => {

--- a/scripts/release-e2e-policy.mjs
+++ b/scripts/release-e2e-policy.mjs
@@ -445,10 +445,12 @@ function suites(...keys) {
 
 // Maximum suite set for each release lane. The normal Changesets lane versions
 // libraries, Architect, and Interviewer, so it always keeps all three suites.
-// Documentation and Website ship none of the suite subjects and need no E2E.
+// Documentation, Website, and Studio ship none of the suite subjects and need
+// no E2E.
 export const SUITES_BY_RELEASE_REF = {
   'changeset-release/documentation': suites(),
   'changeset-release/main': suites('interview', 'interviewer', 'architect'),
+  'changeset-release/studio': suites(),
   'changeset-release/website': suites(),
 };
 

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -271,6 +271,7 @@ test('all release policies share the central snapshot PR target', () => {
     ['pull_request', 'changeset-release/main'],
     ['workflow_dispatch', NORMAL_RELEASE_REF],
     ['workflow_dispatch', 'changeset-release/documentation'],
+    ['workflow_dispatch', 'changeset-release/studio'],
     ['workflow_dispatch', 'changeset-release/website'],
   ]) {
     assert.deepEqual(

--- a/scripts/release-e2e-policy.test.mjs
+++ b/scripts/release-e2e-policy.test.mjs
@@ -115,7 +115,14 @@ test('release lane suites match the workspace dependency graph', () => {
   // the real package.json files so SUITES_BY_RELEASE_REF cannot silently
   // drift when an app gains or drops a suite subject as a dependency.
   const dependenciesByName = new Map();
-  for (const group of ['packages', 'apps', 'tooling', 'workers']) {
+  // apps/studio nests its two deployable halves one level deeper.
+  for (const group of [
+    'packages',
+    'apps',
+    'apps/studio',
+    'tooling',
+    'workers',
+  ]) {
     for (const entry of readdirSync(join(REPO_ROOT, group), {
       withFileTypes: true,
     })) {
@@ -150,6 +157,12 @@ test('release lane suites match the workspace dependency graph', () => {
   const productLanes = {
     [NORMAL_RELEASE_REF]: ['@codaco/architect', '@codaco/interviewer'],
     'changeset-release/documentation': ['@codaco/documentation'],
+    'changeset-release/studio': [
+      '@codaco/studio-client',
+      '@codaco/studio-rpc',
+      '@codaco/studio-server',
+      '@codaco/studio-sync',
+    ],
     'changeset-release/website': ['networkcanvas.com'],
   };
   for (const [releaseRef, products] of Object.entries(productLanes)) {

--- a/scripts/version-gated-products.mjs
+++ b/scripts/version-gated-products.mjs
@@ -85,15 +85,33 @@ export function applyProductReleases(cwd, plans, consumed) {
   }
 }
 
+// What merging each lane's release PR actually does. Documentation and
+// Website deploy to production from their release jobs; Studio has no
+// automated deploy lane yet, so its release PR only records versions and
+// changelogs.
+const LANE_MERGE_EFFECTS = {
+  documentation: (products) =>
+    `Merging this PR releases ${products} to Netlify **production**.`,
+  website: (products) =>
+    `Merging this PR releases ${products} to Netlify **production**.`,
+  studio: (products) =>
+    `Merging this PR versions ${products} and records the changelog entries below. Studio has no automated production deploy lane yet.`,
+};
+
 export function renderPrBody(plans) {
   if (plans.length === 0) return 'No product changes pending.\n';
   const lanes = new Set(plans.map((plan) => releaseLaneForProduct(plan.pkg)));
   if (lanes.size !== 1 || lanes.has(null)) {
     throw new Error('Each release PR must contain exactly one product lane.');
   }
+  const [lane] = lanes;
+  const mergeEffect = LANE_MERGE_EFFECTS[lane];
+  if (!mergeEffect) {
+    throw new Error(`Release lane "${lane}" has no merge-effect description.`);
+  }
   const products = plans.map((plan) => `\`${plan.pkg}\``);
   const lines = [
-    `Merging this PR releases ${products.join(' and ')} to Netlify **production**.`,
+    mergeEffect(products.join(' and ')),
     '',
     '| Product | From | To |',
     '| --- | --- | --- |',

--- a/scripts/version-gated-products.test.mjs
+++ b/scripts/version-gated-products.test.mjs
@@ -46,6 +46,19 @@ function workspace() {
       2,
     ),
   );
+  const studioPackages = {
+    '@codaco/studio-client': 'apps/studio/client',
+    '@codaco/studio-rpc': 'packages/studio-rpc',
+    '@codaco/studio-server': 'apps/studio/server',
+    '@codaco/studio-sync': 'packages/studio-sync',
+  };
+  for (const [name, dir] of Object.entries(studioPackages)) {
+    mkdirSync(join(cwd, dir), { recursive: true });
+    writeFileSync(
+      join(cwd, dir, 'package.json'),
+      JSON.stringify({ name, version: '0.1.0', private: true }, null, 2),
+    );
+  }
   return cwd;
 }
 
@@ -152,6 +165,59 @@ test('validateTargetPackages requires one complete lane', () => {
     validateTargetPackages(['@codaco/documentation', 'networkcanvas.com']),
     null,
   );
+  const studioLane = [
+    '@codaco/studio-client',
+    '@codaco/studio-rpc',
+    '@codaco/studio-server',
+    '@codaco/studio-sync',
+  ];
+  assert.deepEqual(validateTargetPackages(studioLane), studioLane);
+  assert.equal(validateTargetPackages(['@codaco/studio-server']), null);
+  assert.equal(
+    validateTargetPackages([...studioLane, '@codaco/documentation']),
+    null,
+  );
+});
+
+test('versions the studio lane packages that have changesets and consumes only studio changesets', () => {
+  const cwd = workspace();
+  writeFileSync(
+    join(cwd, '.changeset/server.md'),
+    `---\n"@codaco/studio-server": minor\n"@codaco/studio-sync": patch\n---\n\nSync leases`,
+  );
+  writeFileSync(
+    join(cwd, '.changeset/keep.md'),
+    `---\n"@codaco/interview": patch\n---\n\nnormal lane`,
+  );
+
+  const studioLane = [
+    '@codaco/studio-client',
+    '@codaco/studio-rpc',
+    '@codaco/studio-server',
+    '@codaco/studio-sync',
+  ];
+  const { plans, consumed } = planProductReleases(cwd, studioLane);
+  applyProductReleases(cwd, plans, consumed);
+
+  const server = JSON.parse(
+    readFileSync(join(cwd, 'apps/studio/server/package.json'), 'utf8'),
+  );
+  assert.equal(server.version, '0.2.0');
+  const sync = JSON.parse(
+    readFileSync(join(cwd, 'packages/studio-sync/package.json'), 'utf8'),
+  );
+  assert.equal(sync.version, '0.1.1');
+  const client = JSON.parse(
+    readFileSync(join(cwd, 'apps/studio/client/package.json'), 'utf8'),
+  );
+  assert.equal(client.version, '0.1.0');
+  assert.equal(existsSync(join(cwd, '.changeset/server.md')), false);
+  assert.equal(existsSync(join(cwd, '.changeset/keep.md')), true);
+
+  const body = renderPrBody(plans);
+  assert.match(body, /versions `@codaco\/studio-server`/);
+  assert.match(body, /no automated production deploy lane yet/);
+  assert.doesNotMatch(body, /Netlify \*\*production\*\*/);
 });
 
 test('creates a normal semver documentation release and changelog', () => {


### PR DESCRIPTION
## Summary

The open Version Packages PR (#1342) contains `@codaco/studio-server@0.1.1` — a dependency-driven patch bump (`Updated dependencies` on `@codaco/protocol-validation` and `@codaco/shared-consts`) that `changeset version` produced because studio-server is a versioned private package missing from the changeset `ignore` list. Studio should not release through the normal lane at all. This PR moves all four Studio workspace packages — `@codaco/studio-client`, `@codaco/studio-server`, `@codaco/studio-rpc`, and `@codaco/studio-sync` — into a dedicated gated release lane modelled on Documentation and Website.

The lane includes the two boundary packages, not just the deployables, deliberately: a package that is in the changesets `ignore` list but absent from `GATED_PRODUCT_PACKAGES` would let a changeset mix it with a normal-lane package past the `check:changesets` guard, and that mixed file then hard-errors `changeset version` on `main` — the exact failure mode the guard exists to catch on the PR instead.

### How the lane works

- **`.changeset/config.json`** adds the four Studio packages to `ignore`, so the normal lane can never version them again (including dependency bumps). The stale `studio-server@0.1.1` bump on `changeset-release/main` disappears the next time the changesets action regenerates that branch from `main`.
- **`scripts/changeset-app-utils.mjs`** registers them in `GATED_PRODUCT_PACKAGES`/`GATED_PRODUCT_DIRS` and adds a `studio` lane to `GATED_PRODUCT_RELEASE_LANES`. `pnpm check:changesets` therefore rejects Studio mixed with the normal lane or with another gated lane, while one Studio changeset may name any combination of the four packages.
- **`ci-and-release.yml`** adds a Studio entry to the `product-release-pr` matrix, so pushes to `main` maintain a generated **Release Studio** PR on `changeset-release/studio` that versions the Studio packages, writes their changelogs, and consumes their changesets. The prune step already handles the new ignored lane generically.
- **`scripts/version-gated-products.mjs`** makes the release-PR body lane-aware: Documentation and Website keep "releases … to Netlify **production**", while the Studio body says merging records versions and changelogs only — Studio has no automated production deploy lane yet (its Netlify site builds independently for branch previews).
- **`scripts/release-e2e-policy.mjs`** registers `changeset-release/studio` as requiring no E2E suites: no Studio package has `@codaco/interview`, `@codaco/interviewer`, or `@codaco/architect` in its dependency closure. The graph-derived lane test verifies this against the real manifests, with discovery extended to the nested `apps/studio/*` workspaces. `open-e2e-snapshot-update-pr.yml` adds the ref to its known-release-branch set for consistency with the other no-suite lanes.

### Anti-drift tests

- Every package in `GATED_PRODUCT_PACKAGES` must appear in the changesets `ignore` list — the invariant whose absence caused this bug.
- The `product-release-pr` matrix must cover every lane in `GATED_PRODUCT_RELEASE_LANES` with its complete `--package` set (an incomplete set is rejected by `validateTargetPackages` at runtime; the test catches it at review time).
- Lane behaviour coverage in the utils, version, and isolation-guard tests, including a full plan/apply/render pass for a Studio release.

CLAUDE.md and the `creating-a-changeset` and `regenerating-e2e-visual-snapshots` skills now document the Studio lane. No changeset: this is CI/release tooling only.

## Test plan

- [x] `node --test scripts/*.test.mjs` — 220 pass on this base
- [x] `pnpm check:changesets` passes; `changeset status` shows no Studio package in the pending bumps
- [x] `pnpm lint:fix` and `pnpm knip` clean; workflow YAML parse-verified
- [x] No visual-baseline impact (CI/tooling/docs only — no app or package source touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUk51j561FG3mBXs4xibXg