### PR TITLE
fix: allow PostHog relay scripts in Architect and Interviewer

### DIFF
--- a/.changeset/architect-posthog-csp.md
+++ b/.changeset/architect-posthog-csp.md
@@ -1,0 +1,6 @@
+---
+'@codaco/architect': patch
+'@codaco/interviewer': patch
+---
+
+Architect and Interviewer now load analytics and automatic error-reporting modules through the Network Canvas relay without Content Security Policy errors.

--- a/apps/architect/e2e/scripts/run.sh
+++ b/apps/architect/e2e/scripts/run.sh
@@ -29,16 +29,12 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-# VITE_DISABLE_ANALYTICS=true skips analytics.ts's posthog.init entirely.
-# Without it, PostHog's client attempts a `<script src="…surveys.js">` load
-# against connect-src's ph-relay.networkcanvas.com host, which the app's own
-# CSP meta tag (vite.config.ts) allows for connect-src but blocks under
-# script-src — an expected, permanent CSP violation, not a bug, but its timing
-# is non-deterministic, so it can occasionally interleave with a spec's own
-# page.evaluate/addStyleTag calls and surface as a spurious action failure.
-# Reuse the app's build-time analytics gate (already used by vitest and the
-# Netlify PR-preview build — see vite.config.ts / netlify.toml) so the
-# build under test never initializes PostHog at all.
+# VITE_DISABLE_ANALYTICS=true skips analytics.ts's posthog.init entirely. The
+# production CSP allows PostHog's controlled relay under both connect-src and
+# script-src, but E2E must not depend on live analytics requests or their
+# non-deterministic timing. Reuse the app's build-time analytics gate (already
+# used by vitest and the Netlify PR-preview build — see vite.config.ts /
+# netlify.toml) so the build under test never initializes PostHog at all.
 # Visual baselines are amd64-truth: glyph advance widths differ subtly
 # between the image's amd64 and arm64 builds, which moves text wrap points in
 # the print documents — an arm64-generated baseline is a whole line-height off

