### PR TITLE
fix(fresco): enforce HSTS at the Traefik entrypoint

### DIFF
--- a/apps/fresco/SECURITY.md
+++ b/apps/fresco/SECURITY.md
@@ -19,7 +19,7 @@ Fresco is a **single-tenant, single-trust-level** application. Understanding thi
 
 ## Transport & headers
 
-Responses carry `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Strict-Transport-Security`, and `Referrer-Policy` (set to `no-referrer` on `/interview/*` and `/onboard/*` so capability-bearing interview URLs are never leaked via the `Referer` header). User-uploaded assets are served with a validated content type and are forced to download (rather than render inline) for script-capable types such as SVG/HTML. Terminate TLS in front of the app (the bundled `docker-compose.prod.yml` does this with Traefik).
+Responses carry `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Strict-Transport-Security`, and `Referrer-Policy` (set to `no-referrer` on `/interview/*` and `/onboard/*` so capability-bearing interview URLs are never leaked via the `Referer` header). User-uploaded assets are served with a validated content type and are forced to download (rather than render inline) for script-capable types such as SVG/HTML. Terminate TLS in front of the app. The bundled production Compose files do this with Traefik and enforce `Strict-Transport-Security` across the entire HTTPS entrypoint, including proxy-generated redirects and storage responses.
 
 ## Reporting a Vulnerability
 

--- a/apps/fresco/__tests__/dockerCompose.test.ts
+++ b/apps/fresco/__tests__/dockerCompose.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { describe, expect, it } from 'vitest';
+
 const composeFiles = [
   'docker-compose.prod.yml',
   'docker-compose.external-s3.yml',

--- a/apps/fresco/__tests__/dockerCompose.test.ts
+++ b/apps/fresco/__tests__/dockerCompose.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const composeFiles = [
+  'docker-compose.prod.yml',
+  'docker-compose.external-s3.yml',
+  'docker-compose.uploadthing.yml',
+];
+
+describe.each(composeFiles)('%s', (composeFile) => {
+  const compose = readFileSync(path.join(process.cwd(), composeFile), 'utf8');
+
+  it('enforces HSTS across the HTTPS entrypoint', () => {
+    expect(compose).toContain(
+      "      - '--entrypoints.websecure.http.middlewares=fresco-hsts@docker'",
+    );
+    expect(compose).toContain(
+      "      - 'traefik.http.middlewares.fresco-hsts.headers.stsseconds=63072000'",
+    );
+    expect(compose).toContain(
+      "      - 'traefik.http.middlewares.fresco-hsts.headers.stsincludesubdomains=true'",
+    );
+  });
+});

--- a/apps/fresco/docker-compose.external-s3.yml
+++ b/apps/fresco/docker-compose.external-s3.yml
@@ -48,6 +48,8 @@ services:
       - '--providers.docker.exposedbydefault=false'
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
+      # Cover proxy-generated redirects and every service on the HTTPS entrypoint.
+      - '--entrypoints.websecure.http.middlewares=fresco-hsts@docker'
       - '--entrypoints.web.http.redirections.entrypoint.to=websecure'
       - '--entrypoints.web.http.redirections.entrypoint.scheme=https'
       - '--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL in .env (Lets Encrypt contact email)}'
@@ -78,6 +80,8 @@ services:
       PUBLIC_URL: https://${FRESCO_DOMAIN}
     labels:
       - 'traefik.enable=true'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsseconds=63072000'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsincludesubdomains=true'
       - 'traefik.http.routers.fresco.rule=Host(`${FRESCO_DOMAIN:?Set FRESCO_DOMAIN in .env (public domain for this deployment)}`)'
       - 'traefik.http.routers.fresco.entrypoints=websecure'
       - 'traefik.http.routers.fresco.tls.certresolver=letsencrypt'

--- a/apps/fresco/docker-compose.prod.yml
+++ b/apps/fresco/docker-compose.prod.yml
@@ -33,6 +33,8 @@ services:
       - '--providers.docker.exposedbydefault=false'
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
+      # Cover proxy-generated redirects and every service on the HTTPS entrypoint.
+      - '--entrypoints.websecure.http.middlewares=fresco-hsts@docker'
       - '--entrypoints.web.http.redirections.entrypoint.to=websecure'
       - '--entrypoints.web.http.redirections.entrypoint.scheme=https'
       - '--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL in .env (Lets Encrypt contact email)}'
@@ -65,6 +67,8 @@ services:
       PUBLIC_URL: https://${FRESCO_DOMAIN}
     labels:
       - 'traefik.enable=true'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsseconds=63072000'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsincludesubdomains=true'
       - 'traefik.http.routers.fresco.rule=Host(`${FRESCO_DOMAIN:?Set FRESCO_DOMAIN in .env (public domain for this deployment)}`)'
       - 'traefik.http.routers.fresco.entrypoints=websecure'
       - 'traefik.http.routers.fresco.tls.certresolver=letsencrypt'

--- a/apps/fresco/docker-compose.uploadthing.yml
+++ b/apps/fresco/docker-compose.uploadthing.yml
@@ -33,6 +33,8 @@ services:
       - '--providers.docker.exposedbydefault=false'
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
+      # Cover proxy-generated redirects and every service on the HTTPS entrypoint.
+      - '--entrypoints.websecure.http.middlewares=fresco-hsts@docker'
       - '--entrypoints.web.http.redirections.entrypoint.to=websecure'
       - '--entrypoints.web.http.redirections.entrypoint.scheme=https'
       - '--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL in .env (Lets Encrypt contact email)}'
@@ -63,6 +65,8 @@ services:
       PUBLIC_URL: https://${FRESCO_DOMAIN}
     labels:
       - 'traefik.enable=true'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsseconds=63072000'
+      - 'traefik.http.middlewares.fresco-hsts.headers.stsincludesubdomains=true'
       - 'traefik.http.routers.fresco.rule=Host(`${FRESCO_DOMAIN:?Set FRESCO_DOMAIN in .env (public domain for this deployment)}`)'
       - 'traefik.http.routers.fresco.entrypoints=websecure'
       - 'traefik.http.routers.fresco.tls.certresolver=letsencrypt'


### PR DESCRIPTION
## Summary
- apply Fresco's existing two-year HSTS policy at the Traefik `websecure` entrypoint
- cover framework-generated redirects, MinIO responses, and deployment-specific HTTPS routers
- add regression coverage for all three production Compose variants and clarify the security documentation

## Root cause
Next.js applies the application-level security headers to normal responses, but its automatic trailing-slash `308` redirects are returned before those headers are attached. Enforcing HSTS at the TLS boundary ensures every HTTPS response carries the policy.

## Test plan
- [x] `pnpm --filter fresco test` (51 files, 409 tests)
- [x] focused Compose regression test, including a deliberate failing mutation
- [x] `docker compose config --no-interpolate --quiet` for all three production variants
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`
- [x] `pnpm knip`
- [x] `pnpm check:changesets`
- [x] visual-baseline classifier: Architect, Interview, and Interviewer skipped

No changeset is included because this is deployment configuration rather than a Fresco product change.