### PR TITLE
fix(fresco-ui): stop the toolbar flashing a scrollbar as its segments swap

### DIFF
--- a/.agents/skills/creating-a-changeset/SKILL.md
+++ b/.agents/skills/creating-a-changeset/SKILL.md
@@ -32,25 +32,29 @@ whether the behaviour it corrects reached a release before deciding.
 
 Verify it; do not assume from the calendar. "Landed recently" is not
 "unreleased" — a package can ship several times a week — and the answer differs
-per package, because each has its own tag. Find the commit that introduced the
-behaviour you are fixing, then ask whether it is an ancestor of that package's
-newest release tag:
+per package, because each has its own tags. Find the commit that introduced the
+behaviour you are fixing, then ask which of that package's releases contain it:
 
 ```sh
 # What introduced it — `git log -S` finds the commit that added the code
 git log -S 'the-telltale-code' --oneline -- path/to/file.tsx
 
 # Then, per affected package: did that commit ship?
-git fetch --tags --quiet
 shipped_in() { # shipped_in <commit> <package>
-  tag=$(git tag --list "$2@*" --sort=-version:refname | head -1)
-  [ -n "$tag" ] || { echo "$2: NO RELEASE TAG — never published?"; return 2; }
-  git merge-base --is-ancestor "$1" "$tag"
-  case $? in
-    0) echo "$2: SHIPPED in $tag" ;;
-    1) echo "$2: unreleased (newest is $tag)" ;;
-    *) echo "$2: CANNOT TELL — bad commit, or tags not fetched"; return 2 ;;
-  esac
+  local tags
+  git fetch --tags --quiet || {
+    echo "$2: CANNOT TELL — tag fetch failed, local tags may be stale"
+    return 2
+  }
+  tags=$(git tag --list "$2@*" --contains "$1") || {
+    echo "$2: CANNOT TELL — is '$1' a valid commit?"
+    return 2
+  }
+  if [ -n "$tags" ]; then
+    echo "$2: SHIPPED in $(echo $tags)"
+  else
+    echo "$2: unreleased"
+  fi
 }
 
 shipped_in 839aefd11 '@codaco/fresco-ui'
@@ -64,18 +68,25 @@ shipped_in 839aefd11 '@codaco/fresco-ui'
 - **The pending changeset describes the behaviour you just changed** → edit
   that changeset rather than adding a second one. Two notes about one shipped
   behaviour read as two changes.
+- **A Studio package** → this question does not apply. The Studio lane has no
+  tags and no deploy lane yet (its release PR "records versions and changelogs
+  only"), so nothing Studio has reached anyone, and its changesets exist to
+  build the changelog its first release will carry. Write them regardless.
 
-Both guards are load-bearing, and both failures point the same way — towards
-dropping a release note that was needed:
+Two things about the shape of that function, both learned the hard way:
 
-- `--sort=-version:refname`, because the default refname sort is
-  lexicographic: `…@6.10.0` sorts _before_ `…@6.9.0`. Today
-  `git tag --list '@codaco/protocol-validation@*' | tail -1` answers `9.0.0`
-  when the newest release is `12.1.1`, so a defect shipped any time in the
-  last three majors would read as unreleased.
-- `case $?` rather than `&& … || …`, because `--is-ancestor` exits 1 for "no"
-  but 128 for "could not tell" — an unfetched tag, a mistyped commit. A
-  `||` branch calls both of those "unreleased".
+- It asks **which releases contain the commit**, not "what is the newest tag".
+  Naming the newest tag needs version ordering, and version ordering is where
+  this goes wrong. `git tag --list '<pkg>@*' | tail -1` is lexicographic, so
+  `…@6.10.0` sorts before `…@6.9.0` — today it answers
+  `@codaco/protocol-validation@9.0.0` when the newest release is `12.1.1`. Even
+  `--sort=-version:refname` puts `pkg@1.0.0-rc.1` above `pkg@1.0.0`, which is
+  not academic while Architect ships `-beta` tags. `--contains` needs no order.
+- **Every failure is a refusal, never a "no".** A mistyped commit exits 129, an
+  unreachable remote exits 128, and a stale local tag set would answer
+  "unreleased" with total confidence. Each one returns `CANNOT TELL` instead,
+  because the wrong answer here is the silent one: a release note that needed
+  writing and never got written.
 
 This is about the defect, not the diff. A fix that also changes behaviour
 beyond restoring the original intent still needs a changeset for that part.

--- a/.agents/skills/creating-a-changeset/SKILL.md
+++ b/.agents/skills/creating-a-changeset/SKILL.md
@@ -40,12 +40,20 @@ newest release tag:
 # What introduced it — `git log -S` finds the commit that added the code
 git log -S 'the-telltale-code' --oneline -- path/to/file.tsx
 
-# Newest release tag for each affected package
-git tag --list '@codaco/fresco-ui@*' | tail -1
+# Then, per affected package: did that commit ship?
+git fetch --tags --quiet
+shipped_in() { # shipped_in <commit> <package>
+  tag=$(git tag --list "$2@*" --sort=-version:refname | head -1)
+  [ -n "$tag" ] || { echo "$2: NO RELEASE TAG — never published?"; return 2; }
+  git merge-base --is-ancestor "$1" "$tag"
+  case $? in
+    0) echo "$2: SHIPPED in $tag" ;;
+    1) echo "$2: unreleased (newest is $tag)" ;;
+    *) echo "$2: CANNOT TELL — bad commit, or tags not fetched"; return 2 ;;
+  esac
+}
 
-# Shipped, or still pending?
-git merge-base --is-ancestor <commit> '@codaco/fresco-ui@6.0.0' \
-  && echo shipped || echo unreleased
+shipped_in 839aefd11 '@codaco/fresco-ui'
 ```
 
 - **Shipped in any affected package** → write the changeset, naming at least