--- a/apps/architect/scripts/assert-pwa-build.mjs
+++ b/apps/architect/scripts/assert-pwa-build.mjs
@@ -71,6 +71,11 @@ if (strayMaps.length > 0) {
 // The entry module (referenced by index.html) boots the app; it must be
 // precached for an offline start. Derive it rather than hardcode the hash.
 const html = readFileSync(path.join(dist, 'index.html'), 'utf8');
+if (
+  !html.includes('script-src &#39;self&#39; https://ph-relay.networkcanvas.com')
+) {
+  fail('PostHog relay missing from the script-src CSP directive');
+}
 const entry = (html.match(/assets\/[^"']+\.js/) || [])[0];
 if (!entry) fail('no entry chunk referenced in dist/index.html');
 if (!precached.has(entry)) fail(`entry chunk excluded from precache: ${entry}`);

--- a/apps/architect/vite.config.ts
+++ b/apps/architect/vite.config.ts
@@ -23,7 +23,9 @@ const repoRoot = resolve(rootDir, '../..');
 // the HTML, bumps its precache revision, and propagates on the next update.
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
-  "script-src 'self'",
+  // posthog-js loads its remote project config and enabled SDK extensions
+  // (including exception autocapture) as scripts from our controlled relay.
+  "script-src 'self' https://ph-relay.networkcanvas.com",
   "style-src 'self' 'unsafe-inline'",
   "font-src 'self' data:",
   "img-src 'self' data: blob:",

--- a/apps/interviewer/e2e/scripts/run.sh
+++ b/apps/interviewer/e2e/scripts/run.sh
@@ -24,15 +24,11 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-# VITE_DISABLE_ANALYTICS=true skips client.ts's posthog.init entirely.
-# Without it, PostHog's client attempts a `<script src="…surveys.js">` load
-# against connect-src's ph-relay.networkcanvas.com host, which the app's own
-# CSP meta tag (vite.config.ts) allows for connect-src but blocks under
-# script-src — an expected, permanent CSP violation, not a bug, but its timing
-# is non-deterministic, so it can occasionally interleave with a spec's own
-# page.evaluate/addStyleTag calls and surface as a spurious action failure.
-# Reuse the app's build-time analytics gate so the build under test never
-# initializes PostHog at all.
+# VITE_DISABLE_ANALYTICS=true skips client.ts's posthog.init entirely. The
+# production CSP allows PostHog's controlled relay under both connect-src and
+# script-src, but E2E must not depend on live analytics requests or their
+# non-deterministic timing. Reuse the app's build-time analytics gate so the
+# build under test never initializes PostHog at all.
 docker run --rm \
   -e CI=true \
   -e VITE_DISABLE_ANALYTICS=true \

--- a/apps/interviewer/src/__tests__/vite.renderer.config.test.ts
+++ b/apps/interviewer/src/__tests__/vite.renderer.config.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { CSP_DIRECTIVES } from '../../vite.renderer.config';
 
 describe('production content security policy', () => {
+  it('permits scripts from the controlled PostHog relay', () => {
+    expect(CSP_DIRECTIVES).toContain(
+      "script-src 'self' https://ph-relay.networkcanvas.com",
+    );
+  });
+
   it('permits fetching protocol asset object URLs', () => {
     expect(CSP_DIRECTIVES).toContain(
       "connect-src 'self' https://api.github.com https://api.mapbox.com https://events.mapbox.com https://ph-relay.networkcanvas.com blob:",

--- a/apps/interviewer/src/lib/analytics/client.ts
+++ b/apps/interviewer/src/lib/analytics/client.ts
@@ -15,9 +15,8 @@ export function getAnalyticsClient(): Promise<PostHog | null> {
 
 async function initClient(): Promise<PostHog | null> {
   // Skip analytics entirely when disabled at build time (e2e / CI / preview
-  // builds). This also prevents posthog-js's dynamic surveys.js `<script>`
-  // load — blocked by the app CSP under script-src — whose non-deterministic
-  // console error can otherwise flake Playwright actions.
+  // builds). This also prevents live PostHog dependency requests whose
+  // non-deterministic timing can otherwise flake Playwright actions.
   if (import.meta.env.VITE_DISABLE_ANALYTICS === 'true') {
     return null;
   }

--- a/apps/interviewer/vite.renderer.config.ts
+++ b/apps/interviewer/vite.renderer.config.ts
@@ -64,7 +64,9 @@ export const appVersion = pkg.version;
 // else stays 'self'.
 export const CSP_DIRECTIVES = [
   "default-src 'self'",
-  "script-src 'self'",
+  // posthog-js loads its remote project config and enabled SDK extensions
+  // (including exception autocapture) as scripts from our controlled relay.
+  `script-src 'self' ${POSTHOG_RELAY_ORIGIN}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   // Protocol audio/video assets are decrypted to Blobs and played via object


### PR DESCRIPTION
## Summary

- allow the controlled PostHog relay in Architect and Interviewer's `script-src` CSP so runtime configuration, web-vitals, surveys, logs, and exception-capture modules can load
- add regression coverage for both app configurations and update obsolete E2E comments while preserving deterministic analytics opt-out in test builds
- record patch releases for Architect and Interviewer; Fresco needs no change because it does not emit a Content Security Policy

## Test plan

- [x] `pnpm --filter @codaco/architect build`
- [x] `pnpm --filter @codaco/architect test` (2,436 passed, 3 todo)
- [x] Architect Playwright E2E (166 passed)
- [x] Architect production-preview browser verification: all six PostHog relay scripts loaded with no console warnings or errors
- [x] `pnpm --filter @codaco/interviewer build`
- [x] `pnpm --filter @codaco/interviewer test` (522 passed)
- [x] focused Interviewer CSP regression test (2 passed)
- [x] affected Interviewer E2E tests pass when scoped; full parallel and serial runs exposed unrelated existing startup and transition flakes
- [x] Interviewer production-preview browser verification: active CSP included the relay and emitted no console warnings or errors (analytics remained opted out)
- [x] `pnpm typecheck`
- [x] `pnpm lint:fix`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
