### PR TITLE
chore(release): group dependency changelog entries

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "../scripts/changeset-changelog.mjs",
   "commit": false,
   "format": "oxfmt",
   "fixed": [],

--- a/scripts/changeset-changelog.mjs
+++ b/scripts/changeset-changelog.mjs
@@ -1,0 +1,30 @@
+import defaultChangelog from '@changesets/cli/changelog';
+
+const COMMIT_URL =
+  'https://github.com/complexdatacollective/network-canvas-monorepo/commit/';
+
+export function getDependencyReleaseLine(changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) return '';
+
+  const commits = [
+    ...new Set(
+      changesets
+        .map((changeset) => changeset.commit)
+        .filter((commit) => commit !== undefined),
+    ),
+  ];
+  const commitLinks = commits.map(
+    (commit) => `[${commit.slice(0, 7)}](${COMMIT_URL}${commit})`,
+  );
+  const links = commitLinks.length > 0 ? ` (${commitLinks.join(', ')})` : '';
+  const dependencyLines = dependenciesUpdated.map(
+    (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+  );
+
+  return [`- Updated dependencies${links}`, ...dependencyLines].join('\n');
+}
+
+export default {
+  ...defaultChangelog,
+  getDependencyReleaseLine,
+};

--- a/scripts/changeset-changelog.test.mjs
+++ b/scripts/changeset-changelog.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import changelog, { getDependencyReleaseLine } from './changeset-changelog.mjs';
+
+const firstCommit = '1111111aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const secondCommit = '2222222bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const commitUrl =
+  'https://github.com/complexdatacollective/network-canvas-monorepo/commit/';
+
+test('groups dependency changes into one item with unique commit links', () => {
+  const line = getDependencyReleaseLine(
+    [
+      { commit: firstCommit },
+      { commit: secondCommit },
+      { commit: firstCommit },
+    ],
+    [
+      { name: '@codaco/fresco-ui', newVersion: '6.1.0' },
+      { name: '@codaco/interview', newVersion: '9.0.0' },
+    ],
+  );
+
+  assert.equal(
+    line,
+    `- Updated dependencies ([1111111](${commitUrl}${firstCommit}), [2222222](${commitUrl}${secondCommit}))
+  - @codaco/fresco-ui@6.1.0
+  - @codaco/interview@9.0.0`,
+  );
+});
+
+test('keeps a single dependency item when commit metadata is unavailable', () => {
+  assert.equal(
+    getDependencyReleaseLine(
+      [{ commit: undefined }],
+      [{ name: '@codaco/shared-consts', newVersion: '6.0.0' }],
+    ),
+    `- Updated dependencies
+  - @codaco/shared-consts@6.0.0`,
+  );
+});
+
+test('omits the dependency item when no dependencies changed', () => {
+  assert.equal(getDependencyReleaseLine([{ commit: firstCommit }], []), '');
+});
+
+test('retains the standard formatter for direct release notes', () => {
+  assert.equal(
+    changelog.getReleaseLine({
+      commit: firstCommit,
+      summary: 'Describe the direct change.',
+    }),
+    '- 1111111: Describe the direct change.',
+  );
+});


### PR DESCRIPTION
## Summary
- replace the default Changesets changelog formatter with a wrapper that preserves direct release notes
- collapse propagated dependency updates into one item with deduplicated links to every relevant commit
- keep the updated package/version list nested under that single item for future generated release PRs

## Test plan
- [x] `pnpm lint:fix`
- [x] `pnpm test:scripts` (224 tests)
- [x] `pnpm check:changesets`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] run `changeset version` against the current pending release set in a disposable worktree and verify Architect produces one dependency item with 18 commit links after Oxfmt
- [x] assess E2E visual baselines; release-only Node tooling cannot affect rendered pixels or captured app state

No changeset: this is repository release tooling and does not change a released app or package.