@@ -57,8 +65,17 @@ git merge-base --is-ancestor <commit> '@codaco/fresco-ui@6.0.0' \
   that changeset rather than adding a second one. Two notes about one shipped
   behaviour read as two changes.
 
-Fetch tags first (`git fetch --tags`) or a stale local tag list will report a
-shipped defect as unreleased.
+Both guards are load-bearing, and both failures point the same way — towards
+dropping a release note that was needed:
+
+- `--sort=-version:refname`, because the default refname sort is
+  lexicographic: `…@6.10.0` sorts _before_ `…@6.9.0`. Today
+  `git tag --list '@codaco/protocol-validation@*' | tail -1` answers `9.0.0`
+  when the newest release is `12.1.1`, so a defect shipped any time in the
+  last three majors would read as unreleased.
+- `case $?` rather than `&& … || …`, because `--is-ancestor` exits 1 for "no"
+  but 128 for "could not tell" — an unfetched tag, a mistyped commit. A
+  `||` branch calls both of those "unreleased".
 
 This is about the defect, not the diff. A fix that also changes behaviour
 beyond restoring the original intent still needs a changeset for that part.

--- a/.agents/skills/creating-a-changeset/SKILL.md
+++ b/.agents/skills/creating-a-changeset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-a-changeset
-description: 'Use when finishing a change and preparing to open a PR in the network-canvas monorepo — to decide whether a changeset is needed and author it in the correct lane. Keywords: changeset, do I need a changeset, release notes, pnpm changeset, version bump, before opening a PR, releasable change.'
+description: 'Use when finishing a change and preparing to open a PR in the network-canvas monorepo — to decide whether a changeset is needed and author it in the correct lane. Keywords: changeset, do I need a changeset, release notes, pnpm changeset, version bump, before opening a PR, releasable change, unreleased bug, never shipped.'
 ---
 
 # Creating a Changeset
@@ -18,10 +18,50 @@ released package or app:
   (`@codaco/studio-client`, `@codaco/studio-server`, `@codaco/studio-rpc`,
   `@codaco/studio-sync`).
 
-Skip it for repository-docs-only, test-only, CI/tooling-only, or internal
-refactors with no consumer-visible effect. Content changes to the released
+Skip it for repository-docs-only, test-only, CI/tooling-only, internal
+refactors with no consumer-visible effect, or a fix for a defect that never
+shipped (verify that — see below). Content changes to the released
 Documentation or Website products are consumer-visible and do need a changeset.
 Don't add an empty changeset just to have one.
+
+## Before writing one for a fix: was the bug ever released?
+
+A changeset is a release note, so a note for a defect nobody could encounter
+describes a version that never existed. When the change is a **fix**, establish
+whether the behaviour it corrects reached a release before deciding.
+
+Verify it; do not assume from the calendar. "Landed recently" is not
+"unreleased" — a package can ship several times a week — and the answer differs
+per package, because each has its own tag. Find the commit that introduced the
+behaviour you are fixing, then ask whether it is an ancestor of that package's
+newest release tag:
+
+```sh
+# What introduced it — `git log -S` finds the commit that added the code
+git log -S 'the-telltale-code' --oneline -- path/to/file.tsx
+
+# Newest release tag for each affected package
+git tag --list '@codaco/fresco-ui@*' | tail -1
+
+# Shipped, or still pending?
+git merge-base --is-ancestor <commit> '@codaco/fresco-ui@6.0.0' \
+  && echo shipped || echo unreleased
+```
+
+- **Shipped in any affected package** → write the changeset, naming at least
+  the packages whose released versions carry the defect.
+- **Unreleased everywhere** → no changeset. Say so in the PR description, with
+  the introducing commit, so a reviewer reads the omission as a decision rather
+  than an oversight.
+- **The pending changeset describes the behaviour you just changed** → edit
+  that changeset rather than adding a second one. Two notes about one shipped
+  behaviour read as two changes.
+
+Fetch tags first (`git fetch --tags`) or a stale local tag list will report a
+shipped defect as unreleased.
+
+This is about the defect, not the diff. A fix that also changes behaviour
+beyond restoring the original intent still needs a changeset for that part.
 
 ## Release lanes — never mix separately gated products
 

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.test.tsx
@@ -603,6 +603,28 @@ describe('SegmentedToolbar — conditional motion', () => {
       expect(screen.queryByRole('separator')).not.toBeInTheDocument();
     });
   });
+
+  /**
+   * Swapping segments pins each departing control out of flow at its old
+   * coordinates and writes layout-projection transforms on the ones that stay,
+   * so the scroll lane's `scrollWidth` overshoots its `clientWidth` for the
+   * length of every hand-off even though nothing is out of reach. jsdom has no
+   * layout to measure that with, so this guards the decision it forces: the
+   * lane still scrolls, and never paints a bar for it.
+   */
+  it('scrolls the horizontal lane without painting scrollbar chrome', () => {
+    render(
+      <SegmentedToolbar aria-label="Editing tools">
+        <ToolbarIconButton aria-label="List" icon={<List />} />
+      </SegmentedToolbar>,
+    );
+
+    expect(screen.getByRole('toolbar', { name: 'Editing tools' })).toHaveClass(
+      'overflow-x-auto',
+      'scrollbar-none',
+      '[&::-webkit-scrollbar]:hidden',
+    );
+  });
 });
 
 describe('SegmentedToolbar — dragging', () => {

--- a/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
+++ b/packages/fresco-ui/src/SegmentedToolbar/SegmentedToolbar.tsx
@@ -933,7 +933,24 @@ export function SegmentedToolbar({
           'relative flex min-w-0 items-center gap-1',
           orientation === 'vertical'
             ? 'flex-col'
-            : 'm-[-5px] overflow-x-auto overscroll-x-contain p-[5px]',
+            : // The horizontal lane scrolls so that segments which do not fit
+              // stay reachable, with 5px of headroom because a non-`visible`
+              // `overflow-x` clips the other axis too and would otherwise slice
+              // the focus ring off every segment.
+              //
+              // It scrolls WITHOUT scrollbar chrome, because the only thing
+              // that reliably paints one is the toolbar's own motion. Swapping
+              // the segments pins each departing control at its old coordinates
+              // with `position: absolute` (AnimatePresence `popLayout`) and
+              // writes layout-projection transforms on the ones that stay, so
+              // `scrollWidth` runs some 80px past `clientWidth` for the length
+              // of every hand-off. At rest the two are equal. Left to `auto`,
+              // that overshoot flashes a scrollbar across the pill — and where
+              // the platform reserves space for one, grows it 15px taller
+              // mid-animation — to advertise content that was never out of
+              // reach. Genuine overflow still scrolls by wheel, by touch, and
+              // by the toolbar's roving focus.
+              'm-[-5px] scrollbar-none overflow-x-auto overscroll-x-contain p-[5px] [&::-webkit-scrollbar]:hidden',
         )}
       >
         <GroupDisabledContext.Provider value={disabled}>


### PR DESCRIPTION
## Summary

`SegmentedToolbar`'s horizontal lane is a scroll container so segments that do not fit stay reachable rather than being clipped off the edge of the screen (#1388). What that also bought was a scrollbar the toolbar's own motion paints for it: in Architect, every hand-off between the stage timeline and the stage editor drew one across the pill for the length of the animation.

Nothing is out of reach when it appears. Swapping the segments pins each departing control at its old coordinates with `position: absolute` — that is what AnimatePresence's `popLayout` does — and writes layout-projection transforms on the ones that stay, so the lane's `scrollWidth` overshoots its `clientWidth` until the exit settles. Measured live in Architect at 1440px:

| Hand-off | `scrollWidth` | `clientWidth` | at rest |
| --- | --- | --- | --- |
| timeline → editor | 422 | 336 | equal |
| editor → timeline | 508 | 427 | equal |

Where the platform reserves space for a scrollbar rather than overlaying one, that overshoot also grew the pill 15px taller mid-animation and shrank it again — `offsetHeight` 73 against a `clientHeight` of 58.

So the lane keeps scrolling and stops drawing scrollbar chrome for it. Genuine overflow still scrolls by wheel, by touch, and by the roving focus, which carries the focused segment into view; only the bar goes. It is not a worthwhile affordance to keep at that price: the one thing that reliably triggered it was an animation, and a 15px native scrollbar cutting through a floating glass pill was never the designed way to say "there is more here".

### Why not keep the scrollbar honest instead

Anchoring the `popLayout` exit clones outside the scroll container (so they stop inflating its scrollable overflow) does clear the shrinking direction — measured 0px overshoot. The growing direction still overshoots ~80px through the layout-projection transforms Motion writes on the in-flow children, which no geometry change can suppress. Suppressing the chrome is the only fix that covers both.

## No changeset

The defect never shipped. It arrived with 839aefd11, which is on `main` and in the pending changeset set but is an ancestor of neither `@codaco/fresco-ui@6.0.0` nor `@codaco/architect@8.1.0` — no released version has ever drawn this scrollbar, so a release note would announce a fix for something no researcher could have seen.

The pending note that covers 839aefd11's toolbar work (`fresco-ui-release-blocker-fixes.md`: "segmented controls can shrink within narrow containers") stays accurate as written, so it needs no edit either.

The second commit teaches `creating-a-changeset` to run that check. The skill previously asked only whether a change is consumer-visible in a released package — which a fix to `@codaco/fresco-ui` always is — so it could not reach this answer, which turns on the defect's provenance rather than on the diff.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] `pnpm --filter @codaco/fresco-ui test` (1541 tests)
- [x] `pnpm --filter @codaco/architect test` (2436 tests)
- [x] New regression test in `SegmentedToolbar.test.tsx`, confirmed failing with the change reverted and passing with it
- [x] Verified in the running Architect dev server: both hand-offs still show the transient overshoot, zero frames with scrollbar chrome, and with the pill constrained to 260px `scrollLeft` still reaches its maximum and focusing the last segment brings it fully into view
- [x] E2E visual baselines assessed, no regeneration needed: Playwright launches headless Chromium with `--hide-scrollbars`, so no committed baseline for any of the three suites can contain scrollbar chrome. Corroborated by the 24 committed `*-segmented-toolbar.png` captures all being 80–81px tall with no 15px gutter, and by Architect's `codebook.png` showing a scrollable page with no scrollbar drawn